### PR TITLE
Fix OIDC callback URLs

### DIFF
--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -85,6 +85,7 @@ env = environ.Env(
     DISABLE_AUTHENTICATION=(bool, False),
     DUMMY_COMPANY_FORM=(str, "OY"),
     ENABLE_DEBUG_ENV=(bool, False),
+    PUBLIC_URL=(str, ""),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -100,6 +101,7 @@ SOCIAL_SECURITY_NUMBER_HASH_KEY = env.str("SOCIAL_SECURITY_NUMBER_HASH_KEY")
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST")
+PUBLIC_URL = env.str("PUBLIC_URL")
 
 DATABASES = {"default": env.db()}
 

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -76,6 +76,7 @@ env = environ.Env(
     CLEAR_AUDIT_LOG_ENTRIES=(bool, False),
     ENABLE_SEND_AUDIT_LOG=(bool, False),
     ENABLE_ADMIN=(bool, True),
+    PUBLIC_URL=(str, ""),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -88,6 +89,7 @@ if DEBUG and not SECRET_KEY:
     SECRET_KEY = "xxx"
 ENCRYPTION_KEY = env.str("ENCRYPTION_KEY")
 ENABLE_ADMIN = env.bool("ENABLE_ADMIN")
+PUBLIC_URL = env.str("PUBLIC_URL")
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST")

--- a/backend/shared/shared/azure_adfs/config.py
+++ b/backend/shared/shared/azure_adfs/config.py
@@ -1,0 +1,11 @@
+from django_auth_adfs.config import ProviderConfig
+
+from shared.common.utils import get_public_reverse_url
+
+
+class HelsinkiProviderConfig(ProviderConfig):
+    def redirect_uri(self, request):
+        return get_public_reverse_url(request, "django_auth_adfs:callback")
+
+
+provider_config = HelsinkiProviderConfig()

--- a/backend/shared/shared/azure_adfs/urls.py
+++ b/backend/shared/shared/azure_adfs/urls.py
@@ -1,8 +1,9 @@
 from django.urls import include, path, re_path
 
-from shared.azure_adfs.views import HelsinkiOAuth2CallbackView
+from shared.azure_adfs.views import HelsinkiOAuth2CallbackView, HelsinkiOAuth2LoginView
 
 urlpatterns = [
     re_path(r"^callback$", HelsinkiOAuth2CallbackView.as_view(), name="callback"),
+    re_path(r"^login$", HelsinkiOAuth2LoginView.as_view(), name="login"),
     path("", include("django_auth_adfs.urls")),
 ]

--- a/backend/shared/shared/azure_adfs/views.py
+++ b/backend/shared/shared/azure_adfs/views.py
@@ -2,7 +2,9 @@ import logging
 
 from django.conf import settings
 from django.shortcuts import redirect
-from django_auth_adfs.views import OAuth2CallbackView
+from django_auth_adfs.views import OAuth2CallbackView, OAuth2LoginView
+
+from shared.azure_adfs.config import provider_config
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,3 +28,14 @@ class HelsinkiOAuth2CallbackView(OAuth2CallbackView):
             f"Invalid login. Status code: {response.status_code}. Error message: {error_message}."
         )
         return redirect(settings.ADFS_LOGIN_REDIRECT_URL_FAILURE)
+
+
+class HelsinkiOAuth2LoginView(OAuth2LoginView):
+    def get(self, request):
+        """
+        Initiates the OAuth2 flow and redirect the user agent to ADFS
+
+        Args:
+            request (django.http.request.HttpRequest): A Django Request object
+        """
+        return redirect(provider_config.build_authorization_endpoint(request))

--- a/backend/shared/shared/common/utils.py
+++ b/backend/shared/shared/common/utils.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django.urls import reverse
+
+
+def get_public_reverse_url(request, reverse_name: str) -> str:
+    """
+    Builds a public url based on the setting. This is required in some environments that are
+    using separate internal and public URLs.
+    """
+    path = reverse(reverse_name)
+
+    if settings.PUBLIC_URL:
+        return f"{settings.PUBLIC_URL}{path}"
+
+    return request.build_absolute_uri(path)

--- a/backend/shared/shared/oidc/views/eauth_views.py
+++ b/backend/shared/shared/oidc/views/eauth_views.py
@@ -11,6 +11,7 @@ from django.views import View
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
 
+from shared.common.utils import get_public_reverse_url
 from shared.oidc.services import store_token_info_in_eauth_profile
 from shared.oidc.utils import get_checksum_header, get_userinfo
 
@@ -71,12 +72,14 @@ class EauthAuthenticationRequestView(View):
 
         auth_url = settings.EAUTHORIZATIONS_BASE_URL + "/oauth/authorize"
 
+        redirect_uri = get_public_reverse_url(
+            request, "eauth_authentication_callback"
+        ).replace("http://", "https://")
+
         params = {
             "client_id": settings.EAUTHORIZATIONS_CLIENT_ID,
             "response_type": "code",
-            "redirect_uri": request.build_absolute_uri(
-                reverse("eauth_authentication_callback")
-            ).replace("http://", "https://"),
+            "redirect_uri": redirect_uri,
             "user": user_id,
         }
 


### PR DESCRIPTION
## Description :sparkles:

Some environments (such as PLATTA) uses separate internal and public URLs. When Django intiates the OIDC flow, it wants to use the public URL for callbacks but `request.build_absolute_uri()` gives the internal URL.

Add a setting `PUBLIC_URL` to tackle this problem. Use the public url for all of the OIDC flows.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
