### PR TITLE
Fix hot reload on docker-compose + clean up docker scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ YJDH-Kesäseteli
 
 1. Copy the contents of `.env.kesaseteli.example` to `.env.kesaseteli` and modify it if needed.
 
-2. Run `yarn kesaseteli:up`
+2. Run `yarn kesaseteli up` or, if you want to rebuild, then `yarn kesaseteli up --build`
 
 The Frontend is now running at [localhost:3000](https://localhost:3000)
 The backend is now running at [localhost:8000](https://localhost:8000)
+
+3. If services fail to get up, `yarn clean` might help.
 
 ## Benefit
 

--- a/docker-compose.benefit.yml
+++ b/docker-compose.benefit.yml
@@ -38,10 +38,7 @@ services:
       dockerfile: benefit/applicant/Dockerfile
       target: development
     volumes:
-      - ./frontend/benefit/applicant:/app/applicant
-      - ./frontend/shared:/app/shared
-      - /app/node_modules
-      - /app/.next
+      - ./frontend:/app
     env_file:
       - .env.benefit
     ports:

--- a/docker-compose.kesaseteli.yml
+++ b/docker-compose.kesaseteli.yml
@@ -29,15 +29,16 @@ services:
     container_name: kesaseteli-backend
 
   kesaseteli-employer:
+    restart: always
+    depends_on:
+      - postgres
+      - kesaseteli-backend
     build:
       context: ./frontend
       dockerfile: kesaseteli/employer/Dockerfile
       target: development
     volumes:
-      - ./frontend/kesaseteli/employer:/app/employer
-      - ./frontend/shared:/app/shared
-      - /app/node_modules
-      - /app/.next
+      - ./frontend:/app
     env_file:
       - .env.kesaseteli
     container_name: kesaseteli-employer

--- a/package.json
+++ b/package.json
@@ -4,13 +4,7 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "kesaseteli-frontend:up": "docker-compose -f docker-compose.kesaseteli.yml up employer",
-    "kesaseteli-frontend:upbuild": "docker-compose -f docker-compose.kesaseteli.yml up --build employer",
-    "kesaseteli-backend:up": "docker-compose -f docker-compose.kesaseteli.yml up postgres django",
-    "kesaseteli-backend:upbuild": "docker-compose -f docker-compose.kesaseteli.yml up --build postgres django",
-    "kesaseteli:up": "docker-compose -f docker-compose.kesaseteli.yml up",
-    "kesaseteli:upbuild": "yarn kesaseteli:up --build",
-    "stop": "docker kill $(docker ps -q)",
-    "remove": "docker rm $(docker ps -a -q)"
+    "clean": "docker kill -f $(docker ps -q); docker rm -f $(docker ps -a -q)",
+    "kesaseteli": "docker-compose -f docker-compose.kesaseteli.yml up"
   }
 }


### PR DESCRIPTION
## Description :sparkles:
Hot reloading did not work for frontend services in docker-compose. This is now fixed-
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
