### PR TITLE
YJDH-205 | Backend: Fix previous company shown on login

### DIFF
--- a/backend/kesaseteli/applications/api/v1/permissions.py
+++ b/backend/kesaseteli/applications/api/v1/permissions.py
@@ -20,12 +20,7 @@ def get_user_company(request: HttpRequest) -> Optional[Company]:
         return None
 
     eauth_profile = user.oidc_profile.eauthorization_profile
-    user_company = getattr(eauth_profile, "company", None)
-
-    if not user_company:
-        user_company = get_or_create_company_from_eauth_profile(
-            user.oidc_profile.eauthorization_profile, request
-        )
+    user_company = get_or_create_company_from_eauth_profile(eauth_profile, request)
 
     return user_company
 

--- a/backend/shared/shared/oidc/auth.py
+++ b/backend/shared/shared/oidc/auth.py
@@ -165,9 +165,4 @@ class EAuthRestAuthentication(SessionAuthentication):
         ):
             return None
 
-        # Store organization roles in session
-        from shared.oidc.utils import get_organization_roles
-
-        get_organization_roles(user.oidc_profile.eauthorization_profile, request)
-
         return user, auth

--- a/backend/shared/shared/oidc/tests/test_eauth_rest_auth.py
+++ b/backend/shared/shared/oidc/tests/test_eauth_rest_auth.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import pytest
 from django.conf import settings
-from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import override_settings, RequestFactory
 
 from shared.oidc.auth import EAuthRestAuthentication
@@ -19,10 +18,6 @@ def test_eauth_rest_auth_success(requests_mock, eauthorization_profile):
     request = factory.get("/")
     user = eauthorization_profile.oidc_profile.user
     request.user = user
-
-    session_middleware = SessionMiddleware()
-    session_middleware.process_request(request)
-    request.session.save()
 
     organization_roles_json = [
         {
@@ -43,7 +38,6 @@ def test_eauth_rest_auth_success(requests_mock, eauthorization_profile):
         user, auth = eauth_rest_auth.authenticate(request)
 
     assert user == eauthorization_profile.oidc_profile.user
-    assert request.session["organization_roles"] == organization_roles_json[0]
 
 
 @pytest.mark.django_db

--- a/backend/shared/shared/oidc/tests/test_eauth_views.py
+++ b/backend/shared/shared/oidc/tests/test_eauth_views.py
@@ -146,3 +146,4 @@ def test_eauth_callback_view(requests_mock, user_client, user):
     assert abs(
         eauth_profile.access_token_expires - access_token_expires
     ) < timezone.timedelta(seconds=10)
+    assert user_client.session["organization_roles"] == organization_roles_json[0]


### PR DESCRIPTION
## Description :sparkles:

Fix an issue where:
1. User A logs in with company X
2. User session times out.
3. User A logs in with company Y.
4. System shows info of company X.
 
## Issues :bug:

[YJDH-205](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-205)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
