### PR TITLE
add attachment_file_name, fix typo in old migration

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -65,10 +65,19 @@ class AttachmentSerializer(serializers.ModelSerializer):
             "application",
             "attachment_type",
             "attachment_file",
+            "attachment_file_name",
             "content_type",
             "created_at",
         ]
         read_only_fields = ["created_at"]
+
+    attachment_file_name = serializers.SerializerMethodField(
+        "get_attachment_file_name",
+        help_text="The name of the uploaded file",
+    )
+
+    def get_attachment_file_name(self, obj):
+        return obj.attachment_file.name
 
     ATTACHMENT_MODIFICATION_ALLOWED_STATUSES = (
         ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED,

--- a/backend/benefit/applications/migrations/0016_benefit_amount.py
+++ b/backend/benefit/applications/migrations/0016_benefit_amount.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
                 decimal_places=2,
                 max_digits=8,
                 null=True,
-                verbose_name="amount of the benefit granted, calculated by the systems",
+                verbose_name="amount of the benefit granted, calculated by the system",
             ),
         ),
         migrations.AddField(

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -682,9 +682,9 @@ def test_attachment_upload_and_delete(api_client, application):
         },
         format="multipart",
     )
-
     assert response.status_code == 201
     assert len(application.attachments.all()) == 1
+    assert response.data["attachment_file_name"] == os.path.basename(tmp_file.name)
     attachment = application.attachments.all().first()
     assert attachment.attachment_type == AttachmentType.EMPLOYMENT_CONTRACT
     assert os.path.basename(tmp_file.name) == attachment.attachment_file


### PR DESCRIPTION
## Description :sparkles:
Add the name of the originally uploaded file to the API
Also fix an extra "s" letter in old migration

## Issues :bug:
HL-79

## Testing :alembic:
backend/benefit/applications/tests/test_applications_api.py

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
