### PR TITLE
YJDH-135 | Backend: Send language to helsinki profile and suomi.fi

### DIFF
--- a/backend/kesaseteli/common/tests/conftest.py
+++ b/backend/kesaseteli/common/tests/conftest.py
@@ -1,10 +1,11 @@
 import pytest
 from django.contrib.auth.models import Permission
 from rest_framework.test import APIClient
+from shared.common.tests.factories import UserFactory
 from shared.oidc.tests.conftest import *  # noqa
 
 from applications.enums import ApplicationStatus
-from common.tests.factories import ApplicationFactory, CompanyFactory, UserFactory
+from common.tests.factories import ApplicationFactory, CompanyFactory
 
 
 @pytest.fixture

--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -1,22 +1,10 @@
 import random
-import uuid
 
 import factory
-from django.contrib.auth import get_user_model
 
 from applications.enums import ApplicationStatus
 from applications.models import Application, SummerVoucher
 from companies.models import Company
-
-
-class UserFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = get_user_model()
-
-    username = factory.Sequence(lambda n: "user_%s" % uuid.uuid4())
-    email = factory.Faker("email")
-    first_name = factory.Faker("first_name")
-    last_name = factory.Faker("last_name")
 
 
 class CompanyFactory(factory.django.DjangoModelFactory):

--- a/backend/shared/shared/common/tests/factories.py
+++ b/backend/shared/shared/common/tests/factories.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 class UserFactory(factory.django.DjangoModelFactory):
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
-    username = factory.Sequence(lambda n: f"{factory.Faker('user_name')} {n}")
+    username = factory.Faker("user_name")
     email = factory.Faker("email")
 
     class Meta:

--- a/backend/shared/shared/oidc/urls.py
+++ b/backend/shared/shared/oidc/urls.py
@@ -7,6 +7,7 @@ from shared.oidc.views.eauth_views import (
 )
 from shared.oidc.views.hki_views import (
     HelsinkiOIDCAuthenticationCallbackView,
+    HelsinkiOIDCAuthenticationRequestView,
     HelsinkiOIDCBackchannelLogoutView,
     HelsinkiOIDCLogoutView,
     HelsinkiOIDCUserInfoView,
@@ -40,6 +41,11 @@ if settings.MOCK_FLAG:
     ]
 else:
     urlpatterns += [
+        path(
+            "authenticate/",
+            HelsinkiOIDCAuthenticationRequestView.as_view(),
+            name="oidc_authentication_init",
+        ),
         path(
             "callback/",
             HelsinkiOIDCAuthenticationCallbackView.as_view(),

--- a/backend/shared/shared/oidc/views/eauth_views.py
+++ b/backend/shared/shared/oidc/views/eauth_views.py
@@ -79,6 +79,11 @@ class EauthAuthenticationRequestView(View):
             ).replace("http://", "https://"),
             "user": user_id,
         }
+
+        lang = request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME)
+        if lang:
+            params["lang"] = lang
+
         query = urlencode(params)
 
         redirect_url = "{url}?{query}".format(url=auth_url, query=query)
@@ -92,10 +97,22 @@ class EauthAuthenticationCallbackView(View):
     http_method_names = ["get"]
 
     def login_success(self):
-        return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL)
+        url = settings.LOGIN_REDIRECT_URL
+
+        lang = self.request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME)
+        if lang:
+            url = f"{url}/{lang}/"
+
+        return HttpResponseRedirect(url)
 
     def login_failure(self):
-        return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL_FAILURE)
+        url, error_path = settings.LOGIN_REDIRECT_URL_FAILURE.rsplit("/", 1)
+
+        lang = self.request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME)
+        if lang:
+            url = f"{url}/{lang}/{error_path}"
+
+        return HttpResponseRedirect(url)
 
     def get_token_info(self, code):
         """Return token object as a dictionary."""


### PR DESCRIPTION
## Description :sparkles:

Fetches the language from GET parameters on the /authenticate call and sends that to helsinki profile and suomi.fi as a url query parameter. The language is saved in Django session during the auth flow.

## Issues :bug:

[YJDH-136](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-136)
[YJDH-137](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-137)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
