### PR TITLE
Kesäseteli: Add client max body size to local nginx

### DIFF
--- a/localdevelopment/kesaseteli/nginx/nginx.conf
+++ b/localdevelopment/kesaseteli/nginx/nginx.conf
@@ -8,6 +8,7 @@ http {
         ssl_certificate_key localhost.key;
         # Redirect http requests to https
         error_page 497 https://$host:$server_port$request_uri;
+        client_max_body_size 20M;
         location / {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -22,6 +23,7 @@ http {
         server_name localhost;
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
+        client_max_body_size 20M;
         location / {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Description :sparkles:

Add `client_max_body_size 20M;` to local nginx conf to allow uploading large files.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
