### PR TITLE
Accessibility: fix skip to content -link

### DIFF
--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -3,7 +3,8 @@
   "header": {
     "loginLabel": "Sign in to the service",
     "logoutLabel": "Log out",
-    "userAriaLabelPrefix": "User:"
+    "userAriaLabelPrefix": "User:",
+    "linkSkipToContent": "Skip to content"
   },
   "errorPage": {
     "title": "An unexpected error occured",

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -3,7 +3,8 @@
   "header": {
     "loginLabel": "Kirjaudu palveluun",
     "logoutLabel": "Kirjaudu ulos",
-    "userAriaLabelPrefix": "Käyttäjä:"
+    "userAriaLabelPrefix": "Käyttäjä:",
+    "linkSkipToContent": "Siirry sisältöön"
   },
   "errorPage": {
     "title": "Tapahtui odottamaton virhe",

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -3,7 +3,8 @@
   "header": {
     "loginLabel": "Logga in i tjänsten",
     "logoutLabel": "Logga ut",
-    "userAriaLabelPrefix": "Användaren:"
+    "userAriaLabelPrefix": "Användaren:",
+    "linkSkipToContent": "Gå till innehållet"
   },
   "errorPage": {
     "title": "Ett oförväntat fel skedde",

--- a/frontend/kesaseteli/employer/src/components/header/Header.tsx
+++ b/frontend/kesaseteli/employer/src/components/header/Header.tsx
@@ -59,6 +59,7 @@ const Header: React.FC = () => {
   return (
     <BaseHeader
       title={t('common:appName')}
+      skipToContentLabel={t('common:header.linkSkipToContent')}
       menuToggleAriaLabel={t('common:menuToggleAriaLabel')}
       languages={languageOptions}
       locale={locale}

--- a/frontend/shared/src/components/Layout.tsx
+++ b/frontend/shared/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 const Heading = styled.h1`
@@ -14,7 +14,7 @@ const Main = styled.main`
 type AppProps = { children: React.ReactNode; headingText?: string };
 
 const Layout: React.FC<AppProps> = ({ children, headingText }) => (
-  <Main id="main_content">
+  <Main>
     {headingText && <Heading>{headingText}</Heading>}
     {children}
   </Main>

--- a/frontend/shared/src/components/content/Content.tsx
+++ b/frontend/shared/src/components/content/Content.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
+import React from 'react';
+import { MAIN_CONTENT_ID } from 'shared/constants';
 
 import { $Content } from './Content.sc';
 
 type ContentProps = { children: React.ReactNode };
 
 const Content: React.FC<ContentProps> = ({ children }) => (
-  <$Content>{children}</$Content>
+  <$Content id={MAIN_CONTENT_ID}>{children}</$Content>
 );
 
 export default Content;

--- a/frontend/shared/src/components/header/Header.tsx
+++ b/frontend/shared/src/components/header/Header.tsx
@@ -8,6 +8,7 @@ import { useHeader } from './useHeader';
 
 export type HeaderProps = {
   title?: string;
+  skipToContentLabel?: string;
   menuToggleAriaLabel?: string;
   locale: string;
   languages: OptionType<string>[];
@@ -30,6 +31,7 @@ export type HeaderProps = {
 };
 
 const Header: React.FC<HeaderProps> = ({
+  skipToContentLabel,
   title,
   menuToggleAriaLabel,
   languages,
@@ -60,7 +62,7 @@ const Header: React.FC<HeaderProps> = ({
       onMenuToggle={toggleMenu}
       menuToggleAriaLabel={menuToggleAriaLabel || ''}
       skipTo={`#${MAIN_CONTENT_ID}`}
-      skipToContentLabel={MAIN_CONTENT_ID}
+      skipToContentLabel={skipToContentLabel}
       onTitleClick={handleTitleClick}
       logoLanguage={logoLang as LogoLanguage}
       title={title}

--- a/frontend/shared/src/components/layout/Layout.tsx
+++ b/frontend/shared/src/components/layout/Layout.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react';
-import { MAIN_CONTENT_ID } from 'shared/constants';
 
 import { $Main } from './Layout.sc';
 
 type Props = { children: React.ReactNode };
 
-const Layout: React.FC<Props> = ({ children }) => (
-  <$Main id={MAIN_CONTENT_ID} data-testid={MAIN_CONTENT_ID}>
-    {children}
-  </$Main>
-);
+const Layout: React.FC<Props> = ({ children }) => <$Main>{children}</$Main>;
 
 export default Layout;


### PR DESCRIPTION
## Description :sparkles:
Fix skip to content -link, previously the link was present but it didnt jump to the content because the main-component has the id instead of the content component. Also translations added.
![Screenshot 2021-10-26 at 9 44 39 AM](https://user-images.githubusercontent.com/7648194/138823208-e82920c3-cc59-4aa6-a8de-66c68f9df01d.png)

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
