### PR TITLE
HL-252 | Show success notification upon saving the application

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -340,6 +340,10 @@
     "applicationSubmitted": {
       "label": "Hakemus lähetty onnistuneesti",
       "message": "Helsinki-lisä hakemus {{applicationNumber}} ({{applicantName}}) on lähetetty. Saat ilmoituksen kun hakemus on käsitelty."
+    },
+    "applicationSaved": {
+      "label": "Hakemus tallennettu",
+      "message": "Helsinki-lisä hakemus {{applicantName}} on tallennettu."
     }
   },
   "languages": {

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -343,7 +343,7 @@
     },
     "applicationSaved": {
       "label": "Hakemus tallennettu",
-      "message": "Helsinki-lisä hakemus {{applicantName}} on tallennettu."
+      "message": "Helsinki-lisä hakemus {{applicationNumber}} {{applicantName}} on tallennettu."
     }
   },
   "languages": {

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -340,6 +340,10 @@
     "applicationSubmitted": {
       "label": "Hakemus lähetty onnistuneesti",
       "message": "Helsinki-lisä hakemus {{applicationNumber}} ({{applicantName}}) on lähetetty. Saat ilmoituksen kun hakemus on käsitelty."
+    },
+    "applicationSaved": {
+      "label": "Hakemus tallennettu",
+      "message": "Helsinki-lisä hakemus {{applicantName}} on tallennettu."
     }
   },
   "languages": {

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -343,7 +343,7 @@
     },
     "applicationSaved": {
       "label": "Hakemus tallennettu",
-      "message": "Helsinki-lisä hakemus {{applicantName}} on tallennettu."
+      "message": "Helsinki-lisä hakemus {{applicationNumber}} {{applicantName}} on tallennettu."
     }
   },
   "languages": {

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -340,6 +340,10 @@
     "applicationSubmitted": {
       "label": "Hakemus lähetty onnistuneesti",
       "message": "Helsinki-lisä hakemus {{applicationNumber}} ({{applicantName}}) on lähetetty. Saat ilmoituksen kun hakemus on käsitelty."
+    },
+    "applicationSaved": {
+      "label": "Hakemus tallennettu",
+      "message": "Helsinki-lisä hakemus {{applicantName}} on tallennettu."
     }
   },
   "languages": {

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -343,7 +343,7 @@
     },
     "applicationSaved": {
       "label": "Hakemus tallennettu",
-      "message": "Helsinki-lisä hakemus {{applicantName}} on tallennettu."
+      "message": "Helsinki-lisä hakemus {{applicationNumber}} {{applicantName}} on tallennettu."
     }
   },
   "languages": {

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
@@ -8,8 +8,8 @@ import {
   ApplicationData,
 } from 'benefit/applicant/types/application';
 import {
-  getApplicantFullName,
   getApplicationStepString,
+  getFullName,
 } from 'benefit/applicant/utils/common';
 import isEmpty from 'lodash/isEmpty';
 import { useRouter } from 'next/router';
@@ -52,7 +52,7 @@ const useApplicationFormStep5 = (
       application.status === APPLICATION_STATUSES.RECEIVED
     ) {
       setSubmittedApplication({
-        applicantName: getApplicantFullName(
+        applicantName: getFullName(
           application.employee?.firstName,
           application.employee?.lastName
         ),

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step6/useApplicationFormStep6.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step6/useApplicationFormStep6.ts
@@ -12,7 +12,7 @@ import {
   Application,
   ApplicationData,
 } from 'benefit/applicant/types/application';
-import { getApplicantFullName } from 'benefit/applicant/utils/common';
+import { getFullName } from 'benefit/applicant/utils/common';
 import { useRouter } from 'next/router';
 import { TFunction } from 'next-i18next';
 import { useContext, useEffect, useState } from 'react';
@@ -68,7 +68,7 @@ const useApplicationFormStep6 = (
       application.status === APPLICATION_STATUSES.RECEIVED
     ) {
       setSubmittedApplication({
-        applicantName: getApplicantFullName(
+        applicantName: getFullName(
           application.employee?.firstName,
           application.employee?.lastName
         ),

--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -8,7 +8,7 @@ import snakecaseKeys from 'snakecase-keys';
 
 import DeMinimisContext from '../context/DeMinimisContext';
 import { Application, ApplicationData } from '../types/application';
-import { getApplicationStepString,getFullName } from '../utils/common';
+import { getApplicationStepString, getFullName } from '../utils/common';
 import useCreateApplicationQuery from './useCreateApplicationQuery';
 import useUpdateApplicationQuery from './useUpdateApplicationQuery';
 
@@ -138,11 +138,10 @@ const useFormActions = (
         ? await updateApplication(data)
         : await createApplication(data);
 
-      const {
-        employee: { first_name, last_name },
-      } = result;
-
-      const fullName = getFullName(first_name, last_name);
+      const fullName = getFullName(
+        result?.employee?.first_name,
+        result?.employee?.last_name
+      );
       const applicantName = fullName ? `(${fullName})` : '';
 
       hdsToast({

--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -8,7 +8,7 @@ import snakecaseKeys from 'snakecase-keys';
 
 import DeMinimisContext from '../context/DeMinimisContext';
 import { Application, ApplicationData } from '../types/application';
-import { getApplicationStepString } from '../utils/common';
+import { getApplicationStepString,getFullName } from '../utils/common';
 import useCreateApplicationQuery from './useCreateApplicationQuery';
 import useUpdateApplicationQuery from './useUpdateApplicationQuery';
 
@@ -137,6 +137,22 @@ const useFormActions = (
       const result = applicationId
         ? await updateApplication(data)
         : await createApplication(data);
+
+      const {
+        employee: { first_name, last_name },
+      } = result;
+
+      const fullName = getFullName(first_name, last_name);
+      const applicantName = fullName ? `(${fullName})` : '';
+
+      hdsToast({
+        autoDismissTime: 5000,
+        type: 'success',
+        labelText: t('common:notifications.applicationSaved.label'),
+        text: t('common:notifications.applicationSaved.message', {
+          applicantName,
+        }),
+      });
 
       await router.push('/');
       return result;

--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -142,7 +142,7 @@ const useFormActions = (
         result?.employee?.first_name,
         result?.employee?.last_name
       );
-      const applicantName = fullName ? `(${fullName})` : 'ff';
+      const applicantName = fullName ? `(${fullName})` : '';
       const applicationNumber = result?.application_number ?? '';
 
       hdsToast({

--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -142,13 +142,15 @@ const useFormActions = (
         result?.employee?.first_name,
         result?.employee?.last_name
       );
-      const applicantName = fullName ? `(${fullName})` : '';
+      const applicantName = fullName ? `(${fullName})` : 'ff';
+      const applicationNumber = result?.application_number ?? '';
 
       hdsToast({
         autoDismissTime: 5000,
         type: 'success',
         labelText: t('common:notifications.applicationSaved.label'),
         text: t('common:notifications.applicationSaved.message', {
+          applicationNumber,
           applicantName,
         }),
       });

--- a/frontend/benefit/applicant/src/utils/common.ts
+++ b/frontend/benefit/applicant/src/utils/common.ts
@@ -28,7 +28,7 @@ export const getApplicationStepFromString = (step: string): number => {
 export const getApplicationStepString = (step: number): string =>
   `step_${step}`;
 
-export const getApplicantFullName = (
+export const getFullName = (
   firstName: string | undefined,
   lastName: string | undefined
-): string => `${firstName || ''} ${lastName || ''}`;
+): string => [firstName, lastName].join(' ').trim();


### PR DESCRIPTION
## Description :sparkles:
- Show success notification upon saving the application

## Issues :bug:

## Testing :alembic:
- Go to any step of the application, click on "Tallenna ja jatka myöhemmin" at the bottom of the page
- If the saving goes successfully, you will be redirected to the home page
- A success notification will be displayed with the applicant's name (if filled in) and the application number on it

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/137445210-fdb11de6-d082-4471-a77f-e17c56a2f72e.png)

## Additional notes :spiral_notepad:
- The application number is now not assigned due to a bug in the backend