### PR TITLE
YJDH-206 | KS-Backend: Allow viewing submitted applications

### DIFF
--- a/backend/kesaseteli/applications/api/v1/permissions.py
+++ b/backend/kesaseteli/applications/api/v1/permissions.py
@@ -8,7 +8,12 @@ from applications.models import Application
 from companies.models import Company
 from companies.services import get_or_create_company_from_eauth_profile
 
-ALLOWED_APPLICATION_STATUSES = [
+ALLOWED_APPLICATION_VIEW_STATUSES = [
+    ApplicationStatus.DRAFT,
+    ApplicationStatus.SUBMITTED,
+]
+
+ALLOWED_APPLICATION_UPDATE_STATUSES = [
     ApplicationStatus.DRAFT,
 ]
 
@@ -36,7 +41,7 @@ def has_application_permission(request: HttpRequest, application: Application) -
     if (
         application.company == user_company
         and application.user == user
-        and application.status in ALLOWED_APPLICATION_STATUSES
+        and application.status in ALLOWED_APPLICATION_VIEW_STATUSES
     ):
         return True
     return False

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -13,7 +13,8 @@ from rest_framework.response import Response
 from shared.audit_log.viewsets import AuditLoggingModelViewSet
 
 from applications.api.v1.permissions import (
-    ALLOWED_APPLICATION_STATUSES,
+    ALLOWED_APPLICATION_UPDATE_STATUSES,
+    ALLOWED_APPLICATION_VIEW_STATUSES,
     ApplicationPermission,
     get_user_company,
     SummerVoucherPermission,
@@ -23,6 +24,7 @@ from applications.api.v1.serializers import (
     AttachmentSerializer,
     SummerVoucherSerializer,
 )
+from applications.enums import ApplicationStatus
 from applications.models import Application, SummerVoucher
 
 
@@ -49,16 +51,25 @@ class ApplicationViewSet(AuditLoggingModelViewSet):
         return queryset.filter(
             company=user_company,
             user=user,
-            status__in=ALLOWED_APPLICATION_STATUSES,
+            status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
         )
 
     def create(self, request, *args, **kwargs):
         """
         Allow only 1 (DRAFT) application per user & company.
         """
-        if self.get_queryset().exists():
+        if self.get_queryset().filter(status=ApplicationStatus.DRAFT).exists():
             raise ValidationError("Company & user can have only one draft application")
         return super().create(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        """
+        Allow to update only DRAFT status applications.
+        """
+        instance = self.get_object()
+        if instance.status not in ALLOWED_APPLICATION_UPDATE_STATUSES:
+            raise ValidationError("Only DRAFT applications can be updated")
+        return super().update(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
@@ -85,7 +96,7 @@ class SummerVoucherViewSet(AuditLoggingModelViewSet):
         return queryset.filter(
             application__company=user_company,
             application__user=user,
-            application__status__in=ALLOWED_APPLICATION_STATUSES,
+            application__status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
         )
 
     def create(self, request, *args, **kwargs):
@@ -114,6 +125,11 @@ class SummerVoucherViewSet(AuditLoggingModelViewSet):
         Upload a single file as attachment
         """
         obj = self.get_object()
+
+        if obj.application.status not in ALLOWED_APPLICATION_UPDATE_STATUSES:
+            raise ValidationError(
+                "Attachments can be uploaded only for DRAFT applications"
+            )
 
         # Validate request data
         serializer = AttachmentSerializer(
@@ -159,6 +175,11 @@ class SummerVoucherViewSet(AuditLoggingModelViewSet):
             """
             Delete a single attachment as file
             """
+            if obj.application.status not in ALLOWED_APPLICATION_UPDATE_STATUSES:
+                raise ValidationError(
+                    "Attachments can be deleted only for DRAFT applications"
+                )
+
             if (
                 obj.application.status
                 not in AttachmentSerializer.ATTACHMENT_MODIFICATION_ALLOWED_STATUSES

--- a/backend/kesaseteli/applications/tests/test_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_applications_api.py
@@ -376,3 +376,25 @@ def test_application_get_only_finds_own_application(
     response = api_client.get(get_detail_url(application))
     assert response.status_code == 200
     assert str(response.data["id"]) == str(application.id)
+
+
+@pytest.mark.django_db
+def test_application_update_submitted_application(api_client, submitted_application):
+    data = ApplicationSerializer(submitted_application).data
+    data["invoicer_name"] = "test"
+    response = api_client.put(
+        get_detail_url(submitted_application),
+        data,
+    )
+
+    assert response.status_code == 400
+    assert "Only DRAFT applications can be updated" in response.data
+
+
+@pytest.mark.django_db
+def test_applications_view_permissions(api_client, application, submitted_application):
+    response = api_client.get(reverse("v1:application-list"))
+
+    assert response.status_code == 200
+    assert any(x["id"] == str(application.id) for x in response.data)
+    assert any(x["id"] == str(submitted_application.id) for x in response.data)

--- a/backend/kesaseteli/common/tests/conftest.py
+++ b/backend/kesaseteli/common/tests/conftest.py
@@ -37,11 +37,36 @@ def application(company, user_with_profile):
 
 
 @pytest.fixture
+def submitted_application(company, user_with_profile):
+    return ApplicationFactory(
+        status=ApplicationStatus.SUBMITTED, company=company, user=user_with_profile
+    )
+
+
+@pytest.fixture
 def summer_voucher(application):
     summer_voucher = SummerVoucherFactory(application=application)
     yield summer_voucher
     for attachment in summer_voucher.attachments.all():
         attachment.attachment_file.delete(save=False)
+
+
+@pytest.fixture
+def submitted_summer_voucher(submitted_application):
+    summer_voucher = SummerVoucherFactory(application=submitted_application)
+    yield summer_voucher
+    for attachment in summer_voucher.attachments.all():
+        attachment.attachment_file.delete(save=False)
+
+
+@pytest.fixture
+def submitted_employment_contract_attachment(submitted_summer_voucher):
+    attachment = AttachmentFactory(
+        summer_voucher=submitted_summer_voucher,
+        attachment_type=AttachmentType.EMPLOYMENT_CONTRACT,
+    )
+    yield attachment
+    attachment.attachment_file.delete(save=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description :sparkles:

Allow for the users to view already submitted applications. This is needed to show the summary of the application on the thank you page.

## Issues :bug:

[YJDH-206](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-206)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
