### PR TITLE
YJDH-216 | KS-Employer: Add red border on invalid fields

### DIFF
--- a/frontend/kesaseteli/employer/src/components/application/form/DateInput.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/DateInput.tsx
@@ -50,6 +50,7 @@ const DateInput = ({
     clearErrors,
     setValue,
     clearValue,
+    hasError,
   } = useApplicationFormField<string>(id);
 
   const date = convertToUIDateFormat(getValue());
@@ -108,6 +109,8 @@ const DateInput = ({
         onChange={handleChange}
         errorText={errorText}
         label={defaultLabel}
+        invalid={hasError()}
+        aria-invalid={hasError()}
       />
     </$GridCell>
   );

--- a/frontend/kesaseteli/employer/src/components/application/form/TextInput.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/TextInput.tsx
@@ -53,7 +53,7 @@ const TextInput: React.FC<TextInputProps> = ({
   const { t } = useTranslation();
   const { register } = useFormContext<Application>();
 
-  const { getValue, getError, fieldName, getErrorText } =
+  const { getValue, getError, fieldName, getErrorText, hasError } =
     useApplicationFormField<string>(id);
 
   const errorText = React.useMemo((): string | undefined => {
@@ -96,6 +96,8 @@ const TextInput: React.FC<TextInputProps> = ({
         defaultValue={getValue()}
         errorText={errorText}
         label={t(`common:application.form.inputs.${fieldName}`)}
+        invalid={hasError()}
+        aria-invalid={hasError()}
       />
     </$GridCell>
   );


### PR DESCRIPTION
## Description :sparkles:

Add red error border when submitting fields with invalid data.

## Issues :bug:

https://helsinkisolutionoffice.atlassian.net/browse/YJDH-216

## Testing :alembic:

## Screenshots :camera_flash:

![image](https://user-images.githubusercontent.com/31963063/137708362-2ca3e598-6365-4600-a1d3-b735ec9316e1.png)

## Additional notes :spiral_notepad:
