### PR TITLE
YJDH-120 | Update company API

### DIFF
--- a/.github/workflows/ks-pytest.yml
+++ b/.github/workflows/ks-pytest.yml
@@ -53,7 +53,7 @@ jobs:
         run: pip install -r backend/kesaseteli/requirements.txt -r backend/kesaseteli/requirements-dev.txt codecov
 
       - name: Run tests
-        run: pytest backend/kesaseteli/ -ra -vv --doctest-modules --cov=. -n auto
+        run: pytest backend/kesaseteli/ -ra -vv --doctest-modules --cov=. -n auto --dist loadfile
         env:
           DATABASE_URL: postgres://kesaseteli:kesaseteli@postgres/kesaseteli
 

--- a/backend/kesaseteli/applications/tests/conftest.py
+++ b/backend/kesaseteli/applications/tests/conftest.py
@@ -6,16 +6,6 @@ from applications.tests.factories import ApplicationFactory, UserFactory
 
 
 @pytest.fixture
-def api_client():
-    user = UserFactory()
-    permissions = Permission.objects.all()
-    user.user_permissions.set(permissions)
-    client = APIClient()
-    client.force_authenticate(user)
-    return client
-
-
-@pytest.fixture
 def application():
     return ApplicationFactory()
 
@@ -23,3 +13,12 @@ def application():
 @pytest.fixture
 def user():
     return UserFactory()
+
+
+@pytest.fixture
+def api_client(user):
+    permissions = Permission.objects.all()
+    user.user_permissions.set(permissions)
+    client = APIClient()
+    client.force_authenticate(user)
+    return client

--- a/backend/kesaseteli/applications/tests/test_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_applications_api.py
@@ -14,7 +14,7 @@ def get_detail_url(application):
 
 
 @pytest.mark.django_db
-def test_applications_list(api_client, application):
+def test_applications_list(api_client):
     response = api_client.get(reverse("v1:application-list"))
 
     assert response.status_code == 200

--- a/backend/kesaseteli/companies/api/v1/views.py
+++ b/backend/kesaseteli/companies/api/v1/views.py
@@ -10,6 +10,7 @@ from companies.api.v1.serializers import CompanySerializer
 from companies.models import Company
 from companies.services import get_or_create_company_with_business_id
 from companies.tests.data.company_data import DUMMY_COMPANY_DATA
+from oidc.utils import get_organization_roles
 
 
 class GetCompanyView(APIView):
@@ -18,10 +19,24 @@ class GetCompanyView(APIView):
     """
 
     @property
+    def organization_roles_error(self):
+        return Response(
+            "Unable to fetch organization roles from eauthorizations API",
+            status.HTTP_401_UNAUTHORIZED,
+        )
+
+    @property
     def ytj_api_error(self):
         return Response(
             "YTJ API is under heavy load or no company found with the given business id",
-            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status.HTTP_404_NOT_FOUND,
+        )
+
+    @property
+    def ytj_response_error(self):
+        return Response(
+            "Could not handle the response from YTJ API",
+            status.HTTP_404_NOT_FOUND,
         )
 
     @transaction.atomic
@@ -40,18 +55,23 @@ class GetCompanyView(APIView):
     def get(self, request: Request, format: str = None) -> Response:
         if settings.MOCK_FLAG:
             return self.get_mock(request, format)
+
+        eauth_profile = request.user.oidc_profile.eauthorization_profile
+
         try:
-            # TODO: the actual implementation
-            # This implementation is just for demonstrating the integration
-            business_id = request.META.get("HTTP_BUSINESS_ID") or "0877830-0"
+            organization_roles = get_organization_roles(eauth_profile)
+        except HTTPError:
+            return self.organization_roles_error
+
+        business_id = organization_roles.get("identifier")
+
+        try:
             company = get_or_create_company_with_business_id(business_id)
         except HTTPError:
             return self.ytj_api_error
         except ValueError:
-            return Response(
-                "Could not handle the response from YTJ API",
-                status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+            return self.ytj_response_error
+
         company_data = CompanySerializer(company).data
 
         return Response(company_data)

--- a/backend/kesaseteli/companies/tests/conftest.py
+++ b/backend/kesaseteli/companies/tests/conftest.py
@@ -1,1 +1,2 @@
 from applications.tests.conftest import *  # noqa
+from oidc.tests.conftest import oidc_profile  # noqa

--- a/backend/kesaseteli/companies/tests/test_company_api.py
+++ b/backend/kesaseteli/companies/tests/test_company_api.py
@@ -1,3 +1,4 @@
+import copy
 import re
 from unittest import mock
 
@@ -152,10 +153,12 @@ def test_get_company_from_ytj_invalid_response(api_client, requests_mock, user):
     oidc_profile = OIDCProfileFactory(user=user)
     EAuthorizationProfileFactory(oidc_profile=oidc_profile)
 
-    response = DUMMY_YTJ_RESPONSE
-    response["results"][0]["addresses"] = []
+    ytj_reponse = copy.deepcopy(DUMMY_YTJ_RESPONSE)
+    ytj_reponse["results"][0]["addresses"] = []
 
-    set_up_mock_requests(response, DUMMY_YTJ_BUSINESS_DETAILS_RESPONSE, requests_mock)
+    set_up_mock_requests(
+        ytj_reponse, DUMMY_YTJ_BUSINESS_DETAILS_RESPONSE, requests_mock
+    )
 
     org_roles_json = {
         "name": "Activenakusteri Oy",

--- a/backend/kesaseteli/companies/tests/test_company_api.py
+++ b/backend/kesaseteli/companies/tests/test_company_api.py
@@ -1,4 +1,5 @@
 import re
+from unittest import mock
 
 import pytest
 from django.conf import settings
@@ -11,6 +12,7 @@ from companies.tests.data.company_data import (
     DUMMY_YTJ_BUSINESS_DETAILS_RESPONSE,
     DUMMY_YTJ_RESPONSE,
 )
+from oidc.tests.factories import EAuthorizationProfileFactory, OIDCProfileFactory
 
 
 def get_company_api_url():
@@ -45,7 +47,7 @@ def test_get_mock_company_results_in_error(api_client):
     api_client.credentials(HTTP_SESSION_ID="-1")
     response = api_client.get(get_company_api_url())
 
-    assert response.status_code == 500
+    assert response.status_code == 404
     assert (
         response.data
         == "YTJ API is under heavy load or no company found with the given business id"
@@ -53,13 +55,51 @@ def test_get_mock_company_results_in_error(api_client):
 
 
 @pytest.mark.django_db
-@override_settings(MOCK_FLAG=False)
-def test_get_company_from_ytj(api_client, requests_mock):
+@override_settings(
+    MOCK_FLAG=False,
+    EAUTHORIZATIONS_BASE_URL="http://example.com",
+    EAUTHORIZATIONS_CLIENT_ID="test",
+    EAUTHORIZATIONS_CLIENT_SECRET="test",
+)
+def test_get_company_organization_roles_error(api_client, requests_mock, user):
+    oidc_profile = OIDCProfileFactory(user=user)
+    EAuthorizationProfileFactory(oidc_profile=oidc_profile)
+
+    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    requests_mock.get(matcher, text="Error", status_code=401)
+
+    response = api_client.get(get_company_api_url())
+
+    assert response.status_code == 401
+    assert (
+        response.data == "Unable to fetch organization roles from eauthorizations API"
+    )
+
+
+@pytest.mark.django_db
+@override_settings(
+    MOCK_FLAG=False,
+    YTJ_BASE_URL="http://example.com",
+)
+def test_get_company_from_ytj(api_client, requests_mock, user):
+    oidc_profile = OIDCProfileFactory(user=user)
+    EAuthorizationProfileFactory(oidc_profile=oidc_profile)
+
     set_up_mock_requests(
         DUMMY_YTJ_RESPONSE, DUMMY_YTJ_BUSINESS_DETAILS_RESPONSE, requests_mock
     )
 
-    response = api_client.get(get_company_api_url())
+    org_roles_json = {
+        "name": "Activenakusteri Oy",
+        "identifier": "0877830-0",
+        "complete": True,
+        "roles": ["NIMKO"],
+    }
+
+    with mock.patch(
+        "companies.api.v1.views.get_organization_roles", return_value=org_roles_json
+    ):
+        response = api_client.get(get_company_api_url())
 
     assert response.status_code == 200
 
@@ -73,14 +113,30 @@ def test_get_company_from_ytj(api_client, requests_mock):
 
 
 @pytest.mark.django_db
-@override_settings(MOCK_FLAG=False)
-def test_get_company_from_ytj_results_in_error(api_client, requests_mock):
+@override_settings(
+    MOCK_FLAG=False,
+    YTJ_BASE_URL="http://example.com",
+)
+def test_get_company_from_ytj_results_in_error(api_client, requests_mock, user):
+    oidc_profile = OIDCProfileFactory(user=user)
+    EAuthorizationProfileFactory(oidc_profile=oidc_profile)
+
     matcher = re.compile(settings.YTJ_BASE_URL)
-    requests_mock.get(matcher, text="Error", status_code=500)
+    requests_mock.get(matcher, text="Error", status_code=404)
 
-    response = api_client.get(get_company_api_url())
+    org_roles_json = {
+        "name": "Activenakusteri Oy",
+        "identifier": "0877830-0",
+        "complete": True,
+        "roles": ["NIMKO"],
+    }
 
-    assert response.status_code == 500
+    with mock.patch(
+        "companies.api.v1.views.get_organization_roles", return_value=org_roles_json
+    ):
+        response = api_client.get(get_company_api_url())
+
+    assert response.status_code == 404
     assert (
         response.data
         == "YTJ API is under heavy load or no company found with the given business id"
@@ -88,14 +144,30 @@ def test_get_company_from_ytj_results_in_error(api_client, requests_mock):
 
 
 @pytest.mark.django_db
-@override_settings(MOCK_FLAG=False)
-def test_get_company_from_ytj_invalid_response(api_client, requests_mock):
+@override_settings(
+    MOCK_FLAG=False,
+    YTJ_BASE_URL="http://example.com",
+)
+def test_get_company_from_ytj_invalid_response(api_client, requests_mock, user):
+    oidc_profile = OIDCProfileFactory(user=user)
+    EAuthorizationProfileFactory(oidc_profile=oidc_profile)
+
     response = DUMMY_YTJ_RESPONSE
     response["results"][0]["addresses"] = []
 
     set_up_mock_requests(response, DUMMY_YTJ_BUSINESS_DETAILS_RESPONSE, requests_mock)
 
-    response = api_client.get(get_company_api_url())
+    org_roles_json = {
+        "name": "Activenakusteri Oy",
+        "identifier": "0877830-0",
+        "complete": True,
+        "roles": ["NIMKO"],
+    }
 
-    assert response.status_code == 500
+    with mock.patch(
+        "companies.api.v1.views.get_organization_roles", return_value=org_roles_json
+    ):
+        response = api_client.get(get_company_api_url())
+
+    assert response.status_code == 404
     assert response.data == "Could not handle the response from YTJ API"

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -120,6 +120,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "simple_history.middleware.HistoryRequestMiddleware",
 ]
 
 TEMPLATES = [

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -152,10 +152,12 @@ LOGGING = {
 }
 
 REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": [],
-    "DEFAULT_PERMISSION_CLASSES": [],
+    "DEFAULT_AUTHENTICATION_CLASSES": ["oidc.auth.EAuthRestAuthentication"],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
-}  # TODO: Replace with actual authentication & permissions.
+}
 
 YTJ_BASE_URL = env.str("YTJ_BASE_URL")
 YTJ_TIMEOUT = env.int("YTJ_TIMEOUT")

--- a/backend/kesaseteli/oidc/tests/test_eauth_rest_auth.py
+++ b/backend/kesaseteli/oidc/tests/test_eauth_rest_auth.py
@@ -1,0 +1,52 @@
+from unittest import mock
+
+import pytest
+from django.test import RequestFactory
+
+from oidc.auth import EAuthRestAuthentication
+
+
+@pytest.mark.django_db
+def test_eauth_rest_auth_success(eauthorization_profile):
+    factory = RequestFactory()
+    request = factory.get("/")
+    user = eauthorization_profile.oidc_profile.user
+    request.user = user
+
+    with mock.patch(
+        "oidc.auth.SessionAuthentication.authenticate", return_value=(user, None)
+    ):
+        eauth_rest_auth = EAuthRestAuthentication()
+        user, auth = eauth_rest_auth.authenticate(request)
+
+    assert user == eauthorization_profile.oidc_profile.user
+
+
+@pytest.mark.django_db
+def test_eauth_rest_auth_failure_missing_access_token(eauthorization_profile):
+    factory = RequestFactory()
+    request = factory.get("/")
+    user = eauthorization_profile.oidc_profile.user
+    request.user = user
+
+    eauthorization_profile.access_token = ""
+    eauthorization_profile.save()
+
+    with mock.patch(
+        "oidc.auth.SessionAuthentication.authenticate", return_value=(user, None)
+    ):
+        eauth_rest_auth = EAuthRestAuthentication()
+        user_auth_tuple = eauth_rest_auth.authenticate(request)
+
+    assert user_auth_tuple is None
+
+
+def test_eauth_rest_auth_failure():
+    factory = RequestFactory()
+    request = factory.get("/")
+
+    with mock.patch("oidc.auth.SessionAuthentication.authenticate", return_value=None):
+        eauth_rest_auth = EAuthRestAuthentication()
+        user_auth_tuple = eauth_rest_auth.authenticate(request)
+
+    assert user_auth_tuple is None

--- a/backend/kesaseteli/oidc/tests/test_eauth_views.py
+++ b/backend/kesaseteli/oidc/tests/test_eauth_views.py
@@ -63,9 +63,7 @@ def test_get_organization_roles(requests_mock, eauthorization_profile):
     matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
     requests_mock.get(matcher, json=organization_roles_json)
 
-    organization_roles = get_organization_roles(
-        eauthorization_profile.id_token, eauthorization_profile.access_token
-    )
+    organization_roles = get_organization_roles(eauthorization_profile)
 
     assert organization_roles["name"] == organization_roles_json[0]["name"]
     assert organization_roles["identifier"] == organization_roles_json[0]["identifier"]

--- a/backend/kesaseteli/requirements-dev.in
+++ b/backend/kesaseteli/requirements-dev.in
@@ -6,7 +6,6 @@ pytest
 pytest-cov
 pytest-django
 pytest-freezegun
-pytest-randomly
 pytest-xdist[psutil]
 requests-mock
 Werkzeug

--- a/backend/kesaseteli/requirements-dev.txt
+++ b/backend/kesaseteli/requirements-dev.txt
@@ -8,8 +8,6 @@ apipkg==1.5
     # via execnet
 appdirs==1.4.4
     # via black
-appnope==0.1.2
-    # via ipython
 attrs==21.2.0
     # via pytest
 backcall==0.2.0
@@ -34,8 +32,6 @@ freezegun==1.1.0
     # via pytest-freezegun
 idna==2.10
     # via requests
-importlib-metadata==4.5.0
-    # via pytest-randomly
 iniconfig==1.1.1
     # via pytest
 ipython-genutils==0.2.0
@@ -90,8 +86,6 @@ pytest-forked==1.3.0
     # via pytest-xdist
 pytest-freezegun==0.4.2
     # via -r requirements-dev.in
-pytest-randomly==3.8.0
-    # via -r requirements-dev.in
 pytest-xdist[psutil]==2.2.1
     # via -r requirements-dev.in
 pytest==6.2.4
@@ -101,7 +95,6 @@ pytest==6.2.4
     #   pytest-django
     #   pytest-forked
     #   pytest-freezegun
-    #   pytest-randomly
     #   pytest-xdist
 python-dateutil==2.8.1
     # via freezegun
@@ -130,8 +123,6 @@ wcwidth==0.2.5
     # via prompt-toolkit
 werkzeug==2.0.1
     # via -r requirements-dev.in
-zipp==3.4.1
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
## Description :sparkles:

- Add EAuthRestAuthentication as the default authentication class to authorize the user to use the REST API.
- Add IsAuthenticated as the default permission class for the REST API.
- Update the tests to match the new implementation of the company API.
- Small refactors to make the code cleaner.

## Issues :bug:

[YJDH-120](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-120)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
