### PR TITLE
Fix validation to return values

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -292,18 +292,21 @@ class EmployeeSerializer(serializers.ModelSerializer):
     def validate_monthly_pay(self, value):
         if value is not None and value <= 0:
             raise serializers.ValidationError(_("Monthly pay must be greater than 0"))
+        return value
 
     def validate_vacation_money(self, value):
         if value is not None and value < 0:
             raise serializers.ValidationError(
                 _("Vacation money must be a positive number")
             )
+        return value
 
     def validate_other_expenses(self, value):
         if value is not None and value < 0:
             raise serializers.ValidationError(
                 _("Other expenses must be a positive number")
             )
+        return value
 
 
 class ApplicationBatchSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:
Missing return statement causing the serializer field will be always None after validation
## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
