### PR TITLE
HL-300 & HL-346 | Attachments fixes

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step3/attachmentsList/AttachmentsList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step3/attachmentsList/AttachmentsList.tsx
@@ -37,6 +37,7 @@ const AttachmentsList: React.FC<AttachmentsListProps> = ({
     <AttachmentsListBase
       title={t(`${translationsBase}.types.${camelCase(attachmentType)}.title`)}
       attachmentType={attachmentType}
+      name={attachmentType}
       message={showMessage && message}
       attachments={attachments}
       onUpload={handleUpload}

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step3/useApplicationFormStep3.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step3/useApplicationFormStep3.ts
@@ -45,7 +45,17 @@ const useApplicationFormStep3 = (
           )
         );
       }
-      return hasWorkContract && hasPaySubsidyDecision;
+      let hasApprenticeshipProgram = true;
+      if (application.apprenticeshipProgram) {
+        hasApprenticeshipProgram = !isEmpty(
+          application?.attachments?.find(
+            (att) => att.attachmentType === ATTACHMENT_TYPES.EDUCATION_CONTRACT
+          )
+        );
+      }
+      return (
+        hasWorkContract && hasPaySubsidyDecision && hasApprenticeshipProgram
+      );
     }
     if (application.benefitType === BENEFIT_TYPES.COMMISSION) {
       return !isEmpty(

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step4/ApplicationFormStep4.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step4/ApplicationFormStep4.tsx
@@ -20,7 +20,10 @@ import {
   $GridCell,
   $Hr,
 } from 'shared/components/forms/section/FormSection.sc';
-import { ATTACHMENT_MAX_SIZE } from 'shared/constants/attachment-constants';
+import {
+  ATTACHMENT_CONTENT_TYPES,
+  ATTACHMENT_MAX_SIZE,
+} from 'shared/constants/attachment-constants';
 import { useTheme } from 'styled-components';
 
 import StepperActions from '../stepperActions/StepperActions';
@@ -124,7 +127,7 @@ const ApplicationFormStep4: React.FC<DynamicFormStepComponentProps> = ({
                         onUpload={handleUploadAttachment}
                         isUploading={isUploading}
                         attachmentType={ATTACHMENT_TYPES.EMPLOYEE_CONSENT}
-                        allowedFileTypes={['application/pdf']}
+                        allowedFileTypes={ATTACHMENT_CONTENT_TYPES}
                         maxSize={ATTACHMENT_MAX_SIZE}
                         uploadText={t(
                           `${translationsBase}.uploadPowerOfAttorney.action2`


### PR DESCRIPTION
## Description :sparkles:
- Add the validation logic for the Education Contract attachment
- Allow other file types for the power of attorney attachment

## Issues :bug:

## Testing :alembic:
- Create a new application
- Proceed to step 2, under `Palkkatukipäätös` choose `Kyllä`
- Under `Onko kyseessä oppisopimus?` choose `Kyllä`
- Fill in the necessary fields and proceed to the next step
- You should NOT be able to go forward if `Palkkatukipäätös` attachment is missing (the `Jatka` button will be disabled)
- Going to step 4, file types other than PDF are now also acceptable

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
