### PR TITLE
Fix the attachment type on the Handler side

### DIFF
--- a/frontend/benefit/handler/src/components/attachmentsListView/AttachmentsListView.tsx
+++ b/frontend/benefit/handler/src/components/attachmentsListView/AttachmentsListView.tsx
@@ -7,10 +7,10 @@ import {
 } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import theme from 'shared/styles/theme';
-import Attachment from 'shared/types/attachment';
+import { BenefitAttachment } from 'shared/types/attachment';
 
 export interface AttachmentsListViewProps {
-  attachments: Attachment[];
+  attachments: BenefitAttachment[];
   type: ATTACHMENT_TYPES;
   title?: string;
 }
@@ -21,13 +21,13 @@ const AttachmentsListView: React.FC<AttachmentsListViewProps> = ({
   title,
 }) => {
   const attachmentItems = React.useMemo(
-    (): Attachment[] =>
-      attachments?.filter((att: Attachment) => att.attachmentType === type),
+    (): BenefitAttachment[] =>
+      attachments?.filter((att) => att.attachmentType === type),
     [attachments, type]
   );
 
   const handleOpenFile = React.useCallback(
-    (file: Attachment) =>
+    (file: BenefitAttachment) =>
       // eslint-disable-next-line security/detect-non-literal-fs-filename
       window.open(file.attachmentFile, '_blank')?.focus(),
     []
@@ -42,7 +42,7 @@ const AttachmentsListView: React.FC<AttachmentsListViewProps> = ({
               {title}
             </$ViewFieldBold>
           )}
-          {attachmentItems.map((attachment: Attachment) => (
+          {attachmentItems.map((attachment) => (
             <$ViewField
               css={{
                 display: 'flex',

--- a/frontend/benefit/handler/src/components/attachmentsListView/__tests__/AttachmentsListView.test.tsx
+++ b/frontend/benefit/handler/src/components/attachmentsListView/__tests__/AttachmentsListView.test.tsx
@@ -3,7 +3,6 @@ import renderComponent from 'benefit/handler/__tests__/utils/render-component';
 import { ATTACHMENT_TYPES } from 'benefit/handler/constants';
 import { axe } from 'jest-axe';
 import React from 'react';
-import Attachment from 'shared/types/attachment';
 
 import AttachmentsListView, {
   AttachmentsListViewProps,
@@ -22,7 +21,7 @@ describe('AttachmentsListView', () => {
         contentType: 'image/png',
         createdAt: '2021-09-09T10:37:13.341633+03:00',
         id: '68034254-0dff-423d-8659-58864a930ae7',
-      } as Attachment,
+      },
     ],
   };
 

--- a/frontend/benefit/handler/src/types/application.d.ts
+++ b/frontend/benefit/handler/src/types/application.d.ts
@@ -1,4 +1,4 @@
-import Attachment from 'shared/types/attachment';
+import { BenefitAttachment } from 'shared/types/attachment';
 
 import {
   APPLICATION_FIELDS_STEP1_KEYS,
@@ -344,7 +344,7 @@ export type Application = {
   archived?: boolean;
   createdAt?: string | null;
   applicationStep?: string | null;
-  attachments?: Attachment[];
+  attachments?: BenefitAttachment[];
   // create_application_for_company ? not present in the UI?
   applicantTermsApproval?: ApplicantTermsApproval;
   applicantTermsApprovalNeeded?: boolean;


### PR DESCRIPTION
## Description :sparkles:
- Fix the types on the attachments on the Handler side

**Note:** now only shared components have the type Attachment, but service-specific components have the corresponding type (e.g. BenefitAttachment).
