### PR TITLE
HL-318: re-enable running of employment benefit tests

### DIFF
--- a/backend/benefit/calculator/tests/test_handler_excel_examples.py
+++ b/backend/benefit/calculator/tests/test_handler_excel_examples.py
@@ -253,7 +253,7 @@ class EmployeeBenefitExcelTest(SalaryBenefitExcelTest):
 
 SHEETS_TO_TEST = [
     ("Palkan Helsinki-lisä", SalaryBenefitExcelTest),
-    # ("Työllistämisen Helsinki-lisä", EmploymentBenefitExcelTest),
+    ("Työllistämisen Helsinki-lisä", EmployeeBenefitExcelTest),
     # ("Palkkatuettu oppisopimus", ApprenticeshipExcelTest),
 ]
 


### PR DESCRIPTION
## Description :sparkles:

The final fix to the previous PR was left out by mistake

## Issues :bug: HL-318

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
