### PR TITLE
HL-297: require only one pay subsidy decision attachment

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -745,10 +745,6 @@ class ApplicationSerializer(serializers.ModelSerializer):
             req.append(
                 (AttachmentType.PAY_SUBSIDY_DECISION, AttachmentRequirement.REQUIRED)
             )
-        if application.additional_pay_subsidy_percent:
-            req.append(
-                (AttachmentType.PAY_SUBSIDY_DECISION, AttachmentRequirement.REQUIRED)
-            )
         return req
 
     def get_attachment_requirements(self, obj):


### PR DESCRIPTION
even if applicant has two decisions

## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
