### PR TITLE
HL-125: add properties for accessing company address info based on use_alternative_address

### DIFF
--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -45,6 +45,18 @@ def _get_next_application_number():
         return cursor.fetchone()[0]
 
 
+def address_property(field_suffix):
+    def _address_property_getter(self):
+        if self.use_alternative_address:
+            field_prefix = "alternative"
+        else:
+            field_prefix = "official"
+        field_name = f"{field_prefix}_{field_suffix}"
+        return getattr(self, field_name)
+
+    return _address_property_getter
+
+
 class Application(UUIDModel, TimeStampedModel):
     """
     Data model for Helsinki benefit applications
@@ -104,6 +116,13 @@ class Application(UUIDModel, TimeStampedModel):
     alternative_company_postcode = models.CharField(
         max_length=256, verbose_name=_("company post code"), blank=True
     )
+
+    # the following property values are evaluated based on use_alternative_address setting
+    effective_company_street_address = property(
+        address_property("company_street_address")
+    )
+    effective_company_city = property(address_property("company_city"))
+    effective_company_postcode = property(address_property("company_postcode"))
 
     company_bank_account_number = IBANField(
         include_countries=("FI",),

--- a/backend/benefit/applications/tests/test_models.py
+++ b/backend/benefit/applications/tests/test_models.py
@@ -63,3 +63,31 @@ def test_application_batch_modified(application_batch, status, expected_result):
     application_batch.status = status
     application_batch.save()
     assert application_batch.applications_can_be_modified == expected_result
+
+
+def test_application_address(application):
+    application.official_company_city = "official city"
+    application.alternative_company_city = "alternative city"
+    application.official_company_street_address = "official address"
+    application.alternative_company_street_address = "alternative address"
+    application.official_company_postcode = "00100"
+    application.alternative_company_postcode = "00200"
+    application.use_alternative_address = False
+    assert application.effective_company_city == application.official_company_city
+    assert (
+        application.effective_company_street_address
+        == application.official_company_street_address
+    )
+    assert (
+        application.effective_company_postcode == application.official_company_postcode
+    )
+    application.use_alternative_address = True
+    assert application.effective_company_city == application.alternative_company_city
+    assert (
+        application.effective_company_street_address
+        == application.alternative_company_street_address
+    )
+    assert (
+        application.effective_company_postcode
+        == application.alternative_company_postcode
+    )


### PR DESCRIPTION
For Talpa integration. The same code could be useful for other purposes, too

## Description :sparkles:

## Issues :bug:
HL-125

## Testing :alembic:
backend/benefit/applications/tests/test_models.py

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
