### PR TITLE
Fix issue with do_delayed_calls_at_end when using multiple threads

### DIFF
--- a/backend/benefit/common/delay_call.py
+++ b/backend/benefit/common/delay_call.py
@@ -7,30 +7,35 @@ import threading
 __all__ = ["call_now_or_later", "do_delayed_calls_at_end"]
 
 _local = threading.local()
-_local.pending_calls = None
 
 _sentinel = object()
 
 
+def _get_pending_calls():
+    if not hasattr(_local, "pending_calls"):
+        _local.pending_calls = None
+    return _local.pending_calls
+
+
 def call_now_or_later(func, duplicate_check=None):
-    if _local.pending_calls is None:
+    if _get_pending_calls() is None:
         func()
     else:
         if duplicate_check is None:
             duplicate_check = (
                 _sentinel,
-                len(_local.pending_calls),
+                len(_get_pending_calls()),
                 func.__name__,
             )  # unique
-        _local.pending_calls[duplicate_check] = func
+        _get_pending_calls()[duplicate_check] = func
 
 
 def _call_all_pending():
-    if _local.pending_calls is None:
+    if _get_pending_calls() is None:
         raise Exception("This function must be used only with update_at_end")
-    for k, func in list(_local.pending_calls.items()):
+    for k, func in list(_get_pending_calls().items()):
         func()
-    _local.pending_calls.clear()
+    _get_pending_calls().clear()
 
 
 @contextlib.contextmanager
@@ -39,7 +44,7 @@ def do_delayed_calls_at_end():
     # @update_at_end()
     # def foo():
     #     ...
-    if _local.pending_calls is not None:
+    if _get_pending_calls() is not None:
         raise Exception(
             "Nested update_at_end not supported - need to use contextlib.ContextDecorator"
         )
@@ -53,4 +58,4 @@ def do_delayed_calls_at_end():
 
 
 def is_updates_pending():
-    return _local.pending_calls is not None and len(_local.pending_calls) > 0
+    return _get_pending_calls() is not None and len(_get_pending_calls()) > 0


### PR DESCRIPTION
## Description :sparkles:

update_now_or_later results in error when multiple threads are used, as threadlocal variable is not initialized

## Issues :bug: HL-317

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
