### PR TITLE
HL-292: Handlers review page logic

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/Applications.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/Applications.sc.ts
@@ -28,10 +28,10 @@ export const $PageSubHeading = styled.h3`
 `;
 
 export const $PageHeadingHelperText = styled.div`
-  font-size: ${(props) => props.theme.fontSize.heading.s};
+  font-size: ${(props) => props.theme.fontSize.heading.xs};
   font-weight: normal;
   margin-top: ${(props) => props.theme.spacing.l};
-  margin-bottom: ${(props) => props.theme.spacing.m};
+  //margin-bottom: ${(props) => props.theme.spacing.m};
 `;
 
 export const $SpinnerContainer = styled.div`

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
@@ -4,6 +4,7 @@ import { Button, IconPen } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { getFullName } from 'shared/utils/application.utils';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
 import { useTheme } from 'styled-components';
 
@@ -97,12 +98,10 @@ const CompanyInfoView: React.FC<CompanyInfoViewProps> = ({
       >
         <$GridCell $colSpan={3}>
           <$ViewField>
-            {[
+            {getFullName(
               data.companyContactPersonFirstName,
-              data.companyContactPersonLastName,
-            ]
-              .join(' ')
-              .trim()}
+              data.companyContactPersonLastName
+            )}
           </$ViewField>
           <$ViewField>{data.companyContactPersonPhoneNumber}</$ViewField>
           <$ViewField>{data.companyContactPersonEmail}</$ViewField>

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { getFullName } from 'shared/utils/application.utils';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
+import { formatStringFloatValue } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
 import {
@@ -150,7 +151,9 @@ const CompanyInfoView: React.FC<CompanyInfoViewProps> = ({
                   <$SummaryTableValue>{aid.granter}</$SummaryTableValue>
                 </$GridCell>
                 <$GridCell $colSpan={2}>
-                  <$SummaryTableValue>{aid.amount}</$SummaryTableValue>
+                  <$SummaryTableValue>
+                    {formatStringFloatValue(aid.amount)}
+                  </$SummaryTableValue>
                 </$GridCell>
                 <$GridCell>
                   <$SummaryTableValue>

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/__tests__/CompanyInfoView.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/__tests__/CompanyInfoView.test.tsx
@@ -1,5 +1,6 @@
 import { RenderResult } from '@testing-library/react';
 import renderComponent from 'benefit/applicant/__tests__/utils/render-component';
+import { ORGANIZATION_TYPES } from 'benefit/applicant/constants';
 import { axe } from 'jest-axe';
 import React from 'react';
 
@@ -16,6 +17,7 @@ describe('CompanyInfoView', () => {
         postcode: '12345',
         city: 'Helsinki',
         bankAccountNumber: 'FI1234567890',
+        organizationType: ORGANIZATION_TYPES.COMPANY,
       },
     },
     handleStepChange: jest.fn(),

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/employeeView/EmployeeView.tsx
@@ -5,6 +5,7 @@ import { Button, IconPen } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { formatStringFloatValue } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
 import { $ViewField, $ViewFieldBold } from '../../Application.sc';
@@ -141,17 +142,21 @@ const EmployeeView: React.FC<EmployeeViewProps> = ({
             </$ViewField>
             <$ViewField>
               {t(`${translationsBase}.employee.fields.workingHours.view`, {
-                workingHours: data.employee?.workingHours,
+                workingHours: formatStringFloatValue(
+                  data.employee?.workingHours
+                ),
               })}
             </$ViewField>
             <$ViewField>
               {t(`${translationsBase}.employee.fields.monthlyPay.view`, {
-                monthlyPay: data.employee?.monthlyPay,
+                monthlyPay: formatStringFloatValue(data.employee?.monthlyPay),
               })}
             </$ViewField>
             <$ViewField>
               {t(`${translationsBase}.employee.fields.otherExpenses.view`, {
-                otherExpenses: data.employee?.otherExpenses,
+                otherExpenses: formatStringFloatValue(
+                  data.employee?.otherExpenses
+                ),
               })}
             </$ViewField>
             <$ViewField
@@ -162,7 +167,9 @@ const EmployeeView: React.FC<EmployeeViewProps> = ({
               `}
             >
               {t(`${translationsBase}.employee.fields.vacationMoney.view`, {
-                vacationMoney: data.employee?.vacationMoney,
+                vacationMoney: formatStringFloatValue(
+                  data.employee?.vacationMoney
+                ),
               })}
             </$ViewField>
             <$ViewField>

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
@@ -7,15 +7,13 @@ import {
   Application,
   ApplicationData,
 } from 'benefit/applicant/types/application';
-import {
-  getApplicationStepString,
-  getFullName,
-} from 'benefit/applicant/utils/common';
+import { getApplicationStepString } from 'benefit/applicant/utils/common';
 import isEmpty from 'lodash/isEmpty';
 import { useRouter } from 'next/router';
 import { TFunction } from 'next-i18next';
 import { useContext, useEffect } from 'react';
 import hdsToast from 'shared/components/toast/Toast';
+import { getFullName } from 'shared/utils/application.utils';
 import snakecaseKeys from 'snakecase-keys';
 
 type ExtendedComponentProps = {

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step6/useApplicationFormStep6.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step6/useApplicationFormStep6.ts
@@ -12,10 +12,10 @@ import {
   Application,
   ApplicationData,
 } from 'benefit/applicant/types/application';
-import { getFullName } from 'benefit/applicant/utils/common';
 import { useRouter } from 'next/router';
 import { TFunction } from 'next-i18next';
 import { useContext, useEffect, useState } from 'react';
+import { getFullName } from 'shared/utils/application.utils';
 import { invertBooleanArray } from 'shared/utils/array.utils';
 import { capitalize } from 'shared/utils/string.utils';
 import snakecaseKeys from 'snakecase-keys';

--- a/frontend/benefit/applicant/src/constants.ts
+++ b/frontend/benefit/applicant/src/constants.ts
@@ -77,6 +77,7 @@ export enum APPLICATION_FIELDS_STEP1_KEYS {
   DE_MINIMIS_AID_SET = 'deMinimisAidSet',
   CO_OPERATION_NEGOTIATIONS = 'coOperationNegotiations',
   CO_OPERATION_NEGOTIATIONS_DESCRIPTION = 'coOperationNegotiationsDescription',
+  ORGANIZATION_TYPE = 'organizationType',
 }
 
 export enum EMPLOYEE_KEYS {

--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -3,6 +3,7 @@ import camelcaseKeys from 'camelcase-keys';
 import { useRouter } from 'next/router';
 import React, { useContext, useEffect } from 'react';
 import hdsToast from 'shared/components/toast/Toast';
+import { getFullName } from 'shared/utils/application.utils';
 import { convertToBackendDateFormat, parseDate } from 'shared/utils/date.utils';
 import { getNumberValue } from 'shared/utils/string.utils';
 import snakecaseKeys from 'snakecase-keys';
@@ -12,7 +13,6 @@ import { Application, ApplicationData, Employee } from '../types/application';
 import {
   getApplicationStepFromString,
   getApplicationStepString,
-  getFullName,
 } from '../utils/common';
 import useCreateApplicationQuery from './useCreateApplicationQuery';
 import useUpdateApplicationQuery from './useUpdateApplicationQuery';

--- a/frontend/benefit/applicant/src/types/application.d.ts
+++ b/frontend/benefit/applicant/src/types/application.d.ts
@@ -62,6 +62,7 @@ export interface CompanyData {
   postcode: string;
   city: string;
   bank_account_number: string;
+  organization_type: string;
 }
 
 export type Company = {
@@ -73,6 +74,7 @@ export type Company = {
   postcode: string;
   city: string;
   bankAccountNumber: string;
+  organizationType: ORGANIZATION_TYPES;
 };
 
 export interface BaseData {

--- a/frontend/benefit/applicant/src/utils/common.ts
+++ b/frontend/benefit/applicant/src/utils/common.ts
@@ -27,8 +27,3 @@ export const getApplicationStepFromString = (step: string): number => {
 
 export const getApplicationStepString = (step: number): string =>
   `step_${step}`;
-
-export const getFullName = (
-  firstName: string | undefined,
-  lastName: string | undefined
-): string => [firstName, lastName].join(' ').trim();

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1,5 +1,5 @@
 {
-  "appName": "HHelsinki-lisä käsittelijä",
+  "appName": "Helsinki-lisä käsittelijä",
   "header": {
     "navigation": {
       "applications": "Hakemukset",

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -81,6 +81,8 @@
     "fields": {
       "businessId": "Y-tunnus",
       "bankAccountNumber": "Tilinumero",
+      "associationHasBusinessActivities": "Harjoittaako työnantaja elinkeinotoimintaa?",
+      "associationImmediateManagerCheck": "Lähiesihenkilö palkattavalle henkilölle?",
       "applicantLanguage": "Asiointikieli",
       "deMinimisAidGranter": "Tuen myöntäjä",
       "deMinimisAidAmount": "Tuen määrä",
@@ -108,6 +110,28 @@
     "employment": "Työllistämisen Helsinki-lisä",
     "salary": "Palkan Helsinki-lisä",
     "commission": "Toimeksiannon Helsinki-lisä"
+  },
+  "attachments": {
+    "heading1": "Liittet",
+    "types": {
+      "employmentContract": {
+        "title": "Työsopimus"
+      },
+      "paySubsidyDecision": {
+        "title": "Palkkatukipäätös"
+      },
+      "commissionContract": {
+        "title": "Toimeksiantosopimus"
+      },
+      "educationContract": {
+        "title": "Sopimus oppisopimuskoulutuksen järjestämisestä"
+      },
+      "helsinkiBenefitVoucher": {
+        "title": "Helsinki-lisä seteli"
+      }
+    },
+    "add": "Liitä tiedosto",
+    "remove": "Poista liite"
   },
   "utility": {
     "yes": "Kyllä",

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -66,6 +66,10 @@
     }
   },
   "review": {
+    "actions": {
+      "handle": "Ota käsittelyyn",
+      "close": "Sulje"
+    },
     "headings": {
       "heading1": "Työnantajan tiedot",
       "heading1Additional": "Postiosoite päätöstä varten",

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -81,11 +81,23 @@
     "fields": {
       "businessId": "Y-tunnus",
       "bankAccountNumber": "Tilinumero",
-      "applicantLanguage": "Asiointikieli"
+      "applicantLanguage": "Asiointikieli",
+      "deMinimisAidGranter": "Tuen myöntäjä",
+      "deMinimisAidAmount": "Tuen määrä",
+      "deMinimisAidGrantedAt": "Myönnetty",
+      "deMinimisAidTotal": "Yhteensä",
+      "coOperationNegotiations": "Onko hakijalla menossa YT-neuvottelut?",
+      "isLivingInHelsinki": "Helsinki kotikuntana",
+      "apprenticeshipProgram": "Onko kyseessä oppisopimus?"
     }
   },
   "organizationTypes": {
     "company": "Yritys",
     "association": "Yhteisö"
+  },
+  "utility": {
+    "yes": "Kyllä",
+    "no": "Ei",
+    "and": "ja"
   }
 }

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -88,12 +88,26 @@
       "deMinimisAidTotal": "Yhteensä",
       "coOperationNegotiations": "Onko hakijalla menossa YT-neuvottelut?",
       "isLivingInHelsinki": "Helsinki kotikuntana",
-      "apprenticeshipProgram": "Onko kyseessä oppisopimus?"
+      "paySubsidyGranted": "Onko työsuhteeseen myönnetty palkkatuki?",
+      "apprenticeshipProgram": "Onko kyseessä oppisopimus?",
+      "benefitType": "Tukimuoto",
+      "startDate": "Alkaen",
+      "endDate": "Päättyen",
+      "jobTitle": "Tehtävänimike",
+      "workingHours": "Työaika: {{workingHours}} t / viikko",
+      "monthlyPay": "Bruttopalkka {{monthlyPay}} €/kk",
+      "otherExpenses": "Sivukulut {{otherExpenses}} €/kk",
+      "vacationMoney": "Lomaraha {{vacationMoney}} €"
     }
   },
   "organizationTypes": {
     "company": "Yritys",
     "association": "Yhteisö"
+  },
+  "benefitTypes": {
+    "employment": "Työllistämisen Helsinki-lisä",
+    "salary": "Palkan Helsinki-lisä",
+    "commission": "Toimeksiannon Helsinki-lisä"
   },
   "utility": {
     "yes": "Kyllä",

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -68,6 +68,7 @@
   "review": {
     "headings": {
       "heading1": "Työnantajan tiedot",
+      "heading1Additional": "Postiosoite päätöstä varten",
       "heading2": "Yhteyshenkilö",
       "heading3": "Hakijan de minimis-tuet",
       "heading4": "YT-neuvottelut",
@@ -76,6 +77,15 @@
       "heading7": "Haettava tukimuoto ja ajankohta",
       "heading8": "Työsuhde",
       "heading9": "Suostumus"
+    },
+    "fields": {
+      "businessId": "Y-tunnus",
+      "bankAccountNumber": "Tilinumero",
+      "applicantLanguage": "Asiointikieli"
     }
+  },
+  "organizationTypes": {
+    "company": "Yritys",
+    "association": "Yhteisö"
   }
 }

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1,5 +1,5 @@
 {
-  "appName": "HHelsinki-lisä käsittelijä",
+  "appName": "Helsinki-lisä käsittelijä",
   "header": {
     "navigation": {
       "applications": "Hakemukset",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -81,6 +81,8 @@
     "fields": {
       "businessId": "Y-tunnus",
       "bankAccountNumber": "Tilinumero",
+      "associationHasBusinessActivities": "Harjoittaako työnantaja elinkeinotoimintaa?",
+      "associationImmediateManagerCheck": "Lähiesihenkilö palkattavalle henkilölle?",
       "applicantLanguage": "Asiointikieli",
       "deMinimisAidGranter": "Tuen myöntäjä",
       "deMinimisAidAmount": "Tuen määrä",
@@ -108,6 +110,28 @@
     "employment": "Työllistämisen Helsinki-lisä",
     "salary": "Palkan Helsinki-lisä",
     "commission": "Toimeksiannon Helsinki-lisä"
+  },
+  "attachments": {
+    "heading1": "Liittet",
+    "types": {
+      "employmentContract": {
+        "title": "Työsopimus"
+      },
+      "paySubsidyDecision": {
+        "title": "Palkkatukipäätös"
+      },
+      "commissionContract": {
+        "title": "Toimeksiantosopimus"
+      },
+      "educationContract": {
+        "title": "Sopimus oppisopimuskoulutuksen järjestämisestä"
+      },
+      "helsinkiBenefitVoucher": {
+        "title": "Helsinki-lisä seteli"
+      }
+    },
+    "add": "Liitä tiedosto",
+    "remove": "Poista liite"
   },
   "utility": {
     "yes": "Kyllä",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -66,6 +66,10 @@
     }
   },
   "review": {
+    "actions": {
+      "handle": "Ota käsittelyyn",
+      "close": "Sulje"
+    },
     "headings": {
       "heading1": "Työnantajan tiedot",
       "heading1Additional": "Postiosoite päätöstä varten",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -81,11 +81,23 @@
     "fields": {
       "businessId": "Y-tunnus",
       "bankAccountNumber": "Tilinumero",
-      "applicantLanguage": "Asiointikieli"
+      "applicantLanguage": "Asiointikieli",
+      "deMinimisAidGranter": "Tuen myöntäjä",
+      "deMinimisAidAmount": "Tuen määrä",
+      "deMinimisAidGrantedAt": "Myönnetty",
+      "deMinimisAidTotal": "Yhteensä",
+      "coOperationNegotiations": "Onko hakijalla menossa YT-neuvottelut?",
+      "isLivingInHelsinki": "Helsinki kotikuntana",
+      "apprenticeshipProgram": "Onko kyseessä oppisopimus?"
     }
   },
   "organizationTypes": {
     "company": "Yritys",
     "association": "Yhteisö"
+  },
+  "utility": {
+    "yes": "Kyllä",
+    "no": "Ei",
+    "and": "ja"
   }
 }

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -88,12 +88,26 @@
       "deMinimisAidTotal": "Yhteensä",
       "coOperationNegotiations": "Onko hakijalla menossa YT-neuvottelut?",
       "isLivingInHelsinki": "Helsinki kotikuntana",
-      "apprenticeshipProgram": "Onko kyseessä oppisopimus?"
+      "paySubsidyGranted": "Onko työsuhteeseen myönnetty palkkatuki?",
+      "apprenticeshipProgram": "Onko kyseessä oppisopimus?",
+      "benefitType": "Tukimuoto",
+      "startDate": "Alkaen",
+      "endDate": "Päättyen",
+      "jobTitle": "Tehtävänimike",
+      "workingHours": "Työaika: {{workingHours}} t / viikko",
+      "monthlyPay": "Bruttopalkka {{monthlyPay}} €/kk",
+      "otherExpenses": "Sivukulut {{otherExpenses}} €/kk",
+      "vacationMoney": "Lomaraha {{vacationMoney}} €"
     }
   },
   "organizationTypes": {
     "company": "Yritys",
     "association": "Yhteisö"
+  },
+  "benefitTypes": {
+    "employment": "Työllistämisen Helsinki-lisä",
+    "salary": "Palkan Helsinki-lisä",
+    "commission": "Toimeksiannon Helsinki-lisä"
   },
   "utility": {
     "yes": "Kyllä",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -68,6 +68,7 @@
   "review": {
     "headings": {
       "heading1": "Työnantajan tiedot",
+      "heading1Additional": "Postiosoite päätöstä varten",
       "heading2": "Yhteyshenkilö",
       "heading3": "Hakijan de minimis-tuet",
       "heading4": "YT-neuvottelut",
@@ -76,6 +77,15 @@
       "heading7": "Haettava tukimuoto ja ajankohta",
       "heading8": "Työsuhde",
       "heading9": "Suostumus"
+    },
+    "fields": {
+      "businessId": "Y-tunnus",
+      "bankAccountNumber": "Tilinumero",
+      "applicantLanguage": "Asiointikieli"
     }
+  },
+  "organizationTypes": {
+    "company": "Yritys",
+    "association": "Yhteisö"
   }
 }

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -81,6 +81,8 @@
     "fields": {
       "businessId": "Y-tunnus",
       "bankAccountNumber": "Tilinumero",
+      "associationHasBusinessActivities": "Harjoittaako työnantaja elinkeinotoimintaa?",
+      "associationImmediateManagerCheck": "Lähiesihenkilö palkattavalle henkilölle?",
       "applicantLanguage": "Asiointikieli",
       "deMinimisAidGranter": "Tuen myöntäjä",
       "deMinimisAidAmount": "Tuen määrä",
@@ -108,6 +110,28 @@
     "employment": "Työllistämisen Helsinki-lisä",
     "salary": "Palkan Helsinki-lisä",
     "commission": "Toimeksiannon Helsinki-lisä"
+  },
+  "attachments": {
+    "heading1": "Liittet",
+    "types": {
+      "employmentContract": {
+        "title": "Työsopimus"
+      },
+      "paySubsidyDecision": {
+        "title": "Palkkatukipäätös"
+      },
+      "commissionContract": {
+        "title": "Toimeksiantosopimus"
+      },
+      "educationContract": {
+        "title": "Sopimus oppisopimuskoulutuksen järjestämisestä"
+      },
+      "helsinkiBenefitVoucher": {
+        "title": "Helsinki-lisä seteli"
+      }
+    },
+    "add": "Liitä tiedosto",
+    "remove": "Poista liite"
   },
   "utility": {
     "yes": "Kyllä",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -66,6 +66,10 @@
     }
   },
   "review": {
+    "actions": {
+      "handle": "Ota käsittelyyn",
+      "close": "Sulje"
+    },
     "headings": {
       "heading1": "Työnantajan tiedot",
       "heading1Additional": "Postiosoite päätöstä varten",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -81,11 +81,23 @@
     "fields": {
       "businessId": "Y-tunnus",
       "bankAccountNumber": "Tilinumero",
-      "applicantLanguage": "Asiointikieli"
+      "applicantLanguage": "Asiointikieli",
+      "deMinimisAidGranter": "Tuen myöntäjä",
+      "deMinimisAidAmount": "Tuen määrä",
+      "deMinimisAidGrantedAt": "Myönnetty",
+      "deMinimisAidTotal": "Yhteensä",
+      "coOperationNegotiations": "Onko hakijalla menossa YT-neuvottelut?",
+      "isLivingInHelsinki": "Helsinki kotikuntana",
+      "apprenticeshipProgram": "Onko kyseessä oppisopimus?"
     }
   },
   "organizationTypes": {
     "company": "Yritys",
     "association": "Yhteisö"
+  },
+  "utility": {
+    "yes": "Kyllä",
+    "no": "Ei",
+    "and": "ja"
   }
 }

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -88,12 +88,26 @@
       "deMinimisAidTotal": "Yhteensä",
       "coOperationNegotiations": "Onko hakijalla menossa YT-neuvottelut?",
       "isLivingInHelsinki": "Helsinki kotikuntana",
-      "apprenticeshipProgram": "Onko kyseessä oppisopimus?"
+      "paySubsidyGranted": "Onko työsuhteeseen myönnetty palkkatuki?",
+      "apprenticeshipProgram": "Onko kyseessä oppisopimus?",
+      "benefitType": "Tukimuoto",
+      "startDate": "Alkaen",
+      "endDate": "Päättyen",
+      "jobTitle": "Tehtävänimike",
+      "workingHours": "Työaika: {{workingHours}} t / viikko",
+      "monthlyPay": "Bruttopalkka {{monthlyPay}} €/kk",
+      "otherExpenses": "Sivukulut {{otherExpenses}} €/kk",
+      "vacationMoney": "Lomaraha {{vacationMoney}} €"
     }
   },
   "organizationTypes": {
     "company": "Yritys",
     "association": "Yhteisö"
+  },
+  "benefitTypes": {
+    "employment": "Työllistämisen Helsinki-lisä",
+    "salary": "Palkan Helsinki-lisä",
+    "commission": "Toimeksiannon Helsinki-lisä"
   },
   "utility": {
     "yes": "Kyllä",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -68,6 +68,7 @@
   "review": {
     "headings": {
       "heading1": "Työnantajan tiedot",
+      "heading1Additional": "Postiosoite päätöstä varten",
       "heading2": "Yhteyshenkilö",
       "heading3": "Hakijan de minimis-tuet",
       "heading4": "YT-neuvottelut",
@@ -76,6 +77,15 @@
       "heading7": "Haettava tukimuoto ja ajankohta",
       "heading8": "Työsuhde",
       "heading9": "Suostumus"
+    },
+    "fields": {
+      "businessId": "Y-tunnus",
+      "bankAccountNumber": "Tilinumero",
+      "applicantLanguage": "Asiointikieli"
     }
+  },
+  "organizationTypes": {
+    "company": "Yritys",
+    "association": "Yhteisö"
   }
 }

--- a/frontend/benefit/handler/src/components/applicationHeader/ApplicationHeader.tsx
+++ b/frontend/benefit/handler/src/components/applicationHeader/ApplicationHeader.tsx
@@ -1,6 +1,11 @@
+import { APPLICATION_STATUSES } from 'benefit/handler/constants';
+import { Application } from 'benefit/handler/types/application';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import Container from 'shared/components/container/Container';
+import { getFullName } from 'shared/utils/application.utils';
+import { formatDate } from 'shared/utils/date.utils';
+import { getInitials } from 'shared/utils/string.utils';
 
 import {
   $Col,
@@ -12,9 +17,15 @@ import {
   $Wrapper,
 } from './ApplicationHeader.sc';
 
-const ApplicationHeader: React.FC = () => {
+type ApplicationReviewProps = { data: Application };
+
+const ApplicationHeader: React.FC<ApplicationReviewProps> = ({ data }) => {
   const { t } = useTranslation();
   const translationBase = 'common:applications.list.columns';
+  const employeeName = getFullName(
+    data.employee?.firstName,
+    data.employee?.lastName
+  );
 
   return (
     <$Wrapper>
@@ -23,34 +34,38 @@ const ApplicationHeader: React.FC = () => {
           <$Col>
             <$ItemWrapper>
               <$ItemHeader>{t(`${translationBase}.companyName`)}</$ItemHeader>
-              <$ItemValue>Herkkulautanen Oy</$ItemValue>
+              <$ItemValue>{data.company?.name}</$ItemValue>
             </$ItemWrapper>
             <$ItemWrapper>
               <$ItemHeader>{t(`${translationBase}.companyId`)}</$ItemHeader>
-              <$ItemValue>1234567-1234</$ItemValue>
+              <$ItemValue>{data.company?.businessId}</$ItemValue>
             </$ItemWrapper>
             <$ItemWrapper>
               <$ItemHeader>{t(`${translationBase}.companyForm`)}</$ItemHeader>
-              <$ItemValue>Yritys</$ItemValue>
+              <$ItemValue>{data.company?.companyForm}</$ItemValue>
             </$ItemWrapper>
             <$ItemWrapper>
               <$ItemHeader>{t(`${translationBase}.submittedAt`)}</$ItemHeader>
-              <$ItemValue>21.06.2021</$ItemValue>
+              <$ItemValue>
+                {data.submittedAt && formatDate(new Date(data.submittedAt))}
+              </$ItemValue>
             </$ItemWrapper>
             <$ItemWrapper>
               <$ItemHeader>
                 {t(`${translationBase}.applicationNum`)}
               </$ItemHeader>
-              <$ItemValue>123456789</$ItemValue>
+              <$ItemValue>{data.applicationNumber}</$ItemValue>
             </$ItemWrapper>
             <$ItemWrapper>
               <$ItemHeader>{t(`${translationBase}.employeeName`)}</$ItemHeader>
-              <$ItemValue>Teemu Rantamäki</$ItemValue>
+              <$ItemValue>{employeeName}</$ItemValue>
             </$ItemWrapper>
           </$Col>
-          <$Col>
-            <$HandlerWrapper>KK</$HandlerWrapper>
-          </$Col>
+          {data.status === APPLICATION_STATUSES.HANDLING && (
+            <$Col>
+              <$HandlerWrapper>{getInitials(employeeName)}</$HandlerWrapper>
+            </$Col>
+          )}
         </$InnerWrapper>
       </Container>
     </$Wrapper>

--- a/frontend/benefit/handler/src/components/applicationHeader/ApplicationHeader.tsx
+++ b/frontend/benefit/handler/src/components/applicationHeader/ApplicationHeader.tsx
@@ -27,6 +27,11 @@ const ApplicationHeader: React.FC<ApplicationReviewProps> = ({ data }) => {
     data.employee?.lastName
   );
 
+  const handlerName = getFullName(
+    data.calculation?.handlerDetails?.firstName,
+    data.calculation?.handlerDetails?.lastName
+  );
+
   return (
     <$Wrapper>
       <Container>
@@ -69,7 +74,7 @@ const ApplicationHeader: React.FC<ApplicationReviewProps> = ({ data }) => {
           </$Col>
           {data.status === APPLICATION_STATUSES.HANDLING && (
             <$Col>
-              <$HandlerWrapper>{getInitials(employeeName)}</$HandlerWrapper>
+              <$HandlerWrapper>{getInitials(handlerName)}</$HandlerWrapper>
             </$Col>
           )}
         </$InnerWrapper>

--- a/frontend/benefit/handler/src/components/applicationHeader/ApplicationHeader.tsx
+++ b/frontend/benefit/handler/src/components/applicationHeader/ApplicationHeader.tsx
@@ -42,7 +42,13 @@ const ApplicationHeader: React.FC<ApplicationReviewProps> = ({ data }) => {
             </$ItemWrapper>
             <$ItemWrapper>
               <$ItemHeader>{t(`${translationBase}.companyForm`)}</$ItemHeader>
-              <$ItemValue>{data.company?.companyForm}</$ItemValue>
+              <$ItemValue>
+                {t(
+                  `common:organizationTypes.${
+                    data.company?.organizationType || ''
+                  }`
+                )}
+              </$ItemValue>
             </$ItemWrapper>
             <$ItemWrapper>
               <$ItemHeader>{t(`${translationBase}.submittedAt`)}</$ItemHeader>

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
@@ -37,10 +37,18 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
         Cell: ({
           cell: {
             row: {
-              original: { companyName },
+              original: { id, companyName },
             },
           },
-        }) => <$Link>{companyName}</$Link>,
+        }) => (
+          <$Link
+            href={`/application?id=${id}`}
+            rel="noopener noreferrer"
+            aria-label={companyName}
+          >
+            {companyName}
+          </$Link>
+        ),
         Header: getHeader('companyName'),
         accessor: 'companyName',
         width: COLUMN_WIDTH.L,
@@ -71,7 +79,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
       },
     ];
 
-    if (status.includes(APPLICATION_STATUSES.RECEIVED)) {
+    if (status.includes(APPLICATION_STATUSES.HANDLING)) {
       cols.push({
         Header: getHeader('handlerName'),
         accessor: 'handlerName',

--- a/frontend/benefit/handler/src/components/applicationList/useApplicationList.ts
+++ b/frontend/benefit/handler/src/components/applicationList/useApplicationList.ts
@@ -6,6 +6,7 @@ import {
 } from 'benefit/handler/types/application';
 import { TFunction, useTranslation } from 'next-i18next';
 import isServerSide from 'shared/server/is-server-side';
+import { getFullName } from 'shared/utils/application.utils';
 import { formatDate } from 'shared/utils/date.utils';
 
 interface ApplicationListProps {
@@ -16,11 +17,6 @@ interface ApplicationListProps {
   getHeader: (id: string) => string;
   translationsBase: string;
 }
-
-const getFullName = (
-  firstName: string | undefined,
-  lastName: string | undefined
-): string => [firstName, lastName].join(' ');
 
 const translationsBase = 'common:applications.list';
 

--- a/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
@@ -1,10 +1,11 @@
 import ApplicationHeader from 'benefit/handler/components/applicationHeader/ApplicationHeader';
-import { Button, LoadingSpinner } from 'hds-react';
+import { APPLICATION_STATUSES } from 'benefit/handler/constants';
+import { LoadingSpinner } from 'hds-react';
 import * as React from 'react';
 import Container from 'shared/components/container/Container';
-import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import StickyActionBar from 'shared/components/stickyActionBar/StickyActionBar';
 
-import ReviewSection from '../reviewSection/ReviewSection';
+import ReceivedApplicationActions from './actions/receivedApplicationActions/ReceivedApplicationActions';
 import BenefitView from './benefitView/BenefitView';
 import CompanyInfoView from './companyInfoView/CompanyInfoView';
 import ConsentView from './consentView/ConsentView';
@@ -17,9 +18,7 @@ import PaySubsidyView from './paySubsidyView/PaySubsidyView';
 import { useApplicationReview } from './useApplicationReview';
 
 const ApplicationReview: React.FC = () => {
-  const { t, application, isLoading } = useApplicationReview();
-
-  const translationBase = 'common:review.headings';
+  const { application, isLoading } = useApplicationReview();
 
   if (isLoading) {
     return (
@@ -42,22 +41,15 @@ const ApplicationReview: React.FC = () => {
         <BenefitView data={application} />
         <EmploymentView data={application} />
         <ConsentView data={application} />
-        <ReviewSection
-          action={
-            <div>
-              <Button theme="black" variant="secondary">
-                Some button
-              </Button>
-            </div>
-          }
-          header={t(`${translationBase}.heading9`)}
-        >
-          <$GridCell $colSpan={12}>Section contents9</$GridCell>
-        </ReviewSection>
-        <ReviewSection withMargin>
-          <$GridCell $colSpan={12}>Section contents10</$GridCell>
-        </ReviewSection>
       </Container>
+      <StickyActionBar>
+        {application.status === APPLICATION_STATUSES.RECEIVED && (
+          <ReceivedApplicationActions application={application} />
+        )}
+        {application.status === APPLICATION_STATUSES.HANDLING && (
+          <>handling actions</>
+        )}
+      </StickyActionBar>
     </>
   );
 };

--- a/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
@@ -1,10 +1,12 @@
 import ApplicationHeader from 'benefit/handler/components/applicationHeader/ApplicationHeader';
-import { Button , LoadingSpinner } from 'hds-react';
+import { Button, LoadingSpinner } from 'hds-react';
 import * as React from 'react';
 import Container from 'shared/components/container/Container';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 
 import ReviewSection from '../reviewSection/ReviewSection';
+import CompanyInfoView from './companyInfoView/CompanyInfoView';
+import ContactPersonView from './contactPersonView/ContactPersonView';
 import { useApplicationReview } from './useApplicationReview';
 
 const ApplicationReview: React.FC = () => {
@@ -24,12 +26,8 @@ const ApplicationReview: React.FC = () => {
     <>
       <ApplicationHeader data={application} />
       <Container>
-        <ReviewSection header={t(`${translationBase}.heading1`)}>
-          <$GridCell $colSpan={12}>Section contents1</$GridCell>
-        </ReviewSection>
-        <ReviewSection header={t(`${translationBase}.heading2`)}>
-          <$GridCell $colSpan={12}>Section contents2</$GridCell>
-        </ReviewSection>
+        <CompanyInfoView data={application} />
+        <ContactPersonView data={application} />
         <ReviewSection header={t(`${translationBase}.heading3`)}>
           <$GridCell $colSpan={12}>Section contents3</$GridCell>
         </ReviewSection>

--- a/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
@@ -1,30 +1,28 @@
 import ApplicationHeader from 'benefit/handler/components/applicationHeader/ApplicationHeader';
-import { Button } from 'hds-react';
+import { Button , LoadingSpinner } from 'hds-react';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
-import LoadingSkeleton from 'react-loading-skeleton';
 import Container from 'shared/components/container/Container';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 
 import ReviewSection from '../reviewSection/ReviewSection';
+import { useApplicationReview } from './useApplicationReview';
 
 const ApplicationReview: React.FC = () => {
-  const shouldShowSkeleton = false;
-  const { t } = useTranslation();
+  const { t, application, isLoading } = useApplicationReview();
 
   const translationBase = 'common:review.headings';
 
-  if (shouldShowSkeleton) {
+  if (isLoading) {
     return (
       <Container>
-        <LoadingSkeleton width="100%" height="50px" />
+        <LoadingSpinner />
       </Container>
     );
   }
 
   return (
     <>
-      <ApplicationHeader />
+      <ApplicationHeader data={application} />
       <Container>
         <ReviewSection header={t(`${translationBase}.heading1`)}>
           <$GridCell $colSpan={12}>Section contents1</$GridCell>

--- a/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
@@ -7,6 +7,7 @@ import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import ReviewSection from '../reviewSection/ReviewSection';
 import BenefitView from './benefitView/BenefitView';
 import CompanyInfoView from './companyInfoView/CompanyInfoView';
+import ConsentView from './consentView/ConsentView';
 import ContactPersonView from './contactPersonView/ContactPersonView';
 import CoOperationNegotiationsView from './coOperationNegotiationsView/CoOperationNegotiationsView';
 import DeminimisView from './deminimisView/DeminimisView';
@@ -40,6 +41,7 @@ const ApplicationReview: React.FC = () => {
         <PaySubsidyView data={application} />
         <BenefitView data={application} />
         <EmploymentView data={application} />
+        <ConsentView data={application} />
         <ReviewSection
           action={
             <div>

--- a/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
@@ -5,11 +5,13 @@ import Container from 'shared/components/container/Container';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 
 import ReviewSection from '../reviewSection/ReviewSection';
+import BenefitView from './benefitView/BenefitView';
 import CompanyInfoView from './companyInfoView/CompanyInfoView';
 import ContactPersonView from './contactPersonView/ContactPersonView';
 import CoOperationNegotiationsView from './coOperationNegotiationsView/CoOperationNegotiationsView';
 import DeminimisView from './deminimisView/DeminimisView';
 import EmployeeView from './employeeView/EmployeeView';
+import EmploymentView from './employmentView/EmpoymentView';
 import PaySubsidyView from './paySubsidyView/PaySubsidyView';
 import { useApplicationReview } from './useApplicationReview';
 
@@ -36,12 +38,8 @@ const ApplicationReview: React.FC = () => {
         <CoOperationNegotiationsView data={application} />
         <EmployeeView data={application} />
         <PaySubsidyView data={application} />
-        <ReviewSection header={t(`${translationBase}.heading7`)}>
-          <$GridCell $colSpan={12}>Section contents7</$GridCell>
-        </ReviewSection>
-        <ReviewSection header={t(`${translationBase}.heading8`)}>
-          <$GridCell $colSpan={12}>Section contents8</$GridCell>
-        </ReviewSection>
+        <BenefitView data={application} />
+        <EmploymentView data={application} />
         <ReviewSection
           action={
             <div>

--- a/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
@@ -7,6 +7,10 @@ import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import ReviewSection from '../reviewSection/ReviewSection';
 import CompanyInfoView from './companyInfoView/CompanyInfoView';
 import ContactPersonView from './contactPersonView/ContactPersonView';
+import CoOperationNegotiationsView from './coOperationNegotiationsView/CoOperationNegotiationsView';
+import DeminimisView from './deminimisView/DeminimisView';
+import EmployeeView from './employeeView/EmployeeView';
+import PaySubsidyView from './paySubsidyView/PaySubsidyView';
 import { useApplicationReview } from './useApplicationReview';
 
 const ApplicationReview: React.FC = () => {
@@ -28,18 +32,10 @@ const ApplicationReview: React.FC = () => {
       <Container>
         <CompanyInfoView data={application} />
         <ContactPersonView data={application} />
-        <ReviewSection header={t(`${translationBase}.heading3`)}>
-          <$GridCell $colSpan={12}>Section contents3</$GridCell>
-        </ReviewSection>
-        <ReviewSection header={t(`${translationBase}.heading4`)}>
-          <$GridCell $colSpan={12}>Section contents4</$GridCell>
-        </ReviewSection>
-        <ReviewSection header={t(`${translationBase}.heading5`)}>
-          <$GridCell $colSpan={12}>Section contents5</$GridCell>
-        </ReviewSection>
-        <ReviewSection header={t(`${translationBase}.heading5`)}>
-          <$GridCell $colSpan={12}>Section contents6</$GridCell>
-        </ReviewSection>
+        <DeminimisView data={application} />
+        <CoOperationNegotiationsView data={application} />
+        <EmployeeView data={application} />
+        <PaySubsidyView data={application} />
         <ReviewSection header={t(`${translationBase}.heading7`)}>
           <$GridCell $colSpan={12}>Section contents7</$GridCell>
         </ReviewSection>

--- a/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.tsx
@@ -4,6 +4,7 @@ import { LoadingSpinner } from 'hds-react';
 import * as React from 'react';
 import Container from 'shared/components/container/Container';
 import StickyActionBar from 'shared/components/stickyActionBar/StickyActionBar';
+import { $StickyBarSpacing } from 'shared/components/stickyActionBar/StickyActionBar.sc';
 
 import ReceivedApplicationActions from './actions/receivedApplicationActions/ReceivedApplicationActions';
 import BenefitView from './benefitView/BenefitView';
@@ -50,6 +51,7 @@ const ApplicationReview: React.FC = () => {
           <>handling actions</>
         )}
       </StickyActionBar>
+      <$StickyBarSpacing />
     </>
   );
 };

--- a/frontend/benefit/handler/src/components/applicationReview/actions/receivedApplicationActions/ReceivedApplicationActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/receivedApplicationActions/ReceivedApplicationActions.tsx
@@ -1,0 +1,56 @@
+import { APPLICATION_STATUSES, ROUTES } from 'benefit/handler/constants';
+import useUpdateApplicationQuery from 'benefit/handler/hooks/useUpdateApplicationQuery';
+import { Application,ApplicationData  } from 'benefit/handler/types/application';
+import { Button } from 'hds-react';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import {
+  $Grid,
+  $GridCell,
+} from 'shared/components/forms/section/FormSection.sc';
+import snakecaseKeys from 'snakecase-keys';
+
+type Props = {
+  application: Application;
+};
+
+const ReceivedApplicationActions: React.FC<Props> = ({ application }) => {
+  const translationsBase = 'common:review.actions';
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  const { mutate: updateApplication } = useUpdateApplicationQuery();
+
+  const handleCloseClick = (): void => {
+    void router.push(ROUTES.HOME);
+  };
+
+  const handleStatusChange = (): void => {
+    const currentApplicationData: ApplicationData = snakecaseKeys(
+      {
+        ...application,
+        status: APPLICATION_STATUSES.HANDLING,
+      },
+      { deep: true }
+    );
+    updateApplication(currentApplicationData);
+  };
+
+  return (
+    <$Grid>
+      <$GridCell $colSpan={2}>
+        <Button onClick={handleStatusChange} theme="coat">
+          {t(`${translationsBase}.handle`)}
+        </Button>
+      </$GridCell>
+      <$GridCell>
+        <Button onClick={handleCloseClick} theme="black" variant="secondary">
+          {t(`${translationsBase}.close`)}
+        </Button>
+      </$GridCell>
+    </$Grid>
+  );
+};
+
+export default ReceivedApplicationActions;

--- a/frontend/benefit/handler/src/components/applicationReview/actions/receivedApplicationActions/ReceivedApplicationActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/receivedApplicationActions/ReceivedApplicationActions.tsx
@@ -1,6 +1,9 @@
 import { APPLICATION_STATUSES, ROUTES } from 'benefit/handler/constants';
 import useUpdateApplicationQuery from 'benefit/handler/hooks/useUpdateApplicationQuery';
-import { Application,ApplicationData  } from 'benefit/handler/types/application';
+import {
+  Application,
+  ApplicationData,
+} from 'benefit/handler/types/application';
 import { Button } from 'hds-react';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
@@ -11,7 +14,7 @@ import {
 } from 'shared/components/forms/section/FormSection.sc';
 import snakecaseKeys from 'snakecase-keys';
 
-type Props = {
+export type Props = {
   application: Application;
 };
 

--- a/frontend/benefit/handler/src/components/applicationReview/actions/receivedApplicationActions/__tests__/ReceivedApplicationActions.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/receivedApplicationActions/__tests__/ReceivedApplicationActions.test.tsx
@@ -1,0 +1,24 @@
+import { RenderResult } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import ReceivedApplicationActions, {
+  Props,
+} from '../ReceivedApplicationActions';
+
+describe('ReceivedApplicationActions', () => {
+  const initialProps: Props = {
+    application: {},
+  };
+
+  const getComponent = (props: Partial<Props> = {}): RenderResult =>
+    renderComponent(<ReceivedApplicationActions {...initialProps} {...props} />)
+      .renderResult;
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/benefitView/BenefitView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/benefitView/BenefitView.tsx
@@ -1,0 +1,46 @@
+import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import {
+  $ViewField,
+  $ViewFieldBold,
+} from 'shared/components/benefit/summaryView/SummaryView.sc';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+
+const BenefitView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
+  const translationsBase = 'common:review';
+  const { t } = useTranslation();
+  return (
+    <>
+      <ReviewSection
+        withoutDivider
+        header={t(`${translationsBase}.headings.heading7`)}
+      >
+        <$GridCell $colSpan={5}>
+          <$ViewField>
+            {`${t(`${translationsBase}.fields.benefitType`)}: `}
+            <$ViewFieldBold>
+              {t(
+                `common:benefitTypes.${data.benefitType?.split('_')[0] || ''}`
+              )}
+            </$ViewFieldBold>
+          </$ViewField>
+        </$GridCell>
+      </ReviewSection>
+      <ReviewSection>
+        <$GridCell />
+        <$GridCell $colStart={1} $colSpan={2}>
+          <$ViewField>{t(`${translationsBase}.fields.startDate`)}</$ViewField>
+          <$ViewField>{data.startDate ? data.startDate : '-'}</$ViewField>
+        </$GridCell>
+        <$GridCell $colSpan={2}>
+          <$ViewField>{t(`${translationsBase}.fields.endDate`)}</$ViewField>
+          <$ViewField>{data.endDate ? data.endDate : '-'}</$ViewField>
+        </$GridCell>
+      </ReviewSection>
+    </>
+  );
+};
+
+export default BenefitView;

--- a/frontend/benefit/handler/src/components/applicationReview/benefitView/BenefitView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/benefitView/BenefitView.tsx
@@ -1,4 +1,5 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { APPLICATION_STATUSES } from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -12,34 +13,29 @@ const BenefitView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <>
-      <ReviewSection
-        withoutDivider
-        header={t(`${translationsBase}.headings.heading7`)}
-      >
-        <$GridCell $colSpan={5}>
-          <$ViewField>
-            {`${t(`${translationsBase}.fields.benefitType`)}: `}
-            <$ViewFieldBold>
-              {t(
-                `common:benefitTypes.${data.benefitType?.split('_')[0] || ''}`
-              )}
-            </$ViewFieldBold>
-          </$ViewField>
-        </$GridCell>
-      </ReviewSection>
-      <ReviewSection>
-        <$GridCell />
-        <$GridCell $colStart={1} $colSpan={2}>
-          <$ViewField>{t(`${translationsBase}.fields.startDate`)}</$ViewField>
-          <$ViewField>{data.startDate ? data.startDate : '-'}</$ViewField>
-        </$GridCell>
-        <$GridCell $colSpan={2}>
-          <$ViewField>{t(`${translationsBase}.fields.endDate`)}</$ViewField>
-          <$ViewField>{data.endDate ? data.endDate : '-'}</$ViewField>
-        </$GridCell>
-      </ReviewSection>
-    </>
+    <ReviewSection
+      withoutDivider
+      header={t(`${translationsBase}.headings.heading7`)}
+      action={data.status !== APPLICATION_STATUSES.RECEIVED ? <></> : null}
+    >
+      <$GridCell $colSpan={5}>
+        <$ViewField>
+          {`${t(`${translationsBase}.fields.benefitType`)}: `}
+          <$ViewFieldBold>
+            {t(`common:benefitTypes.${data.benefitType?.split('_')[0] || ''}`)}
+          </$ViewFieldBold>
+        </$ViewField>
+      </$GridCell>
+      <$GridCell />
+      <$GridCell $colStart={1} $colSpan={2}>
+        <$ViewField>{t(`${translationsBase}.fields.startDate`)}</$ViewField>
+        <$ViewField>{data.startDate ? data.startDate : '-'}</$ViewField>
+      </$GridCell>
+      <$GridCell $colSpan={2}>
+        <$ViewField>{t(`${translationsBase}.fields.endDate`)}</$ViewField>
+        <$ViewField>{data.endDate ? data.endDate : '-'}</$ViewField>
+      </$GridCell>
+    </ReviewSection>
   );
 };
 

--- a/frontend/benefit/handler/src/components/applicationReview/benefitView/__tests__/BenefitView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/benefitView/__tests__/BenefitView.test.tsx
@@ -1,0 +1,29 @@
+import { RenderResult } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { BENEFIT_TYPES } from 'benefit/handler/constants';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import BenefitView from '../BenefitView';
+
+describe('BenefitView', () => {
+  const initialProps = {
+    data: {
+      benefitType: BENEFIT_TYPES.EMPLOYMENT,
+      startDate: '21-01-2021',
+      endDate: '30-01-2021',
+    },
+  };
+
+  const getComponent = (
+    props: Partial<ApplicationReviewViewProps> = {}
+  ): RenderResult =>
+    renderComponent(<BenefitView {...initialProps} {...props} />).renderResult;
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/coOperationNegotiationsView/CoOperationNegotiationsView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/coOperationNegotiationsView/CoOperationNegotiationsView.tsx
@@ -1,0 +1,41 @@
+import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { Application } from 'benefit/handler/types/application';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import {
+  $ViewField,
+  $ViewFieldBold,
+} from 'shared/components/benefit/summaryView/SummaryView.sc';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+
+export interface CoOperationNegotiationsViewProps {
+  data: Application;
+}
+
+const CoOperationNegotiationsView: React.FC<CoOperationNegotiationsViewProps> =
+  ({ data }) => {
+    const translationsBase = 'common:review';
+    const { t } = useTranslation();
+    // todo: add the association info in the bottom
+    return (
+      <>
+        <ReviewSection header={t(`${translationsBase}.headings.heading4`)}>
+          <$GridCell $colSpan={12}>
+            <$ViewField>
+              {t(`${translationsBase}.fields.coOperationNegotiations`)}
+              <$ViewFieldBold>{` ${t(
+                `common:utility.${data.coOperationNegotiations ? 'yes' : 'no'}`
+              )}`}</$ViewFieldBold>
+            </$ViewField>
+          </$GridCell>
+          {data.coOperationNegotiations && (
+            <$GridCell $colSpan={12}>
+              <$ViewField>{data.coOperationNegotiationsDescription}</$ViewField>
+            </$GridCell>
+          )}
+        </ReviewSection>
+      </>
+    );
+  };
+
+export default CoOperationNegotiationsView;

--- a/frontend/benefit/handler/src/components/applicationReview/coOperationNegotiationsView/CoOperationNegotiationsView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/coOperationNegotiationsView/CoOperationNegotiationsView.tsx
@@ -1,5 +1,5 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { Application } from 'benefit/handler/types/application';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import {
@@ -8,34 +8,26 @@ import {
 } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 
-export interface CoOperationNegotiationsViewProps {
-  data: Application;
-}
-
-const CoOperationNegotiationsView: React.FC<CoOperationNegotiationsViewProps> =
-  ({ data }) => {
-    const translationsBase = 'common:review';
-    const { t } = useTranslation();
-    // todo: add the association info in the bottom
-    return (
-      <>
-        <ReviewSection header={t(`${translationsBase}.headings.heading4`)}>
-          <$GridCell $colSpan={12}>
-            <$ViewField>
-              {t(`${translationsBase}.fields.coOperationNegotiations`)}
-              <$ViewFieldBold>{` ${t(
-                `common:utility.${data.coOperationNegotiations ? 'yes' : 'no'}`
-              )}`}</$ViewFieldBold>
-            </$ViewField>
-          </$GridCell>
-          {data.coOperationNegotiations && (
-            <$GridCell $colSpan={12}>
-              <$ViewField>{data.coOperationNegotiationsDescription}</$ViewField>
-            </$GridCell>
-          )}
-        </ReviewSection>
-      </>
-    );
-  };
+const CoOperationNegotiationsView: React.FC<ApplicationReviewViewProps> = ({
+  data,
+}) => {
+  const translationsBase = 'common:review';
+  const { t } = useTranslation();
+  return (
+    <ReviewSection header={t(`${translationsBase}.headings.heading4`)}>
+      <$GridCell $colSpan={12}>
+        <$ViewField>
+          {t(`${translationsBase}.fields.coOperationNegotiations`)}
+          <$ViewFieldBold>{` ${t(
+            `common:utility.${data.coOperationNegotiations ? 'yes' : 'no'}`
+          )}`}</$ViewFieldBold>
+        </$ViewField>
+        {data.coOperationNegotiations && (
+          <$ViewField>{data.coOperationNegotiationsDescription}</$ViewField>
+        )}
+      </$GridCell>
+    </ReviewSection>
+  );
+};
 
 export default CoOperationNegotiationsView;

--- a/frontend/benefit/handler/src/components/applicationReview/coOperationNegotiationsView/__tests__/CoOperationNegotiationsView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/coOperationNegotiationsView/__tests__/CoOperationNegotiationsView.test.tsx
@@ -1,0 +1,29 @@
+import { RenderResult } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import CoOperationNegotiationsView from '../CoOperationNegotiationsView';
+
+describe('BenefitView', () => {
+  const initialProps = {
+    data: {
+      coOperationNegotiations: true,
+      coOperationNegotiationsDescription: 'some additional information',
+    },
+  };
+
+  const getComponent = (
+    props: Partial<ApplicationReviewViewProps> = {}
+  ): RenderResult =>
+    renderComponent(
+      <CoOperationNegotiationsView {...initialProps} {...props} />
+    ).renderResult;
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/companyInfoView/CompanyInfoView.tsx
@@ -1,5 +1,8 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { ORGANIZATION_TYPES } from 'benefit/handler/constants';
+import {
+  APPLICATION_STATUSES,
+  ORGANIZATION_TYPES,
+} from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -15,7 +18,10 @@ const CompanyInfoView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const { t } = useTranslation();
   const theme = useTheme();
   return (
-    <ReviewSection header={t(`${translationsBase}.headings.heading1`)}>
+    <ReviewSection
+      header={t(`${translationsBase}.headings.heading1`)}
+      action={data.status !== APPLICATION_STATUSES.RECEIVED ? <></> : null}
+    >
       <$GridCell $colSpan={3}>
         <$ViewField>{data.company?.name}</$ViewField>
         <$ViewField>{`${t(`${translationsBase}.fields.businessId`)}: ${

--- a/frontend/benefit/handler/src/components/applicationReview/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/companyInfoView/CompanyInfoView.tsx
@@ -1,0 +1,72 @@
+import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { Application } from 'benefit/handler/types/application';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import {
+  $ViewField,
+  $ViewFieldBold,
+} from 'shared/components/benefit/summaryView/SummaryView.sc';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { useTheme } from 'styled-components';
+
+export interface CompanyInfoViewProps {
+  data: Application;
+}
+
+const CompanyInfoView: React.FC<CompanyInfoViewProps> = ({ data }) => {
+  const translationsBase = 'common:review';
+  const { t } = useTranslation();
+  const theme = useTheme();
+  // todo: add the association info in the bottom
+  return (
+    <>
+      <ReviewSection header={t(`${translationsBase}.headings.heading1`)}>
+        <$GridCell $colSpan={3}>
+          <$ViewField>{data.company?.name}</$ViewField>
+          <$ViewField>{`${t(`${translationsBase}.fields.businessId`)}: ${
+            data.company?.businessId || ''
+          }`}</$ViewField>
+          <$ViewField>
+            {`${t(`${translationsBase}.fields.bankAccountNumber`)}: ${
+              data.companyBankAccountNumber || ''
+            }`}
+          </$ViewField>
+        </$GridCell>
+        <$GridCell $colSpan={3}>
+          <$ViewField>{data.company?.streetAddress}</$ViewField>
+          <$ViewField>{`${data.company?.postcode || ''} ${
+            data.company?.city || ''
+          }`}</$ViewField>
+        </$GridCell>
+      </ReviewSection>
+      {data.alternativeCompanyStreetAddress && (
+        <ReviewSection>
+          <$GridCell
+            $colSpan={12}
+            css={`
+              font-size: ${theme.fontSize.body.m};
+              margin: ${theme.spacing.xs4} 0;
+            `}
+          >
+            <$ViewFieldBold>
+              {t(`${translationsBase}.headings.heading1Additional`)}
+            </$ViewFieldBold>
+          </$GridCell>
+          <$GridCell $colSpan={3}>
+            {data.companyDepartment && (
+              <$ViewField>{data.companyDepartment}</$ViewField>
+            )}
+            <$ViewField>{data.alternativeCompanyStreetAddress}</$ViewField>
+            <$ViewField>
+              {[data.alternativeCompanyPostcode, data.alternativeCompanyCity]
+                .join(' ')
+                .trim()}
+            </$ViewField>
+          </$GridCell>
+        </ReviewSection>
+      )}
+    </>
+  );
+};
+
+export default CompanyInfoView;

--- a/frontend/benefit/handler/src/components/applicationReview/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/companyInfoView/CompanyInfoView.tsx
@@ -1,4 +1,5 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { ORGANIZATION_TYPES } from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -13,7 +14,6 @@ const CompanyInfoView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   const theme = useTheme();
-  // todo: add the association info in the bottom
   return (
     <ReviewSection header={t(`${translationsBase}.headings.heading1`)}>
       <$GridCell $colSpan={3}>
@@ -55,6 +55,32 @@ const CompanyInfoView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
               {[data.alternativeCompanyPostcode, data.alternativeCompanyCity]
                 .join(' ')
                 .trim()}
+            </$ViewField>
+          </$GridCell>
+        </>
+      )}
+      {data.organizationType === ORGANIZATION_TYPES.ASSOCIATION && (
+        <>
+          <$GridCell $colSpan={12}>
+            <$ViewField>
+              {t(`${translationsBase}.fields.associationHasBusinessActivities`)}{' '}
+              <$ViewFieldBold>
+                {t(
+                  `common:utility.${
+                    data.associationHasBusinessActivities ? 'yes' : 'no'
+                  }`
+                )}
+              </$ViewFieldBold>
+            </$ViewField>
+            <$ViewField>
+              {t(`${translationsBase}.fields.associationImmediateManagerCheck`)}{' '}
+              <$ViewFieldBold>
+                {t(
+                  `common:utility.${
+                    data.associationImmediateManagerCheck ? 'yes' : 'no'
+                  }`
+                )}
+              </$ViewFieldBold>
             </$ViewField>
           </$GridCell>
         </>

--- a/frontend/benefit/handler/src/components/applicationReview/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/companyInfoView/CompanyInfoView.tsx
@@ -1,5 +1,5 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { Application } from 'benefit/handler/types/application';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import {
@@ -9,63 +9,57 @@ import {
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { useTheme } from 'styled-components';
 
-export interface CompanyInfoViewProps {
-  data: Application;
-}
-
-const CompanyInfoView: React.FC<CompanyInfoViewProps> = ({ data }) => {
+const CompanyInfoView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   const theme = useTheme();
   // todo: add the association info in the bottom
   return (
-    <>
-      <ReviewSection header={t(`${translationsBase}.headings.heading1`)}>
-        <$GridCell $colSpan={3}>
-          <$ViewField>{data.company?.name}</$ViewField>
-          <$ViewField>{`${t(`${translationsBase}.fields.businessId`)}: ${
-            data.company?.businessId || ''
-          }`}</$ViewField>
-          <$ViewField>
-            {`${t(`${translationsBase}.fields.bankAccountNumber`)}: ${
-              data.companyBankAccountNumber || ''
-            }`}
-          </$ViewField>
-        </$GridCell>
-        <$GridCell $colSpan={3}>
-          <$ViewField>{data.company?.streetAddress}</$ViewField>
-          <$ViewField>{`${data.company?.postcode || ''} ${
-            data.company?.city || ''
-          }`}</$ViewField>
-        </$GridCell>
-        {data.alternativeCompanyStreetAddress && (
-          <>
-            <$GridCell
-              $colSpan={12}
-              css={`
-                font-size: ${theme.fontSize.body.m};
-                margin: ${theme.spacing.xs4} 0;
-              `}
-            >
-              <$ViewFieldBold>
-                {t(`${translationsBase}.headings.heading1Additional`)}
-              </$ViewFieldBold>
-            </$GridCell>
-            <$GridCell $colSpan={3}>
-              {data.companyDepartment && (
-                <$ViewField>{data.companyDepartment}</$ViewField>
-              )}
-              <$ViewField>{data.alternativeCompanyStreetAddress}</$ViewField>
-              <$ViewField>
-                {[data.alternativeCompanyPostcode, data.alternativeCompanyCity]
-                  .join(' ')
-                  .trim()}
-              </$ViewField>
-            </$GridCell>
-          </>
-        )}
-      </ReviewSection>
-    </>
+    <ReviewSection header={t(`${translationsBase}.headings.heading1`)}>
+      <$GridCell $colSpan={3}>
+        <$ViewField>{data.company?.name}</$ViewField>
+        <$ViewField>{`${t(`${translationsBase}.fields.businessId`)}: ${
+          data.company?.businessId || ''
+        }`}</$ViewField>
+        <$ViewField>
+          {`${t(`${translationsBase}.fields.bankAccountNumber`)}: ${
+            data.companyBankAccountNumber || ''
+          }`}
+        </$ViewField>
+      </$GridCell>
+      <$GridCell $colSpan={3}>
+        <$ViewField>{data.company?.streetAddress}</$ViewField>
+        <$ViewField>{`${data.company?.postcode || ''} ${
+          data.company?.city || ''
+        }`}</$ViewField>
+      </$GridCell>
+      {data.alternativeCompanyStreetAddress && (
+        <>
+          <$GridCell
+            $colSpan={12}
+            css={`
+              font-size: ${theme.fontSize.body.m};
+              margin: ${theme.spacing.xs4} 0;
+            `}
+          >
+            <$ViewFieldBold>
+              {t(`${translationsBase}.headings.heading1Additional`)}
+            </$ViewFieldBold>
+          </$GridCell>
+          <$GridCell $colSpan={3}>
+            {data.companyDepartment && (
+              <$ViewField>{data.companyDepartment}</$ViewField>
+            )}
+            <$ViewField>{data.alternativeCompanyStreetAddress}</$ViewField>
+            <$ViewField>
+              {[data.alternativeCompanyPostcode, data.alternativeCompanyCity]
+                .join(' ')
+                .trim()}
+            </$ViewField>
+          </$GridCell>
+        </>
+      )}
+    </ReviewSection>
   );
 };
 

--- a/frontend/benefit/handler/src/components/applicationReview/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/companyInfoView/CompanyInfoView.tsx
@@ -38,33 +38,33 @@ const CompanyInfoView: React.FC<CompanyInfoViewProps> = ({ data }) => {
             data.company?.city || ''
           }`}</$ViewField>
         </$GridCell>
+        {data.alternativeCompanyStreetAddress && (
+          <>
+            <$GridCell
+              $colSpan={12}
+              css={`
+                font-size: ${theme.fontSize.body.m};
+                margin: ${theme.spacing.xs4} 0;
+              `}
+            >
+              <$ViewFieldBold>
+                {t(`${translationsBase}.headings.heading1Additional`)}
+              </$ViewFieldBold>
+            </$GridCell>
+            <$GridCell $colSpan={3}>
+              {data.companyDepartment && (
+                <$ViewField>{data.companyDepartment}</$ViewField>
+              )}
+              <$ViewField>{data.alternativeCompanyStreetAddress}</$ViewField>
+              <$ViewField>
+                {[data.alternativeCompanyPostcode, data.alternativeCompanyCity]
+                  .join(' ')
+                  .trim()}
+              </$ViewField>
+            </$GridCell>
+          </>
+        )}
       </ReviewSection>
-      {data.alternativeCompanyStreetAddress && (
-        <ReviewSection>
-          <$GridCell
-            $colSpan={12}
-            css={`
-              font-size: ${theme.fontSize.body.m};
-              margin: ${theme.spacing.xs4} 0;
-            `}
-          >
-            <$ViewFieldBold>
-              {t(`${translationsBase}.headings.heading1Additional`)}
-            </$ViewFieldBold>
-          </$GridCell>
-          <$GridCell $colSpan={3}>
-            {data.companyDepartment && (
-              <$ViewField>{data.companyDepartment}</$ViewField>
-            )}
-            <$ViewField>{data.alternativeCompanyStreetAddress}</$ViewField>
-            <$ViewField>
-              {[data.alternativeCompanyPostcode, data.alternativeCompanyCity]
-                .join(' ')
-                .trim()}
-            </$ViewField>
-          </$GridCell>
-        </ReviewSection>
-      )}
     </>
   );
 };

--- a/frontend/benefit/handler/src/components/applicationReview/companyInfoView/__tests__/CompanyInfoView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/companyInfoView/__tests__/CompanyInfoView.test.tsx
@@ -1,0 +1,37 @@
+import { RenderResult } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { ORGANIZATION_TYPES } from 'benefit/handler/constants';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import CompanyInfoView from '../CompanyInfoView';
+
+describe('CompanyInfoView', () => {
+  const initialProps = {
+    data: {
+      company: {
+        name: 'Test company',
+        businessId: '123456-1234',
+        companyForm: 'OY',
+        streetAddress: 'Street address',
+        postcode: '12345',
+        city: 'Helsinki',
+        bankAccountNumber: 'FI1234567890',
+        organizationType: ORGANIZATION_TYPES.COMPANY,
+      },
+    },
+  };
+
+  const getComponent = (
+    props: Partial<ApplicationReviewViewProps> = {}
+  ): RenderResult =>
+    renderComponent(<CompanyInfoView {...initialProps} {...props} />)
+      .renderResult;
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/consentView/ConsentView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/consentView/ConsentView.tsx
@@ -1,0 +1,24 @@
+import AttachmentsListView from 'benefit/handler/components/attachmentsListView/AttachmentsListView';
+import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+
+const ConsentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
+  const translationsBase = 'common:review';
+  const { t } = useTranslation();
+  return (
+    <ReviewSection header={t(`${translationsBase}.headings.heading9`)}>
+      <$GridCell $colSpan={12}>
+        <AttachmentsListView
+          type={ATTACHMENT_TYPES.EMPLOYEE_CONSENT}
+          attachments={data.attachments || []}
+        />
+      </$GridCell>
+    </ReviewSection>
+  );
+};
+
+export default ConsentView;

--- a/frontend/benefit/handler/src/components/applicationReview/consentView/ConsentView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/consentView/ConsentView.tsx
@@ -1,6 +1,9 @@
 import AttachmentsListView from 'benefit/handler/components/attachmentsListView/AttachmentsListView';
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
+import {
+  APPLICATION_STATUSES,
+  ATTACHMENT_TYPES,
+} from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -10,7 +13,12 @@ const ConsentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <ReviewSection header={t(`${translationsBase}.headings.heading9`)}>
+    <ReviewSection
+      header={t(`${translationsBase}.headings.heading9`)}
+      action={
+        data.status !== APPLICATION_STATUSES.RECEIVED ? <>some actions</> : null
+      }
+    >
       <$GridCell $colSpan={12}>
         <AttachmentsListView
           type={ATTACHMENT_TYPES.EMPLOYEE_CONSENT}

--- a/frontend/benefit/handler/src/components/applicationReview/contactPersonView/ContactPersonView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/contactPersonView/ContactPersonView.tsx
@@ -1,0 +1,44 @@
+import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { Application } from 'benefit/handler/types/application';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import {
+  $ViewField,
+  $ViewFieldBold,
+} from 'shared/components/benefit/summaryView/SummaryView.sc';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { getFullName } from 'shared/utils/application.utils';
+
+export interface ContactPersonViewProps {
+  data: Application;
+}
+
+const ContactPersonView: React.FC<ContactPersonViewProps> = ({ data }) => {
+  const translationsBase = 'common:review';
+  const { t } = useTranslation();
+  return (
+    <>
+      <ReviewSection header={t(`${translationsBase}.headings.heading2`)}>
+        <$GridCell $colSpan={3}>
+          <$ViewField>
+            {getFullName(
+              data.companyContactPersonFirstName,
+              data.companyContactPersonLastName
+            )}
+          </$ViewField>
+          <$ViewField>{data.companyContactPersonPhoneNumber}</$ViewField>
+          <$ViewField>{data.companyContactPersonEmail}</$ViewField>
+          <$ViewField>
+            {t(`${translationsBase}.fields.applicantLanguage`)}
+            {': '}
+            <$ViewFieldBold>
+              {t(`common:languages.${data.applicantLanguage || ''}`)}
+            </$ViewFieldBold>
+          </$ViewField>
+        </$GridCell>
+      </ReviewSection>
+    </>
+  );
+};
+
+export default ContactPersonView;

--- a/frontend/benefit/handler/src/components/applicationReview/contactPersonView/ContactPersonView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/contactPersonView/ContactPersonView.tsx
@@ -1,5 +1,5 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { Application } from 'benefit/handler/types/application';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import {
@@ -9,35 +9,29 @@ import {
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { getFullName } from 'shared/utils/application.utils';
 
-export interface ContactPersonViewProps {
-  data: Application;
-}
-
-const ContactPersonView: React.FC<ContactPersonViewProps> = ({ data }) => {
+const ContactPersonView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <>
-      <ReviewSection header={t(`${translationsBase}.headings.heading2`)}>
-        <$GridCell $colSpan={3}>
-          <$ViewField>
-            {getFullName(
-              data.companyContactPersonFirstName,
-              data.companyContactPersonLastName
-            )}
-          </$ViewField>
-          <$ViewField>{data.companyContactPersonPhoneNumber}</$ViewField>
-          <$ViewField>{data.companyContactPersonEmail}</$ViewField>
-          <$ViewField>
-            {t(`${translationsBase}.fields.applicantLanguage`)}
-            {': '}
-            <$ViewFieldBold>
-              {t(`common:languages.${data.applicantLanguage || ''}`)}
-            </$ViewFieldBold>
-          </$ViewField>
-        </$GridCell>
-      </ReviewSection>
-    </>
+    <ReviewSection header={t(`${translationsBase}.headings.heading2`)}>
+      <$GridCell $colSpan={3}>
+        <$ViewField>
+          {getFullName(
+            data.companyContactPersonFirstName,
+            data.companyContactPersonLastName
+          )}
+        </$ViewField>
+        <$ViewField>{data.companyContactPersonPhoneNumber}</$ViewField>
+        <$ViewField>{data.companyContactPersonEmail}</$ViewField>
+        <$ViewField>
+          {t(`${translationsBase}.fields.applicantLanguage`)}
+          {': '}
+          <$ViewFieldBold>
+            {t(`common:languages.${data.applicantLanguage || ''}`)}
+          </$ViewFieldBold>
+        </$ViewField>
+      </$GridCell>
+    </ReviewSection>
   );
 };
 

--- a/frontend/benefit/handler/src/components/applicationReview/contactPersonView/ContactPersonView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/contactPersonView/ContactPersonView.tsx
@@ -1,4 +1,5 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { APPLICATION_STATUSES } from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -13,7 +14,10 @@ const ContactPersonView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <ReviewSection header={t(`${translationsBase}.headings.heading2`)}>
+    <ReviewSection
+      header={t(`${translationsBase}.headings.heading2`)}
+      action={data.status !== APPLICATION_STATUSES.RECEIVED ? <></> : null}
+    >
       <$GridCell $colSpan={3}>
         <$ViewField>
           {getFullName(

--- a/frontend/benefit/handler/src/components/applicationReview/contactPersonView/__tests__/ContactPersonView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/contactPersonView/__tests__/ContactPersonView.test.tsx
@@ -1,0 +1,30 @@
+import { RenderResult } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import ContactPersonView from '../ContactPersonView';
+
+describe('ContactPersonView', () => {
+  const initialProps = {
+    data: {
+      companyContactPersonFirstName: 'Pekka',
+      companyContactPersonLastName: 'Kellokoski',
+      companyContactPersonPhoneNumber: '041234567',
+      companyContactPersonEmail: 'test@test.com',
+    },
+  };
+
+  const getComponent = (
+    props: Partial<ApplicationReviewViewProps> = {}
+  ): RenderResult =>
+    renderComponent(<ContactPersonView {...initialProps} {...props} />)
+      .renderResult;
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/deminimisView/DeminimisView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/deminimisView/DeminimisView.tsx
@@ -1,5 +1,6 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { Application, DeMinimisAid } from 'benefit/handler/types/application';
+import { ApplicationReviewViewProps,DeMinimisAid  } from 'benefit/handler/types/application';
+import sumBy from 'lodash/sumBy';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import {
@@ -8,72 +9,64 @@ import {
 } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
+import { formatStringFloatValue } from 'shared/utils/string.utils';
 
-export interface DeminimisViewProps {
-  data: Application;
-}
-
-const DeminimisView: React.FC<DeminimisViewProps> = ({ data }) => {
+const DeminimisView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <>
-      <ReviewSection header={t(`${translationsBase}.headings.heading3`)}>
-        {data.deMinimisAidSet && data.deMinimisAidSet?.length > 0 ? (
-          <>
-            <$GridCell $colSpan={3}>
-              <$SummaryTableHeader>
-                {t(`${translationsBase}.fields.deMinimisAidGranter`)}
-              </$SummaryTableHeader>
-            </$GridCell>
-            <$GridCell $colSpan={2}>
-              <$SummaryTableHeader>
-                {t(`${translationsBase}.fields.deMinimisAidAmount`)}
-              </$SummaryTableHeader>
-            </$GridCell>
-            <$GridCell>
-              <$SummaryTableHeader>
-                {t(`${translationsBase}.fields.deMinimisAidGrantedAt`)}
-              </$SummaryTableHeader>
-            </$GridCell>
-            {data.deMinimisAidSet?.map((aid: DeMinimisAid) => (
-              <React.Fragment
-                key={`${aid.granter ?? ''}${aid.grantedAt ?? ''}`}
-              >
-                <$GridCell $colStart={1} $colSpan={3}>
-                  <$SummaryTableValue>{aid.granter}</$SummaryTableValue>
-                </$GridCell>
-                <$GridCell $colSpan={2}>
-                  <$SummaryTableValue>{`${
-                    aid.amount || ''
-                  } €`}</$SummaryTableValue>
-                </$GridCell>
-                <$GridCell>
-                  <$SummaryTableValue>
-                    {aid.grantedAt ? convertToUIDateFormat(aid.grantedAt) : ''}
-                  </$SummaryTableValue>
-                </$GridCell>
-              </React.Fragment>
-            ))}
-            <$GridCell $colStart={1} $colSpan={3}>
-              <$SummaryTableValue isBold>
-                {t(`${translationsBase}.fields.deMinimisAidTotal`)}
-              </$SummaryTableValue>
-            </$GridCell>
-            <$GridCell $colSpan={2}>
-              <$SummaryTableValue isBold>
-                {`${data.deMinimisAidSet.reduce(
-                  (partial_sum, a) => partial_sum + Number(a.amount),
-                  0
-                )} €`}
-              </$SummaryTableValue>
-            </$GridCell>
-          </>
-        ) : (
-          '-'
-        )}
-      </ReviewSection>
-    </>
+    <ReviewSection header={t(`${translationsBase}.headings.heading3`)}>
+      {data.deMinimisAidSet && data.deMinimisAidSet?.length > 0 ? (
+        <>
+          <$GridCell $colSpan={3}>
+            <$SummaryTableHeader>
+              {t(`${translationsBase}.fields.deMinimisAidGranter`)}
+            </$SummaryTableHeader>
+          </$GridCell>
+          <$GridCell $colSpan={2}>
+            <$SummaryTableHeader>
+              {t(`${translationsBase}.fields.deMinimisAidAmount`)}
+            </$SummaryTableHeader>
+          </$GridCell>
+          <$GridCell>
+            <$SummaryTableHeader>
+              {t(`${translationsBase}.fields.deMinimisAidGrantedAt`)}
+            </$SummaryTableHeader>
+          </$GridCell>
+          {data.deMinimisAidSet?.map((aid: DeMinimisAid) => (
+            <React.Fragment key={`${aid.granter ?? ''}${aid.grantedAt ?? ''}`}>
+              <$GridCell $colStart={1} $colSpan={3}>
+                <$SummaryTableValue>{aid.granter}</$SummaryTableValue>
+              </$GridCell>
+              <$GridCell $colSpan={2}>
+                <$SummaryTableValue>{`${formatStringFloatValue(
+                  aid.amount || ''
+                )} €`}</$SummaryTableValue>
+              </$GridCell>
+              <$GridCell>
+                <$SummaryTableValue>
+                  {aid.grantedAt ? convertToUIDateFormat(aid.grantedAt) : ''}
+                </$SummaryTableValue>
+              </$GridCell>
+            </React.Fragment>
+          ))}
+          <$GridCell $colStart={1} $colSpan={3}>
+            <$SummaryTableValue isBold>
+              {t(`${translationsBase}.fields.deMinimisAidTotal`)}
+            </$SummaryTableValue>
+          </$GridCell>
+          <$GridCell $colSpan={2}>
+            <$SummaryTableValue isBold>
+              {`${sumBy(data.deMinimisAidSet, (grant) =>
+                Number(grant.amount)
+              )} €`}
+            </$SummaryTableValue>
+          </$GridCell>
+        </>
+      ) : (
+        '-'
+      )}
+    </ReviewSection>
   );
 };
 

--- a/frontend/benefit/handler/src/components/applicationReview/deminimisView/DeminimisView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/deminimisView/DeminimisView.tsx
@@ -1,5 +1,9 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { ApplicationReviewViewProps,DeMinimisAid  } from 'benefit/handler/types/application';
+import { APPLICATION_STATUSES } from 'benefit/handler/constants';
+import {
+  ApplicationReviewViewProps,
+  DeMinimisAid,
+} from 'benefit/handler/types/application';
 import sumBy from 'lodash/sumBy';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -15,7 +19,10 @@ const DeminimisView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <ReviewSection header={t(`${translationsBase}.headings.heading3`)}>
+    <ReviewSection
+      header={t(`${translationsBase}.headings.heading3`)}
+      action={data.status !== APPLICATION_STATUSES.RECEIVED ? <></> : null}
+    >
       {data.deMinimisAidSet && data.deMinimisAidSet?.length > 0 ? (
         <>
           <$GridCell $colSpan={3}>

--- a/frontend/benefit/handler/src/components/applicationReview/deminimisView/DeminimisView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/deminimisView/DeminimisView.tsx
@@ -1,0 +1,80 @@
+import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { Application, DeMinimisAid } from 'benefit/handler/types/application';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import {
+  $SummaryTableHeader,
+  $SummaryTableValue,
+} from 'shared/components/benefit/summaryView/SummaryView.sc';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { convertToUIDateFormat } from 'shared/utils/date.utils';
+
+export interface DeminimisViewProps {
+  data: Application;
+}
+
+const DeminimisView: React.FC<DeminimisViewProps> = ({ data }) => {
+  const translationsBase = 'common:review';
+  const { t } = useTranslation();
+  return (
+    <>
+      <ReviewSection header={t(`${translationsBase}.headings.heading3`)}>
+        {data.deMinimisAidSet && data.deMinimisAidSet?.length > 0 ? (
+          <>
+            <$GridCell $colSpan={3}>
+              <$SummaryTableHeader>
+                {t(`${translationsBase}.fields.deMinimisAidGranter`)}
+              </$SummaryTableHeader>
+            </$GridCell>
+            <$GridCell $colSpan={2}>
+              <$SummaryTableHeader>
+                {t(`${translationsBase}.fields.deMinimisAidAmount`)}
+              </$SummaryTableHeader>
+            </$GridCell>
+            <$GridCell>
+              <$SummaryTableHeader>
+                {t(`${translationsBase}.fields.deMinimisAidGrantedAt`)}
+              </$SummaryTableHeader>
+            </$GridCell>
+            {data.deMinimisAidSet?.map((aid: DeMinimisAid) => (
+              <React.Fragment
+                key={`${aid.granter ?? ''}${aid.grantedAt ?? ''}`}
+              >
+                <$GridCell $colStart={1} $colSpan={3}>
+                  <$SummaryTableValue>{aid.granter}</$SummaryTableValue>
+                </$GridCell>
+                <$GridCell $colSpan={2}>
+                  <$SummaryTableValue>{`${
+                    aid.amount || ''
+                  } €`}</$SummaryTableValue>
+                </$GridCell>
+                <$GridCell>
+                  <$SummaryTableValue>
+                    {aid.grantedAt ? convertToUIDateFormat(aid.grantedAt) : ''}
+                  </$SummaryTableValue>
+                </$GridCell>
+              </React.Fragment>
+            ))}
+            <$GridCell $colStart={1} $colSpan={3}>
+              <$SummaryTableValue isBold>
+                {t(`${translationsBase}.fields.deMinimisAidTotal`)}
+              </$SummaryTableValue>
+            </$GridCell>
+            <$GridCell $colSpan={2}>
+              <$SummaryTableValue isBold>
+                {`${data.deMinimisAidSet.reduce(
+                  (partial_sum, a) => partial_sum + Number(a.amount),
+                  0
+                )} €`}
+              </$SummaryTableValue>
+            </$GridCell>
+          </>
+        ) : (
+          '-'
+        )}
+      </ReviewSection>
+    </>
+  );
+};
+
+export default DeminimisView;

--- a/frontend/benefit/handler/src/components/applicationReview/deminimisView/__tests__/DeminimisView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/deminimisView/__tests__/DeminimisView.test.tsx
@@ -1,0 +1,29 @@
+import { RenderResult } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import DeminimisView from '../DeminimisView';
+
+describe('DeminimisView', () => {
+  const initialProps = {
+    data: {
+      deMinimisAidSet: [
+        { grantedAt: '01-02-2021', granter: 'test granter', amount: 1000 },
+      ],
+    },
+  };
+
+  const getComponent = (
+    props: Partial<ApplicationReviewViewProps> = {}
+  ): RenderResult =>
+    renderComponent(<DeminimisView {...initialProps} {...props} />)
+      .renderResult;
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
@@ -1,4 +1,5 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -8,6 +9,8 @@ import {
 } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { getFullName } from 'shared/utils/application.utils';
+
+import AttachmentsListView from '../../attachmentsListView/AttachmentsListView';
 
 const EmployeeView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
@@ -28,6 +31,11 @@ const EmployeeView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
           )}`}</$ViewFieldBold>
         </$ViewField>
       </$GridCell>
+      <AttachmentsListView
+        title={t('common:attachments.types.helsinkiBenefitVoucher.title')}
+        type={ATTACHMENT_TYPES.HELSINKI_BENEFIT_VOUCHER}
+        attachments={data.attachments || []}
+      />
     </ReviewSection>
   );
 };

--- a/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
@@ -1,5 +1,8 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
+import {
+  APPLICATION_STATUSES,
+  ATTACHMENT_TYPES,
+} from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -16,7 +19,12 @@ const EmployeeView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <ReviewSection header={t(`${translationsBase}.headings.heading5`)}>
+    <ReviewSection
+      header={t(`${translationsBase}.headings.heading5`)}
+      action={
+        data.status !== APPLICATION_STATUSES.RECEIVED ? <>some actions</> : null
+      }
+    >
       <$GridCell $colSpan={3}>
         <$ViewField>
           {getFullName(data.employee?.firstName, data.employee?.lastName)}

--- a/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
@@ -1,5 +1,5 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { Application } from 'benefit/handler/types/application';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import {
@@ -9,34 +9,26 @@ import {
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { getFullName } from 'shared/utils/application.utils';
 
-export interface EmployeeViewProps {
-  data: Application;
-}
-
-const EmployeeView: React.FC<EmployeeViewProps> = ({ data }) => {
+const EmployeeView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <>
-      <ReviewSection header={t(`${translationsBase}.headings.heading5`)}>
-        <$GridCell $colSpan={3}>
-          <$ViewField>
-            {getFullName(data.employee?.firstName, data.employee?.lastName)}
-          </$ViewField>
-          <$ViewField>{data.employee?.socialSecurityNumber}</$ViewField>
-          <$ViewField>{data.employee?.phoneNumber}</$ViewField>
-          <$ViewField>
-            {t(`${translationsBase}.fields.isLivingInHelsinki`)}
-            {': '}
-            <$ViewFieldBold>{` ${t(
-              `common:utility.${
-                data.employee?.isLivingInHelsinki ? 'yes' : 'no'
-              }`
-            )}`}</$ViewFieldBold>
-          </$ViewField>
-        </$GridCell>
-      </ReviewSection>
-    </>
+    <ReviewSection header={t(`${translationsBase}.headings.heading5`)}>
+      <$GridCell $colSpan={3}>
+        <$ViewField>
+          {getFullName(data.employee?.firstName, data.employee?.lastName)}
+        </$ViewField>
+        <$ViewField>{data.employee?.socialSecurityNumber}</$ViewField>
+        <$ViewField>{data.employee?.phoneNumber}</$ViewField>
+        <$ViewField>
+          {t(`${translationsBase}.fields.isLivingInHelsinki`)}
+          {': '}
+          <$ViewFieldBold>{` ${t(
+            `common:utility.${data.employee?.isLivingInHelsinki ? 'yes' : 'no'}`
+          )}`}</$ViewFieldBold>
+        </$ViewField>
+      </$GridCell>
+    </ReviewSection>
   );
 };
 

--- a/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
@@ -1,0 +1,43 @@
+import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { Application } from 'benefit/handler/types/application';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import {
+  $ViewField,
+  $ViewFieldBold,
+} from 'shared/components/benefit/summaryView/SummaryView.sc';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { getFullName } from 'shared/utils/application.utils';
+
+export interface EmployeeViewProps {
+  data: Application;
+}
+
+const EmployeeView: React.FC<EmployeeViewProps> = ({ data }) => {
+  const translationsBase = 'common:review';
+  const { t } = useTranslation();
+  return (
+    <>
+      <ReviewSection header={t(`${translationsBase}.headings.heading5`)}>
+        <$GridCell $colSpan={3}>
+          <$ViewField>
+            {getFullName(data.employee?.firstName, data.employee?.lastName)}
+          </$ViewField>
+          <$ViewField>{data.employee?.socialSecurityNumber}</$ViewField>
+          <$ViewField>{data.employee?.phoneNumber}</$ViewField>
+          <$ViewField>
+            {t(`${translationsBase}.fields.isLivingInHelsinki`)}
+            {': '}
+            <$ViewFieldBold>{` ${t(
+              `common:utility.${
+                data.employee?.isLivingInHelsinki ? 'yes' : 'no'
+              }`
+            )}`}</$ViewFieldBold>
+          </$ViewField>
+        </$GridCell>
+      </ReviewSection>
+    </>
+  );
+};
+
+export default EmployeeView;

--- a/frontend/benefit/handler/src/components/applicationReview/employeeView/__tests__/EmployeeView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employeeView/__tests__/EmployeeView.test.tsx
@@ -1,0 +1,31 @@
+import { RenderResult } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import EmployeeView from '../EmployeeView';
+
+describe('EmployeeView', () => {
+  const initialProps = {
+    data: {
+      employee: {
+        firstName: 'test first name',
+        lastName: 'test last name',
+        socialSecurityNumber: '1111111-01',
+        isLivingInHelsinki: true,
+      },
+    },
+  };
+
+  const getComponent = (
+    props: Partial<ApplicationReviewViewProps> = {}
+  ): RenderResult =>
+    renderComponent(<EmployeeView {...initialProps} {...props} />).renderResult;
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
@@ -1,0 +1,52 @@
+import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import { $ViewField } from 'shared/components/benefit/summaryView/SummaryView.sc';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { formatStringFloatValue } from 'shared/utils/string.utils';
+
+const EmploymentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
+  const translationsBase = 'common:review';
+  const { t } = useTranslation();
+  return (
+    <ReviewSection header={t(`${translationsBase}.headings.heading8`)}>
+      <$GridCell $colSpan={5}>
+        <$ViewField>
+          {`${t(`${translationsBase}.fields.jobTitle`)}: ${
+            data.employee?.jobTitle || '-'
+          }`}
+        </$ViewField>
+        <$ViewField>
+          {t(`${translationsBase}.fields.workingHours`, {
+            workingHours: formatStringFloatValue(data.employee?.workingHours),
+          })}
+        </$ViewField>
+        <$ViewField>
+          {t(`${translationsBase}.fields.monthlyPay`, {
+            monthlyPay: formatStringFloatValue(data.employee?.monthlyPay),
+          })}
+        </$ViewField>
+        <$ViewField>
+          {t(`${translationsBase}.fields.otherExpenses`, {
+            otherExpenses: formatStringFloatValue(data.employee?.otherExpenses),
+          })}
+        </$ViewField>
+        <$ViewField
+          css={`
+            &&& {
+              padding-bottom: 0;
+            }
+          `}
+        >
+          {t(`${translationsBase}.fields.vacationMoney`, {
+            vacationMoney: formatStringFloatValue(data.employee?.vacationMoney),
+          })}
+        </$ViewField>
+        <$ViewField>{data.employee?.collectiveBargainingAgreement}</$ViewField>
+      </$GridCell>
+    </ReviewSection>
+  );
+};
+
+export default EmploymentView;

--- a/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
@@ -1,10 +1,13 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $ViewField } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { formatStringFloatValue } from 'shared/utils/string.utils';
+
+import AttachmentsListView from '../../attachmentsListView/AttachmentsListView';
 
 const EmploymentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
@@ -45,6 +48,11 @@ const EmploymentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
         </$ViewField>
         <$ViewField>{data.employee?.collectiveBargainingAgreement}</$ViewField>
       </$GridCell>
+      <AttachmentsListView
+        title={t('common:attachments.types.employmentContract.title')}
+        type={ATTACHMENT_TYPES.EMPLOYMENT_CONTRACT}
+        attachments={data.attachments || []}
+      />
     </ReviewSection>
   );
 };

--- a/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
@@ -1,5 +1,8 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
+import {
+  APPLICATION_STATUSES,
+  ATTACHMENT_TYPES,
+} from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -13,7 +16,12 @@ const EmploymentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <ReviewSection header={t(`${translationsBase}.headings.heading8`)}>
+    <ReviewSection
+      header={t(`${translationsBase}.headings.heading8`)}
+      action={
+        data.status !== APPLICATION_STATUSES.RECEIVED ? <>some actions</> : null
+      }
+    >
       <$GridCell $colSpan={5}>
         <$ViewField>
           {`${t(`${translationsBase}.fields.jobTitle`)}: ${

--- a/frontend/benefit/handler/src/components/applicationReview/employmentView/__tests__/EmploymentView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentView/__tests__/EmploymentView.test.tsx
@@ -1,0 +1,33 @@
+import { RenderResult } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import EmpoymentView from '../EmpoymentView';
+
+describe('EmpoymentView', () => {
+  const initialProps = {
+    data: {
+      employee: {
+        workingHours: 18,
+        monthlyPay: 3000,
+        otherExpenses: 100,
+        vacationMoney: 2000,
+        collectiveBargainingAgreement: 'agreement',
+      },
+    },
+  };
+
+  const getComponent = (
+    props: Partial<ApplicationReviewViewProps> = {}
+  ): RenderResult =>
+    renderComponent(<EmpoymentView {...initialProps} {...props} />)
+      .renderResult;
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyView.tsx
@@ -1,4 +1,5 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -7,6 +8,8 @@ import {
   $ViewFieldBold,
 } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+
+import AttachmentsListView from '../../attachmentsListView/AttachmentsListView';
 
 const PaySubsidyView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
@@ -42,6 +45,11 @@ const PaySubsidyView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
           </$ViewField>
         )}
       </$GridCell>
+      <AttachmentsListView
+        title={t('common:attachments.types.paySubsidyDecision.title')}
+        type={ATTACHMENT_TYPES.PAY_SUBSIDY_CONTRACT}
+        attachments={data.attachments || []}
+      />
     </ReviewSection>
   );
 };

--- a/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyView.tsx
@@ -1,5 +1,5 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { Application } from 'benefit/handler/types/application';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import {
@@ -8,18 +8,14 @@ import {
 } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 
-export interface PaySubsidyViewProps {
-  data: Application;
-}
-
-const PaySubsidyView: React.FC<PaySubsidyViewProps> = ({ data }) => {
+const PaySubsidyView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <>
-      <ReviewSection header={t(`${translationsBase}.headings.heading6`)}>
-        <$GridCell $colSpan={3}>
-          {data.paySubsidyGranted && (
+    <ReviewSection header={t(`${translationsBase}.headings.heading6`)}>
+      <$GridCell $colSpan={12}>
+        {data.paySubsidyGranted ? (
+          <>
             <$ViewFieldBold>
               {t(`common:utility.${data.paySubsidyGranted ? 'yes' : 'no'}`)}
               <$ViewField isInline>{`, ${data.paySubsidyPercent || ''} % ${
@@ -30,17 +26,23 @@ const PaySubsidyView: React.FC<PaySubsidyViewProps> = ({ data }) => {
                   : ''
               }`}</$ViewField>
             </$ViewFieldBold>
-          )}
-
+            <$ViewField>
+              {t(`${translationsBase}.fields.apprenticeshipProgram`)}{' '}
+              <$ViewFieldBold>
+                {t(
+                  `common:utility.${data.apprenticeshipProgram ? 'yes' : 'no'}`
+                )}
+              </$ViewFieldBold>
+            </$ViewField>
+          </>
+        ) : (
           <$ViewField>
-            {t(`${translationsBase}.fields.apprenticeshipProgram`)}{' '}
-            <$ViewFieldBold>
-              {t(`common:utility.${data.apprenticeshipProgram ? 'yes' : 'no'}`)}
-            </$ViewFieldBold>
+            {t(`${translationsBase}.fields.paySubsidyGranted`)}{' '}
+            <$ViewFieldBold>{t('common:utility.no')}</$ViewFieldBold>
           </$ViewField>
-        </$GridCell>
-      </ReviewSection>
-    </>
+        )}
+      </$GridCell>
+    </ReviewSection>
   );
 };
 

--- a/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyView.tsx
@@ -1,0 +1,47 @@
+import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
+import { Application } from 'benefit/handler/types/application';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import {
+  $ViewField,
+  $ViewFieldBold,
+} from 'shared/components/benefit/summaryView/SummaryView.sc';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+
+export interface PaySubsidyViewProps {
+  data: Application;
+}
+
+const PaySubsidyView: React.FC<PaySubsidyViewProps> = ({ data }) => {
+  const translationsBase = 'common:review';
+  const { t } = useTranslation();
+  return (
+    <>
+      <ReviewSection header={t(`${translationsBase}.headings.heading6`)}>
+        <$GridCell $colSpan={3}>
+          {data.paySubsidyGranted && (
+            <$ViewFieldBold>
+              {t(`common:utility.${data.paySubsidyGranted ? 'yes' : 'no'}`)}
+              <$ViewField isInline>{`, ${data.paySubsidyPercent || ''} % ${
+                data.additionalPaySubsidyPercent
+                  ? `${t('common:utility.and')} ${
+                      data.additionalPaySubsidyPercent
+                    } %`
+                  : ''
+              }`}</$ViewField>
+            </$ViewFieldBold>
+          )}
+
+          <$ViewField>
+            {t(`${translationsBase}.fields.apprenticeshipProgram`)}{' '}
+            <$ViewFieldBold>
+              {t(`common:utility.${data.apprenticeshipProgram ? 'yes' : 'no'}`)}
+            </$ViewFieldBold>
+          </$ViewField>
+        </$GridCell>
+      </ReviewSection>
+    </>
+  );
+};
+
+export default PaySubsidyView;

--- a/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyView.tsx
@@ -1,5 +1,8 @@
 import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSection';
-import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
+import {
+  APPLICATION_STATUSES,
+  ATTACHMENT_TYPES,
+} from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -15,7 +18,12 @@ const PaySubsidyView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
-    <ReviewSection header={t(`${translationsBase}.headings.heading6`)}>
+    <ReviewSection
+      header={t(`${translationsBase}.headings.heading6`)}
+      action={
+        data.status !== APPLICATION_STATUSES.RECEIVED ? <>some actions</> : null
+      }
+    >
       <$GridCell $colSpan={12}>
         {data.paySubsidyGranted ? (
           <>

--- a/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/__tests__/PaySubsidyView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/__tests__/PaySubsidyView.test.tsx
@@ -1,0 +1,28 @@
+import { RenderResult } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import PaySubsidyView from '../PaySubsidyView';
+
+describe('PaySubsidyView', () => {
+  const initialProps = {
+    data: {
+      paySubsidyGranted: false,
+      apprenticeshipProgram: true,
+    },
+  };
+
+  const getComponent = (
+    props: Partial<ApplicationReviewViewProps> = {}
+  ): RenderResult =>
+    renderComponent(<PaySubsidyView {...initialProps} {...props} />)
+      .renderResult;
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/benefit/handler/src/components/attachmentsListView/AttachmentsListView.tsx
+++ b/frontend/benefit/handler/src/components/attachmentsListView/AttachmentsListView.tsx
@@ -1,0 +1,75 @@
+import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
+import { IconLinkExternal, IconPaperclip } from 'hds-react';
+import * as React from 'react';
+import {
+  $ViewField,
+  $ViewFieldBold,
+} from 'shared/components/benefit/summaryView/SummaryView.sc';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import theme from 'shared/styles/theme';
+import Attachment from 'shared/types/attachment';
+
+export interface AttachmentsListViewProps {
+  attachments: Attachment[];
+  type: ATTACHMENT_TYPES;
+  title?: string;
+}
+
+const AttachmentsListView: React.FC<AttachmentsListViewProps> = ({
+  attachments,
+  type,
+  title,
+}) => {
+  const attachmentItems = React.useMemo(
+    (): Attachment[] =>
+      attachments?.filter((att: Attachment) => att.attachmentType === type),
+    [attachments, type]
+  );
+
+  const handleOpenFile = React.useCallback(
+    (file: Attachment) =>
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      window.open(file.attachmentFile, '_blank')?.focus(),
+    []
+  );
+
+  return (
+    <>
+      {attachmentItems.length > 0 && (
+        <$GridCell $colStart={1} $colSpan={6}>
+          {title && (
+            <$ViewFieldBold css={{ fontSize: theme.fontSize.body.m }}>
+              {title}
+            </$ViewFieldBold>
+          )}
+          {attachmentItems.map((attachment: Attachment) => (
+            <$ViewField
+              css={{
+                display: 'flex',
+                alignItems: 'center',
+                marginTop: `${theme.spacing.xs}`,
+                fontSize: theme.fontSize.body.m,
+                color: theme.colors.coatOfArms,
+              }}
+              key={attachment.attachmentFileName}
+            >
+              <IconPaperclip
+                css={{ color: theme.colors.black }}
+                aria-label={attachment.attachmentFileName}
+              />
+              {attachment.attachmentFileName}
+              <IconLinkExternal
+                onClick={() => handleOpenFile(attachment)}
+                aria-label={`${attachment.attachmentFileName}_open`}
+                css={{ marginLeft: theme.spacing.xs, cursor: 'pointer' }}
+                size="s"
+              />
+            </$ViewField>
+          ))}
+        </$GridCell>
+      )}
+    </>
+  );
+};
+
+export default AttachmentsListView;

--- a/frontend/benefit/handler/src/components/attachmentsListView/__tests__/AttachmentsListView.test.tsx
+++ b/frontend/benefit/handler/src/components/attachmentsListView/__tests__/AttachmentsListView.test.tsx
@@ -1,0 +1,40 @@
+import { RenderResult } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
+import { axe } from 'jest-axe';
+import React from 'react';
+import Attachment from 'shared/types/attachment';
+
+import AttachmentsListView, {
+  AttachmentsListViewProps,
+} from '../AttachmentsListView';
+
+describe('AttachmentsListView', () => {
+  const initialProps: AttachmentsListViewProps = {
+    type: ATTACHMENT_TYPES.HELSINKI_BENEFIT_VOUCHER,
+    title: 'Attachments',
+    attachments: [
+      {
+        application: '9cfe273b-85d0-468e-b462-c8e5c04ce142',
+        attachmentFile: 'http://localhost:8000/media/Contract.png',
+        attachmentFileName: 'Contract.png',
+        attachmentType: ATTACHMENT_TYPES.HELSINKI_BENEFIT_VOUCHER,
+        contentType: 'image/png',
+        createdAt: '2021-09-09T10:37:13.341633+03:00',
+        id: '68034254-0dff-423d-8659-58864a930ae7',
+      } as Attachment,
+    ],
+  };
+
+  const getComponent = (
+    props: Partial<AttachmentsListViewProps> = {}
+  ): RenderResult =>
+    renderComponent(<AttachmentsListView {...initialProps} {...props} />)
+      .renderResult;
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/benefit/handler/src/components/footer/Footer.tsx
+++ b/frontend/benefit/handler/src/components/footer/Footer.tsx
@@ -1,3 +1,4 @@
+import AppContext from 'benefit/handler/context/AppContext';
 import { Footer } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
@@ -6,6 +7,11 @@ import { $FooterWrapper } from './Footer.sc';
 
 const FooterSection: React.FC = () => {
   const { t } = useTranslation();
+  const { isFooterVisible } = React.useContext(AppContext);
+
+  if (!isFooterVisible) {
+    return null;
+  }
 
   return (
     <$FooterWrapper>

--- a/frontend/benefit/handler/src/components/reviewSection/ReviewSection.sc.ts
+++ b/frontend/benefit/handler/src/components/reviewSection/ReviewSection.sc.ts
@@ -32,6 +32,6 @@ export const $CheckIcon = styled(IconCheckCircle)`
 
 export const $ActionBottom = styled.div`
   background-color: ${(props) => props.theme.colors.silver};
-  padding: ${(props) => props.theme.spacing.s};
+  //padding: ${(props) => props.theme.spacing.s};
   padding-left: 102px;
 `;

--- a/frontend/benefit/handler/src/components/reviewSection/ReviewSection.tsx
+++ b/frontend/benefit/handler/src/components/reviewSection/ReviewSection.tsx
@@ -42,7 +42,9 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({
     <$Wrapper withAction={withAction} bgColor={bgColor}>
       <$WrapperInner withAction={withAction}>
         {withAction && (
-          <$ActionLeft>{action && <$CheckIcon size="m" />}</$ActionLeft>
+          <$ActionLeft>
+            {action && <$CheckIcon aria-label="application-action" size="m" />}
+          </$ActionLeft>
         )}
         <$Section paddingBottom={withAction}>
           {header && (

--- a/frontend/benefit/handler/src/components/reviewSection/ReviewSection.tsx
+++ b/frontend/benefit/handler/src/components/reviewSection/ReviewSection.tsx
@@ -58,6 +58,7 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({
               css={`
                 font-size: ${theme.fontSize.body.l};
                 padding: ${withMargin ? theme.spacing.m : 0} 0;
+                line-height: ${theme.lineHeight.l};
               `}
               role={role}
             >

--- a/frontend/benefit/handler/src/components/reviewSection/ReviewSection.tsx
+++ b/frontend/benefit/handler/src/components/reviewSection/ReviewSection.tsx
@@ -31,6 +31,7 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({
   header,
   action,
   withMargin,
+  withoutDivider,
   role,
   loading,
   ...rest
@@ -65,7 +66,7 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({
               {children}
             </$Grid>
           )}
-          {!withAction && (
+          {!withAction && !withoutDivider && (
             <$Hr
               css={`
                 margin-top: ${theme.spacing.l};

--- a/frontend/benefit/handler/src/constants.ts
+++ b/frontend/benefit/handler/src/constants.ts
@@ -10,6 +10,13 @@ export enum ROUTES {
 
 export enum SUPPORTED_LANGUAGES {
   FI = 'fi',
+  SV = 'sv',
+  EN = 'en',
+}
+
+export enum ORGANIZATION_TYPES {
+  COMPANY = 'company',
+  ASSOCIATION = 'association',
 }
 
 export const DEFAULT_LANGUAGE = SUPPORTED_LANGUAGES.FI;
@@ -49,6 +56,7 @@ export enum APPLICATION_FIELDS_STEP1_KEYS {
   DE_MINIMIS_AID_SET = 'deMinimisAidSet',
   CO_OPERATION_NEGOTIATIONS = 'coOperationNegotiations',
   CO_OPERATION_NEGOTIATIONS_DESCRIPTION = 'coOperationNegotiationsDescription',
+  ORGANIZATION_TYPE = 'organizationType',
 }
 
 export enum EMPLOYEE_KEYS {

--- a/frontend/benefit/handler/src/constants.ts
+++ b/frontend/benefit/handler/src/constants.ts
@@ -20,6 +20,15 @@ export enum BENEFIT_TYPES {
   COMMISSION = 'commission_benefit',
 }
 
+export enum ATTACHMENT_TYPES {
+  EMPLOYMENT_CONTRACT = 'employment_contract',
+  PAY_SUBSIDY_CONTRACT = 'pay_subsidy_decision',
+  COMMISSION_CONTRACT = 'commission_contract',
+  EDUCATION_CONTRACT = 'education_contract',
+  HELSINKI_BENEFIT_VOUCHER = 'helsinki_benefit_voucher',
+  EMPLOYEE_CONSENT = 'employee_consent',
+}
+
 export enum ORGANIZATION_TYPES {
   COMPANY = 'company',
   ASSOCIATION = 'association',

--- a/frontend/benefit/handler/src/constants.ts
+++ b/frontend/benefit/handler/src/constants.ts
@@ -14,6 +14,12 @@ export enum SUPPORTED_LANGUAGES {
   EN = 'en',
 }
 
+export enum BENEFIT_TYPES {
+  EMPLOYMENT = 'employment_benefit',
+  SALARY = 'salary_benefit',
+  COMMISSION = 'commission_benefit',
+}
+
 export enum ORGANIZATION_TYPES {
   COMPANY = 'company',
   ASSOCIATION = 'association',

--- a/frontend/benefit/handler/src/context/AppContext.tsx
+++ b/frontend/benefit/handler/src/context/AppContext.tsx
@@ -4,15 +4,19 @@ import theme from 'shared/styles/theme';
 
 export type AppContextType = {
   isNavigationVisible: boolean;
-  setIsNavigationVisible: (value: boolean) => void;
+  isFooterVisible: boolean;
   layoutBackgroundColor: string;
+  setIsNavigationVisible: (value: boolean) => void;
+  setIsFooterVisible: (value: boolean) => void;
   setLayoutBackgroundColor: (value: string) => void;
 };
 
 const AppContext = React.createContext<AppContextType>({
   isNavigationVisible: false,
+  isFooterVisible: true,
   layoutBackgroundColor: theme.colors.white,
   setIsNavigationVisible: noop,
+  setIsFooterVisible: noop,
   setLayoutBackgroundColor: noop,
 });
 

--- a/frontend/benefit/handler/src/context/AppContextProvider.tsx
+++ b/frontend/benefit/handler/src/context/AppContextProvider.tsx
@@ -5,6 +5,7 @@ import AppContext from './AppContext';
 const AppContextProvider = <P,>({
   children,
 }: React.PropsWithChildren<P>): JSX.Element => {
+  const [isFooterVisible, setIsFooterVisible] = React.useState<boolean>(false);
   const [isNavigationVisible, setIsNavigationVisible] =
     React.useState<boolean>(false);
   const [layoutBackgroundColor, setLayoutBackgroundColor] =
@@ -14,8 +15,10 @@ const AppContextProvider = <P,>({
     <AppContext.Provider
       value={{
         layoutBackgroundColor,
+        isFooterVisible,
         isNavigationVisible,
         setIsNavigationVisible,
+        setIsFooterVisible,
         setLayoutBackgroundColor,
       }}
     >

--- a/frontend/benefit/handler/src/hooks/useApplicationQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useApplicationQuery.ts
@@ -1,0 +1,26 @@
+import { BackendEndpoint } from 'benefit/handler/backend-api/backend-api';
+import useBackendAPI from 'benefit/handler/hooks/useBackendAPI';
+import { ApplicationData } from 'benefit/handler/types/application';
+import { useQuery, UseQueryResult } from 'react-query';
+
+const useApplicationQuery = (
+  id: string
+): UseQueryResult<ApplicationData, Error> => {
+  const { axios, handleResponse } = useBackendAPI();
+
+  return useQuery<ApplicationData, Error>(
+    ['applications', id],
+    () =>
+      !id
+        ? Promise.reject(new Error('Missing application id'))
+        : handleResponse<ApplicationData>(
+            axios.get(`${BackendEndpoint.APPLICATIONS}${id}/`)
+          ),
+    {
+      enabled: Boolean(id),
+      staleTime: Infinity,
+    }
+  );
+};
+
+export default useApplicationQuery;

--- a/frontend/benefit/handler/src/hooks/useUpdateApplicationQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useUpdateApplicationQuery.ts
@@ -1,0 +1,34 @@
+import { AxiosError } from 'axios';
+import { BackendEndpoint } from 'benefit/handler/backend-api/backend-api';
+import useBackendAPI from 'benefit/handler/hooks/useBackendAPI';
+import { ApplicationData } from 'benefit/handler/types/application';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+
+import { ErrorData } from '../types/common';
+
+const useUpdateApplicationQuery = (): UseMutationResult<
+  ApplicationData,
+  AxiosError<ErrorData>,
+  ApplicationData
+> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const queryClient = useQueryClient();
+  return useMutation<ApplicationData, AxiosError<ErrorData>, ApplicationData>(
+    'updateApplication',
+    (application: ApplicationData) =>
+      handleResponse<ApplicationData>(
+        axios.put(
+          `${BackendEndpoint.APPLICATIONS}${application?.id ?? ''}/`,
+          application
+        )
+      ),
+    {
+      onSuccess: () => {
+        void queryClient.invalidateQueries('applications');
+        void queryClient.invalidateQueries('application');
+      },
+    }
+  );
+};
+
+export default useUpdateApplicationQuery;

--- a/frontend/benefit/handler/src/pages/application/index.tsx
+++ b/frontend/benefit/handler/src/pages/application/index.tsx
@@ -7,18 +7,23 @@ import { useEffect } from 'react';
 import theme from 'shared/styles/theme';
 
 const ApplicantIndex: NextPage = () => {
-  const { setIsNavigationVisible, setLayoutBackgroundColor } =
-    React.useContext(AppContext);
+  const {
+    setIsFooterVisible,
+    setIsNavigationVisible,
+    setLayoutBackgroundColor,
+  } = React.useContext(AppContext);
 
   // configure page specific settings
   useEffect(() => {
     setIsNavigationVisible(false);
+    setIsFooterVisible(false);
     setLayoutBackgroundColor(theme.colors.white);
     return () => {
       setIsNavigationVisible(false);
+      setIsFooterVisible(true);
       setLayoutBackgroundColor(theme.colors.white);
     };
-  }, [setIsNavigationVisible, setLayoutBackgroundColor]);
+  }, [setIsFooterVisible, setIsNavigationVisible, setLayoutBackgroundColor]);
 
   return <ApplicationReview />;
 };

--- a/frontend/benefit/handler/src/pages/index.tsx
+++ b/frontend/benefit/handler/src/pages/index.tsx
@@ -11,18 +11,22 @@ import { useEffect } from 'react';
 import theme from 'shared/styles/theme';
 
 const ApplicantIndex: NextPage = () => {
-  const { setIsNavigationVisible, setLayoutBackgroundColor } =
-    React.useContext(AppContext);
+  const {
+    setIsFooterVisible,
+    setIsNavigationVisible,
+    setLayoutBackgroundColor,
+  } = React.useContext(AppContext);
 
   // configure page specific settings
   useEffect(() => {
     setIsNavigationVisible(true);
+    setIsFooterVisible(true);
     setLayoutBackgroundColor(theme.colors.silverLight);
     return () => {
       setIsNavigationVisible(false);
       setLayoutBackgroundColor(theme.colors.white);
     };
-  }, [setIsNavigationVisible, setLayoutBackgroundColor]);
+  }, [setIsFooterVisible, setIsNavigationVisible, setLayoutBackgroundColor]);
 
   const { t } = useTranslation();
 

--- a/frontend/benefit/handler/src/types/application.d.ts
+++ b/frontend/benefit/handler/src/types/application.d.ts
@@ -238,6 +238,7 @@ export type ApplicationData = {
   applicant_terms_in_effect?: ApplicantTermsData;
   approve_terms?: ApproveTermsData;
   calculation?: CalculationData;
+  submitted_at?: string;
 };
 
 export type ApplicationListItemData = {
@@ -345,6 +346,7 @@ export type Application = {
   applicantTermsInEffect?: ApplicantTerms;
   approveTerms?: ApproveTerms;
   calculation?: Calculation;
+  submittedAt?: string;
 } & Step1 &
   Step2;
 

--- a/frontend/benefit/handler/src/types/application.d.ts
+++ b/frontend/benefit/handler/src/types/application.d.ts
@@ -5,6 +5,8 @@ import {
   APPLICATION_FIELDS_STEP2_KEYS,
   DE_MINIMIS_AID_KEYS,
   EMPLOYEE_KEYS,
+  ORGANIZATION_TYPES,
+  SUPPORTED_LANGUAGES,
 } from '../constants';
 
 export type EmployeeData = {
@@ -55,6 +57,7 @@ export type CompanyData = {
   postcode: string;
   city: string;
   bank_account_number: string;
+  organization_type: string;
 };
 
 export type Company = {
@@ -66,6 +69,7 @@ export type Company = {
   postcode: string;
   city: string;
   bankAccountNumber: string;
+  organizationType: ORGANIZATION_TYPES;
 };
 
 export type BaseData = {

--- a/frontend/benefit/handler/src/types/application.d.ts
+++ b/frontend/benefit/handler/src/types/application.d.ts
@@ -3,6 +3,7 @@ import Attachment from 'shared/types/attachment';
 import {
   APPLICATION_FIELDS_STEP1_KEYS,
   APPLICATION_FIELDS_STEP2_KEYS,
+  BENEFIT_TYPES,
   DE_MINIMIS_AID_KEYS,
   EMPLOYEE_KEYS,
   ORGANIZATION_TYPES,
@@ -358,3 +359,7 @@ export type SubmittedApplication = {
   applicationNumber: number;
   applicantName: string;
 };
+
+export interface ApplicationReviewViewProps {
+  data: Application;
+}

--- a/frontend/benefit/handler/src/types/common.d.ts
+++ b/frontend/benefit/handler/src/types/common.d.ts
@@ -1,0 +1,3 @@
+export interface ErrorData {
+  data?: Record<string, string[]>;
+}

--- a/frontend/shared/src/components/benefit/summaryView/SummaryView.sc.ts
+++ b/frontend/shared/src/components/benefit/summaryView/SummaryView.sc.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+type ViewFieldProps = {
+  isInline?: boolean;
+};
+
+export const $ViewField = styled.div<ViewFieldProps>`
+  &:not(:last-child) {
+    padding-bottom: ${(props) =>
+      props.children ? props.theme.spacing.xs4 : 0};
+  }
+  display: ${(props) => (props.isInline ? 'inline' : 'block')};
+  font-weight: 400;
+`;
+
+export const $ViewFieldBold = styled.span`
+  font-weight: 500;
+`;
+
+export const $SummaryTableHeader = styled.div`
+  &:not(:last-child) {
+    padding-bottom: ${(props) =>
+      props.children ? props.theme.spacing.xs2 : 0};
+  }
+  font-size: ${(props) => props.theme.fontSize.body.m};
+  font-weight: 500;
+`;
+
+export const $SummaryTableValue = styled.span`
+  font-size: ${(props) => props.theme.fontSize.body.l};
+`;

--- a/frontend/shared/src/components/benefit/summaryView/SummaryView.sc.ts
+++ b/frontend/shared/src/components/benefit/summaryView/SummaryView.sc.ts
@@ -4,6 +4,10 @@ type ViewFieldProps = {
   isInline?: boolean;
 };
 
+type SummaryTableValueProps = {
+  isBold?: boolean;
+};
+
 export const $ViewField = styled.div<ViewFieldProps>`
   &:not(:last-child) {
     padding-bottom: ${(props) =>
@@ -26,6 +30,7 @@ export const $SummaryTableHeader = styled.div`
   font-weight: 500;
 `;
 
-export const $SummaryTableValue = styled.span`
+export const $SummaryTableValue = styled.span<SummaryTableValueProps>`
   font-size: ${(props) => props.theme.fontSize.body.l};
+  font-weight: ${(props) => (props.isBold ? '600' : '')};
 `;

--- a/frontend/shared/src/components/stickyActionBar/StickyActionBar.sc.ts
+++ b/frontend/shared/src/components/stickyActionBar/StickyActionBar.sc.ts
@@ -8,3 +8,7 @@ export const $Wrapper = styled.div`
   width: 100%;
   box-shadow: 0 0 15px 0 rgba(45, 62, 80, 0.12);
 `;
+
+export const $StickyBarSpacing = styled.div`
+  height: 80px;
+`;

--- a/frontend/shared/src/components/stickyActionBar/StickyActionBar.sc.ts
+++ b/frontend/shared/src/components/stickyActionBar/StickyActionBar.sc.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const $Wrapper = styled.div`
+  position: fixed;
+  z-index: 10;
+  background-color: ${(props) => props.theme.colors.white};
+  bottom: 0;
+  width: 100%;
+  box-shadow: 0 0 15px 0 rgba(45, 62, 80, 0.12);
+`;

--- a/frontend/shared/src/components/stickyActionBar/StickyActionBar.tsx
+++ b/frontend/shared/src/components/stickyActionBar/StickyActionBar.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import Container from 'shared/components/container/Container';
+
+import { $Wrapper } from './StickyActionBar.sc';
+
+type Props = { children: React.ReactNode };
+
+const StickyActionBar: React.FC<Props> = ({ children }) => (
+    <$Wrapper>
+      <Container>{children}</Container>
+    </$Wrapper>
+  );
+
+export default StickyActionBar;

--- a/frontend/shared/src/utils/application.utils.ts
+++ b/frontend/shared/src/utils/application.utils.ts
@@ -26,3 +26,8 @@ export const getFormApplication = (
       } as Employment)
   ),
 });
+
+export const getFullName = (
+  firstName: string | undefined,
+  lastName: string | undefined
+): string => [firstName, lastName].join(' ').trim();


### PR DESCRIPTION
## Description :sparkles:
- Front page:
  - Fixed typo on the header
  - Fixed application lists columns. The Handler column was in the received list instead of Handling list
  - The Application title column is clickable and redirects to the review application page with application id as query string
- Handlers page:
  - The application is fetched from backend. Header and summary review data is presented.
  - The footer is hidden (its agreed that the sticky action bar will be replacing footer on that page)
  - Actions bar for the Received status application is implemented. When clicking Close it will redirect to the frontpage. If clicking handle -> the application status is set to Handling and the UI of the summary page changes (now its not a view mode but edit mode, some section would have additional action bars, different coloring. Actions for review sections are not implemented
- Sticky action bar:
  - Action bar implemented in the shared projects

APPLICANT:
- Fixed font sized on the page header
- Fixed dots to commas of number values in Summary page
-  


## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
