### PR TITLE
Backend: Save organization roles to session on login

### DIFF
--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -15,6 +15,7 @@ from shared.audit_log.viewsets import AuditLoggingModelViewSet
 from applications.api.v1.permissions import (
     ALLOWED_APPLICATION_STATUSES,
     ApplicationPermission,
+    get_user_company,
     SummerVoucherPermission,
 )
 from applications.api.v1.serializers import (
@@ -43,8 +44,7 @@ class ApplicationViewSet(AuditLoggingModelViewSet):
             .prefetch_related("summer_vouchers")
         )
         user = self.request.user
-        eauth_profile = user.oidc_profile.eauthorization_profile
-        user_company = getattr(eauth_profile, "company", None)
+        user_company = get_user_company(self.request)
 
         return queryset.filter(
             company=user_company,
@@ -80,8 +80,7 @@ class SummerVoucherViewSet(AuditLoggingModelViewSet):
             .prefetch_related("attachments")
         )
         user = self.request.user
-        eauth_profile = user.oidc_profile.eauthorization_profile
-        user_company = getattr(eauth_profile, "company", None)
+        user_company = get_user_company(self.request)
 
         return queryset.filter(
             application__company=user_company,

--- a/backend/shared/shared/oidc/auth.py
+++ b/backend/shared/shared/oidc/auth.py
@@ -166,8 +166,8 @@ class EAuthRestAuthentication(SessionAuthentication):
             return None
 
         # Store organization roles in session
-        from shared.oidc.utils import request_organization_roles
+        from shared.oidc.utils import get_organization_roles
 
-        request_organization_roles(user.oidc_profile.eauthorization_profile, request)
+        get_organization_roles(user.oidc_profile.eauthorization_profile, request)
 
         return user, auth

--- a/backend/shared/shared/oidc/tests/test_eauth_views.py
+++ b/backend/shared/shared/oidc/tests/test_eauth_views.py
@@ -105,6 +105,7 @@ def test_eauth_authentication_init_view(requests_mock, user_client, user):
 
 @pytest.mark.django_db
 @override_settings(
+    EAUTHORIZATIONS_CLIENT_ID="ed4b7ae7",
     EAUTHORIZATIONS_BASE_URL="http://example.com",
     LOGIN_REDIRECT_URL="http://example.com/success",
     MOCK_FLAG=False,
@@ -119,6 +120,16 @@ def test_eauth_callback_view(requests_mock, user_client, user):
     }
     matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
     requests_mock.post(matcher, json=token_info)
+
+    organization_roles_json = [
+        {
+            "name": "Activenakusteri Oy",
+            "identifier": "7769480-5",
+            "complete": True,
+            "roles": ["NIMKO"],
+        }
+    ]
+    requests_mock.get(matcher, json=organization_roles_json)
 
     callback_url = f"{reverse('eauth_authentication_callback')}?code=test"
     response = user_client.get(callback_url)

--- a/backend/shared/shared/oidc/views/eauth_views.py
+++ b/backend/shared/shared/oidc/views/eauth_views.py
@@ -151,7 +151,14 @@ class EauthAuthenticationCallbackView(View):
         elif "code" in request.GET:
             try:
                 token_info = self.get_token_info(request.GET["code"])
-                store_token_info_in_eauth_profile(request.user.oidc_profile, token_info)
+                eauthorization_profile = store_token_info_in_eauth_profile(
+                    request.user.oidc_profile, token_info
+                )
+
+                # Store organization roles in session
+                from shared.oidc.utils import request_organization_roles
+
+                request_organization_roles(eauthorization_profile, request)
             except HTTPError as e:
                 logger.error(str(e))
                 return self.login_failure()


### PR DESCRIPTION
## Description :sparkles:

There was a problem when DRF was fetching the organization roles from the suomi.fi eauthorizations API every time instead of using the session variable. Save the organization roles to session on login instead of the DRF session authentication class `EAuthRestAuthentication`.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
