### PR TITLE
YJDH-327 | Use https in NEXT_PUBLIC_BACKEND_URL

### DIFF
--- a/.env.kesaseteli.example
+++ b/.env.kesaseteli.example
@@ -6,7 +6,7 @@ FRONTEND_URL=https://localhost:3000
 # test env FRONTEND_URL: https://yjdh-kesaseteli-ui-test.agw.arodevtest.hel.fi
 # staging env FRONTEND_URL: https://yjdh-kesaseteli-ui-stg.apps.platta.hel.fi
 HANDLER_URL=https://localhost:3100
-NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
+NEXT_PUBLIC_BACKEND_URL=https://localhost:8000
 
 # Authentication
 OIDC_OP_BASE_URL=https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect


### PR DESCRIPTION
PR #410 changed .env.kesaseteli.example NEXT_PUBLIC_BACKEND_URL from
https to http (See commit fdd152dabff7350a212b765eb65517c771c9cdfa).

This caused a problem in testing when copying .env.kesaseteli.example
to .env.kesaseteli and opening https://localhost:3000/:
 - "Access to XMLHttpRequest at 'http://localhost:8000/oidc/userinfo/'
   from origin 'https://localhost:3000' has been blocked by CORS policy:
   Response to preflight request doesn't pass access control check:
   Redirect is not allowed for a preflight request."

Change NEXT_PUBLIC_BACKEND_URL back to https. This removes the above
problem.

Refs YJDH-327