### PR TITLE
Retroactively fix verbose_name field in old migration

### DIFF
--- a/backend/benefit/applications/migrations/0016_benefit_amount.py
+++ b/backend/benefit/applications/migrations/0016_benefit_amount.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
                 decimal_places=2,
                 max_digits=8,
                 null=True,
-                verbose_name="amount of the benefit granted, ",
+                verbose_name="amount of the benefit granted, calculated by the systems",
             ),
         ),
         migrations.AddField(
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
                 decimal_places=2,
                 max_digits=8,
                 null=True,
-                verbose_name="amount of the benefit granted, ",
+                verbose_name="amount of the benefit granted, calculated by the system",
             ),
         ),
         migrations.AddField(


### PR DESCRIPTION
## Description :sparkles:
verbose_name of Application.calculated_benefit_amount was updated without a corresponding migration

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
