### PR TITLE
YJDH-374 | KS-Backend: Make activation email sending more lenient

### DIFF
--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 
 from django.conf import settings
@@ -20,6 +21,8 @@ from applications.enums import (
 )
 from common.utils import validate_finnish_social_security_number
 from companies.models import Company
+
+LOGGER = logging.getLogger(__name__)
 
 
 def validate_school(name) -> None:
@@ -120,13 +123,15 @@ class YouthApplication(HistoricalModel, TimeStampedModel, UUIDModel):
         ) % {"activation_link": activation_link}
 
     def send_activation_email(self, request):
-        send_mail(
+        sent_email_count = send_mail(
             subject=self._activation_email_subject(request),
             message=self._activation_email_message(request),
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[self.email],
             fail_silently=True,
         )
+        if sent_email_count == 0:
+            LOGGER.error("Unable to send youth application's activation email")
 
     @property
     def is_active(self) -> bool:

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -125,7 +125,7 @@ class YouthApplication(HistoricalModel, TimeStampedModel, UUIDModel):
             message=self._activation_email_message(request),
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[self.email],
-            fail_silently=False,
+            fail_silently=True,
         )
 
     @property

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -188,11 +188,6 @@ TEMPLATES = [
     }
 ]
 
-if DEBUG:
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-else:
-    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-
 EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS")
 EMAIL_HOST = env.str("EMAIL_HOST")
 EMAIL_HOST_USER = env.str("EMAIL_HOST_USER")
@@ -254,6 +249,11 @@ YTJ_TIMEOUT = env.int("YTJ_TIMEOUT")
 
 # Mock flag for testing purposes
 MOCK_FLAG = env.bool("MOCK_FLAG")
+
+if MOCK_FLAG:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
 # Authentication
 SESSION_COOKIE_AGE = env.int("SESSION_COOKIE_AGE")


### PR DESCRIPTION
## Description :sparkles:

**This makes the youth browser tests pass again:**
 - The problem was that send_activation_email in the backend
   failed and made the backend return an internal server error.

### Test posting youth application with email backends 

An activation email is sent when posting a youth application.
Add test_youth_application_post_valid_data_with_email_backends which
tests that using different email backends when posting a youth
application works.
 
### KS-Backend: Fail silently in activation email sending 
 
### KS-Backend: Send emails to console only if MOCK_FLAG is true:

Using MOCK_FLAG rather than DEBUG for choosing which email backend to
use seems more appropriate here.

### KS-Backend: Log activation email sending failures

## Issues :bug:

YJDH-374

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
