### PR TITLE
YJDH-199 | KS-Backend: Adjust validation when student born 2004

### DIFF
--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -6,7 +6,11 @@ from django.utils.translation import gettext_lazy as _
 from PIL import Image, UnidentifiedImageError
 from rest_framework import serializers
 
-from applications.enums import ApplicationStatus, AttachmentType
+from applications.enums import (
+    ApplicationStatus,
+    AttachmentType,
+    SummerVoucherExceptionReason,
+)
 from applications.models import Application, Attachment, SummerVoucher
 from companies.api.v1.serializers import CompanySerializer
 from companies.services import get_or_create_company_from_eauth_profile
@@ -236,6 +240,13 @@ class SummerVoucherSerializer(serializers.ModelSerializer):
             return
 
         required_fields = self.REQUIRED_FIELDS_FOR_SUBMITTED_SUMMER_VOUCHERS[:]
+
+        if (
+            data.get("summer_voucher_exception_reason")
+            == SummerVoucherExceptionReason.BORN_2004
+        ):
+            # If the student was born 2004, the summer voucher serial number is not required.
+            required_fields.remove("summer_voucher_serial_number")
 
         for field_name in required_fields:
             if data.get(field_name) in [None, "", []]:

--- a/backend/kesaseteli/applications/tests/test_application_validation.py
+++ b/backend/kesaseteli/applications/tests/test_application_validation.py
@@ -106,6 +106,9 @@ def test_application_status_change_with_missing_summer_voucher_data(
     payslip_attachment,
     missing_field,
 ):
+    summer_voucher.summer_voucher_exception_reason = ""
+    summer_voucher.save()
+
     from_status = ApplicationStatus.DRAFT
     to_status = ApplicationStatus.SUBMITTED
 


### PR DESCRIPTION
## Description :sparkles:

When student was born 2004, `summer_voucher_serial_number` is not required.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
