### PR TITLE
YJDH-216 | Frontend: Add padding to accordion header

### DIFF
--- a/frontend/shared/src/components/accordion/Accordion.module.sc.ts
+++ b/frontend/shared/src/components/accordion/Accordion.module.sc.ts
@@ -45,4 +45,5 @@ export const $HeadingContainer = styled.div`
   justify-content: space-between;
   align-items: center;
   box-sizing: border-box;
+  padding-right: var(--spacing-m);
 `;


### PR DESCRIPTION
## Description :sparkles:

Add padding to the accordion heading container.

## Issues :bug:

[YJDH-216](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-216)

## Testing :alembic:

## Screenshots :camera_flash:

![image](https://user-images.githubusercontent.com/31963063/137684076-c3f0ce56-89e2-4bf2-afc7-b1d751e91eb7.png)

## Additional notes :spiral_notepad:
