### PR TITLE
Change OIDC logout method from GET -> POST

### DIFF
--- a/.env.kesaseteli.example
+++ b/.env.kesaseteli.example
@@ -15,4 +15,3 @@ OIDC_OP_JWKS_ENDPOINT=
 OIDC_OP_LOGOUT_ENDPOINT=
 LOGIN_REDIRECT_URL=http://localhost:3000/
 LOGIN_REDIRECT_URL_FAILURE=http://localhost:3000/login?error=true
-LOGOUT_REDIRECT_URL=http://localhost:3000/login?logout=true

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -50,7 +50,6 @@ env = environ.Env(
     OIDC_OP_LOGOUT_ENDPOINT=(str, ""),
     LOGIN_REDIRECT_URL=(str, ""),
     LOGIN_REDIRECT_URL_FAILURE=(str, ""),
-    LOGOUT_REDIRECT_URL=(str, ""),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -181,7 +180,6 @@ OIDC_OP_JWKS_ENDPOINT = env.str("OIDC_OP_JWKS_ENDPOINT")
 OIDC_OP_LOGOUT_ENDPOINT = env.str("OIDC_OP_LOGOUT_ENDPOINT")
 
 LOGIN_REDIRECT_URL = env.str("LOGIN_REDIRECT_URL")
-LOGOUT_REDIRECT_URL = env.str("LOGOUT_REDIRECT_URL")
 LOGIN_REDIRECT_URL_FAILURE = env.str("LOGIN_REDIRECT_URL_FAILURE")
 
 # local_settings.py can be used to override environment-specific settings

--- a/backend/kesaseteli/oidc/mock_views.py
+++ b/backend/kesaseteli/oidc/mock_views.py
@@ -14,7 +14,7 @@ class MockLogoutView(View):
     def handle_logout(self, request):
         if request.user.is_authenticated:
             auth.logout(request)
-        return HttpResponseRedirect(settings.LOGOUT_REDIRECT_URL or "/")
+        return HttpResponse("OK", status=200)
 
     def get(self, request):
         return self.handle_logout(request)

--- a/backend/kesaseteli/oidc/tests/test_mock_views.py
+++ b/backend/kesaseteli/oidc/tests/test_mock_views.py
@@ -45,14 +45,14 @@ def test_login_view(client):
 @pytest.mark.django_db
 @override_settings(
     MOCK_FLAG=True,
-    LOGOUT_REDIRECT_URL="http://example.com/logout/",
     ROOT_URLCONF=__name__,
 )
 def test_logout_view(user_client, user):
     logout_url = reverse("oidc_logout")
     response = user_client.post(logout_url)
 
-    assert response.url == settings.LOGOUT_REDIRECT_URL
+    assert response.status_code == 200
+    assert response.content == b"OK"
     assert "_auth_user_id" not in user_client.session  # User not authenticated
 
 

--- a/backend/kesaseteli/oidc/tests/test_oidc_views.py
+++ b/backend/kesaseteli/oidc/tests/test_oidc_views.py
@@ -20,7 +20,8 @@ def test_logout_view(requests_mock, user_client, user):
     logout_url = reverse("oidc_logout")
     response = user_client.post(logout_url)
 
-    assert response.url == settings.LOGOUT_REDIRECT_URL
+    assert response.status_code == 200
+    assert response.content == b"OK"
     assert "_auth_user_id" not in user_client.session  # User not authenticated
 
 
@@ -33,7 +34,7 @@ def test_logout_view_without_oidc_profile(requests_mock, user_client, user):
     logout_url = reverse("oidc_logout")
     response = user_client.post(logout_url)
 
-    assert response.url == settings.LOGOUT_REDIRECT_URL
+    assert response.status_code == 200
     assert "_auth_user_id" not in user_client.session  # User not authenticated
 
 

--- a/backend/kesaseteli/oidc/views.py
+++ b/backend/kesaseteli/oidc/views.py
@@ -4,7 +4,7 @@ import requests
 from django.conf import settings
 from django.contrib import auth
 from django.core.exceptions import SuspiciousOperation
-from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.views.generic import View
 from mozilla_django_oidc.views import OIDCLogoutView
 from requests.exceptions import HTTPError
@@ -19,13 +19,13 @@ logger = logging.getLogger(__name__)
 class HelsinkiOIDCLogoutView(OIDCLogoutView):
     """Override OIDCLogoutView to match the keycloak backchannel logout"""
 
-    def get(self, request):
+    def post(self, request):
         if request.user.is_authenticated:
             try:
                 oidc_profile = request.user.oidc_profile
             except OIDCProfile.DoesNotExist:
                 auth.logout(request)
-                return HttpResponseRedirect(self.redirect_url)
+                return HttpResponse("OK", status=200)
 
             payload = {
                 "id_token_hint": oidc_profile.id_token,
@@ -50,7 +50,7 @@ class HelsinkiOIDCLogoutView(OIDCLogoutView):
             auth.logout(request)
             clear_oidc_profiles(oidc_profile)
 
-        return HttpResponseRedirect(self.redirect_url)
+        return HttpResponse("OK", status=200)
 
 
 class HelsinkiOIDCUserInfoView(View):


### PR DESCRIPTION
## Description :sparkles:

- Modify the OIDC logout view to support POST requests instead of GET.
- Return a HttpResponse with status 200 instead of redirect.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
