### PR TITLE
HL-362 | Revert YRTTI API

### DIFF
--- a/backend/benefit/companies/api/v1/views.py
+++ b/backend/benefit/companies/api/v1/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from common.permissions import BFIsAuthenticated, TermsOfServiceAccepted
 from companies.api.v1.serializers import CompanySerializer
 from companies.models import Company
@@ -13,6 +15,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from shared.oidc.utils import get_organization_roles
+
+LOGGER = logging.getLogger(__name__)
 
 
 class GetCompanyView(APIView):
@@ -83,9 +87,14 @@ class GetCompanyView(APIView):
                 except Company.DoesNotExist:
                     # Throw error if API failed or no object found in both places
                     return self.ytj_api_error
-            except (ValueError, KeyError):
+            except (ValueError, KeyError) as err:
+                LOGGER.debug(
+                    "Could not handle the response from Palveluväylä and YRTTI API, error: {}".format(
+                        err
+                    )
+                )
                 return Response(
-                    "Could not handle the response from Palveluväylä API",
+                    "Could not handle the response from Palveluväylä and YRTTI API",
                     status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
         company_data = CompanySerializer(company).data

--- a/backend/benefit/companies/services.py
+++ b/backend/benefit/companies/services.py
@@ -1,9 +1,9 @@
 from common.utils import update_object
 from companies.models import Company
+from requests import HTTPError
 
 from shared.service_bus.service_bus_client import ServiceBusClient
 from shared.yrtti.yrtti_client import YRTTIClient
-from shared.ytj.ytj_client import YTJClient
 
 
 def get_or_create_company_using_company_data(company_data: dict) -> Company:
@@ -19,6 +19,20 @@ def get_or_create_company_using_company_data(company_data: dict) -> Company:
 
 
 def get_or_create_organisation_with_business_id(business_id: str) -> Company:
+    try:
+        organisation = get_or_create_organisation_with_business_id_via_service_bus(
+            business_id
+        )
+    except HTTPError:
+        # Using ServiceBus, it's guarantee to find company, but not association, so if the first request return 404,
+        # try again with YRTTI API
+        organisation = get_or_create_association_with_business_id(business_id)
+    return organisation
+
+
+def get_or_create_organisation_with_business_id_via_service_bus(
+    business_id: str,
+) -> Company:
     """
     Create a company instance using the Palveluväylä integration.
     """
@@ -30,25 +44,13 @@ def get_or_create_organisation_with_business_id(business_id: str) -> Company:
     return get_or_create_company_using_company_data(company_data)
 
 
-def get_or_create_company_with_business_id(business_id: str) -> Company:
-    """
-    Create a company instance using the YTJ integration.
-    """
-    ytj_client = YTJClient()
-
-    ytj_data = ytj_client.get_company_info_with_business_id(business_id)
-    company_data = ytj_client.get_company_data_from_ytj_data(ytj_data)
-
-    return get_or_create_company_using_company_data(company_data)
-
-
 def get_or_create_association_with_business_id(business_id: str) -> Company:
     """
     Create a company instance using the YTJ integration.
     """
-    YTJ_client = YRTTIClient()
+    yrtti_client = YRTTIClient()
 
-    YTJ_data = YTJ_client.get_association_info_with_business_id(business_id)
-    company_data = YTJ_client.get_association_data_from_YTJ_data(YTJ_data)
+    yrtti_data = yrtti_client.get_association_info_with_business_id(business_id)
+    company_data = yrtti_client.get_association_data_from_yrtti_data(yrtti_data)
 
     return get_or_create_company_using_company_data(company_data)

--- a/backend/benefit/companies/tests/conftest.py
+++ b/backend/benefit/companies/tests/conftest.py
@@ -2,7 +2,10 @@ import re
 
 import pytest
 from common.tests.conftest import *  # noqa
-from companies.tests.data.company_data import get_dummy_company_data
+from companies.tests.data.company_data import (
+    DUMMY_ASSOCIATION_DATA,
+    get_dummy_company_data,
+)
 from companies.tests.factories import CompanyFactory
 from django.conf import settings
 
@@ -16,8 +19,27 @@ COMPANY_ROLE_JSON = [
 ]
 
 
+ASSOCIATION_ROLE_JSON = [
+    {
+        "name": DUMMY_ASSOCIATION_DATA["name"],
+        "identifier": DUMMY_ASSOCIATION_DATA["business_id"],
+        "complete": True,
+        "roles": ["NIMKO"],
+    }
+]
+
+
 @pytest.fixture()
 def mock_get_organisation_roles_and_create_company(requests_mock):
     matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
     requests_mock.get(matcher, json=COMPANY_ROLE_JSON)
     return CompanyFactory(business_id=COMPANY_ROLE_JSON[0]["identifier"])
+
+
+@pytest.fixture()
+def mock_get_organisation_roles_and_create_association(requests_mock):
+    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    requests_mock.get(matcher, json=ASSOCIATION_ROLE_JSON)
+    return CompanyFactory(
+        business_id=ASSOCIATION_ROLE_JSON[0]["identifier"], company_form="association"
+    )

--- a/backend/benefit/companies/tests/data/company_data.py
+++ b/backend/benefit/companies/tests/data/company_data.py
@@ -721,7 +721,65 @@ DUMMY_ASSOCIATION_DATA = {
     "city": "Vaasa",
 }
 
-
+DUMMY_YRTTI_RESPONSE = {
+    "BasicInfoResponse": {
+        "AssociationNameInfo": [
+            {
+                "AssociationNameType": "P",
+                "AssociationName": "SIPOON NUORISOMUSIIKINYHDISTYS SUSIMUSA ry",
+                "AssociationNameLanguage": "FI",
+                "AssociationIndustry": None,
+                "AssociationNameStatus": "R",
+                "AssociationNameStartDate": "2007-02-27T00:00:00.000+00:00",
+            },
+            {
+                "AssociationNameType": "P",
+                "AssociationName": "SIPOON NUORISOMUSIIKINYHDISTYS SYSIMUSA ry",
+                "AssociationNameLanguage": "FI",
+                "AssociationIndustry": None,
+                "AssociationNameStatus": "VE",
+                "AssociationNameStartDate": None,
+            },
+        ],
+        "BusinessId": "2686723-5",
+        "RegistrationNumber": "195.883",
+        "Domicile": "753",
+        "DomicileStartDate": "2007-02-27T00:00:00.000+00:00",
+        "AssociationRegistrationLanguage": "FI",
+        "Address": [
+            {
+                "AddressTypeCode": "YRPO",
+                "FormattedAddressFI": "Lamberg Matti Olavi\nKatajakalliontie 16\n01120 Västerskog\nSuomi",
+                "FormattedAddressEN": "Lamberg Matti Olavi\nKatajakalliontie 16\n01120 Västerskog\nFinland",
+                "FormattedAddressSE": "Lamberg Matti Olavi\nKatajakalliontie 16\n01120 Västerskog\nFinland",
+                "CoAddress": None,
+                "StreetName": "Lamberg Matti Olavi\nKatajakalliontie 16",
+                "HouseNumber": None,
+                "Stair": None,
+                "FlatNumber": None,
+                "FlatDivisionLetter": None,
+                "PoBoxPrefix": None,
+                "PoBox": None,
+                "PostCode": "01120",
+                "City": "Västerskog",
+                "CountryCode": "FI",
+                "AddressAbroad": None,
+            }
+        ],
+        "ContactInfo": None,
+        "RegistryDate": "2007-02-27T00:00:00.000+00:00",
+        "LastRegistrationPeriod": "2007-02-27T00:00:00.000+00:00",
+        "AssociationStatus": "R",
+        "AssociationStatusDate": "2007-02-27T00:00:00.000+00:00",
+        "AssociationSpecialCondition": None,
+        "AssociationSpecialConditionDate": None,
+        "EndRegistrationReason": None,
+        "PurposeClassMain": "400",
+        "PurposeClassSecondary": "400",
+    },
+    "faultCode": None,
+    "faultString": None,
+}
 DUMMY_SERVICE_BUS_RESPONSE = {
     "GetCompanyResult": {
         "Company": {

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -92,6 +92,13 @@ env = environ.Env(
     ENABLE_DEBUG_ENV=(bool, False),
     TALPA_ROBOT_AUTH_CREDENTIAL=(str, "username:password"),
     DISABLE_TOS_APPROVAL_CHECK=(bool, False),
+    YRTTI_BASIC_INFO_PATH=(
+        str,
+        "https://yrtti-integration-dev.agw.arodevtest.hel.fi/api/BasicInfo",
+    ),
+    YRTTI_AUTH_USERNAME=(str, "sample_username"),
+    YRTTI_AUTH_PASSWORD=(str, "sample_password"),
+    YRTTI_TIMEOUT=(int, 30),
     SERVICE_BUS_INFO_PATH=(
         str,
         "https://ytj-integration-dev.agw.arodevtest.hel.fi/api/GetCompany",
@@ -347,6 +354,11 @@ MINIMUM_WORKING_HOURS_PER_WEEK = env("MINIMUM_WORKING_HOURS_PER_WEEK")
 WKHTMLTOPDF_BIN = env("WKHTMLTOPDF_BIN")
 
 TALPA_ROBOT_AUTH_CREDENTIAL = env("TALPA_ROBOT_AUTH_CREDENTIAL")
+
+YRTTI_TIMEOUT = env("YRTTI_TIMEOUT")
+YRTTI_BASIC_INFO_PATH = env("YRTTI_BASIC_INFO_PATH")
+YRTTI_AUTH_USERNAME = env("YRTTI_AUTH_USERNAME")
+YRTTI_AUTH_PASSWORD = env("YRTTI_AUTH_PASSWORD")
 
 SERVICE_BUS_TIMEOUT = env("SERVICE_BUS_TIMEOUT")
 SERVICE_BUS_INFO_PATH = env("SERVICE_BUS_INFO_PATH")


### PR DESCRIPTION
## Description :sparkles:
Some test association can't be found in YTJ API. I revert the YRTTI changes so it can be used as a second source 
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
