### PR TITLE
YJDH-376 | Refactor and simplify School

### DIFF
--- a/backend/kesaseteli/applications/admin.py
+++ b/backend/kesaseteli/applications/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+from applications.models import School
+
+admin.site.register(School)

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -42,7 +42,7 @@ class SchoolListView(ListAPIView):
         template='(%(expressions)s) COLLATE "%(function)s"',
     )
 
-    queryset = School.objects.active().order_by(_name_fi.asc())
+    queryset = School.objects.order_by(_name_fi.asc())
     serializer_class = SchoolSerializer
 
     def get_permissions(self):

--- a/backend/kesaseteli/applications/migrations/0016_add_youth_application_field_validation.py
+++ b/backend/kesaseteli/applications/migrations/0016_add_youth_application_field_validation.py
@@ -63,7 +63,7 @@ class Migration(migrations.Migration):
             name="school",
             field=models.CharField(
                 max_length=256,
-                validators=[applications.models.validate_school],
+                validators=[applications.models.validate_name],
                 verbose_name="school",
             ),
         ),
@@ -129,7 +129,7 @@ class Migration(migrations.Migration):
             name="school",
             field=models.CharField(
                 max_length=256,
-                validators=[applications.models.validate_school],
+                validators=[applications.models.validate_name],
                 verbose_name="school",
             ),
         ),

--- a/backend/kesaseteli/applications/migrations/0017_refactor_school.py
+++ b/backend/kesaseteli/applications/migrations/0017_refactor_school.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+import shared.common.validators
+
+
+def remove_deleted_schools(apps, schema_editor):
+    school_model = apps.get_model("applications", "School")
+    school_model.objects.filter(deleted_at__isnull=False).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("applications", "0016_add_youth_application_field_validation"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_deleted_schools, migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name="school",
+            name="deleted_at",
+        ),
+        migrations.AlterField(
+            model_name="school",
+            name="name",
+            field=models.CharField(
+                db_index=True,
+                max_length=256,
+                unique=True,
+                validators=[shared.common.validators.validate_name],
+            ),
+        ),
+    ]

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -25,29 +25,14 @@ from companies.models import Company
 LOGGER = logging.getLogger(__name__)
 
 
-def validate_school(name) -> None:
-    """
-    Raise a ValidationError if the given school is not a listed school and does not
-    validate as a name according to validate_name.
-    """
-    if not School.objects.filter(name=name).exists():
-        validate_name(name)
-
-
-class SchoolQuerySet(models.QuerySet):
-    def active(self):
-        return self.filter(deleted_at__isnull=True)
-
-    def deleted(self):
-        return self.filter(deleted_at__isnull=False)
-
-
 class School(TimeStampedModel, UUIDModel):
-    name = models.CharField(max_length=256, unique=True, db_index=True)
-    deleted_at = models.DateTimeField(
-        blank=True, null=True, verbose_name=_("time deleted")
+    """
+    List of active schools.
+    """
+
+    name = models.CharField(
+        max_length=256, unique=True, db_index=True, validators=[validate_name]
     )
-    objects = SchoolQuerySet.as_manager()
 
     def __str__(self):
         return self.name
@@ -81,7 +66,7 @@ class YouthApplication(HistoricalModel, TimeStampedModel, UUIDModel):
     school = models.CharField(
         max_length=256,
         verbose_name=_("school"),
-        validators=[validate_school],
+        validators=[validate_name],
     )
     is_unlisted_school = models.BooleanField()
     email = models.EmailField(

--- a/backend/kesaseteli/applications/tests/test_application_validation.py
+++ b/backend/kesaseteli/applications/tests/test_application_validation.py
@@ -6,20 +6,14 @@ from applications.api.v1.serializers import (
     SummerVoucherSerializer,
 )
 from applications.enums import ApplicationStatus, AttachmentType
-from applications.models import School, validate_school
+from applications.models import School, validate_name
 from applications.tests.test_applications_api import get_detail_url
 
 
 @pytest.mark.django_db
-def test_validate_school_with_all_active_schools():
-    for school in School.objects.active():
-        validate_school(school.name)
-
-
-@pytest.mark.django_db
-def test_validate_school_with_all_deleted_schools():
-    for school in School.objects.deleted():
-        validate_school(school.name)
+def test_validate_name_with_all_listed_schools():
+    for school in School.objects.all():
+        validate_name(school.name)
 
 
 @pytest.mark.django_db
@@ -30,8 +24,8 @@ def test_validate_school_with_all_deleted_schools():
         "Testikoulu",
     ],
 )
-def test_validate_school_with_valid_unlisted_school(name):
-    validate_school(name)
+def test_validate_name_with_valid_unlisted_school(name):
+    validate_name(name)
 
 
 @pytest.mark.django_db
@@ -43,9 +37,9 @@ def test_validate_school_with_valid_unlisted_school(name):
         "Yläaste (Arabia)",  # Parentheses are not allowed
     ],
 )
-def test_validate_school_with_invalid_unlisted_school(name):
+def test_validate_name_with_invalid_unlisted_school(name):
     with pytest.raises(ValidationError):
-        validate_school(name)
+        validate_name(name)
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/applications/tests/test_schools_api.py
+++ b/backend/kesaseteli/applications/tests/test_schools_api.py
@@ -27,9 +27,9 @@ def test_schools_list_returns_non_empty(api_client):
 
 
 @pytest.mark.django_db
-def test_schools_list_returns_active_school_count(api_client):
+def test_schools_list_returns_school_count(api_client):
     response = api_client.get(get_schools_api_url())
-    assert len(response.json()) == len(School.objects.active())
+    assert len(response.json()) == School.objects.count()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description :sparkles:

Remove deleted schools (i.e. the ones with non-null deleted_at values).
Remove School.deleted_at as unnecessary, all Schools are active now.
Remove SchoolQuerySet as unnecessary.
Replace validate_school use with validate_name, also retroactively.
Add validate_name validator to School.name.
Remove validate_school validator as unnecessary.
Update related tests.
Add School editing to Django admin.

## Issues :bug:

YJDH-230 (Django admin interface for updating schools)
YJDH-376 (Refactoring / simplifying school list maintenance)

## Testing :alembic:

You can edit the school list using Django admin:
 - `yarn youth --build`
 - Login into `https://localhost:8000/admin/` using admin/admin
 - Edit schools using Applications > Schools > Add/Change:
   - ![schools](https://user-images.githubusercontent.com/77663720/148202622-3f7cebcb-3534-40c6-86da-f5c66b5225a9.png)

## Screenshots :camera_flash:

### Django admin main page:
 - ![1](https://user-images.githubusercontent.com/77663720/148202632-bc525d14-7c17-4ab4-a06c-197b50b2b1f3.png)

### Django admin schools page:
 - ![2](https://user-images.githubusercontent.com/77663720/148202639-42852d5c-7ac9-4ea2-b140-8bfd1b263fdc.png)

### Django admin editing school:
 - ![3](https://user-images.githubusercontent.com/77663720/148202644-ba9168da-f963-4867-9975-955b07bd7133.png)

### Django admin error creating duplicate school:
 - ![4](https://user-images.githubusercontent.com/77663720/148202648-757e31db-8980-4ad0-beb4-634ded5339ff.png)

### Django admin error creating school with invalid name:
 - ![5](https://user-images.githubusercontent.com/77663720/148202653-725ee6ed-ef80-4f45-aafc-f37566a39197.png)

## Additional notes :spiral_notepad:
