### PR TITLE
YJDH-274 | KS-Employer: Adjust accessability of tooltips

### DIFF
--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -36,6 +36,7 @@
     "loading": "Loading the application...",
     "loadingFinished": "Loading the application is complete",
     "wizardStepButton": "Go to step",
+    "tooltipShowInfo": "Show information",
     "step1": {
       "name": "Employer",
       "header": "1. Details of the employer",

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -36,6 +36,7 @@
     "loading": "Ladataan hakemusta...",
     "loadingFinished": "Hakemuksen lataus on valmis",
     "wizardStepButton": "Siirry hakemuksen vaiheeseen",
+    "tooltipShowInfo": "Näytä info",
     "step1": {
       "name": "Työnantaja",
       "header": "1. Työnantajan tiedot",

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -36,6 +36,7 @@
     "loading": "Ansökan laddas...",
     "loadingFinished": "Nedladdningen av ansökan är färdig",
     "wizardStepButton": "Gå till steg",
+    "tooltipShowInfo": "Visa information",
     "step1": {
       "name": "Arbetsgivare",
       "header": "1. Arbetsgivarens uppgifter",

--- a/frontend/shared/src/components/forms/heading/Heading.tsx
+++ b/frontend/shared/src/components/forms/heading/Heading.tsx
@@ -1,4 +1,5 @@
 import { LoadingSpinner, Tooltip } from 'hds-react';
+import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 
 import { $Header, HeadingProps } from './Heading.sc';
@@ -9,12 +10,22 @@ const Heading: React.FC<HeadingProps> = ({
   header,
   loading,
   tooltip,
-}) => (
-  <$Header size={size} as={as}>
-    {header}
-    {tooltip && <Tooltip>{tooltip}</Tooltip>}
-    {loading && <LoadingSpinner small />}
-  </$Header>
-);
+}) => {
+  const { t } = useTranslation();
+  return (
+    <$Header size={size} as={as}>
+      {header}
+      {tooltip && (
+        <Tooltip
+          buttonLabel={t('common:application.tooltipShowInfo')}
+          tooltipLabel={tooltip}
+        >
+          {tooltip}
+        </Tooltip>
+      )}
+      {loading && <LoadingSpinner small />}
+    </$Header>
+  );
+};
 
 export default Heading;


### PR DESCRIPTION
## Description :sparkles:

Adjust the the tooltip buttons to show translated aria-labels for users with screen readers.

## Issues :bug:

[YJDH-274](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-274)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
