### PR TITLE
HL-264: fix missing application number in API

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -498,6 +498,7 @@ class ApplicationSerializer(serializers.ModelSerializer):
             "id",
             "status",
             "employee",
+            "application_number",
             "applicant_terms_approval",
             "approve_terms",
             "batch",

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -108,6 +108,7 @@ def test_application_single_read(api_client, application):
     response = api_client.get(get_detail_url(application))
     assert response.data["batch"] is None
     assert response.data["ahjo_decision"] is None
+    assert response.data["application_number"] is not None
     assert response.status_code == 200
 
 


### PR DESCRIPTION
## Description :sparkles:

Add application_number to API fields

## Issues :bug:
HL-264

## Testing :alembic:
backend/benefit/applications/tests/test_applications_api.py:test_application_single_read

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
