### PR TITLE
HL-305 | Fix get organisation roles from session

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -1446,4 +1446,4 @@ class ApplicationSerializer(serializers.ModelSerializer):
         user = get_request_user_from_context(self)
         if settings.DISABLE_AUTHENTICATION:
             return Company.objects.all().order_by("name").first()
-        return get_company_from_user(user)
+        return get_company_from_user(user, self.context.get("request"))

--- a/backend/benefit/applications/api/v1/views.py
+++ b/backend/benefit/applications/api/v1/views.py
@@ -66,7 +66,7 @@ class ApplicationViewSet(viewsets.ModelViewSet):
             if user.is_handler():
                 return qs
             else:
-                company = get_company_from_user(user)
+                company = get_company_from_user(user, self.request)
                 if company:
                     return company.applications.all()
         return Application.objects.none()

--- a/backend/benefit/common/permissions.py
+++ b/backend/benefit/common/permissions.py
@@ -29,7 +29,7 @@ class TermsOfServiceAccepted(permissions.BasePermission):
         else:
             from terms.models import TermsOfServiceApproval
 
-            company = get_company_from_user(user)
+            company = get_company_from_user(user, request)
             if not company:
                 # company deleted from the db? Whatever has happened, applicant can't
                 # proceed without a company.

--- a/backend/benefit/terms/api/v1/views.py
+++ b/backend/benefit/terms/api/v1/views.py
@@ -35,7 +35,7 @@ class ApproveTermsOfServiceView(APIView):
         )  # validate the terms and applicant consents
         user = request.user
 
-        company = get_company_from_user(user)
+        company = get_company_from_user(user, request)
         if not company:
             raise PermissionDenied(
                 detail=_(

--- a/backend/benefit/users/api/v1/serializers.py
+++ b/backend/benefit/users/api/v1/serializers.py
@@ -65,5 +65,5 @@ class UserSerializer(serializers.ModelSerializer):
 
     def is_terms_of_service_approval_needed(self, obj):
         return TermsOfServiceApproval.terms_approval_needed(
-            obj, get_company_from_user(obj)
+            obj, get_company_from_user(obj, self.context.get("request"))
         )

--- a/backend/benefit/users/utils.py
+++ b/backend/benefit/users/utils.py
@@ -12,19 +12,19 @@ def get_request_user_from_context(serializer):
     return None
 
 
-def get_business_id_from_user(user):
+def get_business_id_from_user(user, request=None):
     if user.is_authenticated:
         eauth_profile = user.oidc_profile.eauthorization_profile
-        organization_roles = get_organization_roles(eauth_profile)
+        organization_roles = get_organization_roles(eauth_profile, request)
         return organization_roles.get("identifier")
     return None
 
 
-def get_company_from_user(user):
+def get_company_from_user(user, request=None):
     if settings.DISABLE_AUTHENTICATION:
         return Company.objects.all().order_by("name").first()
 
-    if business_id := get_business_id_from_user(user):
+    if business_id := get_business_id_from_user(user, request):
         try:
             return Company.objects.get(
                 business_id=business_id


### PR DESCRIPTION
## Description :sparkles:
There was a bug in the authentication flow that it always try to fetch the company info from eauth_profile, regardless the token expired in 10 minutes. This is because the `get_organization_roles` from `shared.oidc.utils` has been used incorrectly
Fixed by appending the request to the function
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
