### PR TITLE
YJDH-216 | KS-Employer: Scroll to top of page on wizard transitions

### DIFF
--- a/frontend/shared/src/components/wizard/Wizard.tsx
+++ b/frontend/shared/src/components/wizard/Wizard.tsx
@@ -23,12 +23,16 @@ const Wizard: React.FC<WizardProps> = React.memo(
     const goToNextStep = React.useRef((stepIndex?: number) => {
       if (hasNextStep.current || stepIndex) {
         setActiveStep((step) => stepIndex ?? step + 1);
+        // Scroll to top
+        window.scrollTo(0, 0);
       }
     });
 
     const goToPreviousStep = React.useRef((stepIndex?: number) => {
       if (hasPreviousStep.current || stepIndex) {
         setActiveStep((step) => stepIndex ?? step - 1);
+        // Scroll to top
+        window.scrollTo(0, 0);
       }
     });
 


### PR DESCRIPTION
## Description :sparkles:

Scroll to the top of the page when going to the next or previous step in the application wizard.

## Issues :bug:

[YJDH-216](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-216)

## Testing :alembic:

## Screenshots :camera_flash:

https://user-images.githubusercontent.com/31963063/137727493-d99be5e4-92b8-4cfb-9530-ec3aa7bdb4df.mp4

## Additional notes :spiral_notepad:
