### PR TITLE
YJDH-197 | KS-Employer: Login page

### DIFF
--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -4,12 +4,19 @@
     "loginLabel": "Login",
     "logoutLabel": "Logout",
     "userAriaLabelPrefix": "User:"
-    },
+  },
   "errorPage": {
     "title": "Unknown error occurred",
     "message": "ENG: Yritämme todennäköisesti jo parhaillaan korjata ongelmaa. Yritä myöhemmin uudelleen.",
     "retry": "Reload the page",
     "logout": "Logout"
+  },
+  "loginPage": {
+    "logoutMessageLabel": "You have signed out",
+    "errorLabel": "Unknown error. Sign in again",
+    "sessionExpiredLabel": "Session expired. Sign in again",
+    "infoLabel": "Using the service requires authentication",
+    "infoContent": "Qui consequat qui tempor ut. Sit veniam esse in consectetur eiusmod id aliquip excepteur deserunt enim eiusmod proident amet incididunt. Minim occaecat laborum enim sint in cupidatat. Mollit elit aliqua laboris qui ipsum laboris. Labore incididunt Lorem labore commodo."
   },
   "application": {
     "new": "New application",

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -11,6 +11,13 @@
     "retry": "Lataa sivu uudelleen",
     "logout": "Kirjaudu ulos"
   },
+  "loginPage": {
+    "logoutMessageLabel": "Olet kirjautunut ulos",
+    "errorLabel": "Tapahtui tuntematon virhe. Kirjaudu uudelleen sisään",
+    "sessionExpiredLabel": "Käyttäjäsessio vanhentui. Kirjaudu uudelleen sisään",
+    "infoLabel": "Palvelun käyttäminen edellyttää vahvaa tunnistautumista",
+    "infoContent": "Qui consequat qui tempor ut. Sit veniam esse in consectetur eiusmod id aliquip excepteur deserunt enim eiusmod proident amet incididunt. Minim occaecat laborum enim sint in cupidatat. Mollit elit aliqua laboris qui ipsum laboris. Labore incididunt Lorem labore commodo."
+  },
   "application": {
     "new": "Uusi hakemus",
     "common_error": "Tapahtui tuntematon virhe",

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -11,6 +11,13 @@
     "retry": "SV Lataa sivu uudelleen",
     "logout": "SV Kirjaudu ulos"
   },
+  "loginPage": {
+    "logoutMessageLabel": "Olet kirjautunut ulos SWE",
+    "errorLabel": "Tapahtui tuntematon virhe. Kirjaudu uudelleen sisään SWE",
+    "sessionExpiredLabel": "Käyttäjäsessio vanhentui. Kirjaudu uudelleen sisään SWE",
+    "infoLabel": "Palvelun käyttäminen edellyttää vahvaa tunnistautumista SWE",
+    "infoContent": "SWE Qui consequat qui tempor ut. Sit veniam esse in consectetur eiusmod id aliquip excepteur deserunt enim eiusmod proident amet incididunt. Minim occaecat laborum enim sint in cupidatat. Mollit elit aliqua laboris qui ipsum laboris. Labore incididunt Lorem labore commodo."
+  },
   "application": {
     "new": "Uusi hakemus SWE",
     "common_error": "Tapahtui tuntematon virhe: SWE",

--- a/frontend/kesaseteli/employer/src/components/application/login.sc.ts
+++ b/frontend/kesaseteli/employer/src/components/application/login.sc.ts
@@ -1,0 +1,14 @@
+import { Button, Notification } from 'hds-react';
+import styled from 'styled-components';
+
+export const $PrimaryButton = styled(Button)`
+  background-color: ${(props) => props.theme.colors.coatOfArms} !important;
+  border-color: ${(props) => props.theme.colors.coatOfArms} !important;
+  border-width: 3px !important;
+`;
+
+export const $Notification = styled(Notification)`
+  font-size: ${(props) => props.theme.fontSize.body.s};
+  line-height: ${(props) => props.theme.lineHeight.xl};
+  margin-bottom: ${(props) => props.theme.spacing.xl};
+`;

--- a/frontend/kesaseteli/employer/src/pages/login.tsx
+++ b/frontend/kesaseteli/employer/src/pages/login.tsx
@@ -1,5 +1,8 @@
+import { IconSignin } from 'hds-react';
+import useLogin from 'kesaseteli/employer/hooks/backend/useLogin';
 import { GetStaticProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import Container from 'shared/components/container/Container';
 import withoutAuth from 'shared/components/hocs/withoutAuth';
@@ -7,19 +10,48 @@ import Layout from 'shared/components/Layout';
 import useClearQueryParams from 'shared/hooks/useClearQueryParams';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 
+import { $Notification, $PrimaryButton } from '../components/application/login.sc';
+
 const Login: NextPage = () => {
   useClearQueryParams();
+  const { t } = useTranslation();
   const {
     query: { logout, error, sessionExpired },
   } = useRouter();
+  const login = useLogin();
+
+  const getNotificationLabelKey = (): string => {
+    let notificationLabel = `common:loginPage.infoLabel`
+    if (logout) {
+      notificationLabel = `common:loginPage.logoutMessageLabel`;
+    } else if (error) {
+      notificationLabel = `common:loginPage.errorLabel`;
+    } else if (sessionExpired) {
+      notificationLabel = `common:loginPage.sessionExpiredLabel`;
+    }
+    return notificationLabel;
+  };
+
+  const notificationLabelKey = getNotificationLabelKey();
+  const notificationContent = !logout && !error && !sessionExpired && t(`common:loginPage.infoContent`)
+  const notificationType = error || sessionExpired ? "error" : "info"
+
   return (
     <Container>
-      <Layout headingText="Työnantajan liittymä">
-        {logout && <p>Olet kirjautunut ulos</p>}
-        {error && <p>Tapahtui tuntematon virhe. Kirjaudu uudelleen sisään.</p>}
-        {sessionExpired && (
-          <p>Käyttäjäsessio vanhentui. Kirjaudu uudelleen sisään.</p>
-        )}
+      <Layout>
+        <$Notification
+          label={t(notificationLabelKey)}
+          type={notificationType}
+          size="large"
+        >
+          {notificationContent}
+        </$Notification>
+        <$PrimaryButton
+          iconLeft={<IconSignin />}
+          onClick={login}
+        >
+          {t(`common:header.loginLabel`)}
+        </$PrimaryButton>
       </Layout>
     </Container>
   );

--- a/frontend/shared/src/components/Layout.tsx
+++ b/frontend/shared/src/components/Layout.tsx
@@ -11,7 +11,7 @@ const Main = styled.main`
   padding: 1rem;
 `;
 
-type AppProps = { children: React.ReactNode; headingText: string };
+type AppProps = { children: React.ReactNode; headingText?: string };
 
 const Layout: React.FC<AppProps> = ({ children, headingText }) => (
   <Main id="main_content">


### PR DESCRIPTION
## Description :sparkles:

Add login page styles and translations.

Modify the Layout shared component so that headingText is optional.

Invision: https://invis.io/WT10T1E97XKB#/453766715_Koti_Login

## Issues :bug:

[YJDH-197](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-197)

## Testing :alembic:

## Screenshots :camera_flash:

![Screenshot from 2021-09-15 11-18-49](https://user-images.githubusercontent.com/31963063/133397032-2b73de33-88e6-451d-80c3-25ed748af274.png)


![Screenshot from 2021-09-15 11-19-53](https://user-images.githubusercontent.com/31963063/133397206-14b97d5f-b78b-4288-ad16-855d446495de.png)


![Screenshot from 2021-09-15 11-20-42](https://user-images.githubusercontent.com/31963063/133397324-e278fcb2-c725-41e5-b31c-868ef51ffb6d.png)


## Additional notes :spiral_notepad:
