### PR TITLE
HL-113 | Disable future values for "de minimis" aid

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/DeMinimisAidForm.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/DeMinimisAidForm.tsx
@@ -78,6 +78,7 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
               invalid={!!getErrorMessage(DE_MINIMIS_AID_FIELDS.GRANTED_AT)}
               aria-invalid={!!getErrorMessage(DE_MINIMIS_AID_FIELDS.GRANTED_AT)}
               errorText={getErrorMessage(DE_MINIMIS_AID_FIELDS.GRANTED_AT)}
+              maxDate={new Date()}
               required
             />
           </StyledFieldsContainerWithPadding>


### PR DESCRIPTION
## Description :sparkles:
- Disable future values for "de minimis" aid

## Issues :bug:

## Testing :alembic:
- In the creating / editing process of an application, go to the first step 
- Under "Hakijan de minimis-tuet" select "Kyllä" and fill in the values
- Now the **future** date values are disabled, and the user can only select values from the past
- You should be able to continue to the next step as expected

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
