### PR TITLE
YJDH-109 | Fix kesaseteli nginx setup

### DIFF
--- a/frontend/shared/src/server/next-server.js
+++ b/frontend/shared/src/server/next-server.js
@@ -40,5 +40,5 @@ const checkIsServerReady = (response) => {
 
   await server.listen(port);
   signalReady();
-  console.log(`> Ready on http://localhost:${port}`); // eslint-disable-line no-console
+  console.log(`> Ready on https://localhost:${port}`); // eslint-disable-line no-console
 })();

--- a/localdevelopment/kesaseteli/nginx/Dockerfile
+++ b/localdevelopment/kesaseteli/nginx/Dockerfile
@@ -2,14 +2,8 @@ FROM nginx:latest
 
 RUN apt-get update && apt-get install -y openssl
 
-CMD [ -f "/etc/nginx/localhost.crt" ] || { \
-  cd /etc/nginx && \
-  openssl genrsa -passout pass:password -des3 -out localhost.pass.key 4096  && \
-  openssl rsa -passin pass:password -in localhost.pass.key -out localhost.key && \
-  rm localhost.pass.key && \
-  openssl req -new -key localhost.key -out localhost.csr \
-  -subj "/C=FI/ST=Uusimaa/L=Helsinki/O=CityOfHelsinki/OU=Kanslia/CN=localhost" && \
-  openssl x509 -req -days 365 -in localhost.csr -signkey localhost.key -out localhost.crt && \
-  chmod 744 localhost.csr localhost.key localhost.crt; }
+COPY entrypoint.sh /usr/local/bin
 
-CMD ["nginx", "-g", "daemon off;"]
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/localdevelopment/kesaseteli/nginx/entrypoint.sh
+++ b/localdevelopment/kesaseteli/nginx/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ ! -f "/etc/nginx/localhost.crt" ]; then
+  cd /etc/nginx && \
+  openssl genrsa -passout pass:password -des3 -out localhost.pass.key 4096  && \
+  openssl rsa -passin pass:password -in localhost.pass.key -out localhost.key && \
+  rm localhost.pass.key && \
+  openssl req -new -key localhost.key -out localhost.csr \
+  -subj "/C=FI/ST=Uusimaa/L=Helsinki/O=CityOfHelsinki/OU=Kanslia/CN=localhost" && \
+  openssl x509 -req -days 365 -in localhost.csr -signkey localhost.key -out localhost.crt && \
+  chmod 644 localhost.csr localhost.key localhost.crt
+fi
+
+nginx -g 'daemon off;';
+
+nginx -s reload;


### PR DESCRIPTION
## Description :sparkles:

Fix the nginx setup by adding an entrypoint file where the cert is created if it is missing and starting the nginx server.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
