### PR TITLE
YJDH-356 | KS-Backend: Translate activation email to fi/sv/en

### DIFF
--- a/.github/workflows/ks-pytest.yml
+++ b/.github/workflows/ks-pytest.yml
@@ -49,8 +49,16 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
+      - name: Install gettext dependency
+        run: |
+          apt-get update
+          apt-get install -y gettext
+
       - name: Install dependencies
         run: cd backend/kesaseteli && pip install -r requirements.txt -r requirements-dev.txt codecov
+
+      - name: Compile messages
+        run: cd backend/kesaseteli && python manage.py compilemessages
 
       - name: Run tests
         run: pytest backend/kesaseteli/ -ra -vv --doctest-modules --cov=. -n auto --dist loadfile --pyargs shared

--- a/backend/kesaseteli/README.md
+++ b/backend/kesaseteli/README.md
@@ -28,9 +28,16 @@ Allow user to create test database
 * Create `.env.kesaseteli` file: `touch .env.kesaseteli`
 * Set the `DEBUG` environment variable to `1`.
 * Run `python manage.py migrate`
+* Run `python manage.py compilemessages`
 * Run `python manage.py runserver 0:8000`
 
 The project is now running at [localhost:8000](https://localhost:8000)
+
+### Updating translations
+
+In `backend/kesaseteli/`:
+* Run `python manage.py makemessages --no-location -l fi -l sv -l en`
+* Run `python manage.py compilemessages`
 
 ## Keeping Python requirements up to date
 

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -83,7 +83,7 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
     def create(self, request, *args, **kwargs):
         response = super().create(request, *args, **kwargs)
         youth_application = YouthApplication.objects.get(id=response.data["id"])
-        youth_application.send_activation_email(request)
+        youth_application.send_activation_email(request, youth_application.language)
         return response
 
     def get_permissions(self):

--- a/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
@@ -3,20 +3,21 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-10 06:19+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"POT-Creation-Date: 2022-01-10 09:10+0000\n"
+"PO-Revision-Date: 2022-01-10 08:48+0200\n"
+"Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
+"Language-Team: \n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
 #, python-brace-format
 msgid "Application state transition not allowed: {status} to {value}"
 msgstr ""
@@ -283,13 +284,15 @@ msgid "timestamp of receipt confirmation"
 msgstr ""
 
 msgid "Vahvista sähköpostiosoitteesi"
-msgstr ""
+msgstr "Confirm your email address"
 
 #, python-format
 msgid ""
 "Vahvista sähköpostiosoitteesi klikkaamalla oheista linkkiä:\n"
 "%(activation_link)s"
 msgstr ""
+"Confirm your email address by clicking the following link:\n"
+"%(activation_link)s"
 
 msgid "youth application"
 msgstr ""

--- a/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
@@ -17,7 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
 #, python-brace-format
 msgid "Application state transition not allowed: {status} to {value}"
 msgstr ""
@@ -95,19 +94,19 @@ msgid "payslip"
 msgstr ""
 
 msgid "9th grader"
-msgstr "yhdeksäsluokkalainen"
+msgstr ""
 
 msgid "born 2004"
-msgstr "syntynyt 2004"
+msgstr ""
 
 msgid "yes"
-msgstr "kyllä"
+msgstr ""
 
 msgid "no"
-msgstr "ei"
+msgstr ""
 
 msgid "maybe"
-msgstr "ehkä"
+msgstr ""
 
 msgid "Järjestys"
 msgstr ""

--- a/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
@@ -3,20 +3,20 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-10 06:19+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"POT-Creation-Date: 2022-01-10 09:10+0000\n"
+"PO-Revision-Date: 2022-01-10 08:48+0200\n"
+"Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
+"Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #, python-brace-format
 msgid "Application state transition not allowed: {status} to {value}"

--- a/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
@@ -17,7 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
 #, python-brace-format
 msgid "Application state transition not allowed: {status} to {value}"
 msgstr ""
@@ -95,19 +94,19 @@ msgid "payslip"
 msgstr ""
 
 msgid "9th grader"
-msgstr "yhdeksäsluokkalainen"
+msgstr ""
 
 msgid "born 2004"
-msgstr "syntynyt 2004"
+msgstr ""
 
 msgid "yes"
-msgstr "kyllä"
+msgstr ""
 
 msgid "no"
-msgstr "ei"
+msgstr ""
 
 msgid "maybe"
-msgstr "ehkä"
+msgstr ""
 
 msgid "Järjestys"
 msgstr ""

--- a/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
@@ -3,20 +3,21 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-10 06:19+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"POT-Creation-Date: 2022-01-10 09:10+0000\n"
+"PO-Revision-Date: 2022-01-10 08:48+0200\n"
+"Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
+"Language-Team: \n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
 #, python-brace-format
 msgid "Application state transition not allowed: {status} to {value}"
 msgstr ""
@@ -283,13 +284,15 @@ msgid "timestamp of receipt confirmation"
 msgstr ""
 
 msgid "Vahvista sähköpostiosoitteesi"
-msgstr ""
+msgstr "Bekräfta din e-postadress"
 
 #, python-format
 msgid ""
 "Vahvista sähköpostiosoitteesi klikkaamalla oheista linkkiä:\n"
 "%(activation_link)s"
 msgstr ""
+"Bekräfta din e-postadress genom att klicka på länken nedan:\n"
+"%(activation_link)s"
 
 msgid "youth application"
 msgstr ""

--- a/backend/kesaseteli/applications/tests/conftest.py
+++ b/backend/kesaseteli/applications/tests/conftest.py
@@ -3,12 +3,14 @@ import os
 import factory.random
 import pytest
 from django.conf import settings
+from langdetect import DetectorFactory
 
 from common.tests.conftest import *  # noqa
 
 
 @pytest.fixture(autouse=True)
 def setup_test_environment(settings):
+    DetectorFactory.seed = 0
     factory.random.reseed_random("888")
 
 

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -1,11 +1,15 @@
 import factory.random
+import langdetect
 import pytest
+from django.core import mail
 from django.test import override_settings
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from applications.api.v1.serializers import YouthApplicationSerializer
 from common.tests.factories import YouthApplicationFactory
+
+SUPPORTED_LANGUAGE_CODES = ("fi", "sv", "en")
 
 
 def get_required_fields():
@@ -169,6 +173,55 @@ def test_youth_application_post_valid_data_with_email_backends(
     data = YouthApplicationSerializer(youth_application).data
     response = api_client.post(reverse("v1:youthapplication-list"), data)
     assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("language", SUPPORTED_LANGUAGE_CODES)
+def test_youth_application_post_valid_language(
+    api_client,
+    youth_application,
+    language,
+):
+    youth_application.language = language
+    data = YouthApplicationSerializer(youth_application).data
+    response = api_client.post(reverse("v1:youthapplication-list"), data)
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.django_db
+@override_settings(
+    MOCK_FLAG=True,
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+)
+@pytest.mark.parametrize("language", SUPPORTED_LANGUAGE_CODES)
+def test_youth_application_activation_email_language(
+    api_client,
+    youth_application,
+    language,
+):
+    youth_application.language = language
+    data = YouthApplicationSerializer(youth_application).data
+    api_client.post(reverse("v1:youthapplication-list"), data)
+    assert len(mail.outbox) > 0
+    activation_email = mail.outbox[-1]
+    assert len(activation_email.subject.strip()) > 0
+    assert len(activation_email.body.strip()) > 0
+    detected_email_subject_language = langdetect.detect(activation_email.subject)
+    detected_email_body_language = langdetect.detect(activation_email.body)
+    assert (
+        detected_email_subject_language == language
+    ), "Email subject '{}' used language {} instead of expected {}".format(
+        activation_email.subject,
+        detected_email_subject_language,
+        language,
+    )
+    assert (
+        detected_email_body_language == language
+    ), "Email body '{}' used language {} instead of expected {}".format(
+        activation_email.body,
+        detected_email_body_language,
+        language,
+    )
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/common/locale/en/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/common/locale/en/LC_MESSAGES/django.po
@@ -17,12 +17,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-msgid "Finnish"
-msgstr ""
-
-msgid "English"
-msgstr ""
-
-msgid "Swedish"
+#, python-format
+msgid ""
+"%(value)s is not a valid Finnish social security number. Make sure to have "
+"it in uppercase and without whitespace."
 msgstr ""

--- a/backend/kesaseteli/common/locale/fi/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/common/locale/fi/LC_MESSAGES/django.po
@@ -17,12 +17,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-msgid "Finnish"
-msgstr ""
-
-msgid "English"
-msgstr ""
-
-msgid "Swedish"
+#, python-format
+msgid ""
+"%(value)s is not a valid Finnish social security number. Make sure to have "
+"it in uppercase and without whitespace."
 msgstr ""

--- a/backend/kesaseteli/common/locale/sv/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/common/locale/sv/LC_MESSAGES/django.po
@@ -17,12 +17,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-msgid "Finnish"
-msgstr ""
-
-msgid "English"
-msgstr ""
-
-msgid "Swedish"
+#, python-format
+msgid ""
+"%(value)s is not a valid Finnish social security number. Make sure to have "
+"it in uppercase and without whitespace."
 msgstr ""

--- a/backend/kesaseteli/companies/locale/en/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/companies/locale/en/LC_MESSAGES/django.po
@@ -17,12 +17,26 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-msgid "Finnish"
+msgid "name"
 msgstr ""
 
-msgid "English"
+msgid "business id"
 msgstr ""
 
-msgid "Swedish"
+msgid "company form"
+msgstr ""
+
+msgid "industry"
+msgstr ""
+
+msgid "street address"
+msgstr ""
+
+msgid "postcode"
+msgstr ""
+
+msgid "city"
+msgstr ""
+
+msgid "ytj json"
 msgstr ""

--- a/backend/kesaseteli/companies/locale/fi/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/companies/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-03 13:53+0300\n"
+"POT-Creation-Date: 2022-01-10 06:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,38 +17,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-#: companies/models.py:7
+
 msgid "name"
 msgstr ""
 
-#: companies/models.py:8
 msgid "business id"
 msgstr ""
 
-#: companies/models.py:10
 msgid "company form"
 msgstr ""
 
-#: companies/models.py:12
 msgid "industry"
 msgstr ""
 
-#: companies/models.py:15
 msgid "street address"
 msgstr ""
 
-#: companies/models.py:17
 msgid "postcode"
 msgstr ""
 
-#: companies/models.py:18
 msgid "city"
 msgstr ""
 
-#: companies/models.py:20
 msgid "ytj json"
-msgstr ""
-
-#: companies/models.py:26
-msgid "eauthorization profile"
 msgstr ""

--- a/backend/kesaseteli/companies/locale/sv/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/companies/locale/sv/LC_MESSAGES/django.po
@@ -17,12 +17,26 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-msgid "Finnish"
+msgid "name"
 msgstr ""
 
-msgid "English"
+msgid "business id"
 msgstr ""
 
-msgid "Swedish"
+msgid "company form"
+msgstr ""
+
+msgid "industry"
+msgstr ""
+
+msgid "street address"
+msgstr ""
+
+msgid "postcode"
+msgstr ""
+
+msgid "city"
+msgstr ""
+
+msgid "ytj json"
 msgstr ""

--- a/backend/kesaseteli/docker-entrypoint.sh
+++ b/backend/kesaseteli/docker-entrypoint.sh
@@ -30,6 +30,9 @@ if [[ "$CREATE_SUPERUSER" = "1" ]]; then
     fi
 fi
 
+# Compile messages to make translations work
+python ./manage.py compilemessages
+
 # Start server
 if [[ ! -z "$@" ]]; then
     "$@"

--- a/backend/kesaseteli/kesaseteli/locale/en/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/kesaseteli/locale/en/LC_MESSAGES/django.po
@@ -17,7 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
 msgid "Finnish"
 msgstr ""
 

--- a/backend/kesaseteli/kesaseteli/locale/sv/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/kesaseteli/locale/sv/LC_MESSAGES/django.po
@@ -17,7 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
 msgid "Finnish"
 msgstr ""
 

--- a/backend/kesaseteli/requirements-dev.in
+++ b/backend/kesaseteli/requirements-dev.in
@@ -2,6 +2,7 @@ black
 flake8
 ipython
 isort
+langdetect
 pytest
 pytest-cov
 pytest-django

--- a/backend/kesaseteli/requirements-dev.txt
+++ b/backend/kesaseteli/requirements-dev.txt
@@ -42,6 +42,8 @@ isort==5.8.0
     # via -r requirements-dev.in
 jedi==0.18.0
     # via ipython
+langdetect==1.0.9
+    # via -r requirements-dev.in
 matplotlib-inline==0.1.2
     # via ipython
 mccabe==0.6.1
@@ -106,6 +108,7 @@ requests==2.25.1
     # via requests-mock
 six==1.16.0
     # via
+    #   langdetect
     #   python-dateutil
     #   requests-mock
 toml==0.10.2


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Update fi/sv/en translation files

### KS-Backend: Translate activation email to fi/sv/en 

Add langdetect to requirements-dev.(in|txt). Used for detecting the used
language in the activation email's subject and body in the tests.

Revamp the activation email related functions a little bit. Switched to
using gettext here instead of gettext_lazy because without it the email
subject didn't correctly get translated in the tests. Translate the
activation email subject and body according to the youth application's
language.

Add placeholder translations for the activation email's subject and
body for Swedish and English.

Add tests for Finnish, Swedish and English:
 - test_youth_application_post_valid_language
   - Tests that posting a new youth application is successful with
     different languages
 - test_youth_application_activation_email_language
   - Tests that the activation email's subject and body both use the
     youth application's language
 
### KS-Backend: Compile messages in Docker/GitHub Actions

Affected GitHub Actions:
 - ks-pytest.yml -> (KS) Python tests
 - ks-review.yml -> (KS EMPLOYER) Build & Review & Acceptance tests
   - This is affected by the changes in kesaseteli.Dockerfile

Also add comment about updating translations to README.md.

## Issues :bug:

YJDH-356

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

I didn't add compiling of the backend messages to all of the GitHub
Actions i.e. all .github/workflows/ks-*.yml files but only the ones
necessary to get all the current tests to pass. **We can discuss this
in code review.**