### PR TITLE
YJDH-396 | KS-Backend: Add redirects to youth application activation

### DIFF
--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -1,6 +1,6 @@
 from django.core import exceptions
 from django.db.models import Func
-from django.http import FileResponse, HttpResponse
+from django.http import FileResponse, HttpResponse, HttpResponseRedirect
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 from rest_framework import status
@@ -68,18 +68,11 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
             return HttpResponse(status=status.HTTP_404_NOT_FOUND)
 
         if youth_application.is_active:
-            return HttpResponse(
-                status=status.HTTP_200_OK, content="Youth application already active"
-            )
+            return HttpResponseRedirect(youth_application.already_activated_page_url())
         elif youth_application.has_activation_link_expired:
-            return HttpResponse(
-                status=status.HTTP_401_UNAUTHORIZED,
-                content="Activation link has expired",
-            )
+            return HttpResponseRedirect(youth_application.expired_page_url())
         elif youth_application.activate():
-            return HttpResponse(
-                status=status.HTTP_200_OK, content="Youth application activated"
-            )
+            return HttpResponseRedirect(youth_application.activated_page_url())
 
         return HttpResponse(
             status=status.HTTP_401_UNAUTHORIZED,

--- a/backend/kesaseteli/applications/enums.py
+++ b/backend/kesaseteli/applications/enums.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -13,6 +15,15 @@ APPLICATION_LANGUAGE_CHOICES = (
     ("sv", "svenska"),
     ("en", "english"),
 )
+
+
+def get_supported_languages() -> Tuple[str]:
+    """
+    Get tuple of supported languages
+
+    :return: Tuple of the supported languages' codes, e.g. ('fi', 'sv', 'en')
+    """
+    return list(zip(*APPLICATION_LANGUAGE_CHOICES))[0]
 
 
 class ApplicationStatus(models.TextChoices):

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import timedelta
+from urllib.parse import quote, urljoin
 
 from django.conf import settings
 from django.core.mail import send_mail
@@ -96,6 +97,20 @@ class YouthApplication(TimeStampedModel, UUIDModel):
         verbose_name=_("vtj json"),
         validators=[validate_optional_json],
     )
+
+    def _localized_frontend_page_url(self, page_name):
+        return urljoin(
+            settings.YOUTH_URL, f"/{quote(self.language)}/{quote(page_name)}"
+        )
+
+    def activated_page_url(self):
+        return self._localized_frontend_page_url("activated")
+
+    def expired_page_url(self):
+        return self._localized_frontend_page_url("expired")
+
+    def already_activated_page_url(self):
+        return self._localized_frontend_page_url("already_activated")
 
     def _activation_link(self, request):
         return request.build_absolute_uri(

--- a/backend/kesaseteli/applications/tests/test_misc.py
+++ b/backend/kesaseteli/applications/tests/test_misc.py
@@ -1,0 +1,36 @@
+import pytest
+
+from applications.enums import get_supported_languages
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "youth_url,url_function_name,language,expected_url",
+    [
+        (youth_url, url_function_name, language, f"{youth_url}/{language}/{page_name}")
+        for page_name, url_function_name in [
+            ("activated", "activated_page_url"),
+            ("already_activated", "already_activated_page_url"),
+            ("expired", "expired_page_url"),
+        ]
+        for language in get_supported_languages()
+        for youth_url in ["https://test.com:1234", "https://example.org"]
+    ],
+)
+def test_youth_application_page_url_function(
+    settings,
+    youth_application,
+    youth_url,
+    url_function_name,
+    language,
+    expected_url,
+):
+    settings.YOUTH_URL = youth_url
+    assert hasattr(youth_application, url_function_name)
+    assert callable(getattr(youth_application, url_function_name))
+
+    youth_application.language = language
+    youth_application.save(update_fields=["language"])
+    youth_application.refresh_from_db()
+    url = getattr(youth_application, url_function_name)()
+    assert url == expected_url

--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -12,6 +12,7 @@ from applications.enums import (
     ApplicationStatus,
     ATTACHMENT_CONTENT_TYPE_CHOICES,
     AttachmentType,
+    get_supported_languages,
     HiredWithoutVoucherAssessment,
     SummerVoucherExceptionReason,
 )
@@ -150,7 +151,7 @@ class BaseYouthApplicationFactory(factory.django.DjangoModelFactory):
     is_unlisted_school = factory.LazyAttribute(uses_unlisted_test_school)
     email = factory.Faker("email")
     phone_number = factory.LazyFunction(get_test_phone_number)
-    language = factory.Faker("random_element", elements=["fi", "sv", "en"])
+    language = factory.Faker("random_element", elements=get_supported_languages())
     _is_active = None
 
     class Meta:

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -23,6 +23,7 @@ env = environ.Env(
     STATIC_ROOT=(environ.Path(), default_var_root("static")),
     MEDIA_URL=(str, "/media/"),
     STATIC_URL=(str, "/static/"),
+    YOUTH_URL=(str, "https://localhost:3100"),
     ALLOWED_HOSTS=(list, ["*"]),
     USE_X_FORWARDED_HOST=(bool, False),
     DATABASE_URL=(
@@ -128,6 +129,7 @@ MEDIA_ROOT = env("MEDIA_ROOT")
 STATIC_ROOT = env("STATIC_ROOT")
 MEDIA_URL = env.str("MEDIA_URL")
 STATIC_URL = env.str("STATIC_URL")
+YOUTH_URL = env.str("YOUTH_URL")
 
 ROOT_URLCONF = "kesaseteli.urls"
 WSGI_APPLICATION = "kesaseteli.wsgi.application"


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Add redirects to youth application activation

Redirect on youth application activation to the following frontend URLs
(Language is fi, sv or en):
 - `/<language>/activated` if activation was successful
 - `/<language>/expired` if activation link has expired
 - `/<language>/already_activated` if application is already activated

Add applications.enums.get_supported_languages function:
 - Get the supported languages, currently returns ('fi', 'sv', 'en').

Tests:
 - Make use of applications.enums.get_supported_languages function
 - Update related tests in test_youth_applications_api.py
 - Add test_misc.py:
   - Add test test_youth_application_page_url_function
     - Test that YouthApplication instance's member functions generate
       frontend URLs correctly

Refs YJDH-396 (Redirecting to successful activation page)
Refs YJDH-400 (Redirecting to expired activation link page)
Refs YJDH-401 (Redirecting to already activated page)

## Issues :bug:

YJDH-396, YJDH-400, YJDH-401

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
