### PR TITLE
HL-357 | Employment date range fixes

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/__tests__/dates.test.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/__tests__/dates.test.ts
@@ -8,54 +8,54 @@ describe('dates', () => {
 
   describe('getMinEndDate', () => {
     it('should be one month minus one day after the start date for Employment benefits', () => {
-      const minEndDate = getMinEndDate('1.1.2020', BENEFIT_TYPES.EMPLOYMENT);
+      const minEndDate = getMinEndDate('1.12.2020', BENEFIT_TYPES.EMPLOYMENT);
 
-      expect(minEndDate).toStrictEqual(new Date(2020, 0, 31));
+      expect(minEndDate).toStrictEqual(new Date(2020, 11, 31));
     });
 
     it('should be one month minus one day after the start date for Salary benefits', () => {
-      const minEndDate = getMinEndDate('1.1.2020', BENEFIT_TYPES.SALARY);
+      const minEndDate = getMinEndDate('1.12.2020', BENEFIT_TYPES.SALARY);
 
-      expect(minEndDate).toStrictEqual(new Date(2020, 0, 31));
+      expect(minEndDate).toStrictEqual(new Date(2020, 11, 31));
     });
 
     it('should be the same as the start date for Commission benefits', () => {
-      const minEndDate = getMinEndDate('1.1.2020', BENEFIT_TYPES.COMMISSION);
+      const minEndDate = getMinEndDate('1.12.2020', BENEFIT_TYPES.COMMISSION);
 
-      expect(minEndDate).toStrictEqual(new Date(2020, 0, 1));
+      expect(minEndDate).toStrictEqual(new Date(2020, 11, 1));
     });
 
     it('should be the same as the start date when benefit type is empty or undefined', () => {
-      const minEndDate1 = getMinEndDate('1.1.2020', undefinedBenefit);
-      const minEndDate2 = getMinEndDate('1.1.2020', emptyBenefit);
+      const minEndDate1 = getMinEndDate('1.12.2020', undefinedBenefit);
+      const minEndDate2 = getMinEndDate('1.12.2020', emptyBenefit);
 
-      expect(minEndDate1).toStrictEqual(new Date(2020, 0, 1));
-      expect(minEndDate2).toStrictEqual(new Date(2020, 0, 1));
+      expect(minEndDate1).toStrictEqual(new Date(2020, 11, 1));
+      expect(minEndDate2).toStrictEqual(new Date(2020, 11, 1));
     });
   });
 
   describe('getMaxEndDate', () => {
     it('should be one year minus one day after the start date for Employment benefits', () => {
-      const maxEndDate = getMaxEndDate('1.1.2020', BENEFIT_TYPES.EMPLOYMENT);
+      const maxEndDate = getMaxEndDate('1.12.2020', BENEFIT_TYPES.EMPLOYMENT);
 
-      expect(maxEndDate).toStrictEqual(new Date(2020, 11, 31));
+      expect(maxEndDate).toStrictEqual(new Date(2021, 10, 30));
     });
 
     it('should be one year minus one day after the start date for Salary benefits', () => {
-      const maxEndDate = getMaxEndDate('1.1.2020', BENEFIT_TYPES.SALARY);
+      const maxEndDate = getMaxEndDate('1.12.2020', BENEFIT_TYPES.SALARY);
 
-      expect(maxEndDate).toStrictEqual(new Date(2020, 11, 31));
+      expect(maxEndDate).toStrictEqual(new Date(2021, 10, 30));
     });
 
     it('should be undefined for Commission benefits', () => {
-      const maxEndDate = getMaxEndDate('1.1.2020', BENEFIT_TYPES.COMMISSION);
+      const maxEndDate = getMaxEndDate('1.12.2020', BENEFIT_TYPES.COMMISSION);
 
       expect(maxEndDate).toBeUndefined();
     });
 
     it('should be undefined when benefit type is empty or undefined', () => {
-      const maxEndDate1 = getMaxEndDate('1.1.2020', undefinedBenefit);
-      const maxEndDate2 = getMaxEndDate('1.1.2020', emptyBenefit);
+      const maxEndDate1 = getMaxEndDate('1.12.2020', undefinedBenefit);
+      const maxEndDate2 = getMaxEndDate('1.12.2020', emptyBenefit);
 
       expect(maxEndDate1).toBeUndefined();
       expect(maxEndDate2).toBeUndefined();

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/__tests__/dates.test.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/__tests__/dates.test.ts
@@ -1,6 +1,6 @@
 import { BENEFIT_TYPES } from 'benefit/applicant/constants';
 
-import { getMaxEndDate,getMinEndDate } from '../dates';
+import { getMaxEndDate, getMinEndDate } from '../dates';
 
 describe('dates', () => {
   const undefinedBenefit = undefined;

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/dates.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/dates.ts
@@ -15,7 +15,7 @@ export const getMinEndDate = (
   switch (benefitType) {
     case BENEFIT_TYPES.EMPLOYMENT:
     case BENEFIT_TYPES.SALARY:
-      return addMonths(subDays(parsedStartDate, 1), 1);
+      return subDays(addMonths(parsedStartDate, 1), 1);
 
     case BENEFIT_TYPES.COMMISSION:
     default:
@@ -32,7 +32,7 @@ export const getMaxEndDate = (
   switch (benefitType) {
     case BENEFIT_TYPES.EMPLOYMENT:
     case BENEFIT_TYPES.SALARY:
-      return addMonths(subDays(parsedStartDate, 1), 12);
+      return subDays(addMonths(parsedStartDate, 12), 1);
 
     case BENEFIT_TYPES.COMMISSION:
     default:

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
@@ -12,7 +12,7 @@ import {
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit/applicant/constants';
 import { Step2 } from 'benefit/applicant/types/application';
-import isThisYear from 'date-fns/isThisYear';
+import isAfter from 'date-fns/isAfter';
 import startOfYear from 'date-fns/startOfYear';
 import { FinnishSSN } from 'finnish-ssn';
 import { TFunction } from 'next-i18next';
@@ -76,7 +76,7 @@ export const getValidationSchema = (t: TFunction): Yup.SchemaOf<Step2> =>
         }),
         test: (value = '') => {
           const date = parseDate(value);
-          return date ? isThisYear(date) : false;
+          return date ? isAfter(date, startOfYear(new Date())) : false;
         },
       }),
     [APPLICATION_FIELDS_STEP2_KEYS.END_DATE]: Yup.string().required(


### PR DESCRIPTION
## Description :sparkles:
- Correcting the end date calculation logic
- Fix the unit tests
- Fix the validation of the start date

## Issues :bug:

## Testing :alembic:
- Go to the second step
- Select the salary-based benefit type
- Select the first day of December for example
- The end date should default to the last day of December (previously, it was incorrectly 30th of Dec)

**Note:** Previously, selecting a start date in the next year resulted in a validation error. Now, this is fixed.

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
