### PR TITLE
YJDH-347 | Make social security number check stricter

### DIFF
--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -13,11 +13,29 @@ def test_youth_applications_list(api_client):
 
 
 @pytest.mark.django_db
-def test_youth_application_post_valid_data(api_client, youth_application):
+@pytest.mark.parametrize(
+    "test_value",
+    [
+        "010203-1230",
+        "121212A899H",
+        "111111-111C",
+        "111111A111C",
+        # Django Rest Framework's serializers.CharField trims leading and trailing
+        # whitespace by default, so we allow them here.
+        "     111111-111C",
+        "111111-111C     ",
+        "   111111-111C  ",
+    ],
+)
+def test_youth_application_post_valid_social_security_number(
+    api_client, youth_application, test_value
+):
     data = YouthApplicationSerializer(youth_application).data
+    data["social_security_number"] = test_value
     response = api_client.post(reverse("v1:youthapplication-list"), data)
 
     assert response.status_code == status.HTTP_201_CREATED
+    assert "social_security_number" in response.data
 
 
 @pytest.mark.django_db
@@ -31,11 +49,33 @@ def test_youth_application_post_invalid_language(api_client, youth_application):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "test_value",
+    [
+        # A temporary social security number (900-999)
+        "111111-900U",
+        "111111-9991",
+        # Inner whitespace
+        "111111 -111C",
+        "111111-111 C",
+        " 111111 - 111C ",
+        # Not uppercase
+        "111111-111c",
+        "111111a111C",
+        # Invalid checksum
+        "111111-111X",  # "111111-111C" would be valid
+        "111111A111W",  # "111111A111C" would be valid
+        "010203-123A",  # "010203-1230" would be valid
+        "121212A899F",  # "121212A899H" would be valid
+        # Combination
+        "111111 -111x",  # Invalid checksum, inner whitespace, not uppercase
+    ],
+)
 def test_youth_application_post_invalid_social_security_number(
-    api_client, youth_application
+    api_client, youth_application, test_value
 ):
     data = YouthApplicationSerializer(youth_application).data
-    data["social_security_number"] = "111111-111X"  # "111111-111C" would be valid
+    data["social_security_number"] = test_value
     response = api_client.post(reverse("v1:youthapplication-list"), data)
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/kesaseteli/common/utils.py
+++ b/backend/kesaseteli/common/utils.py
@@ -16,21 +16,41 @@ class DenyAll(BasePermission):
         return False
 
 
+def has_whitespace(value):
+    value_without_whitespace = "".join(value.split())
+    return value != value_without_whitespace
+
+
+def is_uppercase(value):
+    """
+    Is the value all uppercase? Returns True also if there are no alphabetic characters.
+    """
+    return value == value.upper()
+
+
 def validate_finnish_social_security_number(value):
     """
-    Raise a ValidationError if the given value is not a Finnish social security number.
+    Raise a ValidationError if the given value is not an uppercase Finnish social
+    security number with no whitespace.
     """
-    if not is_valid_finnish_social_security_number(value):
+    if (
+        not is_valid_finnish_social_security_number(value)
+        or has_whitespace(value)
+        or not is_uppercase(value)
+    ):
         raise ValidationError(
-            _("%(value)s is not a valid Finnish social security number"),
+            _(
+                "%(value)s is not a valid Finnish social security number. "
+                "Make sure to have it in uppercase and without whitespace."
+            ),
             params={"value": value},
         )
 
 
 def validate_optional_finnish_social_security_number(value):
     """
-    Raise a ValidationError if the given value is not None, an empty string or a Finnish
-    social security number.
+    Raise a ValidationError if the given value is not None, an empty string or an
+    uppercase Finnish social security number with no whitespace.
     """
     if value is not None and value != "":
         validate_finnish_social_security_number(value)


### PR DESCRIPTION
## Description :sparkles:

Add check that the Finnish social security number has no whitespace and
is uppercase. Affects YouthApplication's social security number.

Add more test cases in test_youth_applications_api.py for valid and
invalid social security numbers.

Refs YJDH-347

## Issues :bug:

YJDH-347

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
