### PR TITLE
Fix chicken and egg checking

### DIFF
--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -11,6 +11,7 @@ from companies.tests.data.company_data import (
 )
 from django.conf import settings
 from django.test import override_settings
+from requests import HTTPError
 
 
 def get_company_api_url(business_id=""):
@@ -109,10 +110,8 @@ def test_get_company_from_ytj_results_in_error(
     requests_mock.get(matcher, text="Error", status_code=404)
     # Delete company so that API cannot return object from DB
     mock_get_organisation_roles_and_create_company.delete()
-    response = api_client.get(get_company_api_url())
-
-    assert response.status_code == 403
-    assert response.data["detail"] == "Company information is not available"
+    with pytest.raises(HTTPError):
+        api_client.get(get_company_api_url())
 
 
 @pytest.mark.django_db

--- a/backend/benefit/users/utils.py
+++ b/backend/benefit/users/utils.py
@@ -1,4 +1,5 @@
 from companies.models import Company
+from companies.services import get_or_create_company_with_business_id
 from django.conf import settings
 
 from shared.oidc.utils import get_organization_roles
@@ -24,8 +25,14 @@ def get_company_from_user(user):
         return Company.objects.all().order_by("name").first()
 
     if business_id := get_business_id_from_user(user):
-        return Company.objects.filter(
-            business_id=business_id
-        ).first()  # unique constraint ensures at most one is returned
+        try:
+            return Company.objects.get(
+                business_id=business_id
+            )  # unique constraint ensures at most one is returned
+        except Company.DoesNotExist:
+            # In case we cannot find the Company in DB, try to query it from 3rd party source
+            # This should cover the case when first applicant of company log in because his company
+            # hasn't been created yet
+            return get_or_create_company_with_business_id(business_id)
     else:
         return None


### PR DESCRIPTION
## Description :sparkles:
There is a chicken and egg problem when checking ToS approval. When querying company info, you have to accept ToS, but in order to pass the ToS check, the company data must be present.
If inside ToS approval check, we can create the company if it's not present in the DB, then the problem should be solved.


## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
