### PR TITLE
HL-338: Deminimis aids summary fix

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -60,6 +60,7 @@
         "deMinimisAidsHeading": "Ole hyvä ja listaa kaikki myönnetyt tuet:",
         "deMinimisAidsAdd": "Lisää",
         "deMinimisAidsRemove": "Poista",
+        "deMinimisAidsNo": "Onko hakijalle myönnetty deminimis-tukea?",
         "notifications": {
           "companyInformation": {
             "label": "Tiedot haettu YTJ:stä",
@@ -465,6 +466,8 @@
     "terms": "Terms.PDF"
   },
   "utility": {
-    "and": "ja"
+    "and": "ja",
+    "yes": "Kyllä",
+    "no": "Ei"
   }
 }

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -60,6 +60,7 @@
         "deMinimisAidsHeading": "Ole hyvä ja listaa kaikki myönnetyt tuet:",
         "deMinimisAidsAdd": "Lisää",
         "deMinimisAidsRemove": "Poista",
+        "deMinimisAidsNo": "Onko hakijalle myönnetty deminimis-tukea?",
         "notifications": {
           "companyInformation": {
             "label": "Tiedot haettu YTJ:stä",
@@ -465,6 +466,8 @@
     "terms": "Ehdot.PDF"
   },
   "utility": {
-    "and": "ja"
+    "and": "ja",
+    "yes": "Kyllä",
+    "no": "Ei"
   }
 }

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -60,6 +60,7 @@
         "deMinimisAidsHeading": "Ole hyvä ja listaa kaikki myönnetyt tuet:",
         "deMinimisAidsAdd": "Lisää",
         "deMinimisAidsRemove": "Poista",
+        "deMinimisAidsNo": "Onko hakijalle myönnetty deminimis-tukea?",
         "notifications": {
           "companyInformation": {
             "label": "Tiedot haettu YTJ:stä",
@@ -465,6 +466,8 @@
     "terms": "Terms.PDF"
   },
   "utility": {
-    "and": "ja"
+    "and": "ja",
+    "yes": "Kyllä",
+    "no": "Ei"
   }
 }

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
@@ -166,7 +166,12 @@ const CompanyInfoView: React.FC<CompanyInfoViewProps> = ({
             ))}
           </>
         ) : (
-          '-'
+          <$GridCell $colSpan={12}>
+            <$ViewField>
+              {t(`${translationsBase}.company.deMinimisAidsNo`)}{' '}
+              <$ViewFieldBold>{t('common:utility.no')}</$ViewFieldBold>
+            </$ViewField>
+          </$GridCell>
         )}
       </SummarySection>
       <SummarySection header={t(`${translationsBase}.company.heading5`)}>

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -92,6 +92,7 @@
       "deMinimisAidAmount": "Tuen määrä",
       "deMinimisAidGrantedAt": "Myönnetty",
       "deMinimisAidTotal": "Yhteensä",
+      "deMinimisAidsNo": "Onko hakijalle myönnetty deminimis-tukea?",
       "coOperationNegotiations": "Onko hakijalla menossa YT-neuvottelut?",
       "isLivingInHelsinki": "Helsinki kotikuntana",
       "paySubsidyGranted": "Onko työsuhteeseen myönnetty palkkatuki?",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -92,6 +92,7 @@
       "deMinimisAidAmount": "Tuen määrä",
       "deMinimisAidGrantedAt": "Myönnetty",
       "deMinimisAidTotal": "Yhteensä",
+      "deMinimisAidsNo": "Onko hakijalle myönnetty deminimis-tukea?",
       "coOperationNegotiations": "Onko hakijalla menossa YT-neuvottelut?",
       "isLivingInHelsinki": "Helsinki kotikuntana",
       "paySubsidyGranted": "Onko työsuhteeseen myönnetty palkkatuki?",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -92,6 +92,7 @@
       "deMinimisAidAmount": "Tuen määrä",
       "deMinimisAidGrantedAt": "Myönnetty",
       "deMinimisAidTotal": "Yhteensä",
+      "deMinimisAidsNo": "Onko hakijalle myönnetty deminimis-tukea?",
       "coOperationNegotiations": "Onko hakijalla menossa YT-neuvottelut?",
       "isLivingInHelsinki": "Helsinki kotikuntana",
       "paySubsidyGranted": "Onko työsuhteeseen myönnetty palkkatuki?",

--- a/frontend/benefit/handler/src/components/applicationReview/deminimisView/DeminimisView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/deminimisView/DeminimisView.tsx
@@ -10,6 +10,8 @@ import * as React from 'react';
 import {
   $SummaryTableHeader,
   $SummaryTableValue,
+  $ViewField,
+  $ViewFieldBold,
 } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
@@ -75,7 +77,12 @@ const DeminimisView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
           </$GridCell>
         </>
       ) : (
-        '-'
+        <$GridCell $colSpan={12}>
+          <$ViewField>
+            {t(`${translationsBase}.fields.deMinimisAidsNo`)}{' '}
+            <$ViewFieldBold>{t('common:utility.no')}</$ViewFieldBold>
+          </$ViewField>
+        </$GridCell>
       )}
     </ReviewSection>
   );


### PR DESCRIPTION
## Description :sparkles:
![image](https://user-images.githubusercontent.com/16116141/146135637-da294827-5c48-4541-9b3b-926424b487d8.png)
Should show the text in application summary and handlers review when there are no deminimis aids granted

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
