### PR TITLE
KS-Backend: Fix 502 error in production

### DIFF
--- a/backend/benefit/.prod/uwsgi.ini
+++ b/backend/benefit/.prod/uwsgi.ini
@@ -6,6 +6,7 @@ module = helsinkibenefit.wsgi
 static-map = /static=/var/static
 uid = nobody
 gid = nogroup
+buffer-size = 32768
 master = 1
 processes = 2
 threads = 2

--- a/backend/kesaseteli/.prod/uwsgi.ini
+++ b/backend/kesaseteli/.prod/uwsgi.ini
@@ -6,6 +6,7 @@ module = kesaseteli.wsgi
 static-map = /static=/var/static
 uid = nobody
 gid = nogroup
+buffer-size = 32768
 master = 1
 processes = 2
 threads = 2


### PR DESCRIPTION
## Description :sparkles:

With some long callback URLs, uwsgi will throw 502 errors with the message:

`[WARNING] unable to add HTTP_X_FORWARDED_HOST=... to uwsgi packet, consider increasing buffer size.`

Increase the buffer size to (try to) resolve this.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
