### PR TITLE
Import styled components as "styled" rather than "$"

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/Applications.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/Applications.sc.ts
@@ -1,7 +1,7 @@
 import { Button } from 'hds-react';
-import $ from 'styled-components';
+import styled from 'styled-components';
 
-export const $SecondaryButton = $(Button)`
+export const $SecondaryButton = styled(Button)`
   color: ${(props) => props.theme.colors.black90} !important;
   border-color: ${(props) => props.theme.colors.black90} !important;
   border-width: 3px !important;
@@ -9,21 +9,21 @@ export const $SecondaryButton = $(Button)`
   max-height: 60px;
 `;
 
-export const $PrimaryButton = $(Button)`
+export const $PrimaryButton = styled(Button)`
   background-color: ${(props) => props.theme.colors.coatOfArms} !important;
   border-color: ${(props) => props.theme.colors.coatOfArms} !important;
   border-width: 3px !important;
   width: 170px;
 `;
 
-export const $SupplementaryButton = $(Button)`
+export const $SupplementaryButton = styled(Button)`
   color: ${(props) => props.theme.colors.black90} !important;
   min-width: 170px;
   max-height: 60px;
   margin-top: ${(props) => props.theme.spacing.xs2};
 `;
 
-export const $PageHeader = $.div`
+export const $PageHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -34,15 +34,15 @@ export const $PageHeader = $.div`
   }
 `;
 
-export const $HeaderItem = $.div``;
+export const $HeaderItem = styled.div``;
 
-export const $PageHeading = $.h1`
+export const $PageHeading = styled.h1`
   font-size: ${(props) => props.theme.fontSize.heading.xl};
   font-weight: normal;
   margin: 0;
 `;
 
-export const $PageSubHeading = $.h3`
+export const $PageSubHeading = styled.h3`
   color: ${(props) => props.theme.colors.coatOfArms};
   font-size: ${(props) => props.theme.fontSize.heading.s};
   font-weight: 500;
@@ -50,22 +50,22 @@ export const $PageSubHeading = $.h3`
   margin-bottom: ${(props) => props.theme.spacing.m};
 `;
 
-export const $PageHeadingHelperText = $.div`
+export const $PageHeadingHelperText = styled.div`
   font-size: ${(props) => props.theme.fontSize.heading.s};
   font-weight: normal;
   margin-top: ${(props) => props.theme.spacing.l};
   margin-bottom: ${(props) => props.theme.spacing.m};
 `;
 
-export const $ApplicationActions = $.div`
+export const $ApplicationActions = styled.div`
   display: flex;
   justify-content: space-between;
   margin-top: ${(props) => props.theme.spacing.l};
 `;
 
-export const $ApplicationAction = $.div`
+export const $ApplicationAction = styled.div`
   display: flex;
   flex-direction: column;
 `;
 
-export const $Empty = $.div``;
+export const $Empty = styled.div``;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.sc.ts
@@ -1,11 +1,11 @@
-import $ from 'styled-components';
+import styled from 'styled-components';
 
-export const $Heading = $.h2`
+export const $Heading = styled.h2`
   font-size: ${(props) => props.theme.fontSize.heading.m};
   font-weight: 500;
 `;
 
-export const $ListWrapper = $.ul`
+export const $ListWrapper = styled.ul`
   display: flex;
   flex-direction: column;
   gap: ${(props) => props.theme.spacing.xs2};

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
@@ -1,24 +1,24 @@
-import $, { DefaultTheme } from 'styled-components';
+import styled, { DefaultTheme } from 'styled-components';
 
 interface AvatarProps {
   $backgroundColor: keyof DefaultTheme['colors'];
 }
 
-export const $ListItem = $.li`
+export const $ListItem = styled.li`
   display: flex;
   background-color: ${(props) => props.theme.colors.white};
   padding: ${(props) => props.theme.spacing.xs};
   justify-content: space-between;
 `;
 
-export const $ItemContent = $.div`
+export const $ItemContent = styled.div`
   display: grid;
   grid-template-columns: 60px 3fr repeat(4, minmax(100px, 2fr));
   grid-gap: ${(props) => props.theme.spacing.m};
   width: 100%;
 `;
 
-export const $Avatar = $.div<AvatarProps>`
+export const $Avatar = styled.div<AvatarProps>`
   ${(props) => `
     background-color: ${props.theme.colors[props.$backgroundColor]};
     color: ${props.theme.colors.white};
@@ -35,7 +35,7 @@ export const $Avatar = $.div<AvatarProps>`
   min-width: 60px;
 `;
 
-export const $DataColumn = $.div`
+export const $DataColumn = styled.div`
   color: ${(props) => props.theme.colors.black90};
   display: flex;
   flex-direction: column;
@@ -43,16 +43,16 @@ export const $DataColumn = $.div`
   gap: ${(props) => props.theme.spacing.xs};
 `;
 
-export const $DataHeader = $.div`
+export const $DataHeader = styled.div`
   display: flex;
 `;
 
-export const $DataValue = $.div`
+export const $DataValue = styled.div`
   display: flex;
   font-weight: 600;
 `;
 
-export const $ItemActions = $.div`
+export const $ItemActions = styled.div`
   display: grid;
   justify-content: stretch;
   align-items: center;

--- a/frontend/benefit/applicant/src/components/applications/forms/application/Application.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/Application.sc.ts
@@ -1,7 +1,7 @@
 import { $FormGroup } from 'shared/components/forms/section/FormSection.sc';
-import $ from 'styled-components';
+import styled from 'styled-components';
 
-export const $SubActionContainer = $.div`
+export const $SubActionContainer = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
@@ -14,7 +14,7 @@ export const $SubActionContainer = $.div`
   padding-left: ${(props) => props.theme.spacing.s};
 `;
 
-export const $SubSection = $.div`
+export const $SubSection = styled.div`
   margin-left: 245px;
 
   textarea {
@@ -22,40 +22,40 @@ export const $SubSection = $.div`
   }
 `;
 
-export const $FieildsWithInfoContainer = $.div`
+export const $FieildsWithInfoContainer = styled.div`
   display: flex;
   justify-content: space-between;
 `;
 
-export const $FieildsWithInfoColumn = $.div`
+export const $FieildsWithInfoColumn = styled.div`
   flex: 0 0 50%;
 `;
 
-export const $ContactPersonContainer = $($FormGroup)`
+export const $ContactPersonContainer = styled($FormGroup)`
   display: grid;
   grid-template-columns: 2fr 2fr 1fr 2fr;
   grid-gap: ${(props) => props.theme.spacing.xs};
 `;
 
-export const $EmployerBasicInfoContainer = $($FormGroup)`
+export const $EmployerBasicInfoContainer = styled($FormGroup)`
   display: grid;
   grid-template-columns: 300px 300px 200px 200px;
   grid-gap: ${(props) => props.theme.spacing.xs};
 `;
 
-export const $EmploymentRelationshipContainer = $($FormGroup)`
+export const $EmploymentRelationshipContainer = styled($FormGroup)`
   display: grid;
   grid-template-columns: 410px 200px 400px;
   grid-gap: ${(props) => props.theme.spacing.xs};
 `;
 
-export const $EmploymentMoneyContainer = $($FormGroup)`
+export const $EmploymentMoneyContainer = styled($FormGroup)`
   display: grid;
   grid-template-columns: 200px 200px 200px;
   grid-gap: ${(props) => props.theme.spacing.xs};
 `;
 
-export const $CommissionContainer = $($FormGroup)`
+export const $CommissionContainer = styled($FormGroup)`
   display: grid;
   grid-template-columns: 500px 200px auto;
   grid-gap: ${(props) => props.theme.spacing.xs};

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.sc.ts
@@ -1,8 +1,8 @@
 import { Notification as HDSNotification } from 'hds-react';
 import { $FormGroup } from 'shared/components/forms/section/FormSection.sc';
-import $ from 'styled-components';
+import styled from 'styled-components';
 
-export const $CompanyInfoContainer = $.div`
+export const $CompanyInfoContainer = styled.div`
   display: grid;
   grid-template-columns: 50% 50%;
   grid-template-areas:
@@ -12,19 +12,19 @@ export const $CompanyInfoContainer = $.div`
   width: 100%;
 `;
 
-export const $CompanyInfoSection = $.div`
+export const $CompanyInfoSection = styled.div`
   grid-area: info;
   display: flex;
   flex-wrap: wrap;
 `;
 
-export const $CompanyInfoColumn = $.div`
+export const $CompanyInfoColumn = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 0 50%;
 `;
 
-export const $CompanyInfoRow = $.div`
+export const $CompanyInfoRow = styled.div`
   display: flex;
   line-height: ${(props) => props.theme.lineHeight.l};
   height: ${(props) => `calc(${props.theme.lineHeight.l} * 1em)`};
@@ -32,19 +32,19 @@ export const $CompanyInfoRow = $.div`
   margin-bottom: ${(props) => props.theme.spacing.xs2};
 `;
 
-export const $Notification = $(HDSNotification)`
+export const $Notification = styled(HDSNotification)`
   grid-area: notification;
   font-size: ${(props) => props.theme.fontSize.heading.xs};
 `;
 
-export const $AddressContainer = $($FormGroup)`
+export const $AddressContainer = styled($FormGroup)`
   grid-area: address;
   margin-top: ${(props) => props.theme.spacing.l};
   display: grid;
   grid-template-columns: 2fr 1fr 2fr 1fr;
 `;
 
-export const $IBANContainer = $($FormGroup)`
+export const $IBANContainer = styled($FormGroup)`
   grid-area: iban;
   margin-top: ${(props) => props.theme.spacing.xl};
 

--- a/frontend/benefit/applicant/src/components/mainIngress/MainIngress.sc.ts
+++ b/frontend/benefit/applicant/src/components/mainIngress/MainIngress.sc.ts
@@ -1,32 +1,32 @@
 import { Notification } from 'hds-react';
-import $ from 'styled-components';
+import styled from 'styled-components';
 
-export const $Container = $.div`
+export const $Container = styled.div`
   padding-bottom: ${(props) => props.theme.spacing.m};
 `;
 
-export const $TextContainer = $.div`
+export const $TextContainer = styled.div`
   display: flex;
   box-sizing: border-box;
 `;
 
-export const $Heading = $.h1`
+export const $Heading = styled.h1`
   font-size: ${(props) => props.theme.fontSize.heading.xl};
   font-weight: normal;
 `;
 
-export const $Description = $.p`
+export const $Description = styled.p`
   font-size: ${(props) => props.theme.fontSize.heading.s};
   font-weight: normal;
   line-height: ${(props) => props.theme.lineHeight.l};
 `;
 
-export const $Link = $.span`
+export const $Link = styled.span`
   text-decoration: underline;
   cursor: pointer;
 `;
 
-export const $ActionContainer = $.div`
+export const $ActionContainer = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
@@ -34,6 +34,6 @@ export const $ActionContainer = $.div`
   box-sizing: border-box;
 `;
 
-export const $Notification = $(Notification)`
+export const $Notification = styled(Notification)`
   margin-bottom: ${(props) => props.theme.spacing.xs};
 `;

--- a/frontend/kesaseteli/employer/src/components/companyInfo/CompanyInfo.sc.ts
+++ b/frontend/kesaseteli/employer/src/components/companyInfo/CompanyInfo.sc.ts
@@ -1,12 +1,12 @@
-import $ from 'styled-components';
+import styled from 'styled-components';
 
-export const $CompanyInfoContainer = $.div`
+export const $CompanyInfoContainer = styled.div`
   display: grid;
   grid-template-columns: 17% 17% 16% 16% 17% 17%;
   grid-template-rows: 50% 50%;
   width: 100%;
 `;
 
-export const $CompanyInfoHeader = $.div``;
+export const $CompanyInfoHeader = styled.div``;
 
-export const $CompanyInfoRow = $.div``;
+export const $CompanyInfoRow = styled.div``;

--- a/frontend/shared/src/components/container/Container.sc.ts
+++ b/frontend/shared/src/components/container/Container.sc.ts
@@ -1,15 +1,15 @@
 import { respondAbove } from 'shared/styles/mediaQueries';
-import $ from 'styled-components';
+import styled from 'styled-components';
 
 interface ContainerProps {
   backgroundColor?: string;
 }
 
-export const $Container = $.div<ContainerProps>`
+export const $Container = styled.div<ContainerProps>`
   display: grid;
   background-color: ${(props) => props.backgroundColor || ''};
   grid-template-columns: ${(props) => props.theme.spacing.xs2} 1fr ${(props) =>
-  props.theme.spacing.xs2};
+      props.theme.spacing.xs2};
 
   ${respondAbove('md')`
     grid-template-columns: 1fr minmax(auto, 1240px) 1fr;
@@ -20,6 +20,6 @@ export const $Container = $.div<ContainerProps>`
   }
 `;
 
-export const $Inner = $.div`
+export const $Inner = styled.div`
   padding: ${(props) => props.theme.spacing.xs};
 `;

--- a/frontend/shared/src/components/content/Content.sc.ts
+++ b/frontend/shared/src/components/content/Content.sc.ts
@@ -1,5 +1,5 @@
-import $ from 'styled-components';
+import styled from 'styled-components';
 
-export const $Content = $.div`
+export const $Content = styled.div`
   flex: auto;
 `;

--- a/frontend/shared/src/components/forms/fields/fieldLabel/FieldLabel.sc.ts
+++ b/frontend/shared/src/components/forms/fields/fieldLabel/FieldLabel.sc.ts
@@ -1,17 +1,17 @@
-import $ from 'styled-components';
+import styled from 'styled-components';
 
 export interface FieldLabelProps {
   required?: boolean;
   value?: string;
 }
 
-export const $Content = $.div<FieldLabelProps>`
+export const $Content = styled.div<FieldLabelProps>`
   font-size: ${(props) => props.theme.fontSize.body.m};
   font-weight: 500;
   margin-bottom: ${(props) => props.theme.spacing.m};
 `;
 
-export const $Required = $.span<FieldLabelProps>`
+export const $Required = styled.span<FieldLabelProps>`
   display: inline-block;
   font-size: ${(props) => props.theme.fontSize.body.xl};
   margin-left: ${(props) => props.theme.spacing.xs2};

--- a/frontend/shared/src/components/forms/heading/Heading.sc.ts
+++ b/frontend/shared/src/components/forms/heading/Heading.sc.ts
@@ -1,10 +1,10 @@
-import $, { DefaultTheme } from 'styled-components';
+import styled, { DefaultTheme } from 'styled-components';
 
 export interface HeadingProps {
   size: keyof DefaultTheme['fontSize']['heading'];
 }
 
-export const $Header = $.h1<HeadingProps>`
+export const $Header = styled.h1<HeadingProps>`
   display: flex;
   align-items: center;
   gap: ${(props) => props.theme.spacing.s};

--- a/frontend/shared/src/components/forms/section/FormSection.sc.ts
+++ b/frontend/shared/src/components/forms/section/FormSection.sc.ts
@@ -1,8 +1,8 @@
-import $ from 'styled-components';
+import styled from 'styled-components';
 
 type Props = { backgroundColor?: string };
 
-export const $Section = $.div`
+export const $Section = styled.div`
   display: flex;
   flex-direction: column;
   border-bottom: 1px solid ${(props) => props.theme.colors.black20};
@@ -10,7 +10,7 @@ export const $Section = $.div`
   margin-bottom: ${(props) => props.theme.spacing.s};
 `;
 
-export const $Header = $.h1`
+export const $Header = styled.h1`
   display: flex;
   align-items: center;
   gap: ${(props) => props.theme.spacing.s};
@@ -19,13 +19,13 @@ export const $Header = $.h1`
   margin-bottom: ${(props) => props.theme.spacing.l};
 `;
 
-export const $SubHeader = $.h1`
+export const $SubHeader = styled.h1`
   font-size: ${(props) => props.theme.fontSize.heading.xxs};
   font-weight: 600;
   //margin-bottom: ${(props) => props.theme.spacing.m};
 `;
 
-export const $Content = $.div`
+export const $Content = styled.div`
   display: flex;
   flex-direction: column;
   font-size: ${(props) => props.theme.fontSize.heading.s};
@@ -33,7 +33,7 @@ export const $Content = $.div`
   line-height: ${(props) => props.theme.lineHeight.l};
 `;
 
-export const $FormGroup = $.div<Props>`
+export const $FormGroup = styled.div<Props>`
   display: flex;
   align-items: center;
   font-size: ${(props) => props.theme.fontSize.body.m};
@@ -44,7 +44,7 @@ export const $FormGroup = $.div<Props>`
   background-color: ${(props) => props.backgroundColor};
 `;
 
-export const $FieldsContainerWithPadding = $.div`
+export const $FieldsContainerWithPadding = styled.div`
   display: flex;
   height: 130px;
   padding-left: var(--spacing-m);
@@ -59,7 +59,7 @@ export const $FieldsContainerWithPadding = $.div`
   }
 `;
 
-export const $ViewFieldsContainer = $.div`
+export const $ViewFieldsContainer = styled.div`
   font-size: ${(props) => props.theme.fontSize.body.m};
   display: flex;
   align-items: center;
@@ -76,4 +76,4 @@ export const $ViewFieldsContainer = $.div`
   width: 100%;
 `;
 
-export const $ViewField = $.div``;
+export const $ViewField = styled.div``;

--- a/frontend/shared/src/components/forms/spacing/Spacing.sc.ts
+++ b/frontend/shared/src/components/forms/spacing/Spacing.sc.ts
@@ -1,10 +1,10 @@
-import $, { DefaultTheme } from 'styled-components';
+import styled, { DefaultTheme } from 'styled-components';
 
 export interface SpacingProps {
   size: keyof DefaultTheme['spacing'];
 }
 
-export const $Content = $.div<SpacingProps>`
+export const $Content = styled.div<SpacingProps>`
   width: 100%;
   height: ${(props) => props.theme.spacing[props.size]};
 `;

--- a/frontend/shared/src/components/layout/Layout.sc.ts
+++ b/frontend/shared/src/components/layout/Layout.sc.ts
@@ -1,7 +1,7 @@
 import { breakpoints } from 'shared/styles/mediaQueries';
-import $ from 'styled-components';
+import styled from 'styled-components';
 
-export const $Main = $.main`
+export const $Main = styled.main`
   display: flex;
   flex-direction: column;
   height: 100vh;

--- a/frontend/shared/src/components/stepper/Stepper.sc.ts
+++ b/frontend/shared/src/components/stepper/Stepper.sc.ts
@@ -1,4 +1,4 @@
-import $, { DefaultTheme } from 'styled-components';
+import styled, { DefaultTheme } from 'styled-components';
 
 type Props = { isActive?: boolean };
 
@@ -9,12 +9,12 @@ interface $StepContainerProps {
 const getActiveColor = (isActive: boolean, theme: DefaultTheme): string =>
   isActive ? theme.colors.black90 : theme.colors.black20;
 
-export const $StepsContainer = $.div`
+export const $StepsContainer = styled.div`
   display: flex;
   align-items: center;
 `;
 
-export const $StepContainer = $.div<$StepContainerProps>`
+export const $StepContainer = styled.div<$StepContainerProps>`
   display: flex;
   align-items: center;
   flex-direction: column;
@@ -22,7 +22,7 @@ export const $StepContainer = $.div<$StepContainerProps>`
   z-index: 1;
 `;
 
-export const $StepCircle = $.div<Props>`
+export const $StepCircle = styled.div<Props>`
   height: 36px;
   width: 36px;
   border-radius: 50%;
@@ -36,7 +36,7 @@ export const $StepCircle = $.div<Props>`
   font-size: ${(props) => props.theme.fontSize.body.m};
 `;
 
-export const $StepTitle = $.p<Props>`
+export const $StepTitle = styled.p<Props>`
   text-align: center;
   position: absolute;
   bottom: -40px;
@@ -45,7 +45,7 @@ export const $StepTitle = $.p<Props>`
   font-weight: ${(props) => (props.isActive ? 600 : 500)};
 `;
 
-export const $Divider = $.div<Props>`
+export const $Divider = styled.div<Props>`
   width: 100%;
   height: 4px;
   margin: 4px;


### PR DESCRIPTION
## Description :sparkles:
- In VSCode, importing styled-components in a different name other than `styled` prevents the extension from working properly:
>There's no syntax highlighting?
Syntax Highlighting is specifically made to work with styled so make sure your default import is styled and nothing else.
See: https://github.com/styled-components/vscode-styled-components/issues/118#issuecomment-833007295

Therefore, I renamed the default import from $ to `styled`but kept the components name as they are. e.g:

~~`export const $SecondaryButton = $(Button)`~~
`export const $SecondaryButton = styled(Button)`

## Testing :alembic:
- Everything should works as expected
