### PR TITLE
Try kolga deploy delay params

### DIFF
--- a/.github/workflows/bf-review.yml
+++ b/.github/workflows/bf-review.yml
@@ -33,6 +33,8 @@ env:
   K8S_REQUEST_RAM: 200Mi
   K8S_LIMIT_CPU: 500m
   K8S_LIMIT_RAM: 400Mi
+  K8S_PROBE_FAILURE_THRESHOLD: 30
+  K8S_PROBE_PERIOD: 20
   NEXT_PUBLIC_BACKEND_URL: https://helsinkibenefit-bf-bknd-${{ github.event.pull_request.number }}.${{ secrets.BASE_DOMAIN_STAGING }}
   MOCK_FLAG: 1
 jobs:

--- a/.github/workflows/ks-review.yml
+++ b/.github/workflows/ks-review.yml
@@ -33,6 +33,8 @@ env:
   K8S_REQUEST_RAM: 200Mi
   K8S_LIMIT_CPU: 500m
   K8S_LIMIT_RAM: 400Mi
+  K8S_PROBE_FAILURE_THRESHOLD: 30
+  K8S_PROBE_PERIOD: 20
   FRONTEND_URL: https://ks-empl-${{ github.event.pull_request.number }}.${{ secrets.BASE_DOMAIN_STAGING }}
   HANDLER_URL: https://ks-hndl-${{ github.event.pull_request.number }}.${{ secrets.BASE_DOMAIN_STAGING }}
   NEXT_PUBLIC_BACKEND_URL: https://ks-bknd-${{ github.event.pull_request.number }}.${{ secrets.BASE_DOMAIN_STAGING }}


### PR DESCRIPTION
## Description :sparkles:
Let's try the kolga delay parameters to fix occasionally failing deploys.
Added the following:
`  K8S_PROBE_FAILURE_THRESHOLD: 30
  K8S_PROBE_PERIOD: 20`
  So it should check every 20 second if the service is deployed, and repeating the check 30 times, so it would totally try 600 seconds (10 minutes) before giving up. Originally it would have failed after 210 seconds (3,5min). See description below for more details:
  
> You have the following ways to configure the startup time:

> K8S_PROBE_INITIAL_DELAY: This is the time Kubernetes waits before doing any checks for the application (default: 60)
> K8S_PROBE_FAILURE_THRESHOLD: This is the times the health check can fail before the application is seen as unhealthy (default: 3)
> K8S_PROBE_PERIOD: This is the time between health checks (default: 10)
> Say that you have the default values in use and you are deploying a single instance of an application, that would give you a timeout of:
> (1 * 60) + (3 * 10) + 120 = 210 seconds (3,5min)

> In other words, any startup time under 3,5min should not cause issues.

> Say that you have an application that needs between 8-10min to start up. Then you can do something in the lines of:

> K8S_PROBE_INITIAL_DELAY=480 (7,5min)
> K8S_PROBE_FAILURE_THRESHOLD=6
> K8S_PROBE_PERIOD=20
> This will give you a timeout of:
> (1 * 480) + (6 * 20) + 120 = 720 (12 min)

> and a start time of the application must be less than 720-120 = 600 (10min) 

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
