### PR TITLE
YJDH-80 | Backend: Add mock setup for Helsinki Profile auth flow

### DIFF
--- a/backend/applications/tests/factories.py
+++ b/backend/applications/tests/factories.py
@@ -13,6 +13,18 @@ class UserFactory(factory.django.DjangoModelFactory):
         model = get_user_model()
 
     username = factory.Sequence(lambda n: "user_%d" % (n + 1))
+    email = factory.Faker("email")
+    first_name = factory.Faker("first_name")
+    last_name = factory.Faker("last_name")
+
+    @classmethod
+    def _setup_next_sequence(cls):
+        User = get_user_model()
+        try:
+            latest_id = User.objects.latest("id").id
+            return latest_id + 1
+        except User.DoesNotExist:
+            return 1
 
 
 class SummerVoucherFactory(factory.django.DjangoModelFactory):

--- a/backend/oidc/mock_views.py
+++ b/backend/oidc/mock_views.py
@@ -1,0 +1,58 @@
+from django.conf import settings
+from django.contrib import auth
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.views.generic import View
+
+from applications.tests.factories import UserFactory
+
+
+class MockLogoutView(View):
+    """Mocked user logout"""
+
+    http_method_names = ["get", "post"]
+
+    def handle_logout(self, request):
+        if request.user.is_authenticated:
+            auth.logout(request)
+        return HttpResponseRedirect(settings.LOGOUT_REDIRECT_URL or "/")
+
+    def get(self, request):
+        return self.handle_logout(request)
+
+    def post(self, request):
+        return self.handle_logout(request)
+
+
+class MockUserInfoView(View):
+    """Get mocked userinfo of the logged in user"""
+
+    http_method_names = ["get"]
+
+    def get(self, request):
+        if request.user.is_authenticated:
+            user = request.user
+            userinfo = {
+                "sub": "82e17287-f34e-4e4b-b3d2-15857b3f952a",
+                "national_id_num": "210281-9988",
+                "name": f"{user.first_name} {user.last_name}",
+                "preferred_username": user.username,
+                "given_name": user.first_name,
+                "family_name": user.last_name,
+            }
+            return JsonResponse(userinfo)
+        else:
+            return HttpResponse("Unauthorized", status=401)
+
+
+class MockAuthenticationRequestView(View):
+    """Mocked OIDC client authentication HTTP endpoint"""
+
+    http_method_names = ["get"]
+
+    def get(self, request):
+        if not request.user.is_authenticated:
+            user = UserFactory()
+            auth.login(
+                request, user, backend="django.contrib.auth.backends.ModelBackend"
+            )
+        return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL or "/")

--- a/backend/oidc/tests/test_mock_views.py
+++ b/backend/oidc/tests/test_mock_views.py
@@ -1,0 +1,70 @@
+import pytest
+from django.conf import settings
+from django.test import override_settings
+from django.urls import path, reverse
+
+from oidc.mock_views import (
+    MockAuthenticationRequestView,
+    MockLogoutView,
+    MockUserInfoView,
+)
+
+urlpatterns = [
+    path(
+        "oidc/authenticate/",
+        MockAuthenticationRequestView.as_view(),
+        name="oidc_authentication_init",
+    ),
+    path(
+        "oidc/logout/",
+        MockLogoutView.as_view(),
+        name="oidc_logout",
+    ),
+    path(
+        "oidc/userinfo/",
+        MockUserInfoView.as_view(),
+        name="oidc_userinfo",
+    ),
+]
+
+
+@pytest.mark.django_db
+@override_settings(
+    MOCK_FLAG=True,
+    LOGIN_REDIRECT_URL="http://example.com/login/",
+    ROOT_URLCONF=__name__,
+)
+def test_login_view(client):
+    login_url = reverse("oidc_authentication_init")
+    response = client.get(login_url)
+
+    assert response.url == settings.LOGIN_REDIRECT_URL
+    assert "_auth_user_id" in client.session  # User authenticated
+
+
+@pytest.mark.django_db
+@override_settings(
+    MOCK_FLAG=True,
+    LOGOUT_REDIRECT_URL="http://example.com/logout/",
+    ROOT_URLCONF=__name__,
+)
+def test_logout_view(user_client, user):
+    logout_url = reverse("oidc_logout")
+    response = user_client.post(logout_url)
+
+    assert response.url == settings.LOGOUT_REDIRECT_URL
+    assert "_auth_user_id" not in user_client.session  # User not authenticated
+
+
+@pytest.mark.django_db
+@override_settings(MOCK_FLAG=True, ROOT_URLCONF=__name__)
+def test_userinfo_view(user_client, user):
+    logout_url = reverse("oidc_userinfo")
+    response = user_client.get(logout_url)
+
+    response = response.json()
+
+    assert response["name"] == f"{user.first_name} {user.last_name}"
+    assert response["preferred_username"] == user.username
+    assert response["given_name"] == user.first_name
+    assert response["family_name"] == user.last_name

--- a/backend/oidc/urls.py
+++ b/backend/oidc/urls.py
@@ -1,17 +1,44 @@
+from django.conf import settings
 from django.urls import include, path
 
+from oidc.mock_views import (
+    MockAuthenticationRequestView,
+    MockLogoutView,
+    MockUserInfoView,
+)
 from oidc.views import HelsinkiOIDCLogoutView, HelsinkiOIDCUserInfoView
 
-urlpatterns = [
-    path(
-        "logout/",
-        HelsinkiOIDCLogoutView.as_view(),
-        name="oidc_logout",
-    ),
-    path(
-        "userinfo/",
-        HelsinkiOIDCUserInfoView.as_view(),
-        name="oidc_userinfo",
-    ),
-    path("", include("mozilla_django_oidc.urls")),
-]
+urlpatterns = []
+
+if settings.MOCK_FLAG:
+    urlpatterns += [
+        path(
+            "oidc/authenticate/",
+            MockAuthenticationRequestView.as_view(),
+            name="oidc_authentication_init",
+        ),
+        path(
+            "oidc/logout/",
+            MockLogoutView.as_view(),
+            name="oidc_logout",
+        ),
+        path(
+            "oidc/userinfo/",
+            MockUserInfoView.as_view(),
+            name="oidc_userinfo",
+        ),
+    ]
+else:
+    urlpatterns += [
+        path(
+            "logout/",
+            HelsinkiOIDCLogoutView.as_view(),
+            name="oidc_logout",
+        ),
+        path(
+            "userinfo/",
+            HelsinkiOIDCUserInfoView.as_view(),
+            name="oidc_userinfo",
+        ),
+        path("", include("mozilla_django_oidc.urls")),
+    ]


### PR DESCRIPTION
## Description :sparkles:

For testing purposes mock the oidc auth flow views so that it is not required to call Helsinki Profile.

## Issues :bug:

[YJDH-80](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-80)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
