### PR TITLE
KS-Backend: Refine attachments & logout

### DIFF
--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -1,5 +1,3 @@
-import os
-
 from django.core import exceptions
 from django.http import FileResponse
 from django.utils.text import format_lazy
@@ -160,7 +158,7 @@ class SummerVoucherViewSet(AuditLoggingModelViewSet):
             Read a single attachment as file
             """
             attachment = obj.attachments.filter(pk=attachment_pk).first()
-            if not attachment or not os.path.isfile(attachment.attachment_file.path):
+            if not attachment or not attachment.attachment_file:
                 return Response(
                     {
                         "detail": format_lazy(
@@ -194,6 +192,5 @@ class SummerVoucherViewSet(AuditLoggingModelViewSet):
                 return Response(
                     {"detail": _("File not found.")}, status=status.HTTP_404_NOT_FOUND
                 )
-            instance.attachment_file.delete(save=False)
             instance.delete()
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -209,6 +209,10 @@ class Attachment(UUIDModel, TimeStampedModel):
     )
     attachment_file = models.FileField(verbose_name=_("application attachment content"))
 
+    def delete(self, using=None, keep_parents=False):
+        self.attachment_file.delete()
+        super().delete(using=using, keep_parents=keep_parents)
+
     class Meta:
         verbose_name = _("attachment")
         verbose_name_plural = _("attachments")

--- a/backend/kesaseteli/applications/templates/application_excel_download.html
+++ b/backend/kesaseteli/applications/templates/application_excel_download.html
@@ -11,7 +11,7 @@
 
 
         <div class="col-md-12 text-end mt-2">
-            <a href="{% url 'django_auth_adfs:logout' %}" class="btn btn-info btn-md">{% trans 'Kirjaudu ulos' %}</a>
+            <a href="{% url 'logout' %}" class="btn btn-info btn-md">{% trans 'Kirjaudu ulos' %}</a>
         </div>
 
         <h1>Lataa Excel tiedostoja</h1>

--- a/backend/kesaseteli/kesaseteli/urls.py
+++ b/backend/kesaseteli/kesaseteli/urls.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.auth.views import LogoutView
 from django.http import HttpResponse
 from django.urls import include, path
 from rest_framework import routers
@@ -20,6 +21,7 @@ urlpatterns = [
     path(
         "excel-download/", ApplicationExcelDownloadView.as_view(), name="excel-download"
     ),
+    path("logout/", LogoutView.as_view(), name="logout"),
 ]
 
 


### PR DESCRIPTION
## Description :sparkles:

Small adjustments to improve the attachment handling. For example we won't check if the file exists with os.path.isfile since we are using the blob storage.

Use the django logout view instead of the Azure ADFS logout to log the user out from the excel download view. This is because if using the Azure logout, the user will be logged out of all sites related to the ADFS login.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
