### PR TITLE
HL-256 | Add the required asterisk to the attachments headers

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step3/ApplicationFormStep3.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step3/ApplicationFormStep3.tsx
@@ -35,11 +35,13 @@ const ApplicationFormStep3: React.FC<DynamicFormStepComponentProps> = ({
           <AttachmentsList
             attachments={attachments}
             attachmentType={ATTACHMENT_TYPES.EMPLOYMENT_CONTRACT}
+            required
           />
           {apprenticeshipProgram && (
             <AttachmentsList
               attachments={attachments}
               attachmentType={ATTACHMENT_TYPES.EDUCATION_CONTRACT}
+              required
             />
           )}
           {paySubsidyGranted && (
@@ -47,6 +49,7 @@ const ApplicationFormStep3: React.FC<DynamicFormStepComponentProps> = ({
               attachments={attachments}
               attachmentType={ATTACHMENT_TYPES.PAY_SUBSIDY_CONTRACT}
               showMessage={showSubsidyMessage}
+              required
             />
           )}
         </>
@@ -55,6 +58,7 @@ const ApplicationFormStep3: React.FC<DynamicFormStepComponentProps> = ({
         <AttachmentsList
           attachments={attachments}
           attachmentType={ATTACHMENT_TYPES.COMMISSION_CONTRACT}
+          required
         />
       )}
       <AttachmentsList

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step3/attachmentsList/AttachmentsList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step3/attachmentsList/AttachmentsList.tsx
@@ -10,12 +10,14 @@ export interface AttachmentsListProps {
   attachmentType: ATTACHMENT_TYPES;
   showMessage?: boolean;
   attachments?: Attachment[];
+  required?: boolean;
 }
 
 const AttachmentsList: React.FC<AttachmentsListProps> = ({
   attachmentType,
   showMessage,
   attachments,
+  required,
 }) => {
   const {
     t,
@@ -42,6 +44,7 @@ const AttachmentsList: React.FC<AttachmentsListProps> = ({
       onOpen={handleOpenFile}
       isUploading={isUploading}
       isRemoving={isRemoving}
+      required={required}
     />
   );
 };


### PR DESCRIPTION
## Description :sparkles:
- Add the required asterisk to the attachments headers

## Issues :bug:

## Testing :alembic:
- On the application's fourth step, an asterisk indicates that the attachment is required

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/137482891-94dd04b0-7ea1-486d-85cc-914ed11c2d7f.png)

## Additional notes :spiral_notepad:
