### PR TITLE
HL-294 | Fix resetting the Additional Pay Subsidy value

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -271,7 +271,9 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
                 options={[
                   {
                     label: selectLabel,
-                    value: '',
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore TODO: remove ts-ignore when HDS is fixed
+                    value: null,
                   },
                   ...subsidyOptions,
                 ]}


### PR DESCRIPTION
## Description :sparkles:
- Replace empty string with `null` value for resetting the value

## Issues :bug:

## Testing :alembic:
- Go to the second step 
- First, select the additional pay subsidy percentage value
- "Deselect" the value by choosing "Valitse" from the dropdown
- You should be able to proceed with the application by saving it or going to the next step

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
