### PR TITLE
HL-99 | Deleting draft applications

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
@@ -24,6 +24,7 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
     t,
     handleSubmit,
     handleSave,
+    handleDelete,
     getErrorMessage,
     clearDeminimisAids,
     getDefaultSelectValue,
@@ -281,7 +282,11 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
           </$GridCell>
         )}
       </FormSection>
-      <StepperActions handleSubmit={handleSubmit} handleSave={handleSave} />
+      <StepperActions
+        handleSubmit={handleSubmit}
+        handleSave={handleSave}
+        handleDelete={handleDelete}
+      />
     </form>
   );
 };

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
@@ -30,6 +30,7 @@ type ExtendedComponentProps = {
   getErrorMessage: (fieldName: string) => string | undefined;
   handleSubmit: () => void;
   handleSave: () => void;
+  handleDelete?: () => void;
   clearDeminimisAids: () => void;
   formik: FormikProps<Application>;
   deMinimisAidSet: DeMinimisAid[];
@@ -42,7 +43,7 @@ const useApplicationFormStep1 = (
 ): ExtendedComponentProps => {
   const { t } = useTranslation();
   const { setDeMinimisAids } = React.useContext(DeMinimisContext);
-  const { onNext, onSave } = useFormActions(application);
+  const { onNext, onSave, onDelete } = useFormActions(application);
 
   const translationsBase = 'common:applications.sections.company';
   // todo: check the isSubmitted logic, when its set to false and how affects the validation message
@@ -108,6 +109,8 @@ const useApplicationFormStep1 = (
 
   const handleSave = (): void => onSave(values);
 
+  const handleDelete = values.id ? (): void => onDelete(values.id) : undefined;
+
   const clearDeminimisAids = React.useCallback((): void => {
     setDeMinimisAids([]);
     void setFieldValue(fields.deMinimisAid.name, null);
@@ -139,6 +142,7 @@ const useApplicationFormStep1 = (
     getErrorMessage,
     handleSubmit,
     handleSave,
+    handleDelete,
     clearDeminimisAids,
     deMinimisAidSet: application.deMinimisAidSet || [],
     languageOptions,

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
@@ -109,7 +109,10 @@ const useApplicationFormStep1 = (
 
   const handleSave = (): void => onSave(values);
 
-  const handleDelete = values.id ? (): void => onDelete(values.id) : undefined;
+  const applicationId = values?.id;
+  const handleDelete = applicationId
+    ? (): void => onDelete(applicationId)
+    : undefined;
 
   const clearDeminimisAids = React.useCallback((): void => {
     setDeMinimisAids([]);

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -47,6 +47,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
     handleSubmit,
     handleSave,
     handleBack,
+    handleDelete,
     getErrorMessage,
     getSelectValue,
     fields,
@@ -243,6 +244,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
                 }
                 options={subsidyOptions}
                 id={fields.paySubsidyPercent.name}
+                name={fields.paySubsidyPercent.name}
                 placeholder={selectLabel}
                 invalid={!!getErrorMessage(fields.paySubsidyPercent.name)}
                 aria-invalid={!!getErrorMessage(fields.paySubsidyPercent.name)}
@@ -253,6 +255,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
                     white-space: pre;
                   }
                 `}
+                data-testid={fields.paySubsidyPercent.name}
               />
             </$GridCell>
             <$GridCell $colSpan={2} $colStart={4}>
@@ -691,6 +694,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
         handleSubmit={handleSubmit}
         handleSave={handleSave}
         handleBack={handleBack}
+        handleDelete={handleDelete}
       />
     </form>
   );

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/useApplicationFormStep2.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/useApplicationFormStep2.ts
@@ -46,6 +46,7 @@ type UseApplicationFormStep2Props = {
   getErrorMessage: (fieldName: string) => string | undefined;
   handleBack: () => void;
   handleSave: () => void;
+  handleDelete: () => void;
   handleSubmit: () => void;
   clearBenefitValues: () => void;
   clearCommissionValues: () => void;
@@ -66,7 +67,7 @@ const useApplicationFormStep2 = (
   const translationsBase = 'common:applications.sections.employee';
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
 
-  const { onNext, onSave, onBack } = useFormActions(application);
+  const { onNext, onSave, onBack, onDelete } = useFormActions(application);
 
   const formik = useFormik<Application>({
     initialValues: {
@@ -169,6 +170,8 @@ const useApplicationFormStep2 = (
   };
 
   const handleSave = (): void => onSave(values);
+
+  const handleDelete = (): void => onDelete(values.id ?? '');
 
   const clearCommissionValues = React.useCallback((): void => {
     void setFieldValue(fields.employee.commissionDescription.name, '');
@@ -281,6 +284,7 @@ const useApplicationFormStep2 = (
     handleSubmit,
     handleSave,
     handleBack: onBack,
+    handleDelete,
   };
 };
 

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step3/ApplicationFormStep3.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step3/ApplicationFormStep3.tsx
@@ -16,6 +16,7 @@ const ApplicationFormStep3: React.FC<DynamicFormStepComponentProps> = ({
     handleBack,
     handleNext,
     handleSave,
+    handleDelete,
     benefitType,
     apprenticeshipProgram,
     paySubsidyGranted,
@@ -75,6 +76,7 @@ const ApplicationFormStep3: React.FC<DynamicFormStepComponentProps> = ({
         handleSubmit={handleNext}
         handleSave={handleSave}
         handleBack={handleBack}
+        handleDelete={handleDelete}
       />
     </>
   );

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step3/useApplicationFormStep3.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step3/useApplicationFormStep3.ts
@@ -11,6 +11,7 @@ type ExtendedComponentProps = {
   handleNext: () => void;
   handleSave: () => void;
   handleBack: () => void;
+  handleDelete: () => void;
   attachments: BenefitAttachment[];
   hasRequiredAttachments: boolean;
   paySubsidyGranted: boolean;
@@ -19,10 +20,11 @@ type ExtendedComponentProps = {
 const useApplicationFormStep3 = (
   application: Application
 ): ExtendedComponentProps => {
-  const { onNext, onSave, onBack } = useFormActions(application);
+  const { onNext, onSave, onBack, onDelete } = useFormActions(application);
 
   const handleNext = (): void => onNext(application);
   const handleSave = (): void => onSave(application);
+  const handleDelete = (): void => onDelete(application.id ?? '');
 
   const isRequiredAttachmentsUploaded = (): boolean => {
     if (
@@ -60,6 +62,7 @@ const useApplicationFormStep3 = (
     handleNext,
     handleSave,
     handleBack: onBack,
+    handleDelete,
     benefitType: application?.benefitType,
     apprenticeshipProgram: Boolean(application?.apprenticeshipProgram),
     showSubsidyMessage: Boolean(

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step4/ApplicationFormStep4.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step4/ApplicationFormStep4.tsx
@@ -35,6 +35,7 @@ const ApplicationFormStep4: React.FC<DynamicFormStepComponentProps> = ({
     handleBack,
     handleNext,
     handleSave,
+    handleDelete,
     handleRemoveAttachment,
     handleUploadAttachment,
     translationsBase,
@@ -159,6 +160,7 @@ const ApplicationFormStep4: React.FC<DynamicFormStepComponentProps> = ({
         handleSubmit={handleNext}
         handleSave={handleSave}
         handleBack={handleBack}
+        handleDelete={handleDelete}
       />
     </>
   );

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step4/useApplicationFormStep4.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step4/useApplicationFormStep4.ts
@@ -15,6 +15,7 @@ type ExtendedComponentProps = {
   handleNext: () => void;
   handleSave: () => void;
   handleBack: () => void;
+  handleDelete: () => void;
   handleRemoveAttachment: (attachmentId: string) => void;
   handleUploadAttachment: (attachment: FormData) => void;
   translationsBase: string;
@@ -29,7 +30,7 @@ const useApplicationFormStep4 = (
   const translationsBase = 'common:applications.sections.credentials.sections';
   const { t } = useTranslation();
 
-  const { onNext, onSave, onBack } = useFormActions(application);
+  const { onNext, onSave, onBack, onDelete } = useFormActions(application);
 
   const {
     mutate: uploadAttachment,
@@ -66,6 +67,7 @@ const useApplicationFormStep4 = (
 
   const handleNext = (): void => onNext(application);
   const handleSave = (): void => onSave(application);
+  const handleDelete = (): void => onDelete(application.id ?? '');
 
   const getEmployeeConsentAttachment = (): BenefitAttachment | undefined =>
     application.attachments?.find(
@@ -90,6 +92,7 @@ const useApplicationFormStep4 = (
     handleNext,
     handleSave,
     handleBack: onBack,
+    handleDelete,
     handleUploadAttachment,
     handleRemoveAttachment,
     isRemoving,

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/ApplicationFormStep5.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/ApplicationFormStep5.tsx
@@ -21,6 +21,7 @@ const ApplicationFormStep5: React.FC<DynamicFormStepComponentProps> = ({
     handleBack,
     handleSave,
     handleSubmit,
+    handleDelete,
     handleStepChange,
     translationsBase,
     isSubmit,
@@ -130,6 +131,7 @@ const ApplicationFormStep5: React.FC<DynamicFormStepComponentProps> = ({
         handleSave={handleSave}
         handleSubmit={handleSubmit}
         handleBack={handleBack}
+        handleDelete={handleDelete}
       />
     </>
   );

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
@@ -21,6 +21,7 @@ type ExtendedComponentProps = {
   handleSave: () => void;
   handleSubmit: () => void;
   handleBack: () => void;
+  handleDelete: () => void;
   handleStepChange: (step: number) => void;
   translationsBase: string;
   isSubmit: boolean;
@@ -77,7 +78,7 @@ const useApplicationFormStep5 = (
     }
   }, [t, updateApplicationErrorStep5]);
 
-  const { onBack, onSave } = useFormActions(application);
+  const { onBack, onSave, onDelete } = useFormActions(application);
 
   const handleStepChange = (nextStep: number): void => {
     const currentApplicationData: ApplicationData = snakecaseKeys(
@@ -91,6 +92,7 @@ const useApplicationFormStep5 = (
   };
 
   const handleSave = (): void => onSave(application);
+  const handleDelete = (): void => onDelete(application.id ?? '');
 
   const handleSubmit = (): void => {
     const submitFields = isSubmit
@@ -111,6 +113,7 @@ const useApplicationFormStep5 = (
     handleSave,
     handleSubmit,
     handleBack: onBack,
+    handleDelete,
     handleStepChange,
     translationsBase,
     isSubmit,

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step6/useApplicationFormStep6.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step6/useApplicationFormStep6.ts
@@ -25,6 +25,7 @@ type ExtendedComponentProps = {
   handleBack: () => void;
   handleSubmit: () => void;
   handleSave: () => void;
+  handleDelete: () => void;
   handleClick: (consentIndex: number) => void;
   getErrorText: (consentIndex: number) => string;
   translationsBase: string;
@@ -54,7 +55,7 @@ const useApplicationFormStep6 = (
 
   const [errorsArray, setErrorsArray] = useState<boolean[]>(getInitialvalues());
 
-  const { onSave, onBack } = useFormActions(application);
+  const { onSave, onBack, onDelete } = useFormActions(application);
 
   const { setSubmittedApplication, submittedApplication } =
     useContext(AppContext);
@@ -125,12 +126,14 @@ const useApplicationFormStep6 = (
   };
 
   const handleSave = (): void => onSave(application);
+  const handleDelete = (): void => onDelete(application.id ?? '');
 
   return {
     t,
     handleBack: onBack,
     handleSubmit,
     handleSave,
+    handleDelete,
     handleClick,
     getErrorText,
     translationsBase,

--- a/frontend/benefit/applicant/src/components/applications/forms/application/stepperActions/StepperActions.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/stepperActions/StepperActions.tsx
@@ -61,26 +61,27 @@ const StepperActions: React.FC<StepperActionsProps> = ({
               : t(`${translationsBase}.continue`)}
           </Button>
         </$GridCell>
-        <$GridCell $colSpan={10} $colStart={2} justifySelf="center">
-          <Button
-            theme="black"
-            variant="supplementary"
-            iconLeft={<IconCross />}
-            onClick={() => setIsConfirmationModalOpen(true)}
-            disabled={!handleDelete}
-          >
-            {t(`${translationsBase}.deleteApplication`)}
-          </Button>
-        </$GridCell>
+        {handleDelete && (
+          <$GridCell $colSpan={10} $colStart={2} justifySelf="center">
+            <Button
+              theme="black"
+              variant="supplementary"
+              iconLeft={<IconCross />}
+              onClick={() => setIsConfirmationModalOpen(true)}
+            >
+              {t(`${translationsBase}.deleteApplication`)}
+            </Button>
+          </$GridCell>
+        )}
       </$Grid>
-      {isConfirmationModalOpen && (
+      {isConfirmationModalOpen && handleDelete && (
         <Modal
           id="StepperActions-confirmDeleteApplicationModal"
           isOpen={isConfirmationModalOpen}
           title={t(`${translationsBase}.deleteApplicationConfirm`)}
           submitButtonLabel={t(`${translationsBase}.deleteApplication`)}
           handleToggle={() => setIsConfirmationModalOpen(false)}
-          handleSubmit={() => handleDelete?.()}
+          handleSubmit={handleDelete}
           variant="danger"
         >
           {t(`${translationsBase}.deleteApplicationDescription`)}

--- a/frontend/benefit/applicant/src/components/applications/forms/application/stepperActions/StepperActions.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/stepperActions/StepperActions.tsx
@@ -1,15 +1,17 @@
 import { useTranslation } from 'benefit/applicant/i18n';
 import { Button, IconArrowLeft, IconArrowRight, IconCross } from 'hds-react';
-import * as React from 'react';
+import React, { useState } from 'react';
 import {
   $Grid,
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
+import Modal from 'shared/components/modal/Modal';
 
 type StepperActionsProps = {
   lastStep?: boolean;
   disabledNext?: boolean;
   handleBack?: () => void;
+  handleDelete?: () => void;
   handleSubmit: () => void;
   handleSave: () => void;
 };
@@ -18,54 +20,80 @@ const StepperActions: React.FC<StepperActionsProps> = ({
   lastStep,
   disabledNext,
   handleBack,
+  handleDelete,
   handleSubmit,
   handleSave,
 }: StepperActionsProps) => {
   const { t } = useTranslation();
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
   const translationsBase = 'common:applications.actions';
+
   return (
-    <$Grid>
-      <$GridCell $colSpan={3} justifySelf="start">
-        {handleBack && (
+    <>
+      <$Grid>
+        <$GridCell $colSpan={3} justifySelf="start">
+          {handleBack && (
+            <Button
+              theme="black"
+              variant="secondary"
+              iconLeft={<IconArrowLeft />}
+              onClick={handleBack}
+            >
+              {t(`${translationsBase}.back`)}
+            </Button>
+          )}
+        </$GridCell>
+        <$GridCell $colSpan={6} justifySelf="center">
+          <Button theme="black" variant="secondary" onClick={handleSave}>
+            {t(`${translationsBase}.saveAndContinueLater`)}
+          </Button>
+        </$GridCell>
+        <$GridCell $colSpan={3} justifySelf="end">
+          <Button
+            theme="coat"
+            disabled={disabledNext}
+            iconRight={!lastStep ? <IconArrowRight /> : null}
+            onClick={handleSubmit}
+            data-testid="nextButton"
+          >
+            {lastStep
+              ? t(`${translationsBase}.send`)
+              : t(`${translationsBase}.continue`)}
+          </Button>
+        </$GridCell>
+        <$GridCell $colSpan={10} $colStart={2} justifySelf="center">
           <Button
             theme="black"
-            variant="secondary"
-            iconLeft={<IconArrowLeft />}
-            onClick={handleBack}
+            variant="supplementary"
+            iconLeft={<IconCross />}
+            onClick={() => setIsConfirmationModalOpen(true)}
+            disabled={!handleDelete}
           >
-            {t(`${translationsBase}.back`)}
+            {t(`${translationsBase}.deleteApplication`)}
           </Button>
-        )}
-      </$GridCell>
-      <$GridCell $colSpan={6} justifySelf="center">
-        <Button theme="black" variant="secondary" onClick={handleSave}>
-          {t(`${translationsBase}.saveAndContinueLater`)}
-        </Button>
-      </$GridCell>
-      <$GridCell $colSpan={3} justifySelf="end">
-        <Button
-          theme="coat"
-          disabled={disabledNext}
-          iconRight={!lastStep ? <IconArrowRight /> : null}
-          onClick={handleSubmit}
+        </$GridCell>
+      </$Grid>
+      {isConfirmationModalOpen && (
+        <Modal
+          id="StepperActions-confirmDeleteApplicationModal"
+          isOpen={isConfirmationModalOpen}
+          title={t(`${translationsBase}.deleteApplicationConfirm`)}
+          submitButtonLabel={t(`${translationsBase}.deleteApplication`)}
+          handleToggle={() => setIsConfirmationModalOpen(false)}
+          handleSubmit={() => handleDelete?.()}
+          variant="danger"
         >
-          {lastStep
-            ? t(`${translationsBase}.send`)
-            : t(`${translationsBase}.continue`)}
-        </Button>
-      </$GridCell>
-      <$GridCell $colSpan={10} $colStart={2} justifySelf="center">
-        <Button theme="black" variant="supplementary" iconLeft={<IconCross />}>
-          {t(`${translationsBase}.deleteApplication`)}
-        </Button>
-      </$GridCell>
-    </$Grid>
+          {t(`${translationsBase}.deleteApplicationDescription`)}
+        </Modal>
+      )}
+    </>
   );
 };
 
 const defaultProps = {
   lastStep: false,
   handleBack: undefined,
+  handleDelete: undefined,
   disabledNext: false,
 };
 

--- a/frontend/benefit/applicant/src/hooks/useDeleteApplicationQuery.ts
+++ b/frontend/benefit/applicant/src/hooks/useDeleteApplicationQuery.ts
@@ -1,0 +1,29 @@
+import { AxiosError } from 'axios';
+import { BackendEndpoint } from 'benefit/applicant/backend-api/backend-api';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+import { ErrorData } from '../types/common';
+
+const useDeleteApplicationQuery = (): UseMutationResult<
+  null,
+  AxiosError<ErrorData>,
+  string
+> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const queryClient = useQueryClient();
+  return useMutation<null, AxiosError<ErrorData>, string>(
+    'deleteApplication',
+    (id: string) =>
+      handleResponse<null>(
+        axios.delete(`${BackendEndpoint.APPLICATIONS}${id}/`)
+      ),
+    {
+      onSuccess: () => {
+        queryClient.removeQueries('applications', { exact: true });
+      },
+    }
+  );
+};
+
+export default useDeleteApplicationQuery;

--- a/frontend/benefit/applicant/src/hooks/useDeleteApplicationQuery.ts
+++ b/frontend/benefit/applicant/src/hooks/useDeleteApplicationQuery.ts
@@ -12,7 +12,7 @@ const useDeleteApplicationQuery = (): UseMutationResult<
 > => {
   const { axios, handleResponse } = useBackendAPI();
   const queryClient = useQueryClient();
-  return useMutation<null, AxiosError<ErrorData>, string>(
+  return useMutation(
     'deleteApplication',
     (id: string) =>
       handleResponse<null>(

--- a/frontend/benefit/applicant/src/hooks/useDeleteApplicationQuery.ts
+++ b/frontend/benefit/applicant/src/hooks/useDeleteApplicationQuery.ts
@@ -19,9 +19,8 @@ const useDeleteApplicationQuery = (): UseMutationResult<
         axios.delete(`${BackendEndpoint.APPLICATIONS}${id}/`)
       ),
     {
-      onSuccess: () => {
-        queryClient.removeQueries('applications', { exact: true });
-      },
+      onSuccess: () =>
+        queryClient.removeQueries('applications', { exact: true }),
     }
   );
 };

--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -34,7 +34,7 @@ const useFormActions = (application: Application): FormActions => {
   const { mutateAsync: createApplication, error: createApplicationError } =
     useCreateApplicationQuery();
 
-  const { mutateAsync: deleteApplication, error: deleteApplicationError } =
+  const { mutate: deleteApplication, error: deleteApplicationError } =
     useDeleteApplicationQuery();
 
   const createApplicationAndAppendId = async (
@@ -197,22 +197,19 @@ const useFormActions = (application: Application): FormActions => {
     return undefined;
   };
 
-  const onDelete = async (id: string): Promise<void> => {
-    try {
-      await deleteApplication(id);
-      await router.push('/');
+  const onDelete = (id: string): void => {
+    deleteApplication(id, {
+      onSuccess: () => {
+        hdsToast({
+          autoDismissTime: 5000,
+          type: 'success',
+          labelText: t('common:notifications.applicationDeleted.label'),
+          text: t('common:notifications.applicationDeleted.message'),
+        });
 
-      hdsToast({
-        autoDismissTime: 5000,
-        type: 'success',
-        labelText: t('common:notifications.applicationDeleted.label'),
-        text: t('common:notifications.applicationDeleted.message'),
-      });
-
-      await router.push('/');
-    } catch (error) {
-      // useEffect will catch this error
-    }
+        return router.push('/');
+      },
+    });
   };
 
   return {

--- a/frontend/shared/src/components/modal/Modal.tsx
+++ b/frontend/shared/src/components/modal/Modal.tsx
@@ -1,0 +1,70 @@
+import { Button, Dialog, DialogVariant } from 'hds-react';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type ModalProps = {
+  id: string;
+  submitButtonLabel: string;
+  actionDisabled?: boolean;
+  title?: string;
+  className?: string;
+  isOpen: boolean;
+  scrollable?: boolean;
+  variant?: DialogVariant;
+  handleToggle: () => void;
+  handleSubmit: (e: React.SyntheticEvent) => void;
+  children?: React.ReactNode;
+};
+
+const Modal: React.FC<ModalProps> = ({
+  actionDisabled,
+  id,
+  title,
+  className,
+  isOpen,
+  scrollable,
+  submitButtonLabel,
+  variant,
+  handleToggle,
+  handleSubmit,
+  children,
+}) => {
+  const { t } = useTranslation();
+  const onAccept = (e: React.SyntheticEvent): void => {
+    handleSubmit(e);
+    handleToggle();
+  };
+  const titleId = `${id}-dialog-title`;
+  const closeButtonLabelText = t('common:applications.actions.close');
+
+  return (
+    <Dialog
+      id={id}
+      aria-labelledby={titleId}
+      isOpen={isOpen}
+      className={className}
+      close={handleToggle}
+      closeButtonLabelText={closeButtonLabelText}
+      scrollable={scrollable}
+      variant={variant}
+    >
+      {title && <Dialog.Header title={title} id={id} />}
+      {children && <Dialog.Content>{children}</Dialog.Content>}
+      <Dialog.ActionButtons>
+        <Button theme="black" variant="secondary" onClick={handleToggle}>
+          {t('common:applications.actions.close')}
+        </Button>
+        <Button
+          theme="coat"
+          variant={variant}
+          onClick={onAccept}
+          disabled={actionDisabled}
+        >
+          {submitButtonLabel}
+        </Button>
+      </Dialog.ActionButtons>
+    </Dialog>
+  );
+};
+
+export default Modal;

--- a/frontend/shared/src/components/modal/Modal.tsx
+++ b/frontend/shared/src/components/modal/Modal.tsx
@@ -51,7 +51,12 @@ const Modal: React.FC<ModalProps> = ({
       {title && <Dialog.Header title={title} id={id} />}
       {children && <Dialog.Content>{children}</Dialog.Content>}
       <Dialog.ActionButtons>
-        <Button theme="black" variant="secondary" onClick={handleToggle}>
+        <Button
+          theme="black"
+          variant="secondary"
+          onClick={handleToggle}
+          data-testid="cancel"
+        >
           {t('common:applications.actions.close')}
         </Button>
         <Button
@@ -59,6 +64,7 @@ const Modal: React.FC<ModalProps> = ({
           variant={variant}
           onClick={onAccept}
           disabled={actionDisabled}
+          data-testid="submit"
         >
           {submitButtonLabel}
         </Button>

--- a/frontend/shared/src/components/modal/__tests__/Modal.test.tsx
+++ b/frontend/shared/src/components/modal/__tests__/Modal.test.tsx
@@ -1,0 +1,25 @@
+import { axe } from 'jest-axe';
+import React from 'react';
+import { render, RenderResult } from 'shared/__tests__/utils/test-utils';
+
+import Modal, { ModalProps } from '../Modal';
+
+describe('Modal', () => {
+  const initialProps: ModalProps = {
+    id: 'modal-id',
+    submitButtonLabel: 'Submit',
+    isOpen: true,
+    handleSubmit: jest.fn(),
+    handleToggle: jest.fn(),
+  };
+
+  const getComponent = (props: Partial<ModalProps> = {}): RenderResult =>
+    render(<Modal {...initialProps} {...props} />);
+
+  it('should render with no accessibility violations', async () => {
+    const { container } = getComponent();
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/shared/src/components/modal/__tests__/Modal.test.tsx
+++ b/frontend/shared/src/components/modal/__tests__/Modal.test.tsx
@@ -13,6 +13,10 @@ describe('Modal', () => {
     handleToggle: jest.fn(),
   };
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const getComponent = (props: Partial<ModalProps> = {}): RenderResult =>
     render(<Modal {...initialProps} {...props} />);
 
@@ -21,5 +25,24 @@ describe('Modal', () => {
     const results = await axe(container);
 
     expect(results).toHaveNoViolations();
+  });
+
+  it('should call handleSubmit & handleToggle when the submit button is clicked', () => {
+    const { getByTestId } = getComponent();
+    const submitButton = getByTestId('submit');
+
+    submitButton.click();
+
+    expect(initialProps.handleSubmit).toHaveBeenCalledTimes(1);
+    expect(initialProps.handleToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call handleToggle when the cancel button is clicked', () => {
+    const { getByTestId } = getComponent();
+    const cancelButton = getByTestId('cancel');
+
+    cancelButton.click();
+
+    expect(initialProps.handleToggle).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Description :sparkles:
- Implement a shared Modal component
- Implement the deleting logic in the form actions custom hook
- Add the deleting functionality to all steps

## Issues :bug:

## Testing :alembic:
- From the application list, click on the edit button of one of the draft applications
- At the bottom of the page, click on the delete button
- A confirmation modal should open
- By confirming, the application should be deleted and you'll be redirected to the home page
- A success toast will appear to confirm that the application has been successfully deleted

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/145425560-8f3b11d0-f5e7-4ff5-98ed-731059bf4dd9.png)

## Additional notes :spiral_notepad:
