### PR TITLE
YKDH-263: Bugfix: cannot type a date with two digit day with keyboard to the date input

### DIFF
--- a/frontend/kesaseteli/employer/src/components/application/form/DateInput.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/DateInput.tsx
@@ -1,6 +1,7 @@
 import { DateInput as HdsDateInput } from 'hds-react';
 import useApplicationFormField from 'kesaseteli/employer/hooks/application/useApplicationFormField';
 import isEmpty from 'lodash/isEmpty';
+import noop from 'lodash/noop';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import {
@@ -80,9 +81,9 @@ const DateInput = ({
   }, [errorType, errorMessage, setError, t]);
 
   // TODO: This can be removed after backend supports invalid values in draft save
-  const handleChange = React.useCallback(
-    (dateString: string) => {
-      const uiDate = convertToUIDateFormat(dateString);
+  const handleBlur = React.useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      const uiDate = convertToUIDateFormat(event.target.value);
       if (isEmpty(uiDate)) {
         setError({ type: 'pattern' });
         clearValue();
@@ -110,9 +111,8 @@ const DateInput = ({
         initialMonth={new Date()}
         defaultValue={date}
         language={locale}
-        // for some reason date picker causes error "Cannot read property 'createEvent' of null" in tests. It's not needed for tests so it's disabled for them.
-        disableDatePicker={process.env.NODE_ENV === 'test'}
-        onChange={handleChange}
+        onBlur={handleBlur}
+        onChange={noop}
         errorText={getErrorText()}
         label={defaultLabel}
         invalid={hasError()}


### PR DESCRIPTION
## Description :sparkles:
It was impossible to type with keyboard a date with two day digits (eg. 12.5.2020) because onChange function jumps the caret position to the end if the date is invalid during typing. Fixed by using onBlur instead.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
