### PR TITLE
YJDH-271 | KS-Employer: Add aria role button to wizard steps

### DIFF
--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -35,6 +35,7 @@
     "common_error": "An unexpected error occurred: ",
     "loading": "Loading the application...",
     "loadingFinished": "Loading the application is complete",
+    "wizardStepButton": "Go to step",
     "step1": {
       "name": "Employer",
       "header": "1. Details of the employer",

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -35,6 +35,7 @@
     "common_error": "Tapahtui odottamaton virhe",
     "loading": "Ladataan hakemusta...",
     "loadingFinished": "Hakemuksen lataus on valmis",
+    "wizardStepButton": "Siirry hakemuksen vaiheeseen",
     "step1": {
       "name": "Työnantaja",
       "header": "1. Työnantajan tiedot",

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -35,6 +35,7 @@
     "common_error": "Ett oförväntat fel skedde",
     "loading": "Ansökan laddas...",
     "loadingFinished": "Nedladdningen av ansökan är färdig",
+    "wizardStepButton": "Gå till steg",
     "step1": {
       "name": "Arbetsgivare",
       "header": "1. Arbetsgivarens uppgifter",

--- a/frontend/shared/src/components/stepper/WizardStep.tsx
+++ b/frontend/shared/src/components/stepper/WizardStep.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import useWizard from 'shared/hooks/useWizard';
 
@@ -6,6 +7,7 @@ import { $StepCircle, $StepContainer, $StepTitle } from './Stepper.sc';
 type Props = { title: string; index?: number; lastVisitedStep?: number };
 
 const WizardStep: React.FC<Props> = ({ title, index = 0, lastVisitedStep }) => {
+  const { t } = useTranslation();
   const { activeStep, goToPreviousStep, goToNextStep } = useWizard();
   const isActive = index < (lastVisitedStep ?? activeStep + 1);
 
@@ -25,7 +27,17 @@ const WizardStep: React.FC<Props> = ({ title, index = 0, lastVisitedStep }) => {
     <$StepContainer
       onClick={goToStep}
       isActive={isActive}
-      role={isActive ? 'button' : undefined}
+      role="button"
+      aria-disabled={!isActive}
+      aria-label={`${t('common:application.wizardStepButton')} ${t(
+        `common:application.step${index + 1}.header`
+      )}`}
+      tabIndex={0}
+      onKeyPress={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          goToStep();
+        }
+      }}
     >
       <$StepCircle isActive={isActive}>{index + 1}</$StepCircle>
       <$StepTitle isActive={isActive}>{title}</$StepTitle>


### PR DESCRIPTION
## Description :sparkles:

Add `role="button"` for active step buttons in the wizard steps.

## Issues :bug:

[YJDH-271](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-271)
[YJDH-279](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-279)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
