### PR TITLE
YJDH-293 | KS-Employer: Add modify datepicker validation

### DIFF
--- a/frontend/kesaseteli/employer/src/components/application/form/DateInput.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/DateInput.tsx
@@ -1,7 +1,6 @@
 import { DateInput as HdsDateInput } from 'hds-react';
 import useApplicationFormField from 'kesaseteli/employer/hooks/application/useApplicationFormField';
 import isEmpty from 'lodash/isEmpty';
-import noop from 'lodash/noop';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import { RegisterOptions, UseFormRegister } from 'react-hook-form';
@@ -78,9 +77,9 @@ const DateInput = ({
   }, [errorType, errorMessage, setError, t]);
 
   // TODO: This can be removed after backend supports invalid values in draft save
-  const handleBlur = React.useCallback(
-    (event: React.FocusEvent<HTMLInputElement>) => {
-      const uiDate = convertToUIDateFormat(event.target.value);
+  const handleChange = React.useCallback(
+    (dateString: string) => {
+      const uiDate = convertToUIDateFormat(dateString);
       if (isEmpty(uiDate)) {
         setError({ type: 'pattern' });
         clearValue();
@@ -111,8 +110,7 @@ const DateInput = ({
         // for some reason date picker causes error "Warning: An update to ForwardRef inside a test was not wrapped in act" in tests.
         // Date picker is not needed for tests so it's disabled for them.
         disableDatePicker={process.env.NODE_ENV === 'test'}
-        onBlur={handleBlur}
-        onChange={noop}
+        onChange={handleChange}
         errorText={getErrorText()}
         label={defaultLabel}
         invalid={hasError()}


### PR DESCRIPTION
## Description :sparkles:

Change the onBlur event to onChange to validate the datepicker value correctly even when the date is picked with the datepicker element instead of writing it.

## Issues :bug:

[YJDH-293](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-293)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
