### PR TITLE
YJDH-268 | KS-Employer: Add accessability statement to footer

### DIFF
--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -80,7 +80,7 @@
           "9th_grader": "9th grader",
           "born_2004": "Born in 2004"
         },
-        "hired_without_voucher_assessment" : {
+        "hired_without_voucher_assessment": {
           "yes": "Yes",
           "no": "No",
           "maybe": "Maybe"
@@ -141,7 +141,9 @@
     "copyrightText": "City of Helsinki",
     "allRightsReservedText": "All rights reserved",
     "accessibilityStatement": "Accessibility statement",
-    "information": "Information on the service"
+    "accessibilityStatementLink": "https://www.hel.fi/helsinki/en/administration/information/accessibility/accessibility-statements",
+    "information": "Information on the service",
+    "informationLink": "https://kesaseteli.fi/en/"
   },
   "languages": {
     "fi": "Suomeksi",
@@ -171,7 +173,7 @@
     "errorMessage": "Something went wrong. Please try again later."
   },
   "applications": {
-    "sections" : {
+    "sections": {
       "attachments": {
         "types": {
           "employment_contract": {

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -80,7 +80,7 @@
           "9th_grader": "9.-luokkalainen",
           "born_2004": "Syntynyt vuonna 2004"
         },
-        "hired_without_voucher_assessment" : {
+        "hired_without_voucher_assessment": {
           "yes": "Kyllä",
           "no": "En",
           "maybe": "Ehkä"
@@ -141,7 +141,9 @@
     "copyrightText": "Helsingin kaupunki",
     "allRightsReservedText": "Kaikki oikeudet pidätetään",
     "accessibilityStatement": "Saavutettavuusseloste",
-    "information": "Tietoa palvelusta"
+    "accessibilityStatementLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/saavutettavuus/saavutettavuusselosteet",
+    "information": "Tietoa palvelusta",
+    "informationLink": "https://kesaseteli.fi/"
   },
   "languages": {
     "fi": "Suomeksi",
@@ -171,7 +173,7 @@
     "errorMessage": "Jotain meni pieleen. Yritä myöhemmin uudelleen."
   },
   "applications": {
-    "sections" : {
+    "sections": {
       "attachments": {
         "types": {
           "employment_contract": {

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -80,7 +80,7 @@
           "9th_grader": "9 klassist",
           "born_2004": "Född 2004"
         },
-        "hired_without_voucher_assessment" : {
+        "hired_without_voucher_assessment": {
           "yes": "Jo",
           "no": "Nej",
           "maybe": "Kanske"
@@ -141,7 +141,9 @@
     "copyrightText": "Helsingfors stad",
     "allRightsReservedText": "Med ensamrätt",
     "accessibilityStatement": "Tillgänglighetsutlåtande",
-    "information": "Information om servicen"
+    "accessibilityStatementLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/tillganglighet/tillganglighetsutlatanden",
+    "information": "Information om servicen",
+    "informationLink": "https://kesaseteli.fi/sv/"
   },
   "languages": {
     "fi": "Suomeksi",
@@ -171,7 +173,7 @@
     "errorMessage": "Något gick fel. Försök igen senare."
   },
   "applications": {
-    "sections" : {
+    "sections": {
       "attachments": {
         "types": {
           "employment_contract": {

--- a/frontend/kesaseteli/employer/src/components/footer/Footer.tsx
+++ b/frontend/kesaseteli/employer/src/components/footer/Footer.tsx
@@ -12,7 +12,22 @@ const FooterSection: React.FC = () => {
         <Footer.Base
           copyrightHolder={t('common:footer.copyrightText')}
           copyrightText={t('common:footer.allRightsReservedText')}
-        />
+        >
+          <Footer.Item
+            as="a"
+            rel="noopener noreferrer"
+            target="_blank"
+            href={t('common:footer.informationLink')}
+            label={t('common:footer.information')}
+          />
+          <Footer.Item
+            as="a"
+            rel="noopener noreferrer"
+            target="_blank"
+            href={t('common:footer.accessibilityStatementLink')}
+            label={t('common:footer.accessibilityStatement')}
+          />
+        </Footer.Base>
       </Footer>
     </$FooterWrapper>
   );


### PR DESCRIPTION
## Description :sparkles:

Add accessability statement link and service information link to the footer element.

## Issues :bug:

[YJDH-268](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-268)
[YJDH-269](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-269)

## Testing :alembic:

## Screenshots :camera_flash:

![image](https://user-images.githubusercontent.com/31963063/138427318-66d784e6-1993-4961-8eb6-417b34b1ee0c.png)

## Additional notes :spiral_notepad:
