### PR TITLE
DEVOPS-340 No dependabot builds

### DIFF
--- a/.github/workflows/bf-review.yml
+++ b/.github/workflows/bf-review.yml
@@ -37,6 +37,9 @@ env:
   MOCK_FLAG: 1
 jobs:
   build:
+    # No building for dependabot PRs
+    # See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#handling-pull_request-events
+    if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -143,26 +146,26 @@ jobs:
           message: |
             **Helsinkibenefit-${{ matrix.service }} is deployed to: ${{ env.ENVIRONMENT_URL }}** :rocket::rocket::rocket:
       - name: Deploy Quarter Hourly Cronjobs
-          uses: City-of-Helsinki/setup-cronjob-action@main
-          with:
-            image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}
-            image_tag:  ${{ github.sha }}
-            secret_name: project-yjdh-benefit-secret
-            kubeconfig_raw: ${{ secrets.KUBECONFIG_RAW_STAGING}}
-            target_namespace: ${{ secrets.K8S_NAMESPACE_STAGING }}
-            name: "benefit-quarter-hourly-cronjob"
-            schedule: '*/15 * * * *'
-            command: "{/bin/sh}"
-            args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py runjobs quarter_hourly 2>&1}"
+        uses: City-of-Helsinki/setup-cronjob-action@main
+        with:
+          image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}
+          image_tag:  ${{ github.sha }}
+          secret_name: project-yjdh-benefit-secret
+          kubeconfig_raw: ${{ secrets.KUBECONFIG_RAW_STAGING}}
+          target_namespace: ${{ secrets.K8S_NAMESPACE_STAGING }}
+          name: "benefit-quarter-hourly-cronjob"
+          schedule: '*/15 * * * *'
+          command: "{/bin/sh}"
+          args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py runjobs quarter_hourly 2>&1}"
       - name: Deploy Monthly Cronjobs
-          uses: City-of-Helsinki/setup-cronjob-action@main
-          with:
-            image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}
-            image_tag:  ${{ github.sha }}
-            secret_name: project-yjdh-benefit-secret
-            kubeconfig_raw: ${{ secrets.KUBECONFIG_RAW_STAGING}}
-            target_namespace: ${{ secrets.K8S_NAMESPACE_STAGING }}
-            name: "benefit-monthly-cronjob"
-            schedule: '0 0 1 * *'
-            command: "{/bin/sh}"
-            args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py runjobs monthly 2>&1}"
+        uses: City-of-Helsinki/setup-cronjob-action@main
+        with:
+          image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}
+          image_tag:  ${{ github.sha }}
+          secret_name: project-yjdh-benefit-secret
+          kubeconfig_raw: ${{ secrets.KUBECONFIG_RAW_STAGING}}
+          target_namespace: ${{ secrets.K8S_NAMESPACE_STAGING }}
+          name: "benefit-monthly-cronjob"
+          schedule: '0 0 1 * *'
+          command: "{/bin/sh}"
+          args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py runjobs monthly 2>&1}"

--- a/.github/workflows/bf-stop_review.yml
+++ b/.github/workflows/bf-stop_review.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   stop_review:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     name: Stop Review
     steps:

--- a/.github/workflows/ks-review.yml
+++ b/.github/workflows/ks-review.yml
@@ -39,6 +39,7 @@ env:
   MOCK_FLAG: 1
 jobs:
   build:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ks-stop_review.yml
+++ b/.github/workflows/ks-stop_review.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   stop_review:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     name: Stop Review
     steps:


### PR DESCRIPTION
Disable review pipeline for dependabot as it requires secrets

## Description :sparkles:

Disable review builds if PR is opened by dependabot as
- It can't access (by default) to secrets
- Usually there's more than one dependency to update
- No lock files updated in dependabot PRs.

## Issues :bug:
- DEVOPS-340

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
Documentation: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#handling-pull_request-events