### PR TITLE
Update company API to use query string instead of header

### DIFF
--- a/.env.benefit.example
+++ b/.env.benefit.example
@@ -4,6 +4,7 @@ CREATE_SUPERUSER=1
 EMPLOYER_URL=http://localhost:3000
 HANDLER_URL=http://localhost:3100
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
+CORS_ORIGIN_ALLOW_ALL=1
 
 # Authentication
 OIDC_RP_CLIENT_ID=

--- a/backend/benefit/companies/api/v1/views.py
+++ b/backend/benefit/companies/api/v1/views.py
@@ -39,10 +39,9 @@ class GetCompanyView(APIView):
         return Response(company_data)
 
     @transaction.atomic
-    def get(self, request: Request, format: str = None) -> Response:
+    def get(self, request: Request, business_id: str, format: str = None) -> Response:
         if settings.MOCK_FLAG:
             return self.get_mock(request, format)
-        business_id = request.META.get("HTTP_BUSINESS_ID")
         if not business_id:
             return self.api_usage_http_error("Missing business id")
         try:

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -12,8 +12,8 @@ from django.conf import settings
 from django.test import override_settings
 
 
-def get_company_api_url():
-    return "/v1/company/"
+def get_company_api_url(business_id=None):
+    return "/v1/company/{}".format(business_id)
 
 
 def set_up_mock_requests(
@@ -57,11 +57,8 @@ def test_get_company_from_ytj(api_client, requests_mock):
     set_up_mock_requests(
         DUMMY_YTJ_RESPONSE, DUMMY_YTJ_BUSINESS_DETAILS_RESPONSE, requests_mock
     )
-    api_client.credentials(
-        HTTP_BUSINESS_ID=DUMMY_YTJ_RESPONSE["results"][0]["businessId"]
-    )
-
-    response = api_client.get(get_company_api_url())
+    business_id = DUMMY_YTJ_RESPONSE["results"][0]["businessId"]
+    response = api_client.get(get_company_api_url(business_id))
 
     assert response.status_code == 200
 
@@ -79,10 +76,8 @@ def test_get_company_from_ytj(api_client, requests_mock):
 def test_get_company_from_ytj_results_in_error(api_client, requests_mock):
     matcher = re.compile(settings.YTJ_BASE_URL)
     requests_mock.get(matcher, text="Error", status_code=404)
-    api_client.credentials(
-        HTTP_BUSINESS_ID=DUMMY_YTJ_RESPONSE["results"][0]["businessId"]
-    )
-    response = api_client.get(get_company_api_url())
+    business_id = DUMMY_YTJ_RESPONSE["results"][0]["businessId"]
+    response = api_client.get(get_company_api_url(business_id))
 
     assert response.status_code == 404
     assert (
@@ -97,11 +92,8 @@ def test_get_company_from_ytj_with_fallback_data(api_client, requests_mock):
     set_up_mock_requests(
         DUMMY_YTJ_RESPONSE, DUMMY_YTJ_BUSINESS_DETAILS_RESPONSE, requests_mock
     )
-    api_client.credentials(
-        HTTP_BUSINESS_ID=DUMMY_YTJ_RESPONSE["results"][0]["businessId"]
-    )
-
-    response = api_client.get(get_company_api_url())
+    business_id = DUMMY_YTJ_RESPONSE["results"][0]["businessId"]
+    response = api_client.get(get_company_api_url(business_id))
 
     # First request to save Company to DB
     assert response.status_code == 200
@@ -111,7 +103,7 @@ def test_get_company_from_ytj_with_fallback_data(api_client, requests_mock):
     matcher = re.compile(settings.YTJ_BASE_URL)
     requests_mock.get(matcher, text="Error", status_code=404)
 
-    response = api_client.get(get_company_api_url())
+    response = api_client.get(get_company_api_url(business_id))
     # Still be able to query company data
     assert response.data["business_id"] == DUMMY_COMPANY_DATA["business_id"]
 
@@ -123,11 +115,8 @@ def test_get_company_from_ytj_invalid_response(api_client, requests_mock):
     response["results"][0]["addresses"] = []
 
     set_up_mock_requests(response, DUMMY_YTJ_BUSINESS_DETAILS_RESPONSE, requests_mock)
-    api_client.credentials(
-        HTTP_BUSINESS_ID=DUMMY_YTJ_RESPONSE["results"][0]["businessId"]
-    )
-
-    response = api_client.get(get_company_api_url())
+    business_id = DUMMY_YTJ_RESPONSE["results"][0]["businessId"]
+    response = api_client.get(get_company_api_url(business_id))
 
     assert response.status_code == 500
     assert response.data == "Could not handle the response from YTJ API"

--- a/backend/benefit/helsinkibenefit/urls.py
+++ b/backend/benefit/helsinkibenefit/urls.py
@@ -9,7 +9,7 @@ router = routers.DefaultRouter()
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("v1/", include((router.urls, "v1"), namespace="v1")),
-    path("v1/company/", GetCompanyView.as_view()),
+    path("v1/company/<str:business_id>", GetCompanyView.as_view()),
 ]
 
 


### PR DESCRIPTION
## Description :sparkles:
Changing Company Get API to get business_id from path instead of header, which is more convenient for client side

Also add the CORS_ORIGIN_ALLOW_ALL = 1 to example .env 
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
