### PR TITLE
HL-363 | Fix the values of the De Minimis Aid Set

### DIFF
--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -120,10 +120,14 @@ const useFormActions = (application: Application): FormActions => {
       apprenticeshipProgram: currentValues.apprenticeshipProgram || false,
     };
 
+    const deMinimisAidSet = deMinimisAids.length
+      ? deMinimisAids
+      : currentValues.deMinimisAidSet ?? [];
+
     return {
       ...application,
       ...normalizedValues,
-      deMinimisAidSet: deMinimisAids,
+      deMinimisAidSet,
     };
   };
 

--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -120,9 +120,10 @@ const useFormActions = (application: Application): FormActions => {
       apprenticeshipProgram: currentValues.apprenticeshipProgram || false,
     };
 
-    const deMinimisAidSet = deMinimisAids.length
-      ? deMinimisAids
-      : currentValues.deMinimisAidSet ?? [];
+    const deMinimisAidSet =
+      deMinimisAids.length > 0
+        ? deMinimisAids
+        : currentValues.deMinimisAidSet ?? [];
 
     return {
       ...application,


### PR DESCRIPTION
## Description :sparkles:
- The De Minimis Aid values were always overridden by the corresponding context values, now this is fixed

## Issues :bug:

## Testing :alembic:
- Create a new application
- Add some values to the De Minimis Aid
- Continue to step 2
- After filling in the required field, you should be able to proceed with the application with no errors

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
