### PR TITLE
YJHD-147 | Send frontend test failures to slack

### DIFF
--- a/.github/workflows/ks-frontend-tests-push.yml
+++ b/.github/workflows/ks-frontend-tests-push.yml
@@ -1,12 +1,8 @@
-name: (KS) Lint, Unit and Component tests
+name: (KS) Frontend tests & build on push to develop & main
 
 on:
-  pull_request:
-    paths:
-      - 'frontend/shared/**'
-      - 'frontend/*'
-      - 'frontend/kesaseteli/**'
-      - '.github/workflows/ks-frontend-tests.yml'
+  push:
+    branches: [develop, main]
   workflow_dispatch:
 defaults:
   run:
@@ -39,6 +35,17 @@ jobs:
         run: yarn test:coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
+      - name: Frontend test failure slack notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_USERNAME: GitHub-Alerts
+          SLACK_TITLE: ${{ github.workflow }} has *FAILED*!
+          SLACK_MESSAGE: "*Frontend tests have failed!*"
+          SLACK_CHANNEL: yjdh-alerts
+        if: failure()
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -62,3 +69,13 @@ jobs:
         run: yarn --prefer-offline --frozen-lockfile --check-files
       - name: Check that building dev application works
         run: yarn build
+      - name: Frontend build failure slack notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_USERNAME: GitHub-Alerts
+          SLACK_TITLE: ${{ github.workflow }} has *FAILED*!
+          SLACK_MESSAGE: "*Frontend build has failed!*"
+          SLACK_CHANNEL: yjdh-alerts
+        if: failure()


### PR DESCRIPTION
## Description :sparkles:

On pushes to main or develop branch, send a message to slack from failed frontend tests.

## Issues :bug:

[YJDH-147](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-147)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
