### PR TITLE
HL-299 | Fix salary benefit type message step 2

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -386,7 +386,8 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           </SelectionGroup>
         </$GridCell>
 
-        {formik.values.benefitType === BENEFIT_TYPES.SALARY && (
+        {formik.values.benefitType === BENEFIT_TYPES.SALARY 
+          && formik.values.apprenticeshipProgram === true && (
           <$GridCell $colSpan={6}>
             <$Notification
               label={t(`${translationsBase}.notifications.salaryBenefit.label`)}
@@ -401,11 +402,11 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
         <$GridCell $colSpan={8}>
           {!formik.values.benefitType
             ? t(`${translationsBase}.messages.selectBenefitType`)
-            : t(
-                `${translationsBase}.messages.${camelCase(
-                  formik.values.benefitType
-                )}Selected`
-              )}
+            : formik.values.benefitType === BENEFIT_TYPES.SALARY 
+              && formik.values.apprenticeshipProgram === false
+            ? ''
+            : t(`${translationsBase}.messages.${camelCase(formik.values.benefitType)}Selected`
+          )}
         </$GridCell>
         <$GridCell $colStart={1} $colSpan={2}>
           <DateInput


### PR DESCRIPTION
## Description
Remove unnecessary messages when selecting salary benefit type

>When I choose that there is palkkatuki, but it is not oppisopimus and then choose the benefit type Palkan Helsinki-lisä, I ?get the infobox of oppisopimus and there is text: Oppisopimuksessa 12 kk ylittävältä jaksolta tehdään uusi hakemus. I don’t want information about oppisopimus, if I choose that it is not oppisopimus. 

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
Before:
![image](https://user-images.githubusercontent.com/1481118/146846723-b1290f7c-5ff3-4424-a823-a26136c9101c.png)
After:

![Screenshot 2021-12-21 at 1 40 08](https://user-images.githubusercontent.com/1481118/146847051-dc8b9662-816c-4472-b2b3-d09e672d4198.png)
![Screenshot 2021-12-21 at 1 40 18](https://user-images.githubusercontent.com/1481118/146847057-831845b4-8647-4faa-8fac-46c861912b6b.png)

## Additional notes :spiral_notepad: