### PR TITLE
HL-149 | Export Application Batch to PDF before sending to AHJO

### DIFF
--- a/.github/workflows/bf-pytest.yml
+++ b/.github/workflows/bf-pytest.yml
@@ -48,6 +48,11 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
+      - name: Install wkhtmltopdf dependency
+        run: |
+          apt-get update
+          apt-get install -y wkhtmltopdf
+
       - name: Install dependencies
         run: cd backend/benefit && pip install -r requirements.txt -r requirements-dev.txt codecov
 

--- a/backend/benefit/README.md
+++ b/backend/benefit/README.md
@@ -5,10 +5,13 @@ Prerequisites:
 * PostgreSQL 12
 * Python 3.8
 
+
 ### Installing Python requirements
 
 * Run `pip install -r requirements.txt`
 * Run `pip install -r requirements-dev.txt` (development requirements)
+* If you are not using Docker image, in order to export application batch as PDF (via `pdfkit`), it's required to install
+ `wkhtmltopdf`. Run: `sudo apt-get install wkhtmltopdf`
 
 ### Database
 
@@ -52,6 +55,7 @@ The project is now running at [localhost:8000](http://localhost:8000)
 5. To install Python requirements run:
 
     * `pip-sync requirements.txt requirements-dev.txt`
+   
 
 
 ## Documentation

--- a/backend/benefit/applications/api/v1/application_batch_views.py
+++ b/backend/benefit/applications/api/v1/application_batch_views.py
@@ -1,11 +1,18 @@
 from applications.api.v1.serializers import ApplicationBatchSerializer
 from applications.enums import ApplicationBatchStatus
 from applications.models import ApplicationBatch
+from applications.services.ahjo_integration import export_application_batch
+from django.http import HttpResponse
+from django.utils import timezone
+from django.utils.text import format_lazy
+from django.utils.translation import gettext_lazy as _
 from django_filters import rest_framework as filters
 from django_filters.widgets import CSVWidget
 from drf_spectacular.utils import extend_schema
-from rest_framework import filters as drf_filters, viewsets
+from rest_framework import filters as drf_filters, status, viewsets
+from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 
 
 class ApplicationBatchFilter(filters.FilterSet):
@@ -28,7 +35,7 @@ class ApplicationBatchFilter(filters.FilterSet):
 
 
 @extend_schema(
-    description="API for create/read/update/delete operations on Helsinki benefit application batches"
+    description="API for create/read/update/delete/export operations on Helsinki benefit application batches"
 )
 class ApplicationBatchViewSet(viewsets.ModelViewSet):
     queryset = ApplicationBatch.objects.all()
@@ -44,3 +51,40 @@ class ApplicationBatchViewSet(viewsets.ModelViewSet):
         "applications__company_name",
         "applications__company_contact_person_email",
     ]
+
+    @action(methods=("GET",), detail=True, url_path="export")
+    def export_batch(self, request, *args, **kwargs):
+        """
+        Export ApplicationBatch to pdf format
+        """
+        batch = self.get_object()
+        if batch.status != ApplicationBatchStatus.AWAITING_AHJO_DECISION:
+            if batch.status == ApplicationBatchStatus.DRAFT:
+                batch.status = ApplicationBatchStatus.AWAITING_AHJO_DECISION
+                batch.save()
+            else:
+                return Response(
+                    {
+                        "detail": _(
+                            "Application status cannot be exported because of invalid status"
+                        )
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        if batch.applications.count() <= 0:
+            return Response(
+                {"detail": _("Cannot export empty batch")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        zip_file = export_application_batch(batch)
+        file_name = format_lazy(
+            _("Application batch {date}"),
+            date=timezone.now().strftime("%d-%m-%Y %H.%M.%S"),
+        )
+        response = HttpResponse(zip_file, content_type="application/x-zip-compressed")
+        response["Content-Disposition"] = "attachment; filename={file_name}.zip".format(
+            file_name=file_name
+        )
+        return response

--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -5,6 +5,7 @@ from applications.enums import (
     ApplicationStep,
     AttachmentType,
     BenefitType,
+    OrganizationType,
 )
 from companies.models import Company
 from django.db import connection, models
@@ -282,6 +283,16 @@ class Application(UUIDModel, TimeStampedModel):
         if self.batch:
             return self.batch.ahjo_decision
         return None
+
+    @property
+    def ahjo_application_number(self):
+        # Adding prefix to application number before sending to AHJO based on the company form
+        if (
+            OrganizationType.resolve_organization_type(self.company.company_form)
+            == OrganizationType.ASSOCIATION
+        ):
+            return "R{}".format(self.application_number)
+        return "Y{}".format(self.application_number)
 
     def __str__(self):
         return "{}: {} {}".format(self.pk, self.company_name, self.status)

--- a/backend/benefit/applications/services/ahjo_integration.py
+++ b/backend/benefit/applications/services/ahjo_integration.py
@@ -1,0 +1,209 @@
+import os
+import zipfile
+from io import BytesIO
+
+import jinja2
+import pdfkit
+from applications.enums import ApplicationStatus, OrganizationType
+from django.utils import timezone
+
+PDF_PATH = os.path.join(os.path.dirname(__file__) + "/pdf_templates")
+TEMPLATE_ID_ASSOCIATION = "associations"
+TEMPLATE_ID_COMPANIES_BENEFIT_WITH_DE_MINIMIS_AID = (
+    "companies_benefit_with_de_minimis_aid"
+)
+TEMPLATE_ID_COMPANIES_BENEFIT_WITHOUT_DE_MINIMIS_AID = (
+    "companies_benefit_without_de_minimis_aid"
+)
+TEMPLATE_ID_COMPOSED_ACCEPTED_PUBLIC = "composed_accepted_public"
+TEMPLATE_ID_COMPOSED_ACCEPTED_PRIVATE = "composed_accepted_private"
+TEMPLATE_ID_COMPOSED_DECLINED_PUBLIC = "composed_declined_public"
+TEMPLATE_ID_COMPOSED_DECLINED_PRIVATE = "composed_declined_private"
+
+JINJA_TEMPLATES_COMPOSED = {
+    TEMPLATE_ID_COMPOSED_ACCEPTED_PUBLIC: {
+        "path": "composed_accepted_public.html",
+        "file_name": "Liite 1 Helsinki-lisä 2021 koontiliite yhteisöille "
+        "mallipohja julkinen.pdf",
+    },
+    TEMPLATE_ID_COMPOSED_ACCEPTED_PRIVATE: {
+        "path": "composed_accepted_private.html",
+        "file_name": "Helsinki-lisä 2021 koontiliite yhteisöille mallipohja "
+        "salassa pidettävä.pdf",
+    },
+    TEMPLATE_ID_COMPOSED_DECLINED_PUBLIC: {
+        "path": "composed_declined_public.html",
+        "file_name": "Helsinki-lisä 2021 kielteiset päätökset hakijakohtainen "
+        "mallipohja {start_number}-{end_number} salassa "
+        "pidettävä.pdf",
+    },
+    TEMPLATE_ID_COMPOSED_DECLINED_PRIVATE: {
+        "path": "composed_declined_private.html",
+        "file_name": "Helsinki-lisä 2021 kielteiset päätökset koontiliite "
+        "yrityksille {start_number}-{end_number} mallipohja salassa "
+        "pidettävä.pdf",
+    },
+}
+
+JINJA_TEMPLATES_SINGLE = {
+    TEMPLATE_ID_ASSOCIATION: {
+        "path": "associations.html",
+        "file_name": "Liite 2 hakijakohtainen mallipohja yhteisöt {app_number}.pdf",
+    },
+    TEMPLATE_ID_COMPANIES_BENEFIT_WITH_DE_MINIMIS_AID: {
+        "path": "companies_benefit_with_de_minimis_aid.html",
+        "file_name": "Liite 2 hakijakohtainen mallipohja de minimis "
+        "yritykset {app_number}.pdf",
+    },
+    TEMPLATE_ID_COMPANIES_BENEFIT_WITHOUT_DE_MINIMIS_AID: {
+        "path": "companies_benefit_without_de_minimis_aid.html",
+        "file_name": "Liite 3 hakijakohtainen mallipohja ei de "
+        "minimis yritykset {app_number}.pdf",
+    },
+}
+
+
+def _get_template(path):
+    template_loader = jinja2.FileSystemLoader(searchpath=PDF_PATH)
+    env = jinja2.Environment(loader=template_loader, autoescape=True)
+    return env.get_template(path)
+
+
+def prepare_pdf_files(apps):
+    pdf_files = []
+    # SINGLE FILE PER APP
+    for app in apps:
+        pdf_files.append(generate_single_file(app))
+
+    # COMPOSED FILES
+    pdf_files += generate_composed_files(apps)
+
+    return pdf_files
+
+
+def generate_single_file(app):
+    # Association
+    if (
+        OrganizationType.resolve_organization_type(app.company.company_form)
+        == OrganizationType.ASSOCIATION
+    ):
+        template_config = JINJA_TEMPLATES_SINGLE[TEMPLATE_ID_ASSOCIATION]
+        file_name = template_config["file_name"].format(
+            app_number=app.ahjo_application_number
+        )
+        temp = _get_template(template_config["path"])
+        html = temp.render(app=app, year=timezone.now().year)
+    # Company application
+    elif app.de_minimis_aid:
+        template_config = JINJA_TEMPLATES_SINGLE[
+            TEMPLATE_ID_COMPANIES_BENEFIT_WITH_DE_MINIMIS_AID
+        ]
+        file_name = template_config["file_name"].format(
+            app_number=app.ahjo_application_number
+        )
+        temp = _get_template(template_config["path"])
+        html = temp.render(app=app, year=timezone.now().year)
+    # Company application without de minimis aid
+    else:
+        template_config = JINJA_TEMPLATES_SINGLE[
+            TEMPLATE_ID_COMPANIES_BENEFIT_WITHOUT_DE_MINIMIS_AID
+        ]
+        file_name = template_config["file_name"].format(
+            app_number=app.ahjo_application_number
+        )
+        temp = _get_template(template_config["path"])
+        html = temp.render(app=app, year=timezone.now().year)
+    single_pdf = pdfkit.from_string(html, False)
+    return file_name, single_pdf, html
+
+
+def generate_composed_files(apps):
+    files = []
+    # Accepted applications
+    accepted_apps = [app for app in apps if app.status == ApplicationStatus.ACCEPTED]
+    if len(accepted_apps):
+        start_number = accepted_apps[0].application_number
+        end_number = accepted_apps[-1].application_number
+
+        template_config = JINJA_TEMPLATES_COMPOSED[TEMPLATE_ID_COMPOSED_ACCEPTED_PUBLIC]
+        public_accepted_template = _get_template(template_config["path"])
+        file_name = template_config["file_name"].format(
+            start_number=start_number, end_number=end_number
+        )
+        html = public_accepted_template.render(
+            apps=accepted_apps,
+            year=timezone.now().year,
+            start_number=start_number,
+            end_number=end_number,
+        )
+        files.append((file_name, pdfkit.from_string(html, False), html))
+
+        template_config = JINJA_TEMPLATES_COMPOSED[
+            TEMPLATE_ID_COMPOSED_ACCEPTED_PRIVATE
+        ]
+        private_accepted_template = _get_template(template_config["path"])
+        file_name = template_config["file_name"].format(
+            start_number=start_number, end_number=end_number
+        )
+        html = private_accepted_template.render(
+            apps=accepted_apps,
+            year=timezone.now().year,
+            start_number=start_number,
+            end_number=end_number,
+        )
+        files.append((file_name, pdfkit.from_string(html, False), html))
+
+    # Rejected applications
+    rejected_apps = [app for app in apps if app.status == ApplicationStatus.REJECTED]
+    if len(rejected_apps):
+        start_number = rejected_apps[0].application_number
+        end_number = rejected_apps[-1].application_number
+
+        template_config = JINJA_TEMPLATES_COMPOSED[TEMPLATE_ID_COMPOSED_DECLINED_PUBLIC]
+        public_declined_template = _get_template(template_config["path"])
+        file_name = template_config["file_name"].format(
+            start_number=start_number, end_number=end_number
+        )
+        html = public_declined_template.render(
+            apps=rejected_apps,
+            year=timezone.now().year,
+            start_number=start_number,
+            end_number=end_number,
+        )
+        files.append((file_name, pdfkit.from_string(html, False), html))
+
+        template_config = JINJA_TEMPLATES_COMPOSED[
+            TEMPLATE_ID_COMPOSED_DECLINED_PRIVATE
+        ]
+        private_declined_template = _get_template(template_config["path"])
+        file_name = template_config["file_name"].format(
+            start_number=start_number, end_number=end_number
+        )
+        html = private_declined_template.render(
+            apps=rejected_apps,
+            year=timezone.now().year,
+            start_number=start_number,
+            end_number=end_number,
+        )
+        files.append((file_name, pdfkit.from_string(html, False), html))
+    return files
+
+
+def generate_zip(files):
+    mem_zip = BytesIO()
+
+    with zipfile.ZipFile(mem_zip, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for f in files:
+            zf.writestr(f[0], f[1])
+
+    return mem_zip.getvalue()
+
+
+def export_application_batch(batch):
+    pdf_files = prepare_pdf_files(
+        batch.applications.select_related("company")
+        .select_related("employee")
+        .order_by("application_number")
+        .all()
+    )
+    return generate_zip(pdf_files)

--- a/backend/benefit/applications/services/pdf_templates/associations.html
+++ b/backend/benefit/applications/services/pdf_templates/associations.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+    <h1>Työllisyydenhoidon Helsinki-lisän myöntäminen yhteisöille vuonna {{ year }}, hakemus nro
+        {{ app.ahjo_application_number}}</h1>
+    <table style="border: 1px solid black">
+        <caption></caption>
+        <tr>
+            <th scope="col">Hakemus-numero</th>
+            <th scope="col">Hakija</th>
+            <th scope="col">Y-tunnus</th>
+            <th scope="col">Työllistetyn sukunimi</th>
+            <th scope="col">Työllistetyn etunimi</th>
+            <th scope="col">Alkaa</th>
+        </tr>
+        <tr>
+            <td>{{ app.ahjo_application_number }}</td>
+            <td>{{ app.company_name }}</td>
+            <td>{{ app.company.business_id }}</td>
+            <td>{{ app.employee.first_name }}</td>
+            <td>{{ app.employee.last_name }}</td>
+            <td>{{ app.start_date }}</td>
+        </tr>
+    </table>
+
+{% endblock %}

--- a/backend/benefit/applications/services/pdf_templates/base.html
+++ b/backend/benefit/applications/services/pdf_templates/base.html
@@ -1,0 +1,25 @@
+<!doctype html>
+
+<html lang="fi">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+<head>
+    <title>Ahjo PDF</title>
+    <style>
+    table, td, th {
+        border: 1px solid black;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        text-align: center;
+    }
+    body {
+        font-family: Arial, sans-serif;
+    }
+    </style>
+</head>
+<body>
+{% block content %}
+{%  endblock %}
+</body>
+</html>

--- a/backend/benefit/applications/services/pdf_templates/companies_benefit_with_de_minimis_aid.html
+++ b/backend/benefit/applications/services/pdf_templates/companies_benefit_with_de_minimis_aid.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Työllisyydenhoidon Helsinki-lisän myöntäminen yrityksille vuonna {{ year }}, hakemus nro
+        {{ app.ahjo_application_number}}</h1>
+    <table aria-label="AHJO report""AHJO report" style="border: 1px solid black">
+        <tr>
+        <th scope="col">Hakemus-numero</th>
+        <th scope="col">Hakija</th>
+        <th scope="col">Y-tunnus</th>
+        <th scope="col">Työllistetyn sukunimi</th>
+        <th scope="col">Työllistetyn etunimi</th>
+        <th scope="col">Alkaa</th>
+        </tr>
+        <tr>
+            <td>{{ app.ahjo_application_number }}</td>
+            <td>{{ app.company_name }}</td>
+            <td>{{ app.company.business_id }}</td>
+            <td>{{ app.employee.first_name }}</td>
+            <td>{{ app.employee.last_name }}</td>
+            <td>{{ app.start_date }}</td>
+        </tr>
+    </table>
+
+    <p>Tämän päätöksen suoma tuki myönnetään vähämerkityksisenä eli ns. de minimis -tukena. Tuen myöntämisessä noudatetaan komission asetusta (EU) 1407/2013, 24.12.2013, perustamissopimuksen 107 ja 108 artiklan soveltamisesta vähämerkityksiseen tukeen (EUVL nro L352, 24.12.2013).</p>
+{% endblock %}

--- a/backend/benefit/applications/services/pdf_templates/companies_benefit_without_de_minimis_aid.html
+++ b/backend/benefit/applications/services/pdf_templates/companies_benefit_without_de_minimis_aid.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Työllisyydenhoidon Helsinki-lisän myöntäminen yrityksille vuonna {{ year }}, hakemus nro
+    {{ app.ahjo_application_number}}</h1>
+<table aria-label="AHJO report""AHJO report" style="border: 1px solid black">
+    <tr>
+    <th scope="col">Hakemus-numero</th>
+    <th scope="col">Hakija</th>
+    <th scope="col">Y-tunnus</th>
+    <th scope="col">Työllistetyn sukunimi</th>
+    <th scope="col">Työllistetyn etunimi</th>
+    <th scope="col">Alkaa</th>
+    </tr>
+    <tr>
+        <td>{{ app.ahjo_application_number }}</td>
+        <td>{{ app.company_name }}</td>
+        <td>{{ app.company.business_id }}</td>
+        <td>{{ app.employee.first_name }}</td>
+        <td>{{ app.employee.last_name }}</td>
+        <td>{{ app.start_date }}</td>
+    </tr>
+</table>
+{% endblock %}

--- a/backend/benefit/applications/services/pdf_templates/composed_accepted_private.html
+++ b/backend/benefit/applications/services/pdf_templates/composed_accepted_private.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Liite 1 Työllisyydenhoidon Helsinki-lisän myöntäminen yhteisöille vuonna {{ year }}, hakemus nro
+    {{ start_number }} - {{ end_number }}</h1>
+<table aria-label="AHJO report""AHJO report" style="border: 1px solid black">
+    <tr>
+    <th scope="col">Hakemus-numero</th>
+    <th scope="col">Hakija</th>
+    <th scope="col">Y-tunnus</th>
+    <th scope="col">Työllistetyn sukunimi</th>
+    <th scope="col">Työllistetyn etunimi</th>
+    <th scope="col">Alkaa</th>
+    </tr>
+    {% for app in apps %}
+        <tr>
+            <td>{{ app.ahjo_application_number }}</td>
+            <td>{{ app.company_name }}</td>
+            <td>{{ app.company.business_id }}</td>
+            <td>{{ app.employee.first_name }}</td>
+            <td>{{ app.employee.last_name }}</td>
+            <td>{{ app.start_date }}</td>
+        </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/backend/benefit/applications/services/pdf_templates/composed_accepted_public.html
+++ b/backend/benefit/applications/services/pdf_templates/composed_accepted_public.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Liite 1 Työllisyydenhoidon Helsinki-lisän myöntäminen yhteisöille vuonna {{ year }}, hakemus nro
+    {{ start_number }} - {{ end_number }}</h1>
+<table aria-label="AHJO report""AHJO report" style="border: 1px solid black">
+    <tr>
+    <th scope="col">Hakemus-numero</th>
+    <th scope="col">Hakija</th>
+    <th scope="col">Y-tunnus</th>
+    <th scope="col">Työllistetyn sukunimi</th>
+    <th scope="col">Työllistetyn etunimi</th>
+    <th scope="col">Alkaa</th>
+    </tr>
+    {% for app in apps %}
+        <tr>
+            <td>{{ app.ahjo_application_number }}</td>
+            <td>{{ app.company_name }}</td>
+            <td>{{ app.company.business_id }}</td>
+            {% if loop.index == 1 %}
+                <td colspan="2" rowspan="{{ apps | length }}">Salassa pidettävä, JulkL 24§ 1 mom 25 k., Henkilötieto poistettu</td>
+            {% endif %}
+            <td>{{ app.start_date }}</td>
+        </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/backend/benefit/applications/services/pdf_templates/composed_declined_private.html
+++ b/backend/benefit/applications/services/pdf_templates/composed_declined_private.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Liite 1 Työllisyydenhoidon Helsinki-lisän myöntäminen yhteisöille vuonna {{ year }}, hakemus nro
+    {{ start_number }} - {{ end_number }}</h1>
+<table aria-label="AHJO report""AHJO report" style="border: 1px solid black">
+    <tr>
+    <th scope="col">Hakemus-numero</th>
+    <th scope="col">Hakija</th>
+    <th scope="col">Y-tunnus</th>
+    <th scope="col">Työllistetyn sukunimi</th>
+    <th scope="col">Työllistetyn etunimi</th>
+    <th scope="col">Alkaa</th>
+    </tr>
+    {% for app in apps %}
+        <tr>
+            <td>{{ app.ahjo_application_number }}</td>
+            <td>{{ app.company_name }}</td>
+            <td>{{ app.company.business_id }}</td>
+            <td>{{ app.employee.first_name }}</td>
+            <td>{{ app.employee.last_name }}</td>
+            <td>{{ app.start_date }}</td>
+        </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/backend/benefit/applications/services/pdf_templates/composed_declined_public.html
+++ b/backend/benefit/applications/services/pdf_templates/composed_declined_public.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Liite 1 Työllisyydenhoidon Helsinki-lisän myöntäminen yhteisöille vuonna {{ year }}, hakemus nro
+    {{ start_number }} - {{ end_number }}</h1>
+<table aria-label="AHJO report""AHJO report" style="border: 1px solid black">
+    <tr>
+    <th scope="col">Hakemus-numero</th>
+    <th scope="col">Hakija</th>
+    <th scope="col">Y-tunnus</th>
+    <th scope="col">Työllistetyn sukunimi</th>
+    <th scope="col">Työllistetyn etunimi</th>
+    <th scope="col">Alkaa</th>
+    </tr>
+    {% for app in apps %}
+        <tr>
+            <td>{{ app.ahjo_application_number }}</td>
+            <td>{{ app.company_name }}</td>
+            <td>{{ app.company.business_id }}</td>
+            {% if loop.index == 1 %}
+                <td colspan="2" rowspan="{{ apps | length }}">Salassa pidettävä, JulkL 24§ 1 mom 25 k., Henkilötieto poistettu</td>
+            {% endif %}
+            <td>{{ app.start_date }}</td>
+        </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/backend/benefit/applications/tests/snapshots/snap_test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/snapshots/snap_test_ahjo_integration.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+snapshots = Snapshot()
+
+snapshots["test_generate_composed_template_html 1"] = [
+    "Liite 1 Helsinki-lisä 2021 koontiliite yhteisöille mallipohja julkinen.pdf",
+    "Helsinki-lisä 2021 koontiliite yhteisöille mallipohja salassa pidettävä.pdf",
+    "Helsinki-lisä 2021 kielteiset päätökset hakijakohtainen mallipohja 125010-125010 salassa pidettävä.pdf",
+    "Helsinki-lisä 2021 kielteiset päätökset koontiliite yrityksille 125010-125010 mallipohja salassa pidettävä.pdf",
+]
+
+snapshots[
+    "test_generate_single_template_html[oy-False] 1"
+] = """<!doctype html>
+
+<html lang="fi">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+<head>
+    <title>Ahjo PDF</title>
+    <style>
+    table, td, th {
+        border: 1px solid black;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        text-align: center;
+    }
+    body {
+        font-family: Arial, sans-serif;
+    }
+    </style>
+</head>
+<body>
+
+<h1>Työllisyydenhoidon Helsinki-lisän myöntäminen yrityksille vuonna 2021, hakemus nro
+    Y125007</h1>
+<table aria-label="AHJO report""AHJO report" style="border: 1px solid black">
+    <tr>
+    <th scope="col">Hakemus-numero</th>
+    <th scope="col">Hakija</th>
+    <th scope="col">Y-tunnus</th>
+    <th scope="col">Työllistetyn sukunimi</th>
+    <th scope="col">Työllistetyn etunimi</th>
+    <th scope="col">Alkaa</th>
+    </tr>
+    <tr>
+        <td>Y125007</td>
+        <td>Example.</td>
+        <td>8906333-4</td>
+        <td>Kimberly</td>
+        <td>Baker</td>
+        <td>2021-07-02</td>
+    </tr>
+</table>
+
+</body>
+</html>"""
+
+snapshots[
+    "test_generate_single_template_html[oy-True] 1"
+] = """<!doctype html>
+
+<html lang="fi">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+<head>
+    <title>Ahjo PDF</title>
+    <style>
+    table, td, th {
+        border: 1px solid black;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        text-align: center;
+    }
+    body {
+        font-family: Arial, sans-serif;
+    }
+    </style>
+</head>
+<body>
+
+    <h1>Työllisyydenhoidon Helsinki-lisän myöntäminen yrityksille vuonna 2021, hakemus nro
+        Y125008</h1>
+    <table aria-label="AHJO report""AHJO report" style="border: 1px solid black">
+        <tr>
+        <th scope="col">Hakemus-numero</th>
+        <th scope="col">Hakija</th>
+        <th scope="col">Y-tunnus</th>
+        <th scope="col">Työllistetyn sukunimi</th>
+        <th scope="col">Työllistetyn etunimi</th>
+        <th scope="col">Alkaa</th>
+        </tr>
+        <tr>
+            <td>Y125008</td>
+            <td>Example.</td>
+            <td>8906333-4</td>
+            <td>Kimberly</td>
+            <td>Baker</td>
+            <td>2021-07-02</td>
+        </tr>
+    </table>
+
+    <p>Tämän päätöksen suoma tuki myönnetään vähämerkityksisenä eli ns. de minimis -tukena. Tuen myöntämisessä noudatetaan komission asetusta (EU) 1407/2013, 24.12.2013, perustamissopimuksen 107 ja 108 artiklan soveltamisesta vähämerkityksiseen tukeen (EUVL nro L352, 24.12.2013).</p>
+
+</body>
+</html>"""
+
+snapshots[
+    "test_generate_single_template_html[ry-False] 1"
+] = """<!doctype html>
+
+<html lang="fi">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+<head>
+    <title>Ahjo PDF</title>
+    <style>
+    table, td, th {
+        border: 1px solid black;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        text-align: center;
+    }
+    body {
+        font-family: Arial, sans-serif;
+    }
+    </style>
+</head>
+<body>
+
+
+    <h1>Työllisyydenhoidon Helsinki-lisän myöntäminen yhteisöille vuonna 2021, hakemus nro
+        R125006</h1>
+    <table style="border: 1px solid black">
+        <caption></caption>
+        <tr>
+            <th scope="col">Hakemus-numero</th>
+            <th scope="col">Hakija</th>
+            <th scope="col">Y-tunnus</th>
+            <th scope="col">Työllistetyn sukunimi</th>
+            <th scope="col">Työllistetyn etunimi</th>
+            <th scope="col">Alkaa</th>
+        </tr>
+        <tr>
+            <td>R125006</td>
+            <td>Example.</td>
+            <td>8906333-4</td>
+            <td>Kimberly</td>
+            <td>Baker</td>
+            <td>2021-07-02</td>
+        </tr>
+    </table>
+
+
+</body>
+</html>"""

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -1,0 +1,84 @@
+import io
+import zipfile
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+from applications.enums import ApplicationStatus
+from applications.models import Application
+from applications.services.ahjo_integration import (
+    export_application_batch,
+    generate_composed_files,
+    generate_single_file,
+)
+from applications.tests.factories import ApplicationFactory
+from common.tests.conftest import *  # noqa
+
+
+@pytest.fixture(autouse=True)
+def autouse_django_db(db, django_db_setup, django_db_blocker):
+    pass
+
+
+@pytest.mark.parametrize(
+    "company_type, de_minimis_aid",
+    [
+        ("ry", False),
+        ("oy", False),
+        ("oy", True),
+    ],
+)
+@patch("applications.services.ahjo_integration.pdfkit.from_string")
+def test_generate_single_template_html(
+    mock_pdf_convert, snapshot, company_type, de_minimis_aid
+):
+    mock_pdf_convert.return_value = {}
+    app = ApplicationFactory(
+        company__company_form=company_type, de_minimis_aid=de_minimis_aid
+    )
+    # Only assert html snapshot for easier comparison
+    _, _, html = generate_single_file(app)
+    snapshot.assert_match(html)
+
+
+@patch("applications.services.ahjo_integration.pdfkit.from_string")
+def test_generate_composed_template_html(mock_pdf_convert, snapshot):
+    mock_pdf_convert.return_value = {}
+    app_1 = ApplicationFactory.create(
+        status=ApplicationStatus.ACCEPTED, start_date=date.today()
+    )
+    app_2 = ApplicationFactory.create(
+        status=ApplicationStatus.REJECTED, start_date=date.today()
+    )
+    app_3 = ApplicationFactory.create(
+        status=ApplicationStatus.CANCELLED, start_date=date.today()
+    )
+    apps = Application.objects.all()
+
+    # Only snapshot html content for easier comparison
+    files = generate_composed_files(apps)
+    assert len(files) == 4
+    snapshot.assert_match([f[0] for f in files])
+
+    assert app_1.ahjo_application_number in files[0][2]
+    assert app_1.ahjo_application_number not in files[3][2]
+
+    assert app_2.ahjo_application_number not in files[0][2]
+    assert app_2.ahjo_application_number in files[3][2]
+
+    assert app_3.ahjo_application_number not in files[0][2]
+    assert app_3.ahjo_application_number not in files[3][2]
+
+
+def test_export_application_batch(application_batch):
+    application_batch.applications.add(
+        ApplicationFactory(status=ApplicationStatus.ACCEPTED)
+    )
+    application_batch.applications.add(
+        ApplicationFactory(status=ApplicationStatus.REJECTED)
+    )
+
+    zip_file = export_application_batch(application_batch)
+    file_like_object = io.BytesIO(zip_file)
+    archive = zipfile.ZipFile(file_like_object)
+    assert len(archive.infolist()) == application_batch.applications.count() + 4

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -74,6 +74,7 @@ env = environ.Env(
     ELASTICSEARCH_API_KEY=(str, ""),
     CLEAR_AUDIT_LOG_ENTRIES=(bool, False),
     ENABLE_SEND_AUDIT_LOG=(bool, False),
+    WKHTMLTOPDF_BIN=(str, "/usr/bin/wkhtmltopdf"),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -300,6 +301,8 @@ ELASTICSEARCH_CLOUD_ID = env("ELASTICSEARCH_CLOUD_ID")
 ELASTICSEARCH_API_ID = env("ELASTICSEARCH_API_ID")
 ELASTICSEARCH_API_KEY = env("ELASTICSEARCH_API_KEY")
 ENABLE_SEND_AUDIT_LOG = env("ENABLE_SEND_AUDIT_LOG")
+
+WKHTMLTOPDF_BIN = env("WKHTMLTOPDF_BIN")
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.

--- a/backend/benefit/requirements-dev.in
+++ b/backend/benefit/requirements-dev.in
@@ -7,5 +7,6 @@ pytest
 pytest-cov
 pytest-django
 pytest-freezegun
+snapshottest
 requests-mock
 Werkzeug

--- a/backend/benefit/requirements-dev.txt
+++ b/backend/benefit/requirements-dev.txt
@@ -6,6 +6,8 @@
 #
 appdirs==1.4.4
     # via black
+appnope==0.1.2
+    # via ipython
 attrs==21.2.0
     # via pytest
 backcall==0.2.0
@@ -26,6 +28,8 @@ factory-boy==3.2.0
     # via -r requirements-dev.in
 faker==8.1.1
     # via factory-boy
+fastdiff==0.3.0
+    # via snapshottest
 flake8==3.9.1
     # via -r requirements-dev.in
 freezegun==1.1.0
@@ -100,6 +104,11 @@ six==1.16.0
     # via
     #   python-dateutil
     #   requests-mock
+    #   snapshottest
+snapshottest==0.6.0
+    # via -r requirements-dev.in
+termcolor==1.1.0
+    # via snapshottest
 text-unidecode==1.3
     # via faker
 toml==0.10.2
@@ -113,6 +122,10 @@ traitlets==5.0.5
     #   matplotlib-inline
 urllib3==1.26.4
     # via requests
+wasmer-compiler-cranelift==1.0.0
+    # via fastdiff
+wasmer==1.0.0
+    # via fastdiff
 wcwidth==0.2.5
     # via prompt-toolkit
 werkzeug==2.0.1

--- a/backend/benefit/requirements.in
+++ b/backend/benefit/requirements.in
@@ -21,4 +21,6 @@ django-storages[azure]
 Pillow
 filetype
 elasticsearch
+Jinja2
+pdfkit
 -e file:../shared

--- a/backend/benefit/requirements.txt
+++ b/backend/benefit/requirements.txt
@@ -87,14 +87,20 @@ idna==2.10
     # via requests
 inflection==0.5.1
     # via drf-spectacular
+jinja2==3.0.1
+    # via -r requirements.in
 josepy==1.8.0
     # via mozilla-django-oidc
 jsonschema==3.2.0
     # via drf-spectacular
+markupsafe==2.0.1
+    # via jinja2
 mozilla-django-oidc==1.2.4
     # via
     #   -r requirements.in
     #   yjdh-backend-shared
+pdfkit==0.6.1
+    # via -r requirements.in
 phonenumbers==8.12.25
     # via django-phonenumber-field
 pillow==8.3.0

--- a/backend/benefit/setup.cfg
+++ b/backend/benefit/setup.cfg
@@ -4,7 +4,7 @@ exclude = *migrations*
 ignore = E309
 
 [flake8]
-exclude = migrations
+exclude = migrations,snapshots
 max-line-length = 120
 max-complexity = 10
 

--- a/backend/docker/benefit.Dockerfile
+++ b/backend/docker/benefit.Dockerfile
@@ -13,6 +13,7 @@ RUN apt-install.sh \
         netcat \
         libpq-dev \
         build-essential \
+        wkhtmltopdf \
     && pip install -U pip \
     && pip install --no-cache-dir -r /app/requirements.txt \
     && pip install --no-cache-dir  -r /app/requirements-prod.txt \

--- a/backend/shared/precommit-setup.cfg
+++ b/backend/shared/precommit-setup.cfg
@@ -4,7 +4,7 @@ exclude = *migrations*
 ignore = E309
 
 [flake8]
-exclude = migrations
+exclude = migrations,snapshots
 max-line-length = 120
 max-complexity = 10
 

--- a/backend/shared/setup.cfg
+++ b/backend/shared/setup.cfg
@@ -4,7 +4,7 @@ exclude = *migrations*
 ignore = E309
 
 [flake8]
-exclude = migrations
+exclude = migrations,snapshots
 max-line-length = 120
 max-complexity = 10
 


### PR DESCRIPTION
## Description :sparkles:
- Add API endpoint to export application batch
- Each application in a batch will be generated to a single PDF files, the template will be decided based on the application type (company type, deminimis aid)
- Composed files are also generated, each will have two version: private and public, where the public pdf won't include employee data


NOTE: After the demo with PO, it turned out that the template should be updated so it can contain more information of the application, also design for the template might be considered later. So this PR is basically focus on the export function and its logic, any change to the template can be update later in a separated PR

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
Some example PDF:
Public composed file
[Liite 1 Helsinki-lisä 2021 koontiliite yhteisöille mallipohja julkinen.pdf](https://github.com/City-of-Helsinki/yjdh/files/7084038/Liite.1.Helsinki-lisa.2021.koontiliite.yhteisoille.mallipohja.julkinen.pdf)
Private composoed file
[Helsinki-lisä 2021 koontiliite yhteisöille mallipohja salassa pidettävä.pdf](https://github.com/City-of-Helsinki/yjdh/files/7084045/Helsinki-lisa.2021.koontiliite.yhteisoille.mallipohja.salassa.pidettava.pdf)

Single application file
[Liite 2 hakijakohtainen mallipohja yhteisöt R125000.pdf](https://github.com/City-of-Helsinki/yjdh/files/7084046/Liite.2.hakijakohtainen.mallipohja.yhteisot.R125000.pdf)

## Additional notes :spiral_notepad:
