### PR TITLE
HL-321 | Integrate YRTTI API

### DIFF
--- a/backend/benefit/companies/services.py
+++ b/backend/benefit/companies/services.py
@@ -1,6 +1,8 @@
 from common.utils import update_object
 from companies.models import Company
+from requests import HTTPError
 
+from shared.yrtti.yrtti_client import YRTTIClient
 from shared.ytj.ytj_client import YTJClient
 
 
@@ -16,6 +18,15 @@ def get_or_create_company_using_company_data(company_data: dict) -> Company:
     return company
 
 
+def get_or_create_organisation_with_business_id(business_id: str) -> Company:
+    try:
+        organisation = get_or_create_company_with_business_id(business_id)
+    except HTTPError:
+        # Try again with YRTTI API
+        organisation = get_or_create_association_with_business_id(business_id)
+    return organisation
+
+
 def get_or_create_company_with_business_id(business_id: str) -> Company:
     """
     Create a company instance using the YTJ integration.
@@ -24,5 +35,17 @@ def get_or_create_company_with_business_id(business_id: str) -> Company:
 
     ytj_data = ytj_client.get_company_info_with_business_id(business_id)
     company_data = ytj_client.get_company_data_from_ytj_data(ytj_data)
+
+    return get_or_create_company_using_company_data(company_data)
+
+
+def get_or_create_association_with_business_id(business_id: str) -> Company:
+    """
+    Create a company instance using the YTJ integration.
+    """
+    yrtti_client = YRTTIClient()
+
+    yrtti_data = yrtti_client.get_association_info_with_business_id(business_id)
+    company_data = yrtti_client.get_association_data_from_yrtti_data(yrtti_data)
 
     return get_or_create_company_using_company_data(company_data)

--- a/backend/benefit/companies/tests/conftest.py
+++ b/backend/benefit/companies/tests/conftest.py
@@ -2,14 +2,26 @@ import re
 
 import pytest
 from common.tests.conftest import *  # noqa
-from companies.tests.data.company_data import get_dummy_company_data
+from companies.tests.data.company_data import (
+    DUMMY_ASSOCIATION_DATA,
+    get_dummy_company_data,
+)
 from companies.tests.factories import CompanyFactory
 from django.conf import settings
 
-ORGANISATION_ROLE_JSON = [
+COMPANY_ROLE_JSON = [
     {
         "name": get_dummy_company_data()["name"],
         "identifier": get_dummy_company_data()["business_id"],
+        "complete": True,
+        "roles": ["NIMKO"],
+    }
+]
+
+ASSOCIATION_ROLE_JSON = [
+    {
+        "name": DUMMY_ASSOCIATION_DATA["name"],
+        "identifier": DUMMY_ASSOCIATION_DATA["business_id"],
         "complete": True,
         "roles": ["NIMKO"],
     }
@@ -19,5 +31,14 @@ ORGANISATION_ROLE_JSON = [
 @pytest.fixture()
 def mock_get_organisation_roles_and_create_company(requests_mock):
     matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
-    requests_mock.get(matcher, json=ORGANISATION_ROLE_JSON)
-    return CompanyFactory(business_id=ORGANISATION_ROLE_JSON[0]["identifier"])
+    requests_mock.get(matcher, json=COMPANY_ROLE_JSON)
+    return CompanyFactory(business_id=COMPANY_ROLE_JSON[0]["identifier"])
+
+
+@pytest.fixture()
+def mock_get_organisation_roles_and_create_association(requests_mock):
+    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    requests_mock.get(matcher, json=ASSOCIATION_ROLE_JSON)
+    return CompanyFactory(
+        business_id=ASSOCIATION_ROLE_JSON[0]["identifier"], company_form="association"
+    )

--- a/backend/benefit/companies/tests/data/company_data.py
+++ b/backend/benefit/companies/tests/data/company_data.py
@@ -709,3 +709,75 @@ DUMMY_YTJ_BUSINESS_DETAILS_RESPONSE = {
         }
     ],
 }
+
+DUMMY_ASSOCIATION_DATA = {
+    "id": "8c0c7a56-cb98-4c31-87ca-6f1853253987",
+    "name": "SIPOON NUORISOMUSIIKINYHDISTYS SUSIMUSA ry",
+    "business_id": "2686723-5",
+    "company_form": "association",
+    "bank_account_number": "FI2112345600000785",
+    "street_address": "Vasaratie 4 A 3",
+    "postcode": "65350",
+    "city": "Vaasa",
+}
+
+
+DUMMY_YRTTI_RESPONSE = {
+    "BasicInfoResponse": {
+        "AssociationNameInfo": [
+            {
+                "AssociationNameType": "P",
+                "AssociationName": "SIPOON NUORISOMUSIIKINYHDISTYS SUSIMUSA ry",
+                "AssociationNameLanguage": "FI",
+                "AssociationIndustry": None,
+                "AssociationNameStatus": "R",
+                "AssociationNameStartDate": "2007-02-27T00:00:00.000+00:00",
+            },
+            {
+                "AssociationNameType": "P",
+                "AssociationName": "SIPOON NUORISOMUSIIKINYHDISTYS SYSIMUSA ry",
+                "AssociationNameLanguage": "FI",
+                "AssociationIndustry": None,
+                "AssociationNameStatus": "VE",
+                "AssociationNameStartDate": None,
+            },
+        ],
+        "BusinessId": "2686723-5",
+        "RegistrationNumber": "195.883",
+        "Domicile": "753",
+        "DomicileStartDate": "2007-02-27T00:00:00.000+00:00",
+        "AssociationRegistrationLanguage": "FI",
+        "Address": [
+            {
+                "AddressTypeCode": "YRPO",
+                "FormattedAddressFI": "Lamberg Matti Olavi\nKatajakalliontie 16\n01120 Västerskog\nSuomi",
+                "FormattedAddressEN": "Lamberg Matti Olavi\nKatajakalliontie 16\n01120 Västerskog\nFinland",
+                "FormattedAddressSE": "Lamberg Matti Olavi\nKatajakalliontie 16\n01120 Västerskog\nFinland",
+                "CoAddress": None,
+                "StreetName": "Lamberg Matti Olavi\nKatajakalliontie 16",
+                "HouseNumber": None,
+                "Stair": None,
+                "FlatNumber": None,
+                "FlatDivisionLetter": None,
+                "PoBoxPrefix": None,
+                "PoBox": None,
+                "PostCode": "01120",
+                "City": "Västerskog",
+                "CountryCode": "FI",
+                "AddressAbroad": None,
+            }
+        ],
+        "ContactInfo": None,
+        "RegistryDate": "2007-02-27T00:00:00.000+00:00",
+        "LastRegistrationPeriod": "2007-02-27T00:00:00.000+00:00",
+        "AssociationStatus": "R",
+        "AssociationStatusDate": "2007-02-27T00:00:00.000+00:00",
+        "AssociationSpecialCondition": None,
+        "AssociationSpecialConditionDate": None,
+        "EndRegistrationReason": None,
+        "PurposeClassMain": "400",
+        "PurposeClassSecondary": "400",
+    },
+    "faultCode": None,
+    "faultString": None,
+}

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -92,6 +92,13 @@ env = environ.Env(
     ENABLE_DEBUG_ENV=(bool, False),
     TALPA_ROBOT_AUTH_CREDENTIAL=(str, "username:password"),
     DISABLE_TOS_APPROVAL_CHECK=(bool, False),
+    YRTTI_BASIC_INFO_PATH=(
+        str,
+        "https://ytj-integration-dev.agw.arodevtest.hel.fi/api/BasicInfo",
+    ),
+    YRTTI_AUTH_USERNAME=(str, "sample_username"),
+    YRTTI_AUTH_PASSWORD=(str, "sample_password"),
+    YRTTI_TIMEOUT=(int, 30),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -340,6 +347,11 @@ MINIMUM_WORKING_HOURS_PER_WEEK = env("MINIMUM_WORKING_HOURS_PER_WEEK")
 WKHTMLTOPDF_BIN = env("WKHTMLTOPDF_BIN")
 
 TALPA_ROBOT_AUTH_CREDENTIAL = env("TALPA_ROBOT_AUTH_CREDENTIAL")
+
+YRTTI_TIMEOUT = env("YRTTI_TIMEOUT")
+YRTTI_BASIC_INFO_PATH = env("YRTTI_BASIC_INFO_PATH")
+YRTTI_AUTH_USERNAME = env("YRTTI_AUTH_USERNAME")
+YRTTI_AUTH_PASSWORD = env("YRTTI_AUTH_PASSWORD")
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.

--- a/backend/benefit/helsinkibenefit/urls.py
+++ b/backend/benefit/helsinkibenefit/urls.py
@@ -59,9 +59,6 @@ urlpatterns = [
     path("v1/", include(handler_app_router.urls)),
     path("v1/terms/approve_terms_of_service/", ApproveTermsOfServiceView.as_view()),
     path("v1/company/", GetCompanyView.as_view()),
-    path(
-        "v1/company/<str:business_id>", GetCompanyView.as_view()
-    ),  # FIXME: Remove this later
     path("v1/users/me/", CurrentUserView.as_view()),
     path("oidc/", include("shared.oidc.urls")),
     path("oauth2/", include("shared.azure_adfs.urls")),

--- a/backend/benefit/users/utils.py
+++ b/backend/benefit/users/utils.py
@@ -1,5 +1,5 @@
 from companies.models import Company
-from companies.services import get_or_create_company_with_business_id
+from companies.services import get_or_create_organisation_with_business_id
 from django.conf import settings
 
 from shared.oidc.utils import get_organization_roles
@@ -32,6 +32,6 @@ def get_company_from_request(request):
             # In case we cannot find the Company in DB, try to query it from 3rd party source
             # This should cover the case when first applicant of company log in because his company
             # hasn't been created yet
-            return get_or_create_company_with_business_id(business_id)
+            return get_or_create_organisation_with_business_id(business_id)
     else:
         return None

--- a/backend/shared/shared/yrtti/yrtti_client.py
+++ b/backend/shared/shared/yrtti/yrtti_client.py
@@ -1,0 +1,72 @@
+import requests
+from django.conf import settings
+
+TARGET_ASSOCIATION_NAME_TYPE = "P"
+TARGET_ASSOCIATION_NAME_LANGUAGE = "FI"
+TARGET_ASSOCIATION_NAME_STATUS = "R"
+
+
+class YRTTIClient:
+    def __init__(self):
+        if not all([settings.YRTTI_BASIC_INFO_PATH, settings.YRTTI_TIMEOUT]):
+            raise ValueError("YRTTI client settings not configured.")
+
+    def _post(self, url: str, username: str, password: str, data: dict) -> dict:
+        response = requests.post(
+            url, auth=(username, password), timeout=settings.YRTTI_TIMEOUT, json=data
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_association_data_from_yrtti_data(self, yrtti_data: dict) -> dict:
+        """
+        Get the required company fields from YRTTI data.
+        """
+        association_name = self._get_active_association_name(
+            yrtti_data["AssociationNameInfo"]
+        )
+        # There might be a list of addresses, but it is impossible to identify which one is the primary address from
+        # the data so we just select the first one. Most of the time there is only 1 address
+        address = yrtti_data["Address"][0]
+        company_data = {
+            "name": association_name["AssociationName"],
+            "business_id": yrtti_data["BusinessId"],
+            "company_form": "association",
+            "industry": association_name["AssociationIndustry"] or "",
+            "street_address": self._sanitize_text(address["StreetName"]),
+            "postcode": address["PostCode"],
+            "city": address["City"],
+        }
+
+        return company_data
+
+    def get_association_info_with_business_id(self, business_id: str) -> dict:
+        query = {"BusinessId": business_id}
+        company_info_url = f"{settings.YRTTI_BASIC_INFO_PATH}"
+        yrtti_data = self._post(
+            company_info_url,
+            username=settings.YRTTI_AUTH_USERNAME,
+            password=settings.YRTTI_AUTH_PASSWORD,
+            data=query,
+        )
+        return yrtti_data["BasicInfoResponse"]
+
+    def _sanitize_text(self, text: str) -> str:
+        # Some text fields from YRTTI includes \n character, replace it with space
+        if text:
+            return text.replace("\n", " ")
+        return ""
+
+    def _get_active_association_name(self, name_info: dict) -> str:
+        # There will be the case where an association has more than one name
+        # Here we only pick up latest name available
+        active_names = [
+            name
+            for name in name_info
+            if name["AssociationNameType"] == TARGET_ASSOCIATION_NAME_TYPE
+            and name["AssociationNameLanguage"] == TARGET_ASSOCIATION_NAME_LANGUAGE
+            and name["AssociationNameStatus"] == TARGET_ASSOCIATION_NAME_STATUS
+        ]
+        if len(active_names) == 0:
+            raise ValueError("Cannot find active association name")
+        return active_names[0]


### PR DESCRIPTION
## Description :sparkles:
YRTTI API Integration to query association info via Palveluväylä
Documentation of YRTTI API can be found: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/7562068053/Working+document+Integration+to+Palveluv+yl+from+app+developer+s+perspective

- Added a YRTTIClient to `shared` component, although AFAIK Kesaseteli does not support application for association.
- Update company query logic so it'll try to get association info if the first query to company return nothing.
- Update unittests
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
