### PR TITLE
Fixing dependabot pr builds: use '-' separator instead of '/' in dependabot pr branch names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    pull-request-branch-name:
+      separator: "-"
   - package-ecosystem: "npm"
     directory: "frontend/"
     schedule:
       interval: "daily"
+    pull-request-branch-name:
+      separator: "-"
   - package-ecosystem: "pip"
     directory: "backend/"
     schedule:
       interval: "daily"
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
