### PR TITLE
YJDH-345 | KS-Backend: Use Finnish PostgreSQL in Docker

### DIFF
--- a/.github/workflows/ks-pytest.yml
+++ b/.github/workflows/ks-pytest.yml
@@ -20,7 +20,10 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        build:
+          context: ../../backend
+          dockerfile: ./docker/kesaseteli.Dockerfile
+          target: finnish_postgres
         ports:
           - 5432:5432
         options: >-
@@ -32,6 +35,8 @@ jobs:
           POSTGRES_USER: kesaseteli
           POSTGRES_PASSWORD: kesaseteli
           POSTGRES_DB: kesaseteli
+          LC_COLLATE: 'fi_FI.UTF-8'
+          LC_CTYPE: 'fi_FI.UTF-8'
 
     steps:
       - name: Check out repository

--- a/backend/docker/kesaseteli.Dockerfile
+++ b/backend/docker/kesaseteli.Dockerfile
@@ -1,4 +1,13 @@
 # ==============================
+FROM postgres:12 as finnish_postgres
+# ==============================
+RUN sed -i -e 's/# fi_FI.UTF-8 UTF-8/fi_FI.UTF-8 UTF-8/' /etc/locale.gen \
+    && locale-gen
+ENV LANG fi_FI.UTF-8
+ENV LANGUAGE fi_FI:fi
+ENV LC_ALL fi_FI.UTF-8
+
+# ==============================
 FROM helsinkitest/python:3.8-slim as appbase
 # ==============================
 RUN mkdir /entrypoint

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -1,5 +1,4 @@
 from django.core import exceptions
-from django.db.models import Func
 from django.http import FileResponse, HttpResponse
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
@@ -33,16 +32,7 @@ from common.utils import DenyAll
 
 
 class SchoolListView(ListAPIView):
-    # PostgreSQL specific functionality:
-    # - Custom sorter for name field to ensure finnish language sorting order.
-    # - NOTE: This can be removed if the database is made to use collation fi_FI.UTF8
-    _name_fi = Func(
-        "name",
-        function="fi-FI-x-icu",  # fi_FI.UTF8 would be best but wasn't available
-        template='(%(expressions)s) COLLATE "%(function)s"',
-    )
-
-    queryset = School.objects.order_by(_name_fi.asc())
+    queryset = School.objects.all()
     serializer_class = SchoolSerializer
 
     def get_permissions(self):

--- a/docker-compose.youth.yml
+++ b/docker-compose.youth.yml
@@ -1,12 +1,17 @@
 version: "3.8"
 services:
   postgres:
-    image: postgres:12
+    build:
+      context: ./backend
+      dockerfile: ./docker/kesaseteli.Dockerfile
+      target: finnish_postgres
     restart: on-failure
     environment:
       POSTGRES_USER: kesaseteli
       POSTGRES_PASSWORD: kesaseteli
       POSTGRES_DB: kesaseteli
+      LC_COLLATE: 'fi_FI.UTF-8'
+      LC_CTYPE: 'fi_FI.UTF-8'
     ports:
       - 5434:5432
     volumes:


### PR DESCRIPTION
## Description :sparkles:

Based on discussion in https://github.com/docker-library/postgres/issues/725#issuecomment-624141851

### KS-Backend: Use Finnish PostgreSQL in Docker:

backend/docker/kesaseteli.Dockerfile:
 - Add finnish_postgres target based on postgres:12 which sets up the
   PostgreSQL image to use Finnish language and database collation

docker-compose.youth.yml:
 - Use the finnish_postgres target

Using finnish_postgres kesaseteli-db is initialized like this:
 - The database cluster will be initialized with locale "fi_FI.UTF-8".
 - The default database encoding has accordingly been set to "UTF8".
 - The default text search configuration will be set to "finnish".

Listing the databases in the kesaseteli-db using
```docker exec -it kesaseteli-db psql -Ukesaseteli -c"\l"```
now gives (Removed irrelevant information for compact output):

```
                       List of databases
    Name    |   Owner    | Encoding |   Collate   |    Ctype    |
------------+------------+----------+-------------+-------------+
 kesaseteli | kesaseteli | UTF8     | fi_FI.UTF-8 | fi_FI.UTF-8 |
 postgres   | kesaseteli | UTF8     | fi_FI.UTF-8 | fi_FI.UTF-8 |
 template0  | kesaseteli | UTF8     | fi_FI.UTF-8 | fi_FI.UTF-8 |
 template1  | kesaseteli | UTF8     | fi_FI.UTF-8 | fi_FI.UTF-8 |
```

### SchoolListView: Remove unnecessary custom sorter:

Now the underlying PostgreSQL database uses fi_FI.UTF-8 collation so the
sorting works without the custom sorter.

### ks-pytest.yml: Use Finnish PostgreSQL:

Use Finnish PostgreSQL in review environment's (KS) Python tests so
test_schools_list_returns_sorted_collection test from
applications/tests/test_schools_api.py passes in review environment.

## Issues :bug:

YJDH-345

## Testing :alembic:

If you need to you can drop the database volume so it gets recreated with the correct language and collation:
```
docker-compose -f .\docker-compose.youth.yml down
docker volume rm yjdh_pgdata
yarn youth --build
```

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
