### PR TITLE
YJDH-69 | Eauthorizations OIDC flow

### DIFF
--- a/.env.kesaseteli.example
+++ b/.env.kesaseteli.example
@@ -1,9 +1,10 @@
 DEBUG=1
 APPLY_MIGRATIONS=1
 CREATE_SUPERUSER=1
+CORS_ORIGIN_ALLOW_ALL=1
 EMPLOYER_URL=http://localhost:3000
 HANDLER_URL=http://localhost:3100
-NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
+NEXT_PUBLIC_BACKEND_URL=https://localhost:8000
 
 # Authentication
 OIDC_OP_BASE_URL=https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect
@@ -11,6 +12,11 @@ OIDC_RP_CLIENT_ID=
 OIDC_RP_CLIENT_SECRET=
 LOGIN_REDIRECT_URL=http://localhost:3000/
 LOGIN_REDIRECT_URL_FAILURE=http://localhost:3000/login?error=true
+
+EAUTHORIZATIONS_BASE_URL=https://asiointivaltuustarkastus.test.suomi.fi
+EAUTHORIZATIONS_CLIENT_ID=
+EAUTHORIZATIONS_CLIENT_SECRET=
+EAUTHORIZATIONS_API_OAUTH_SECRET=
 
 # Mock integrations
 MOCK_FLAG=1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ YJDH-Kesäseteli
 2. Run `yarn kesaseteli:up`
 
 The Frontend is now running at [localhost:3000](http://localhost:3000)
-The backend is now running at [localhost:8000](http://localhost:8000)
+The backend is now running at [localhost:8000](https://localhost:8000)
 
 ## Benefit
 

--- a/backend/kesaseteli/README.md
+++ b/backend/kesaseteli/README.md
@@ -30,7 +30,7 @@ Allow user to create test database
 * Run `python manage.py migrate`
 * Run `python manage.py runserver 0:8000`
 
-The project is now running at [localhost:8000](http://localhost:8000)
+The project is now running at [localhost:8000](https://localhost:8000)
 
 ## Keeping Python requirements up to date
 

--- a/backend/kesaseteli/docker-entrypoint.sh
+++ b/backend/kesaseteli/docker-entrypoint.sh
@@ -35,7 +35,7 @@ fi
 if [[ ! -z "$@" ]]; then
     "$@"
 elif [[ "$DEV_SERVER" = "1" ]]; then
-    python ./manage.py runserver 0.0.0.0:8000
+    python ./manage.py runserver_plus 0.0.0.0:8000 --cert-file /tmp/cert.crt
 else
     uwsgi --ini .prod/uwsgi.ini
 fi

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -48,6 +48,10 @@ env = environ.Env(
     OIDC_OP_BASE_URL=(str, ""),
     LOGIN_REDIRECT_URL=(str, ""),
     LOGIN_REDIRECT_URL_FAILURE=(str, ""),
+    EAUTHORIZATIONS_BASE_URL=(str, ""),
+    EAUTHORIZATIONS_CLIENT_ID=(str, ""),
+    EAUTHORIZATIONS_CLIENT_SECRET=(str, ""),
+    EAUTHORIZATIONS_API_OAUTH_SECRET=(str, ""),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -161,6 +165,7 @@ MOCK_FLAG = env.bool("MOCK_FLAG")
 
 # Authentication
 SESSION_COOKIE_AGE = env.int("SESSION_COOKIE_AGE")
+SESSION_COOKIE_SECURE = True
 
 AUTHENTICATION_BACKENDS = (
     "oidc.auth.HelsinkiOIDCAuthenticationBackend",
@@ -182,6 +187,11 @@ OIDC_OP_LOGOUT_ENDPOINT = f"{OIDC_OP_BASE_URL}/logout"
 
 LOGIN_REDIRECT_URL = env.str("LOGIN_REDIRECT_URL")
 LOGIN_REDIRECT_URL_FAILURE = env.str("LOGIN_REDIRECT_URL_FAILURE")
+
+EAUTHORIZATIONS_BASE_URL = env.str("EAUTHORIZATIONS_BASE_URL")
+EAUTHORIZATIONS_CLIENT_ID = env.str("EAUTHORIZATIONS_CLIENT_ID")
+EAUTHORIZATIONS_CLIENT_SECRET = env.str("EAUTHORIZATIONS_CLIENT_SECRET")
+EAUTHORIZATIONS_API_OAUTH_SECRET = env.str("EAUTHORIZATIONS_API_OAUTH_SECRET")
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.

--- a/backend/kesaseteli/oidc/tests/test_auth_backend.py
+++ b/backend/kesaseteli/oidc/tests/test_auth_backend.py
@@ -26,11 +26,11 @@ def check_token_info(user, oidc_profile, token_info):
     assert oidc_profile.access_token == token_info["access_token"]
     assert abs(
         oidc_profile.access_token_expires - access_token_expires
-    ) < datetime.timedelta(seconds=5)
+    ) < datetime.timedelta(seconds=10)
     assert oidc_profile.refresh_token == token_info["refresh_token"]
     assert abs(
         oidc_profile.refresh_token_expires - refresh_token_expires
-    ) < datetime.timedelta(seconds=5)
+    ) < datetime.timedelta(seconds=10)
 
 
 def check_user_info(user, claims):
@@ -44,6 +44,7 @@ def check_user_info(user, claims):
 @override_settings(
     AUTHENTICATION_BACKENDS=("django.contrib.auth.backends.ModelBackend",),
     OIDC_OP_USER_ENDPOINT="http://example.com/userinfo/",
+    MOCK_FLAG=False,
 )
 def test_authenticate(requests_mock):
     auth_backend = HelsinkiOIDCAuthenticationBackend()
@@ -140,6 +141,7 @@ def test_store_token_info_in_oidc_profile(user):
 @pytest.mark.django_db
 @override_settings(
     OIDC_OP_TOKEN_ENDPOINT="http://example.com/token/",
+    MOCK_FLAG=False,
 )
 def test_refresh_token(oidc_profile, requests_mock):
     auth_backend = HelsinkiOIDCAuthenticationBackend()

--- a/backend/kesaseteli/oidc/tests/test_eauth_views.py
+++ b/backend/kesaseteli/oidc/tests/test_eauth_views.py
@@ -1,0 +1,137 @@
+import re
+from unittest import mock
+
+import pytest
+from django.conf import settings
+from django.test import override_settings
+from django.urls import reverse
+from django.utils import timezone
+from freezegun import freeze_time
+
+from oidc.tests.factories import OIDCProfileFactory
+from oidc.utils import get_checksum_header, get_organization_roles
+
+
+@freeze_time("2017-02-09T10:29:42.09")
+@override_settings(
+    EAUTHORIZATIONS_CLIENT_ID="ed4b7ae7",
+    EAUTHORIZATIONS_CLIENT_SECRET="3ba56df8-88b8-4805-9b04-2f8e7a61",
+    MOCK_FLAG=False,
+)
+def test_get_checksum_header():
+    """
+    Docs (only in Finnish):
+    Search for "Tarkistesumman laskemiseen toteutetun funktion verifiointi":
+    https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/5a781dc75cb4f10dde9735e4
+
+    Checksum verification:
+    path = "/service/hpa/user/register/ed4b7ae7/080297-915A?requestId=02fd35dc-99e6-477b-b6e2-03f02cbf3666"
+    client_id = "ed4b7ae7"
+    client_secret = "3ba56df8-88b8-4805-9b04-2f8e7a61"
+    time_stamp = "2017-02-09T10:29:42.090000+00:00"
+    __________________
+    Result:
+    ed4b7ae7 2017-02-09T10:29:42.090000+00:00 GeRKoGmGd0RFk33s2vNHutJf/TrEdwSM2Vb7qWXLESY=
+    """
+    path = "/service/hpa/user/register/ed4b7ae7/080297-915A?requestId=02fd35dc-99e6-477b-b6e2-03f02cbf3666"
+    checksum = get_checksum_header(path)
+
+    assert (
+        checksum
+        == "ed4b7ae7 2017-02-09T10:29:42.090000+00:00 GeRKoGmGd0RFk33s2vNHutJf/TrEdwSM2Vb7qWXLESY="
+    )
+
+
+@pytest.mark.django_db
+@override_settings(
+    EAUTHORIZATIONS_BASE_URL="http://example.com",
+    LOGIN_REDIRECT_URL="http://example.com/success",
+    EAUTHORIZATIONS_CLIENT_ID="test",
+    EAUTHORIZATIONS_CLIENT_SECRET="test",
+    MOCK_FLAG=False,
+)
+def test_get_organization_roles(requests_mock, eauthorization_profile):
+    organization_roles_json = [
+        {
+            "name": "Activenakusteri Oy",
+            "identifier": "7769480-5",
+            "complete": True,
+            "roles": ["NIMKO"],
+        }
+    ]
+
+    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    requests_mock.get(matcher, json=organization_roles_json)
+
+    organization_roles = get_organization_roles(
+        eauthorization_profile.id_token, eauthorization_profile.access_token
+    )
+
+    assert organization_roles["name"] == organization_roles_json[0]["name"]
+    assert organization_roles["identifier"] == organization_roles_json[0]["identifier"]
+
+
+@pytest.mark.django_db
+@override_settings(
+    EAUTHORIZATIONS_BASE_URL="http://example.com",
+    EAUTHORIZATIONS_CLIENT_ID="test",
+    EAUTHORIZATIONS_CLIENT_SECRET="test",
+    MOCK_FLAG=False,
+)
+def test_eauth_authentication_init_view(requests_mock, user_client, user):
+    OIDCProfileFactory(user=user)
+
+    register_user_info = {
+        "sessionId": "test_session",
+        "userId": "test_user",
+    }
+
+    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    requests_mock.get(matcher, json=register_user_info)
+
+    authentication_url = reverse("eauth_authentication_init")
+
+    userinfo = {
+        "national_id_num": "210281-9988",
+    }
+
+    with mock.patch("oidc.views.eauth_views.get_userinfo", return_value=userinfo):
+        response = user_client.get(authentication_url)
+
+    assert response.status_code == 302
+    assert settings.EAUTHORIZATIONS_BASE_URL in response.url
+    assert "test_user" in response.url
+
+
+@pytest.mark.django_db
+@override_settings(
+    EAUTHORIZATIONS_BASE_URL="http://example.com",
+    LOGIN_REDIRECT_URL="http://example.com/success",
+    MOCK_FLAG=False,
+)
+def test_eauth_callback_view(requests_mock, user_client, user):
+    oidc_profile = OIDCProfileFactory(user=user)
+
+    token_info = {
+        "access_token": "test2",
+        "expires_in": 600,
+        "refresh_token": "test3",
+    }
+    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    requests_mock.post(matcher, json=token_info)
+
+    callback_url = f"{reverse('eauth_authentication_callback')}?code=test"
+    response = user_client.get(callback_url)
+
+    assert response.status_code == 302
+    assert response.url == settings.LOGIN_REDIRECT_URL
+
+    oidc_profile.refresh_from_db()
+    eauth_profile = oidc_profile.eauthorization_profile
+
+    access_token_expires = timezone.now() + timezone.timedelta(seconds=600)
+    assert eauth_profile.access_token == "test2"
+    assert eauth_profile.refresh_token == "test3"
+    assert abs(
+        eauth_profile.access_token_expires - access_token_expires
+    ) < timezone.timedelta(seconds=10)

--- a/backend/kesaseteli/oidc/tests/test_oidc_views.py
+++ b/backend/kesaseteli/oidc/tests/test_oidc_views.py
@@ -10,7 +10,10 @@ from oidc.tests.factories import OIDCProfileFactory
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_OP_LOGOUT_ENDPOINT="http://example.com/logout/")
+@override_settings(
+    OIDC_OP_LOGOUT_ENDPOINT="http://example.com/logout/",
+    MOCK_FLAG=False,
+)
 def test_logout_view(requests_mock, user_client, user):
     OIDCProfileFactory(user=user)
 
@@ -26,7 +29,10 @@ def test_logout_view(requests_mock, user_client, user):
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_OP_LOGOUT_ENDPOINT="http://example.com/logout/")
+@override_settings(
+    OIDC_OP_LOGOUT_ENDPOINT="http://example.com/logout/",
+    MOCK_FLAG=False,
+)
 def test_logout_view_without_oidc_profile(requests_mock, user_client, user):
     matcher = re.compile(settings.OIDC_OP_LOGOUT_ENDPOINT)
     requests_mock.post(matcher)
@@ -39,7 +45,10 @@ def test_logout_view_without_oidc_profile(requests_mock, user_client, user):
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_OP_USER_ENDPOINT="http://example.com/userinfo/")
+@override_settings(
+    OIDC_OP_USER_ENDPOINT="http://example.com/userinfo/",
+    MOCK_FLAG=False,
+)
 def test_userinfo_view(requests_mock, user_client, user):
     OIDCProfileFactory(
         user=user,
@@ -65,7 +74,10 @@ def test_userinfo_view(requests_mock, user_client, user):
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_OP_USER_ENDPOINT="http://example.com/userinfo/")
+@override_settings(
+    OIDC_OP_USER_ENDPOINT="http://example.com/userinfo/",
+    MOCK_FLAG=False,
+)
 def test_userinfo_view_without_oidc_profile(user_client):
     userinfo_url = reverse("oidc_userinfo")
     response = user_client.get(userinfo_url)
@@ -74,7 +86,10 @@ def test_userinfo_view_without_oidc_profile(user_client):
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_OP_USER_ENDPOINT="http://example.com/userinfo/")
+@override_settings(
+    OIDC_OP_USER_ENDPOINT="http://example.com/userinfo/",
+    MOCK_FLAG=False,
+)
 def test_userinfo_view_with_userinfo_returning_401(requests_mock, user_client, user):
     OIDCProfileFactory(
         user=user,

--- a/backend/kesaseteli/oidc/urls.py
+++ b/backend/kesaseteli/oidc/urls.py
@@ -1,7 +1,15 @@
 from django.conf import settings
 from django.urls import include, path
 
-from oidc.views.hki_views import HelsinkiOIDCLogoutView, HelsinkiOIDCUserInfoView
+from oidc.views.eauth_views import (
+    EauthAuthenticationCallbackView,
+    EauthAuthenticationRequestView,
+)
+from oidc.views.hki_views import (
+    HelsinkiOIDCAuthenticationCallbackView,
+    HelsinkiOIDCLogoutView,
+    HelsinkiOIDCUserInfoView,
+)
 from oidc.views.mock_views import (
     MockAuthenticationRequestView,
     MockLogoutView,
@@ -31,6 +39,11 @@ if settings.MOCK_FLAG:
 else:
     urlpatterns += [
         path(
+            "callback/",
+            HelsinkiOIDCAuthenticationCallbackView.as_view(),
+            name="oidc_authentication_callback",
+        ),
+        path(
             "logout/",
             HelsinkiOIDCLogoutView.as_view(),
             name="oidc_logout",
@@ -41,4 +54,14 @@ else:
             name="oidc_userinfo",
         ),
         path("", include("mozilla_django_oidc.urls")),
+        path(
+            "eauthorizations/authenticate/",
+            EauthAuthenticationRequestView.as_view(),
+            name="eauth_authentication_init",
+        ),
+        path(
+            "eauthorizations/callback/",
+            EauthAuthenticationCallbackView.as_view(),
+            name="eauth_authentication_callback",
+        ),
     ]

--- a/backend/kesaseteli/oidc/utils.py
+++ b/backend/kesaseteli/oidc/utils.py
@@ -1,3 +1,12 @@
+import base64
+import hashlib
+import hmac
+from uuid import uuid4
+
+import requests
+from django.conf import settings
+from django.utils import timezone
+
 from oidc.auth import HelsinkiOIDCAuthenticationBackend
 from oidc.models import OIDCProfile
 
@@ -10,3 +19,44 @@ def get_userinfo(access_token: str) -> dict:
 def refresh_hki_tokens(oidc_profile: OIDCProfile) -> OIDCProfile:
     auth_backend = HelsinkiOIDCAuthenticationBackend()
     return auth_backend.refresh_tokens(oidc_profile)
+
+
+def get_checksum_header(path: str) -> str:
+    """
+    suomi.fi has a custom checksum that needs to be added for the requests.
+    Docs (only in Finnish):
+    Search for "4.3 Tarkistesumman laskeminen" and :
+    https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/5a781dc75cb4f10dde9735e4
+    """
+    timestamp = timezone.now().isoformat()
+    message = f"{path} {timestamp}"
+
+    byte_secret = settings.EAUTHORIZATIONS_CLIENT_SECRET.encode()
+    byte_message = message.encode()
+
+    hash_result = hmac.new(byte_secret, byte_message, hashlib.sha256)
+    checksum = base64.b64encode(hash_result.digest()).decode()
+    return f"{settings.EAUTHORIZATIONS_CLIENT_ID} {timestamp} {checksum}"
+
+
+def get_organization_roles(session_id: str, access_token: str) -> dict:
+    """
+    Docs (only in Finnish):
+    Search for "Taulukossa 14"
+    https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/592d774503f6d100018db5dd
+    """
+    request_id = uuid4()
+    path = f"/service/ypa/api/organizationRoles/{session_id}?requestId={request_id}"
+    organization_roles_endpoint = f"{settings.EAUTHORIZATIONS_BASE_URL}{path}"
+
+    checksum_header = get_checksum_header(path)
+
+    response = requests.get(
+        organization_roles_endpoint,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-AsiointivaltuudetAuthorization": checksum_header,
+        },
+    )
+    response.raise_for_status()
+    return response.json()[0]

--- a/backend/kesaseteli/oidc/views/eauth_views.py
+++ b/backend/kesaseteli/oidc/views/eauth_views.py
@@ -1,0 +1,142 @@
+import logging
+from urllib.parse import urlencode
+from uuid import uuid4
+
+import requests
+from django.conf import settings
+from django.contrib import auth
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.views import View
+from requests.auth import HTTPBasicAuth
+from requests.exceptions import HTTPError
+
+from oidc.services import store_token_info_in_eauth_profile
+from oidc.utils import get_checksum_header, get_userinfo
+
+logger = logging.getLogger(__name__)
+
+
+class EauthAuthenticationRequestView(View):
+    """
+    Eauth client authentication HTTP endpoint
+
+    Docs that describe the flow (only in Finnish):
+    https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/592d774503f6d100018db5dd
+    """
+
+    http_method_names = ["get"]
+
+    def login_failure(self):
+        return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL_FAILURE)
+
+    def register_user(self, person_id):
+        """
+        Docs of this method (only in Finnish):
+        Search for "Web API -session aloitus eli rekisteröintipyyntö"
+        https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/592d774503f6d100018db5dd
+        """
+        request_id = uuid4()
+        path = f"/service/ypa/user/register/{settings.EAUTHORIZATIONS_CLIENT_ID}/{person_id}?requestId={request_id}"
+
+        checksum_header = get_checksum_header(path)
+
+        response = requests.get(
+            settings.EAUTHORIZATIONS_BASE_URL + path,
+            headers={
+                "X-AsiointivaltuudetAuthorization": checksum_header,
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get(self, request):
+        """Eauth client authentication initialization HTTP endpoint"""
+        if not (
+            hasattr(request.user, "oidc_profile")
+            and request.user.oidc_profile.access_token
+        ):
+            return self.login_failure()
+
+        oidc_profile = request.user.oidc_profile
+        user_info = get_userinfo(oidc_profile.access_token)
+
+        user_ssn = user_info.get("national_id_num")
+        register_info = self.register_user(user_ssn)
+
+        session_id = register_info.get("sessionId")
+        user_id = register_info.get("userId")
+
+        store_token_info_in_eauth_profile(oidc_profile, {"id_token": session_id})
+
+        auth_url = settings.EAUTHORIZATIONS_BASE_URL + "/oauth/authorize"
+
+        params = {
+            "client_id": settings.EAUTHORIZATIONS_CLIENT_ID,
+            "response_type": "code",
+            "redirect_uri": request.build_absolute_uri(
+                reverse("eauth_authentication_callback")
+            ),
+            "user": user_id,
+        }
+        query = urlencode(params)
+
+        redirect_url = "{url}?{query}".format(url=auth_url, query=query)
+
+        return HttpResponseRedirect(redirect_url)
+
+
+class EauthAuthenticationCallbackView(View):
+    """Eauth client callback HTTP endpoint"""
+
+    http_method_names = ["get"]
+
+    def login_success(self):
+        return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL)
+
+    def login_failure(self):
+        return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL_FAILURE)
+
+    def get_token_info(self, code):
+        """Return token object as a dictionary."""
+        auth_header = HTTPBasicAuth(
+            settings.EAUTHORIZATIONS_CLIENT_ID,
+            settings.EAUTHORIZATIONS_API_OAUTH_SECRET,
+        )
+
+        token_endpoint_url = settings.EAUTHORIZATIONS_BASE_URL + "/oauth/token"
+
+        params = {
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": self.request.build_absolute_uri(
+                reverse("eauth_authentication_callback")
+            ),
+        }
+        query = urlencode(params)
+
+        token_url = "{url}?{query}".format(url=token_endpoint_url, query=query)
+        response = requests.post(
+            token_url,
+            auth=auth_header,
+        )
+        response.raise_for_status()
+
+        return response.json()
+
+    def get(self, request):
+        """Eauth client authentication callback HTTP endpoint"""
+        if request.GET.get("error"):
+            if request.user.is_authenticated:
+                auth.logout(request)
+            assert not request.user.is_authenticated
+            logger.error(str(request.GET["error"]))
+        elif "code" in request.GET:
+            try:
+                token_info = self.get_token_info(request.GET["code"])
+                store_token_info_in_eauth_profile(request.user.oidc_profile, token_info)
+            except HTTPError as e:
+                logger.error(str(e))
+                return self.login_failure()
+            return self.login_success()
+        return self.login_failure()

--- a/backend/kesaseteli/oidc/views/hki_views.py
+++ b/backend/kesaseteli/oidc/views/hki_views.py
@@ -4,9 +4,10 @@ import requests
 from django.conf import settings
 from django.contrib import auth
 from django.core.exceptions import SuspiciousOperation
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.urls import reverse
 from django.views.generic import View
-from mozilla_django_oidc.views import OIDCLogoutView
+from mozilla_django_oidc.views import OIDCAuthenticationCallbackView, OIDCLogoutView
 from requests.exceptions import HTTPError
 
 from oidc.models import OIDCProfile
@@ -14,6 +15,14 @@ from oidc.services import clear_oidc_profiles
 from oidc.utils import get_userinfo, refresh_hki_tokens
 
 logger = logging.getLogger(__name__)
+
+
+class HelsinkiOIDCAuthenticationCallbackView(OIDCAuthenticationCallbackView):
+    """Override OIDC client authentication callback login success method"""
+
+    def login_success(self):
+        super().login_success()
+        return HttpResponseRedirect(reverse("eauth_authentication_init"))
 
 
 class HelsinkiOIDCLogoutView(OIDCLogoutView):

--- a/backend/kesaseteli/requirements-dev.in
+++ b/backend/kesaseteli/requirements-dev.in
@@ -5,4 +5,6 @@ isort
 pytest
 pytest-cov
 pytest-django
+pytest-freezegun
 requests-mock
+Werkzeug

--- a/backend/kesaseteli/requirements-dev.txt
+++ b/backend/kesaseteli/requirements-dev.txt
@@ -24,6 +24,8 @@ decorator==5.0.9
     # via ipython
 flake8==3.9.2
     # via -r requirements-dev.in
+freezegun==1.1.0
+    # via pytest-freezegun
 idna==2.10
     # via requests
 iniconfig==1.1.1
@@ -72,11 +74,16 @@ pytest-cov==2.12.0
     # via -r requirements-dev.in
 pytest-django==4.3.0
     # via -r requirements-dev.in
+pytest-freezegun==0.4.2
+    # via -r requirements-dev.in
 pytest==6.2.4
     # via
     #   -r requirements-dev.in
     #   pytest-cov
     #   pytest-django
+    #   pytest-freezegun
+python-dateutil==2.8.1
+    # via freezegun
 regex==2021.4.4
     # via black
 requests-mock==1.9.2
@@ -84,7 +91,9 @@ requests-mock==1.9.2
 requests==2.25.1
     # via requests-mock
 six==1.16.0
-    # via requests-mock
+    # via
+    #   python-dateutil
+    #   requests-mock
 toml==0.10.2
     # via
     #   black
@@ -98,6 +107,8 @@ urllib3==1.26.4
     # via requests
 wcwidth==0.2.5
     # via prompt-toolkit
+werkzeug==2.0.1
+    # via -r requirements-dev.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/frontend/kesaseteli/employer/src/backend-api/backend-url.ts
+++ b/frontend/kesaseteli/employer/src/backend-api/backend-url.ts
@@ -1,4 +1,4 @@
 const getBackendUrl = (): string =>
-  process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+  process.env.NEXT_PUBLIC_BACKEND_URL || 'https://localhost:8000';
 
 export default getBackendUrl;


### PR DESCRIPTION
## Description :sparkles:

Run local django server with SSL sertificate to get https callback urls that are required by suomi.fi eauthorizations. Also running the localhost as https also helps to bring the local environment closer to staging / production.

Add functionality for the suomi.fi eauthorizations flow. Upon successful helsinki profiili authentication, redirect the user straight to the suomi.fi valtuudet authorization init view that first handles the user registration for the valtuudet API and then redirects the user to the valtuudet authentication flow to choose the company on whose behalf they are doing business.

After receiving the "code" in EauthAuthenticationCallbackView, switch that to the auth tokens from the suomi.fi token endpoint. Save the tokens to EAuthorizationProfile for later use and to fetch the organization roles (and the business id) with `oidc.utils.get_organization_roles`.

Refs YJDH-69

## Issues :bug:

[YJDH-69](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-69)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

TODO:
Use `oidc.utils.get_organization_roles` function to fetch the company business id to be used with the YTJ integration.