### PR TITLE
Backend: Fix refreshing tokens

### DIFF
--- a/backend/shared/shared/oidc/auth.py
+++ b/backend/shared/shared/oidc/auth.py
@@ -10,7 +10,10 @@ from mozilla_django_oidc.utils import absolutify
 from requests.exceptions import HTTPError
 from rest_framework.authentication import SessionAuthentication
 
-from shared.oidc.services import store_token_info_in_oidc_profile
+from shared.oidc.services import (
+    store_token_info_in_oidc_profile,
+    update_token_info_in_oidc_profile,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -110,7 +113,7 @@ class HelsinkiOIDCAuthenticationBackend(OIDCAuthenticationBackend):
         )
         response.raise_for_status()
 
-        return store_token_info_in_oidc_profile(oidc_profile.user, response.json())
+        return update_token_info_in_oidc_profile(oidc_profile, response.json())
 
 
 class EAuthRestAuthentication(SessionAuthentication):
@@ -160,8 +163,6 @@ class EAuthRestAuthentication(SessionAuthentication):
         if not (
             hasattr(user, "oidc_profile")
             and hasattr(user.oidc_profile, "eauthorization_profile")
-            and user.oidc_profile.eauthorization_profile.id_token
-            and user.oidc_profile.eauthorization_profile.access_token
         ):
             return None
 

--- a/backend/shared/shared/oidc/services.py
+++ b/backend/shared/shared/oidc/services.py
@@ -17,6 +17,14 @@ def create_oidc_profile(user, defaults: dict) -> OIDCProfile:
     return oidc_profile
 
 
+def update_oidc_profile(oidc_profile, defaults: dict) -> OIDCProfile:
+    oidc_profile, _ = OIDCProfile.objects.update_or_create(
+        user=oidc_profile.user,
+        defaults=defaults,
+    )
+    return oidc_profile
+
+
 def clear_oidc_profiles(
     oidc_profiles: Union[OIDCProfile, "QuerySet[OIDCProfile]"]
 ) -> None:
@@ -60,6 +68,14 @@ def store_token_info_in_oidc_profile(user, token_info):
     defaults = get_defaults(token_info)
 
     oidc_profile = create_oidc_profile(user, defaults)
+    return oidc_profile
+
+
+def update_token_info_in_oidc_profile(oidc_profile, token_info):
+    """Update token info in the OIDCProfile instance and return the updated instance."""
+    defaults = get_defaults(token_info)
+
+    oidc_profile = update_oidc_profile(oidc_profile, defaults)
     return oidc_profile
 
 

--- a/backend/shared/shared/oidc/tests/test_eauth_rest_auth.py
+++ b/backend/shared/shared/oidc/tests/test_eauth_rest_auth.py
@@ -56,25 +56,6 @@ def test_eauth_rest_auth_success_mock(user):
     assert user.oidc_profile.eauthorization_profile
 
 
-@pytest.mark.django_db
-def test_eauth_rest_auth_failure_missing_access_token(eauthorization_profile):
-    factory = RequestFactory()
-    request = factory.get("/")
-    user = eauthorization_profile.oidc_profile.user
-    request.user = user
-
-    eauthorization_profile.access_token = ""
-    eauthorization_profile.save()
-
-    with mock.patch(
-        "shared.oidc.auth.SessionAuthentication.authenticate", return_value=(user, None)
-    ):
-        eauth_rest_auth = EAuthRestAuthentication()
-        user_auth_tuple = eauth_rest_auth.authenticate(request)
-
-    assert user_auth_tuple is None
-
-
 def test_eauth_rest_auth_failure():
     factory = RequestFactory()
     request = factory.get("/")


### PR DESCRIPTION
## Description :sparkles:

Fix the refreshing of helsinki profile access token. No need to create a new OIDCProfile instance but instead need to update the existing instance.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
