### PR TITLE
HL-228 | Remove the link from the Helsinki logo on the header

### DIFF
--- a/frontend/benefit/applicant/src/components/header/Header.tsx
+++ b/frontend/benefit/applicant/src/components/header/Header.tsx
@@ -10,7 +10,6 @@ const Header: React.FC = () => {
     languageOptions,
     handleLanguageChange,
     handleNavigationItemClick,
-    handleTitleClick,
   } = useHeader();
 
   return (
@@ -21,7 +20,6 @@ const Header: React.FC = () => {
       locale={locale}
       onLanguageChange={handleLanguageChange}
       onNavigationItemClick={handleNavigationItemClick}
-      onTitleClick={handleTitleClick}
     />
   );
 };

--- a/frontend/benefit/applicant/src/components/header/useHeader.ts
+++ b/frontend/benefit/applicant/src/components/header/useHeader.ts
@@ -16,7 +16,6 @@ type ExtendedComponentProps = {
     newLanguage: OptionType<string>
   ) => void;
   handleNavigationItemClick: (pathname: string) => void;
-  handleTitleClick: () => void;
 };
 
 const useHeader = (): ExtendedComponentProps => {
@@ -41,15 +40,12 @@ const useHeader = (): ExtendedComponentProps => {
     void router.push(pathname);
   };
 
-  const handleTitleClick = (): void => handleNavigationItemClick('/');
-
   return {
     t,
     languageOptions,
     locale,
     handleLanguageChange,
     handleNavigationItemClick,
-    handleTitleClick,
   };
 };
 

--- a/frontend/shared/src/components/header/Header.tsx
+++ b/frontend/shared/src/components/header/Header.tsx
@@ -16,7 +16,7 @@ export type HeaderProps = {
     e: React.SyntheticEvent<unknown>,
     language: OptionType<string>
   ) => void;
-  onTitleClick: (callback: () => void) => void;
+  onTitleClick?: (callback: () => void) => void;
   onNavigationItemClick: (pathname: string) => void;
   login?: {
     isAuthenticated: boolean;
@@ -50,6 +50,10 @@ const Header: React.FC<HeaderProps> = ({
     handleLogout,
   } = useHeader(locale, onNavigationItemClick, login);
 
+  const handleTitleClick = onTitleClick
+    ? () => onTitleClick(closeMenu)
+    : undefined;
+
   return (
     <Navigation
       menuOpen={menuOpen}
@@ -57,7 +61,7 @@ const Header: React.FC<HeaderProps> = ({
       menuToggleAriaLabel={menuToggleAriaLabel || ''}
       skipTo={`#${MAIN_CONTENT_ID}`}
       skipToContentLabel={MAIN_CONTENT_ID}
-      onTitleClick={() => onTitleClick(closeMenu)}
+      onTitleClick={handleTitleClick}
       logoLanguage={logoLang as LogoLanguage}
       title={title}
     >


### PR DESCRIPTION
## Description :sparkles:
- Remove the link from the Helsinki logo on the header

## Issues :bug:

## Testing :alembic:
- The Helsinki logo on the header is no longer clickable 

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
