### PR TITLE
Fix platta browser tests with real integrations

### DIFF
--- a/frontend/kesaseteli/employer/browser-tests/actions/application.actions.ts
+++ b/frontend/kesaseteli/employer/browser-tests/actions/application.actions.ts
@@ -35,19 +35,28 @@ export const fillStep1Form = async (
   await step1Form.actions.fillContactPersonPhone(contact_person_phone_number);
   await step1Form.actions.fillStreetAddress(street_address);
   if (is_separate_invoicer) {
-    await step1Form.actions.toggleSeparateInvoicerCheckbox();
+    await step1Form.actions.selectSeparateInvoicerCheckbox();
     await step1Form.actions.fillInvoicerName(invoicer_name);
     await step1Form.actions.fillInvoicerEmail(invoicer_email);
     await step1Form.actions.fillInvoicerPhone(invoicer_phone_number);
   }
 };
 
+export const removeStep2ExistingForms = async (
+  t: TestController
+): Promise<void> => {
+  const step2 = getStep2Components(t);
+  const form = await step2.form();
+  await form.actions.openAllClosedAccordions();
+  await form.actions.removeAllAccordions();
+};
 export const fillStep2EmployeeForm = async (
   t: TestController,
   employment: Employment,
   index = 0
 ): Promise<void> => {
   const step2 = getStep2Components(t);
+
   const addButton = await step2.addEmploymentButton();
   if (index > 0) {
     await addButton.actions.click();
@@ -72,6 +81,7 @@ export const fillStep2EmployeeForm = async (
       employment.summer_voucher_serial_number
     );
   }
+  await step2Employment.actions.removeExistingAttachments();
   await Promise.all(
     employment.employment_contract.map(async (attachment) =>
       step2Employment.actions.addEmploymentContractAttachment(attachment)
@@ -131,6 +141,7 @@ export const loginAndfillApplication = async (
     await wizard.actions.clickSaveAndContinueButton();
   }
   if (toStep >= 2) {
+    await removeStep2ExistingForms(t);
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < application.summer_vouchers.length; i++) {
       const employment = application.summer_vouchers[i];

--- a/frontend/kesaseteli/employer/browser-tests/actions/employer-header.actions.ts
+++ b/frontend/kesaseteli/employer/browser-tests/actions/employer-header.actions.ts
@@ -15,9 +15,5 @@ export const doEmployerLogin = async (
   const headerUser = await getHeaderComponents(t).headerUser();
   await headerUser.expectations.userIsLoggedOut();
   await headerUser.actions.clickloginButton();
-  const suomifiData = await doLogin(t, lang, cachedUser);
-  if (suomifiData.user) {
-    await headerUser.expectations.userIsLoggedIn(suomifiData.user);
-  }
-  return suomifiData;
+  return doLogin(t, lang, cachedUser);
 };

--- a/frontend/kesaseteli/employer/browser-tests/application-page/application.testcafe.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/application.testcafe.ts
@@ -19,9 +19,8 @@ let urlUtils: ReturnType<typeof getUrlUtils>;
 const url = getFrontendUrl('/');
 let headerComponents: ReturnType<typeof getHeaderComponents>;
 
-fixture('Application')
+const setup = fixture('Application')
   .page(url)
-  .requestHooks(new HttpRequestHook(url))
   .beforeEach(async (t) => {
     clearDataToPrintOnFailure(t);
     urlUtils = getUrlUtils(t);
@@ -48,6 +47,8 @@ if (isRealIntegrationsEnabled()) {
     await step1Form.expectations.isFulFilledWith(application);
   });
 } else {
+  setup.requestHooks(new HttpRequestHook(url));
+
   test('Fills up invoicer form and retrieves its data when reloading page', async (t: TestController) => {
     const { id: applicationId, ...step1FormData } =
       await loginAndfillApplication(t, 1);

--- a/frontend/kesaseteli/employer/browser-tests/application-page/application.testcafe.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/application.testcafe.ts
@@ -1,3 +1,4 @@
+import { getBackendDomain } from '@frontend/kesaseteli-shared/src/backend-api/backend-api';
 import { getHeaderComponents } from '@frontend/shared/browser-tests/components/header.components';
 import { HttpRequestHook } from '@frontend/shared/browser-tests/hooks/http-request-hook';
 import isRealIntegrationsEnabled from '@frontend/shared/browser-tests/utils/is-real-integrations-enabled';
@@ -19,8 +20,9 @@ let urlUtils: ReturnType<typeof getUrlUtils>;
 const url = getFrontendUrl('/');
 let headerComponents: ReturnType<typeof getHeaderComponents>;
 
-const setup = fixture('Application')
+fixture('Application')
   .page(url)
+  .requestHooks(new HttpRequestHook(url, getBackendDomain()))
   .beforeEach(async (t) => {
     clearDataToPrintOnFailure(t);
     urlUtils = getUrlUtils(t);
@@ -47,8 +49,6 @@ if (isRealIntegrationsEnabled()) {
     await step1Form.expectations.isFulFilledWith(application);
   });
 } else {
-  setup.requestHooks(new HttpRequestHook(url));
-
   test('Fills up invoicer form and retrieves its data when reloading page', async (t: TestController) => {
     const { id: applicationId, ...step1FormData } =
       await loginAndfillApplication(t, 1);

--- a/frontend/kesaseteli/employer/browser-tests/application-page/step1.components.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/step1.components.ts
@@ -167,8 +167,11 @@ export const getStep1Components = (t: TestController) => {
           address
         );
       },
-      toggleSeparateInvoicerCheckbox() {
-        return t.click(selectors.separateInvoicerCheckbox());
+      async selectSeparateInvoicerCheckbox(expectedValue = true) {
+        const currentValue = await selectors.separateInvoicerCheckbox().checked;
+        if (currentValue !== expectedValue) {
+          await t.click(selectors.separateInvoicerCheckbox());
+        }
       },
       fillInvoicerName(name?: string) {
         return fillInput(

--- a/frontend/kesaseteli/employer/browser-tests/application-page/step1.components.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/step1.components.ts
@@ -14,7 +14,7 @@ export const getStep1Components = (t: TestController) => {
   const companyTable = async (company: Company) => {
     const selectors = {
       companyTable() {
-        return screen.findAllByRole('grid', { name: /yrityksen tiedot/i });
+        return screen.findAllByRole('region', { name: /yrityksen tiedot/i });
       },
     };
     const expectations = {

--- a/frontend/kesaseteli/employer/browser-tests/application-page/step2.components.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/step2.components.ts
@@ -30,29 +30,79 @@ export const getStep2Components = (t: TestController) => {
     });
   const withinForm = (): ReturnType<typeof within> => within(formSelector());
 
+  const accordionSelector = (isOpen = true, index = 0) =>
+    screen.findByTestId(`accordion-${index}-${isOpen ? 'open' : 'closed'}`);
+  const withinAccordion = (
+    isOpen = true,
+    index = 0
+  ): ReturnType<typeof within> => within(accordionSelector(isOpen, index));
+
+  const form = async () => {
+    const selectors = {
+      title() {
+        return formSelector();
+      },
+    };
+    const expectations = {
+      async isPresent() {
+        await t
+          .expect(selectors.title().exists)
+          .ok(await getErrorMessage(t), { timeout: 10_000 });
+      },
+    };
+    const actions = {
+      async openAllClosedAccordions() {
+        /* eslint-disable no-await-in-loop */
+        for (;;) {
+          const closedAccordion = accordionSelector(false);
+          if (await closedAccordion.exists) {
+            await t.click(closedAccordion);
+          } else {
+            break;
+          }
+        }
+        /* eslint-enable no-await-in-loop */
+      },
+      async removeAllAccordions() {
+        /* eslint-disable no-await-in-loop */
+        for (;;) {
+          const removeButtons = within(formSelector()).findAllByRole('button', {
+            name: /poista tiedot/i,
+          });
+          if (await removeButtons.exists) {
+            await t.click(removeButtons.nth(0));
+          } else {
+            break;
+          }
+        }
+        /* eslint-enable no-await-in-loop */
+      },
+    };
+    await expectations.isPresent();
+    return {
+      expectations,
+      actions,
+    };
+  };
+
   const employmentAccordion = async (employeeIndex = 0) => {
-    const accordionSelector = (isOpen = true) =>
-      screen.findByTestId(
-        `accordion-${employeeIndex}-${isOpen ? 'open' : 'closed'}`
-      );
-    const withinAccordion = (isOpen = true): ReturnType<typeof within> =>
-      within(accordionSelector(isOpen));
+    const withinThisAccordion = () => withinAccordion(true, employeeIndex);
 
     const selectors = {
       employeeNameInput() {
-        return withinAccordion().findByRole('textbox', {
+        return withinThisAccordion().findByRole('textbox', {
           name: /^työntekijän nimi/i,
         });
       },
       ssnInput() {
-        return withinAccordion().findByRole('textbox', {
+        return withinThisAccordion().findByRole('textbox', {
           name: /^henkilötunnus/i,
         });
       },
       gradeOrBirthYearRadioInput(
         type: EmploymentExceptionReason = '9th_grader'
       ) {
-        return withinAccordion().findByRole('radio', {
+        return withinThisAccordion().findByRole('radio', {
           name: getSelectionGroupTranslation(
             'summer_voucher_exception_reason',
             type
@@ -60,94 +110,99 @@ export const getStep2Components = (t: TestController) => {
         });
       },
       homeCityInput() {
-        return withinAccordion().findByRole('textbox', {
+        return withinThisAccordion().findByRole('textbox', {
           name: /^kotipaikka/i,
         });
       },
       postcodeInput() {
-        return withinAccordion().findByRole('spinbutton', {
+        return withinThisAccordion().findByRole('spinbutton', {
           name: /^postinumero/i,
         });
       },
       phoneNumberInput() {
-        return withinAccordion().findByRole('textbox', {
+        return withinThisAccordion().findByRole('textbox', {
           name: /^puhelinnumero/i,
         });
       },
       employmentPostcodeInput() {
-        return withinAccordion().findByRole('spinbutton', {
+        return withinThisAccordion().findByRole('spinbutton', {
           name: /^työn suorituspaikan postinumero/i,
         });
       },
       schoolInput() {
-        return withinAccordion().findByRole('textbox', {
+        return withinThisAccordion().findByRole('textbox', {
           name: /^koulun nimi/i,
         });
       },
       serialNumberInput() {
-        return withinAccordion().findByRole('textbox', {
+        return withinThisAccordion().findByRole('textbox', {
           name: /^kesäsetelin sarjanumero/i,
         });
       },
       employmentContractAttachmentInput: () =>
-        withinAccordion().findByTestId(
+        withinThisAccordion().findByTestId(
           `summer_vouchers.${employeeIndex}.employment_contract`
         ),
       employmentContractAttachmentButton: () =>
-        withinAccordion().findByRole('button', {
+        withinThisAccordion().findByRole('button', {
           name: /^työsopimus/i,
         }),
       attachmentLink: (attachment: KesaseteliAttachment) =>
-        withinAccordion()
+        withinThisAccordion()
           .findAllByRole('link', {
             name: new RegExp(getAttachmentFileName(attachment), 'i'),
           })
           .nth(0),
       payslipAttachmentInput: () =>
-        withinAccordion().findByTestId(
+        withinThisAccordion().findByTestId(
           `summer_vouchers.${employeeIndex}.payslip`
         ),
       payslipAttachmentButton: () =>
-        withinAccordion().findByRole('button', {
+        withinThisAccordion().findByRole('button', {
           name: /^palkkatodistus/i,
         }),
       startDateInput() {
-        return withinAccordion().findByRole('textbox', {
+        return withinThisAccordion().findByRole('textbox', {
           name: /^työsuhteen alkamispäivä/i,
         });
       },
       endDateInput() {
-        return withinAccordion().findByRole('textbox', {
+        return withinThisAccordion().findByRole('textbox', {
           name: /^työsuhteen päättymispäivä/i,
         });
       },
       workHoursInput() {
-        return withinAccordion().findByRole('spinbutton', {
+        return withinThisAccordion().findByRole('spinbutton', {
           name: /^tehdyt työtunnit/i,
         });
       },
       descriptionInput() {
-        return withinAccordion().findByRole('textbox', {
+        return withinThisAccordion().findByRole('textbox', {
           name: /^kuvaus työtehtävistä/i,
         });
       },
       salaryInput() {
-        return withinAccordion().findByRole('spinbutton', {
+        return withinThisAccordion().findByRole('spinbutton', {
           name: /^maksettu palkka/i,
         });
       },
       hiredWithoutVoucherAssessmentRadioInput(
         type: EmployeeHiredWithoutVoucherAssessment = 'maybe'
       ) {
-        return withinAccordion().findByRole('radio', {
+        return withinThisAccordion().findByRole('radio', {
           name: getSelectionGroupTranslation(
             'hired_without_voucher_assessment',
             type
           ),
         });
       },
+      removeAttachmentButtons() {
+        return withinThisAccordion().findAllByRole('link', {
+          name: /poista tiedosto/i,
+        });
+      },
       saveButton() {
-        return withinAccordion().findByRole('button', {
+        return withinThisAccordion().findByRole('button', {
           name: /^tallenna tiedot/i,
         });
       },
@@ -158,7 +213,7 @@ export const getStep2Components = (t: TestController) => {
           .expect(formSelector().exists)
           .ok(await getErrorMessage(t), { timeout: 10_000 });
         await t
-          .expect(accordionSelector(isOpen).exists)
+          .expect(accordionSelector(isOpen, employeeIndex).exists)
           .ok(await getErrorMessage(t), { timeout: 10_000 });
       },
       async isAttachmentUploaded(attachment: KesaseteliAttachment) {
@@ -295,6 +350,19 @@ export const getStep2Components = (t: TestController) => {
           selectors.hiredWithoutVoucherAssessmentRadioInput(type)
         );
       },
+      async removeExistingAttachments() {
+        /* eslint-disable no-await-in-loop */
+        for (;;) {
+          const removeAttachmentButtons = selectors.removeAttachmentButtons();
+
+          if (await removeAttachmentButtons.exists) {
+            await t.click(removeAttachmentButtons.nth(0));
+          } else {
+            break;
+          }
+        }
+        /* eslint-enable no-await-in-loop */
+      },
       async clickSaveEmployeeButton() {
         return t.click(selectors.saveButton());
       },
@@ -335,6 +403,7 @@ export const getStep2Components = (t: TestController) => {
   };
 
   return {
+    form,
     employmentAccordion,
     addEmploymentButton,
   };

--- a/frontend/kesaseteli/employer/browser-tests/application-page/summary.components.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/summary.components.ts
@@ -69,7 +69,7 @@ export const getSummaryComponents = async (t: TestController) => {
         ) =>
           expectElementHasValue(
             selectors.employerField(field),
-            value ?? String(company[field])
+            value || String(company[field]) || '-'
           );
         const header = selectors.companyHeading();
         await expectElementHasValue(header, company.name);

--- a/frontend/kesaseteli/employer/browser-tests/index-page/userActions.testcafe.ts
+++ b/frontend/kesaseteli/employer/browser-tests/index-page/userActions.testcafe.ts
@@ -19,13 +19,16 @@ const appNameTranslation: Translation = {
 const url = getFrontendUrl('/');
 let headerComponents: ReturnType<typeof getHeaderComponents>;
 
-fixture('Frontpage')
+const setup = fixture('Frontpage')
   .page(url)
-  .requestHooks(new HttpRequestHook(url))
   .beforeEach(async (t) => {
     clearDataToPrintOnFailure(t);
     headerComponents = getHeaderComponents(t, appNameTranslation);
   });
+
+if (!isRealIntegrationsEnabled()) {
+  setup.requestHooks(new HttpRequestHook(url));
+}
 
 test('user can authenticate and logout', async (t: TestController) => {
   const suomiFiData = await doEmployerLogin(t);

--- a/frontend/kesaseteli/employer/browser-tests/index-page/userActions.testcafe.ts
+++ b/frontend/kesaseteli/employer/browser-tests/index-page/userActions.testcafe.ts
@@ -1,10 +1,11 @@
+import { getBackendDomain } from '@frontend/kesaseteli-shared/src/backend-api/backend-api';
 import {
   getHeaderComponents,
   Translation,
 } from '@frontend/shared/browser-tests/components/header.components';
 import { HttpRequestHook } from '@frontend/shared/browser-tests/hooks/http-request-hook';
-import isRealIntegrationsEnabled from '@frontend/shared/browser-tests/utils/is-real-integrations-enabled';
 import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
+
 import { getFrontendUrl } from '../utils/url.utils';
 
 const appNameTranslation: Translation = {
@@ -16,16 +17,13 @@ const appNameTranslation: Translation = {
 const url = getFrontendUrl('/');
 let headerComponents: ReturnType<typeof getHeaderComponents>;
 
-const setup = fixture('Frontpage')
+fixture('Frontpage')
   .page(url)
+  .requestHooks(new HttpRequestHook(url, getBackendDomain()))
   .beforeEach(async (t) => {
     clearDataToPrintOnFailure(t);
     headerComponents = getHeaderComponents(t, appNameTranslation);
   });
-
-if (!isRealIntegrationsEnabled()) {
-  setup.requestHooks(new HttpRequestHook(url));
-}
 
 test('user can authenticate and logout', async () => {
   const headerUser = await headerComponents.headerUser();

--- a/frontend/kesaseteli/employer/browser-tests/index-page/userActions.testcafe.ts
+++ b/frontend/kesaseteli/employer/browser-tests/index-page/userActions.testcafe.ts
@@ -5,9 +5,6 @@ import {
 import { HttpRequestHook } from '@frontend/shared/browser-tests/hooks/http-request-hook';
 import isRealIntegrationsEnabled from '@frontend/shared/browser-tests/utils/is-real-integrations-enabled';
 import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
-import TestController from 'testcafe';
-
-import { doEmployerLogin } from '../actions/employer-header.actions';
 import { getFrontendUrl } from '../utils/url.utils';
 
 const appNameTranslation: Translation = {

--- a/frontend/kesaseteli/employer/browser-tests/index-page/userActions.testcafe.ts
+++ b/frontend/kesaseteli/employer/browser-tests/index-page/userActions.testcafe.ts
@@ -30,12 +30,8 @@ if (!isRealIntegrationsEnabled()) {
   setup.requestHooks(new HttpRequestHook(url));
 }
 
-test('user can authenticate and logout', async (t: TestController) => {
-  const suomiFiData = await doEmployerLogin(t);
+test('user can authenticate and logout', async () => {
   const headerUser = await headerComponents.headerUser();
-  if (isRealIntegrationsEnabled() && suomiFiData?.user) {
-    await headerUser.expectations.userIsLoggedIn(suomiFiData.user);
-  }
   await headerUser.actions.clicklogoutButton();
   await headerUser.expectations.userIsLoggedOut();
 });

--- a/frontend/kesaseteli/youth/browser-tests/index-page/indexPage.testcafe.ts
+++ b/frontend/kesaseteli/youth/browser-tests/index-page/indexPage.testcafe.ts
@@ -1,22 +1,20 @@
+import { getBackendDomain } from '@frontend/kesaseteli-shared/src/backend-api/backend-api';
 import { HttpRequestHook } from '@frontend/shared/browser-tests/hooks/http-request-hook';
 import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
 
 import { fakeYouthFormData } from '../../src/__tests__/utils/fake-objects';
 import { getFrontendUrl } from '../utils/url.utils';
 import { getIndexPageComponents } from './indexPage.components';
-import isRealIntegrationsEnabled from 'shared/utils/is-real-integrations-enabled';
 
 const url = getFrontendUrl('/');
+const host = getBackendDomain();
 
-const setup = fixture('Frontpage')
+fixture('Frontpage')
   .page(url)
+  .requestHooks(new HttpRequestHook(url, getBackendDomain()))
   .beforeEach(async (t) => {
     clearDataToPrintOnFailure(t);
   });
-
-if (!isRealIntegrationsEnabled()) {
-  setup.requestHooks(new HttpRequestHook(url));
-}
 
 test('can fill up youth application', async (t) => {
   const indexPageComponents = await getIndexPageComponents(t);

--- a/frontend/kesaseteli/youth/browser-tests/index-page/indexPage.testcafe.ts
+++ b/frontend/kesaseteli/youth/browser-tests/index-page/indexPage.testcafe.ts
@@ -4,15 +4,19 @@ import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/
 import { fakeYouthFormData } from '../../src/__tests__/utils/fake-objects';
 import { getFrontendUrl } from '../utils/url.utils';
 import { getIndexPageComponents } from './indexPage.components';
+import isRealIntegrationsEnabled from 'shared/utils/is-real-integrations-enabled';
 
 const url = getFrontendUrl('/');
 
-fixture('Frontpage')
+const setup = fixture('Frontpage')
   .page(url)
-  .requestHooks(new HttpRequestHook(url))
   .beforeEach(async (t) => {
     clearDataToPrintOnFailure(t);
   });
+
+if (!isRealIntegrationsEnabled()) {
+  setup.requestHooks(new HttpRequestHook(url));
+}
 
 test('can fill up youth application', async (t) => {
   const indexPageComponents = await getIndexPageComponents(t);

--- a/frontend/kesaseteli/youth/browser-tests/index-page/userActions.testcafe.ts
+++ b/frontend/kesaseteli/youth/browser-tests/index-page/userActions.testcafe.ts
@@ -1,14 +1,15 @@
+import { getBackendDomain } from '@frontend/kesaseteli-shared/src/backend-api/backend-api';
 import {
   getHeaderComponents,
   Translation,
 } from '@frontend/shared/browser-tests/components/header.components';
 import { HttpRequestHook } from '@frontend/shared/browser-tests/hooks/http-request-hook';
 import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
-import isRealIntegrationsEnabled from 'shared/utils/is-real-integrations-enabled';
 
 import { getFrontendUrl } from '../utils/url.utils';
 
 const url = getFrontendUrl('/');
+
 let headerComponents: ReturnType<typeof getHeaderComponents>;
 
 const appTranslation: Translation = {
@@ -17,16 +18,13 @@ const appTranslation: Translation = {
   sv: 'SV Nuorten kesäseteli',
 };
 
-const setup = fixture('Frontpage')
+fixture('Frontpage')
   .page(url)
+  .requestHooks(new HttpRequestHook(url, getBackendDomain()))
   .beforeEach(async (t) => {
     clearDataToPrintOnFailure(t);
     headerComponents = getHeaderComponents(t, appTranslation);
   });
-
-if (!isRealIntegrationsEnabled()) {
-  setup.requestHooks(new HttpRequestHook(url));
-}
 
 test('can change to languages', async () => {
   const languageDropdown = await headerComponents.languageDropdown();

--- a/frontend/kesaseteli/youth/browser-tests/index-page/userActions.testcafe.ts
+++ b/frontend/kesaseteli/youth/browser-tests/index-page/userActions.testcafe.ts
@@ -4,6 +4,7 @@ import {
 } from '@frontend/shared/browser-tests/components/header.components';
 import { HttpRequestHook } from '@frontend/shared/browser-tests/hooks/http-request-hook';
 import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
+import isRealIntegrationsEnabled from 'shared/utils/is-real-integrations-enabled';
 
 import { getFrontendUrl } from '../utils/url.utils';
 
@@ -16,13 +17,16 @@ const appTranslation: Translation = {
   sv: 'SV Nuorten kesäseteli',
 };
 
-fixture('Frontpage')
+const setup = fixture('Frontpage')
   .page(url)
-  .requestHooks(new HttpRequestHook(url))
   .beforeEach(async (t) => {
     clearDataToPrintOnFailure(t);
     headerComponents = getHeaderComponents(t, appTranslation);
   });
+
+if (!isRealIntegrationsEnabled()) {
+  setup.requestHooks(new HttpRequestHook(url));
+}
 
 test('can change to languages', async () => {
   const languageDropdown = await headerComponents.languageDropdown();

--- a/frontend/shared/browser-tests/actions/login-action.ts
+++ b/frontend/shared/browser-tests/actions/login-action.ts
@@ -58,7 +58,7 @@ const doSuomiFiLogin = async (
   }
   await profileForm.actions.clickContinueButton();
   const companiesTable = await suomiFiValtuutusComponents.companiesTable();
-  const company = await companiesTable.actions.selectCompanyRadioButton(1);
+  const company = await companiesTable.actions.selectCompanyRadioButton(2);
   const authorizeForm = await suomiFiValtuutusComponents.authorizeForm();
   await authorizeForm.actions.clickSubmitButton(lang);
   return { user, company };

--- a/frontend/shared/browser-tests/actions/login-action.ts
+++ b/frontend/shared/browser-tests/actions/login-action.ts
@@ -58,7 +58,7 @@ const doSuomiFiLogin = async (
   }
   await profileForm.actions.clickContinueButton();
   const companiesTable = await suomiFiValtuutusComponents.companiesTable();
-  const company = await companiesTable.actions.selectCompanyRadioButton(0);
+  const company = await companiesTable.actions.selectCompanyRadioButton(1);
   const authorizeForm = await suomiFiValtuutusComponents.authorizeForm();
   await authorizeForm.actions.clickSubmitButton(lang);
   return { user, company };

--- a/frontend/shared/browser-tests/components/header.components.ts
+++ b/frontend/shared/browser-tests/components/header.components.ts
@@ -14,19 +14,22 @@ const translations = {
     login: 'Kirjaudu palveluun',
     logout: 'Kirjaudu ulos',
     language: 'Suomeksi',
-    userInfo: (user?: User) => new RegExp(`Käyttäjä: ${user?.name ?? ''}`),
+    userInfo: (user?: User) =>
+      new RegExp(`Käyttäjä: ${user?.name ?? 'Mika Hietanen'}`),
   },
   sv: {
     login: 'Logga in i tjänsten',
     logout: 'Logga ut',
     language: 'På svenska',
-    userInfo: (user?: User) => new RegExp(`Användare: ${user?.name ?? ''}`),
+    userInfo: (user?: User) =>
+      new RegExp(`Användare: ${user?.name ?? 'Mika Hietanen'}`),
   },
   en: {
     login: 'Sign in to the service',
     logout: 'Log out',
     language: 'In English',
-    userInfo: (user?: User) => new RegExp(`User: ${user?.name ?? ''}`),
+    userInfo: (user?: User) =>
+      new RegExp(`User: ${user?.name ?? 'Mika Hietanen'}`),
   },
 };
 

--- a/frontend/shared/browser-tests/hooks/http-request-hook.ts
+++ b/frontend/shared/browser-tests/hooks/http-request-hook.ts
@@ -8,14 +8,19 @@ type Event = {
 export class HttpRequestHook extends RequestHook {
   private referer: string;
 
-  constructor(referer: string) {
+  private host: string;
+
+  constructor(referer: string, host: string) {
     super();
     this.referer = referer;
+    this.host = host;
   }
 
   async onRequest(event: Event): Promise<void> {
-    // eslint-disable-next-line no-param-reassign
-    event.requestOptions.headers.Referer = this.referer;
+    if (this.host.includes(event.requestOptions.headers.host)) {
+      // eslint-disable-next-line no-param-reassign
+      event.requestOptions.headers.Referer = this.referer;
+    }
   }
 
   // eslint-disable-next-line class-methods-use-this,@typescript-eslint/no-empty-function


### PR DESCRIPTION
## Description :sparkles:
Browser tests on #yjdh-alerts havent been working for a long time. request hook didnt work on suomi fi profile, now it is fixed.
Also test can manage with draft application if previous run has failed and left a draft behind.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
