### PR TITLE
YJDH-175 | Backend: Save organization roles in session

### DIFF
--- a/backend/benefit/companies/api/v1/views.py
+++ b/backend/benefit/companies/api/v1/views.py
@@ -4,10 +4,10 @@ from companies.services import get_or_create_company_with_business_id
 from companies.tests.data.company_data import DUMMY_COMPANY_DATA
 from django.conf import settings
 from django.db import transaction
+from django.http import HttpRequest
 from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
 from requests.exceptions import HTTPError
 from rest_framework import status
-from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -37,7 +37,7 @@ class GetCompanyView(APIView):
         return Response(message, status.HTTP_400_BAD_REQUEST)
 
     @transaction.atomic
-    def get_mock(self, request: Request, format: str = None) -> Response:
+    def get_mock(self, request: HttpRequest, format: str = None) -> Response:
         # This mocked get method will be used for testing purposes for the frontend.
         session_id = request.META.get("HTTP_SESSION_ID")
         if session_id == "-1":
@@ -57,7 +57,7 @@ class GetCompanyView(APIView):
     )
     @transaction.atomic
     def get(
-        self, request: Request, business_id: str = None, format: str = None
+        self, request: HttpRequest, business_id: str = None, format: str = None
     ) -> Response:
         if settings.MOCK_FLAG:
             return self.get_mock(request, format)
@@ -67,7 +67,7 @@ class GetCompanyView(APIView):
             eauth_profile = request.user.oidc_profile.eauthorization_profile
 
             try:
-                organization_roles = get_organization_roles(eauth_profile)
+                organization_roles = get_organization_roles(eauth_profile, request)
             except HTTPError:
                 return self.organization_roles_error
 

--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -261,9 +261,10 @@ class ApplicationSerializer(serializers.ModelSerializer):
 
     @transaction.atomic
     def create(self, validated_data):
-        user = self.context["request"].user
+        request = self.context["request"]
+        user = request.user
         company = get_or_create_company_from_eauth_profile(
-            user.oidc_profile.eauthorization_profile
+            user.oidc_profile.eauthorization_profile, request
         )
         validated_data["company"] = company
         validated_data["user"] = user

--- a/backend/kesaseteli/companies/api/v1/views.py
+++ b/backend/kesaseteli/companies/api/v1/views.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import transaction
-from rest_framework.request import Request
+from django.http import HttpRequest
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -16,7 +16,7 @@ class GetCompanyView(APIView):
     """
 
     @transaction.atomic
-    def get_mock(self, request: Request, format: str = None) -> Response:
+    def get_mock(self, request: HttpRequest, format: str = None) -> Response:
         # This mocked get method will be used for testing purposes for the frontend.
         session_id = request.META.get("HTTP_SESSION_ID")
         if session_id == "-1":
@@ -32,12 +32,12 @@ class GetCompanyView(APIView):
         return Response(company_data)
 
     @transaction.atomic
-    def get(self, request: Request, format: str = None) -> Response:
+    def get(self, request: HttpRequest, format: str = None) -> Response:
         if settings.MOCK_FLAG:
             return self.get_mock(request, format)
 
         company = get_or_create_company_from_eauth_profile(
-            request.user.oidc_profile.eauthorization_profile
+            request.user.oidc_profile.eauthorization_profile, request
         )
 
         company_data = CompanySerializer(company).data

--- a/backend/kesaseteli/companies/services.py
+++ b/backend/kesaseteli/companies/services.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django.http import HttpRequest
 from requests.exceptions import HTTPError
 from rest_framework.exceptions import NotFound
 from shared.oidc.models import EAuthorizationProfile
@@ -54,10 +55,10 @@ def get_or_create_company_with_name_and_business_id(
 
 
 def get_or_create_company_using_organization_roles(
-    eauth_profile: EAuthorizationProfile,
+    eauth_profile: EAuthorizationProfile, request: HttpRequest
 ) -> Company:
     try:
-        organization_roles = get_organization_roles(eauth_profile)
+        organization_roles = get_organization_roles(eauth_profile, request)
     except HTTPError:
         raise NotFound(
             detail="Unable to fetch organization roles from eauthorizations API"
@@ -85,7 +86,7 @@ def get_or_create_company_using_organization_roles(
 
 
 def get_or_create_company_from_eauth_profile(
-    eauth_profile: EAuthorizationProfile,
+    eauth_profile: EAuthorizationProfile, request: HttpRequest
 ) -> Company:
     """
     The flow will execute only step 1 or steps 1-4 if company does not exist in db.
@@ -105,5 +106,7 @@ def get_or_create_company_from_eauth_profile(
         if settings.MOCK_FLAG:
             company = CompanyFactory(eauth_profile=eauth_profile)
         else:
-            company = get_or_create_company_using_organization_roles(eauth_profile)
+            company = get_or_create_company_using_organization_roles(
+                eauth_profile, request
+            )
     return company

--- a/backend/shared/shared/oidc/auth.py
+++ b/backend/shared/shared/oidc/auth.py
@@ -165,4 +165,9 @@ class EAuthRestAuthentication(SessionAuthentication):
         ):
             return None
 
+        # Store organization roles in session
+        from shared.oidc.utils import request_organization_roles
+
+        request_organization_roles(user.oidc_profile.eauthorization_profile, request)
+
         return user, auth

--- a/backend/shared/shared/oidc/tests/test_eauth_rest_auth.py
+++ b/backend/shared/shared/oidc/tests/test_eauth_rest_auth.py
@@ -1,17 +1,40 @@
+import re
 from unittest import mock
 
 import pytest
+from django.conf import settings
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import override_settings, RequestFactory
 
 from shared.oidc.auth import EAuthRestAuthentication
 
 
 @pytest.mark.django_db
-def test_eauth_rest_auth_success(eauthorization_profile):
+@override_settings(
+    EAUTHORIZATIONS_BASE_URL="http://example.com",
+    EAUTHORIZATIONS_CLIENT_ID="test",
+)
+def test_eauth_rest_auth_success(requests_mock, eauthorization_profile):
     factory = RequestFactory()
     request = factory.get("/")
     user = eauthorization_profile.oidc_profile.user
     request.user = user
+
+    session_middleware = SessionMiddleware()
+    session_middleware.process_request(request)
+    request.session.save()
+
+    organization_roles_json = [
+        {
+            "name": "Activenakusteri Oy",
+            "identifier": "7769480-5",
+            "complete": True,
+            "roles": ["NIMKO"],
+        }
+    ]
+
+    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    requests_mock.get(matcher, json=organization_roles_json)
 
     with mock.patch(
         "shared.oidc.auth.SessionAuthentication.authenticate", return_value=(user, None)
@@ -20,6 +43,7 @@ def test_eauth_rest_auth_success(eauthorization_profile):
         user, auth = eauth_rest_auth.authenticate(request)
 
     assert user == eauthorization_profile.oidc_profile.user
+    assert request.session["organization_roles"] == organization_roles_json[0]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description :sparkles:

Refactor get_organization_roles so that the roles are saved in session after login. After login the roles will be fetched from the session.

This is done because the access token that we get from suomi.fi is used only for getting these roles and the ttl of the token is only 10 minutes. So later when calling this function we can be assured that the roles are already fetched and there is no need to call the suomi.fi organizationRoles API.

## Issues :bug:

[YJDH-175](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-175)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
