### PR TITLE
Backend: Fix ADFS login username

### DIFF
--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -305,7 +305,7 @@ AUTH_ADFS = {
     "CLIENT_ID": ADFS_CLIENT_ID,
     "CLIENT_SECRET": ADFS_CLIENT_SECRET,
     "CLAIM_MAPPING": {"email": "email"},
-    "USERNAME_CLAIM": "unique_name",
+    "USERNAME_CLAIM": "name",
     "TENANT_ID": ADFS_TENANT_ID,
     "RELYING_PARTY_ID": ADFS_CLIENT_ID,
 }

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -271,7 +271,7 @@ AUTH_ADFS = {
     "CLIENT_ID": ADFS_CLIENT_ID,
     "CLIENT_SECRET": ADFS_CLIENT_SECRET,
     "CLAIM_MAPPING": {"email": "email"},
-    "USERNAME_CLAIM": "unique_name",
+    "USERNAME_CLAIM": "name",
     "TENANT_ID": ADFS_TENANT_ID,
     "RELYING_PARTY_ID": ADFS_CLIENT_ID,
 }

--- a/backend/shared/shared/azure_adfs/README.md
+++ b/backend/shared/shared/azure_adfs/README.md
@@ -46,7 +46,7 @@ To start using this package, follow these steps:
         "CLIENT_ID": ADFS_CLIENT_ID,
         "CLIENT_SECRET": ADFS_CLIENT_SECRET,
         "CLAIM_MAPPING": {"email": "email"},
-        "USERNAME_CLAIM": "unique_name",
+        "USERNAME_CLAIM": "name",
         "TENANT_ID": ADFS_TENANT_ID,
         "RELYING_PARTY_ID": ADFS_CLIENT_ID,
     }


### PR DESCRIPTION
## Description :sparkles:

With certain users the `unique_name` parameter contains illegal characters for a django username. Use the `name` parameter instead which should be the email of the user, thus valid username and unique as well.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
