### PR TITLE
 YJDH-161 | Remove stale company info from eauthorization profile

### DIFF
--- a/backend/shared/shared/oidc/services.py
+++ b/backend/shared/shared/oidc/services.py
@@ -62,10 +62,13 @@ def store_token_info_in_oidc_profile(user, token_info):
 def update_or_create_eauth_profile(
     oidc_profile: OIDCProfile, defaults: dict
 ) -> EAuthorizationProfile:
-    eauth_profile, _ = EAuthorizationProfile.objects.update_or_create(
+    eauth_profile, created = EAuthorizationProfile.objects.update_or_create(
         oidc_profile=oidc_profile,
         defaults=defaults,
     )
+    if not created and getattr(eauth_profile, "company", None):
+        eauth_profile.company = None
+        eauth_profile.save()
     return eauth_profile
 
 


### PR DESCRIPTION
## Description :sparkles:

Old company info is preserved if an user re-logins with a different company. Remove the company info on login if company info exists.

## Issues :bug:

[YJDH-161](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-161)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
