### PR TITLE
HL-215 | Add Talpa export endpoint

### DIFF
--- a/backend/benefit/applications/api/v1/application_batch_views.py
+++ b/backend/benefit/applications/api/v1/application_batch_views.py
@@ -2,7 +2,10 @@ from applications.api.v1.serializers import ApplicationBatchSerializer
 from applications.enums import ApplicationBatchStatus
 from applications.models import ApplicationBatch
 from applications.services.ahjo_integration import export_application_batch
+from applications.services.talpa_integration import TalpaService
+from common.authentications import RobotBasicAuthentication
 from common.permissions import BFIsAuthenticated, TermsOfServiceAccepted
+from django.db import transaction
 from django.http import HttpResponse
 from django.utils import timezone
 from django.utils.text import format_lazy
@@ -12,6 +15,7 @@ from django_filters.widgets import CSVWidget
 from drf_spectacular.utils import extend_schema
 from rest_framework import filters as drf_filters, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 
@@ -87,4 +91,41 @@ class ApplicationBatchViewSet(viewsets.ModelViewSet):
         response["Content-Disposition"] = "attachment; filename={file_name}.zip".format(
             file_name=file_name
         )
+        return response
+
+    @action(
+        methods=("GET",),
+        detail=False,
+        url_path="talpa_export",
+        authentication_classes=[RobotBasicAuthentication],
+        permission_classes=[AllowAny],
+    )
+    @transaction.atomic
+    def talpa_export_batch(self, request, *args, **kwargs):
+        """
+        Export ApplicationBatch to CSV format for Talpa Robot
+        """
+        approved_batches = ApplicationBatch.objects.filter(
+            status=ApplicationBatchStatus.DECIDED_ACCEPTED
+        )
+        if approved_batches.count() == 0:
+            return Response(
+                {
+                    "detail": _(
+                        "There is no available application to export, please try again later"
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        talpa_service = TalpaService(approved_batches)
+        csv_file = talpa_service.get_talpa_csv_string()
+        file_name = format_lazy(
+            _("TALPA export {date}"),
+            date=timezone.now().strftime("%d-%m-%Y %H.%M.%S"),
+        )
+        response = HttpResponse(csv_file, content_type="text/csv")
+        response["Content-Disposition"] = "attachment; filename={file_name}.csv".format(
+            file_name=file_name
+        )
+        approved_batches.all().update(status=ApplicationBatchStatus.SENT_TO_TALPA)
         return response

--- a/backend/benefit/applications/services/talpa_integration.py
+++ b/backend/benefit/applications/services/talpa_integration.py
@@ -48,8 +48,8 @@ class TalpaService:
     def _get_header_row(self):
         return [col.heading for col in self.TALPA_COLUMNS]
 
-    def __init__(self, application_batch):
-        self.application_batch = application_batch
+    def __init__(self, application_batches):
+        self.application_batches = application_batches
 
     def write_talpa_csv_file(self, path):
         csv_string = self.get_talpa_csv_string()
@@ -60,7 +60,9 @@ class TalpaService:
         return self._make_csv(self.get_talpa_lines())
 
     def get_applications(self):
-        return self.application_batch.applications.order_by(
+        from applications.models import Application
+
+        return Application.objects.filter(batch__in=self.application_batches).order_by(
             "company__name", "application_number"
         )
 

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -35,7 +35,7 @@ def application_batch():
 
 @pytest.fixture
 def talpa_service(application_batch):
-    return TalpaService(application_batch)
+    return TalpaService([application_batch])
 
 
 @pytest.fixture

--- a/backend/benefit/applications/tests/test_talpa_integration.py
+++ b/backend/benefit/applications/tests/test_talpa_integration.py
@@ -63,7 +63,7 @@ def test_talpa_csv_decimal(talpa_service_with_one_application):
 def test_talpa_csv_date(talpa_service_with_one_application):
     application = talpa_service_with_one_application.get_applications().first()
     application.batch.decision_date = datetime.date(2021, 8, 27)
-    application.save()
+    application.batch.save()
     csv_lines = _split_csv(talpa_service_with_one_application.get_talpa_csv_string())
     assert csv_lines[1][11] == '"2021-08-27"'
 
@@ -71,7 +71,7 @@ def test_talpa_csv_date(talpa_service_with_one_application):
 def test_talpa_csv_missing_data(talpa_service_with_one_application):
     application = talpa_service_with_one_application.get_applications().first()
     application.batch.decision_date = None
-    application.save()
+    application.batch.save()
     with pytest.raises(ValueError):
         talpa_service_with_one_application.get_talpa_csv_string()
 

--- a/backend/benefit/common/authentications.py
+++ b/backend/benefit/common/authentications.py
@@ -1,0 +1,39 @@
+import binascii
+from base64 import b64decode
+
+from django.conf import settings
+from rest_framework import authentication
+from rest_framework.exceptions import AuthenticationFailed
+
+
+class RobotBasicAuthentication(authentication.BaseAuthentication):
+    """
+    HTTP Basic authentication against preset credentials.
+    """
+
+    www_authenticate_realm = "api"
+    credentials = settings.TALPA_ROBOT_AUTH_CREDENTIAL
+
+    def authenticate(self, request):
+        try:
+            auth, encoded = authentication.get_authorization_header(request).split(
+                maxsplit=1
+            )
+        except ValueError:
+            raise AuthenticationFailed("Invalid basic header.")
+
+        if not auth or auth.lower() != b"basic":
+            raise AuthenticationFailed("Authentication needed")
+
+        try:
+            credentials = b64decode(encoded).decode(authentication.HTTP_HEADER_ENCODING)
+        except (TypeError, UnicodeDecodeError, binascii.Error):
+            raise AuthenticationFailed(
+                "Invalid basic header. Credentials not correctly base64 encoded."
+            )
+
+        if self.credentials != credentials:
+            raise AuthenticationFailed("Invalid username/password.")
+
+    def authenticate_header(self, request):
+        return 'Basic realm="{}"'.format(self.www_authenticate_realm)

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -90,6 +90,7 @@ env = environ.Env(
     DUMMY_COMPANY_FORM=(str, "OY"),
     TERMS_OF_SERVICE_SESSION_KEY=(str, "_tos_session"),
     ENABLE_DEBUG_ENV=(bool, False),
+    TALPA_ROBOT_AUTH_CREDENTIAL=(str, "username:password"),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -332,6 +333,8 @@ MAX_UPLOAD_SIZE = 10485760  # 10MB
 MINIMUM_WORKING_HOURS_PER_WEEK = env("MINIMUM_WORKING_HOURS_PER_WEEK")
 
 WKHTMLTOPDF_BIN = env("WKHTMLTOPDF_BIN")
+
+TALPA_ROBOT_AUTH_CREDENTIAL = env("TALPA_ROBOT_AUTH_CREDENTIAL")
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.


### PR DESCRIPTION
## Description :sparkles:
- Added a new endpoint for Talpa robot to export application batch payment data
- Endpoint is secured using basic authentication
- IP restriction should be done using azure gateway so it's not in the scope of this change
- Slight modification to `talpa_service.py` in order to support multiple batches export
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
