### PR TITLE
Refactor: use NotificationPage as base component for all ok/error pages

### DIFF
--- a/frontend/kesaseteli/youth/src/pages/activated.tsx
+++ b/frontend/kesaseteli/youth/src/pages/activated.tsx
@@ -1,32 +1,24 @@
+import useActivationLinkExpirationHours from 'kesaseteli/youth/hooks/useActivationLinkExpirationHours';
 import { GetStaticProps, NextPage } from 'next';
-import Head from 'next/head';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import Container from 'shared/components/container/Container';
 import Heading from 'shared/components/forms/heading/Heading';
-import { $Notification } from 'shared/components/notification/Notification.sc';
+import NotificationPage from 'shared/components/pages/NotificationPage';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 
 const ActivatedPage: NextPage = () => {
   const { t } = useTranslation();
-
   return (
-    <Container>
-      <Head>
-        <title>
-          {t(`common:activatedPage.title`)} | {t(`common:appName`)}
-        </title>
-      </Head>
-      <$Notification
-        label={t(`common:activatedPage.notificationTitle`)}
-        type="success"
-        size="large"
-      >
-        {t('common:activatedPage.notificationMessage')}
-      </$Notification>
+    <NotificationPage
+      type="success"
+      title={t(`common:activatedPage.notificationTitle`)}
+      message={t(`common:activatedPage.notificationMessage`, {
+        expirationHours: useActivationLinkExpirationHours(),
+      })}
+    >
       <Heading size="l" header={t('common:activatedPage.title')} as="h2" />
       <p>{t('common:activatedPage.paragraph_1')}</p>
-    </Container>
+    </NotificationPage>
   );
 };
 

--- a/frontend/kesaseteli/youth/src/pages/already_activated.tsx
+++ b/frontend/kesaseteli/youth/src/pages/already_activated.tsx
@@ -1,13 +1,14 @@
-import ActivationErrorPage from 'kesaseteli/youth/components/activation-error-page/ActivationErrorPage';
 import { GetStaticProps } from 'next';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
+import NotificationPage from 'shared/components/pages/NotificationPage';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 
 const AlreadyActivatedPage: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <ActivationErrorPage
+    <NotificationPage
+      type="error"
       title={t(`common:alreadyActivatedPage.title`)}
       message={t(`common:alreadyActivatedPage.notificationMessage`)}
       goToFrontPageText={t('common:alreadyActivatedPage.goToFrontendPage')}

--- a/frontend/kesaseteli/youth/src/pages/already_assigned.tsx
+++ b/frontend/kesaseteli/youth/src/pages/already_assigned.tsx
@@ -1,8 +1,8 @@
 import { GetStaticProps } from 'next';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 import NotificationPage from 'shared/components/pages/NotificationPage';
+import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 
 const AlreadyAssignedPage: React.FC = () => {
   const { t } = useTranslation();

--- a/frontend/kesaseteli/youth/src/pages/already_assigned.tsx
+++ b/frontend/kesaseteli/youth/src/pages/already_assigned.tsx
@@ -1,13 +1,14 @@
-import ActivationErrorPage from 'kesaseteli/youth/components/activation-error-page/ActivationErrorPage';
 import { GetStaticProps } from 'next';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+import NotificationPage from 'shared/components/pages/NotificationPage';
 
 const AlreadyAssignedPage: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <ActivationErrorPage
+    <NotificationPage
+      type="error"
       title={t(`common:alreadyAssignedPage.title`)}
       message={t(`common:alreadyAssignedPage.notificationMessage`)}
       goToFrontPageText={t(`common:activationErrorPage.goToFrontendPage`)}

--- a/frontend/kesaseteli/youth/src/pages/email_in_use.tsx
+++ b/frontend/kesaseteli/youth/src/pages/email_in_use.tsx
@@ -1,14 +1,15 @@
-import ActivationErrorPage from 'kesaseteli/youth/components/activation-error-page/ActivationErrorPage';
 import useActivationLinkExpirationHours from 'kesaseteli/youth/hooks/useActivationLinkExpirationHours';
 import { GetStaticProps } from 'next';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+import NotificationPage from 'shared/components/pages/NotificationPage';
 
 const EmailInUsePage: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <ActivationErrorPage
+    <NotificationPage
+      type="error"
       title={t(`common:emailInUsePage.title`)}
       message={t(`common:emailInUsePage.notificationMessage`, {
         expirationHours: useActivationLinkExpirationHours(),

--- a/frontend/kesaseteli/youth/src/pages/email_in_use.tsx
+++ b/frontend/kesaseteli/youth/src/pages/email_in_use.tsx
@@ -2,8 +2,8 @@ import useActivationLinkExpirationHours from 'kesaseteli/youth/hooks/useActivati
 import { GetStaticProps } from 'next';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 import NotificationPage from 'shared/components/pages/NotificationPage';
+import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 
 const EmailInUsePage: React.FC = () => {
   const { t } = useTranslation();

--- a/frontend/kesaseteli/youth/src/pages/expired.tsx
+++ b/frontend/kesaseteli/youth/src/pages/expired.tsx
@@ -1,14 +1,15 @@
-import ActivationErrorPage from 'kesaseteli/youth/components/activation-error-page/ActivationErrorPage';
 import useActivationLinkExpirationHours from 'kesaseteli/youth/hooks/useActivationLinkExpirationHours';
 import { GetStaticProps } from 'next';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+import NotificationPage from 'shared/components/pages/NotificationPage';
 
 const ExpiredPage: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <ActivationErrorPage
+    <NotificationPage
+      type="error"
       title={t(`common:expiredPage.title`)}
       message={t(`common:expiredPage.notificationMessage`, {
         expirationHours: useActivationLinkExpirationHours(),

--- a/frontend/kesaseteli/youth/src/pages/expired.tsx
+++ b/frontend/kesaseteli/youth/src/pages/expired.tsx
@@ -2,8 +2,8 @@ import useActivationLinkExpirationHours from 'kesaseteli/youth/hooks/useActivati
 import { GetStaticProps } from 'next';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 import NotificationPage from 'shared/components/pages/NotificationPage';
+import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 
 const ExpiredPage: React.FC = () => {
   const { t } = useTranslation();

--- a/frontend/kesaseteli/youth/src/pages/thankyou.tsx
+++ b/frontend/kesaseteli/youth/src/pages/thankyou.tsx
@@ -1,47 +1,21 @@
-import { Button, IconArrowRight } from 'hds-react';
 import useActivationLinkExpirationHours from 'kesaseteli/youth/hooks/useActivationLinkExpirationHours';
 import { GetStaticProps, NextPage } from 'next';
-import Head from 'next/head';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import Container from 'shared/components/container/Container';
-import FormSection from 'shared/components/forms/section/FormSection';
-import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
-import { $Notification } from 'shared/components/notification/Notification.sc';
-import useGoToFrontPage from 'shared/hooks/useGoToFrontPage';
+import NotificationPage from 'shared/components/pages/NotificationPage';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 
 const ThankYouPage: NextPage = () => {
   const { t } = useTranslation();
-
   return (
-    <Container>
-      <Head>
-        <title>
-          {t(`common:thankyouPage.title`)} | {t(`common:appName`)}
-        </title>
-      </Head>
-      <$Notification
-        label={t(`common:thankyouPage.notificationTitle`)}
-        type="success"
-        size="large"
-      >
-        {t(`common:thankyouPage.notificationMessage`, {
-          expirationHours: useActivationLinkExpirationHours(),
-        })}
-      </$Notification>
-      <FormSection columns={1} withoutDivider>
-        <$GridCell>
-          <Button
-            theme="coat"
-            iconRight={<IconArrowRight />}
-            onClick={useGoToFrontPage()}
-          >
-            {t(`common:thankyouPage.goToFrontendPage`)}
-          </Button>
-        </$GridCell>
-      </FormSection>
-    </Container>
+    <NotificationPage
+      type="success"
+      title={t(`common:thankyouPage.notificationTitle`)}
+      message={t(`common:thankyouPage.notificationMessage`, {
+        expirationHours: useActivationLinkExpirationHours(),
+      })}
+      goToFrontPageText={t('common:thankyouPage.goToFrontendPage')}
+    />
   );
 };
 

--- a/frontend/shared/src/components/pages/NotificationPage.tsx
+++ b/frontend/shared/src/components/pages/NotificationPage.tsx
@@ -1,4 +1,9 @@
-import { Button, IconArrowRight } from 'hds-react';
+import {
+  Button,
+  IconArrowRight,
+  NotificationSizeInline,
+  NotificationType,
+} from 'hds-react';
 import Head from 'next/head';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
@@ -9,15 +14,21 @@ import { $Notification } from 'shared/components/notification/Notification.sc';
 import useGoToFrontPage from 'shared/hooks/useGoToFrontPage';
 
 type Props = {
+  type: NotificationType;
+  size?: NotificationSizeInline;
   title: string;
-  message: string;
+  message: React.ReactNode;
   goToFrontPageText?: string;
+  children?: React.ReactNode;
 };
 
-const ActivationErrorPage: React.FC<Props> = ({
+const NotificationPage: React.FC<Props> = ({
+  type,
+  size = 'large',
   title,
   message,
   goToFrontPageText,
+  children,
 }) => {
   const { t } = useTranslation();
   const goToFrontPage = useGoToFrontPage();
@@ -28,9 +39,10 @@ const ActivationErrorPage: React.FC<Props> = ({
           {title} | {t(`common:appName`)}
         </title>
       </Head>
-      <$Notification label={title} type="error" size="large">
+      <$Notification label={title} type={type} size={size}>
         {message}
       </$Notification>
+      {children}
       {goToFrontPageText && (
         <FormSection columns={1} withoutDivider>
           <$GridCell>
@@ -49,8 +61,10 @@ const ActivationErrorPage: React.FC<Props> = ({
   );
 };
 
-ActivationErrorPage.defaultProps = {
+NotificationPage.defaultProps = {
+  size: 'large',
   goToFrontPageText: undefined,
+  children: null,
 };
 
-export default ActivationErrorPage;
+export default NotificationPage;

--- a/frontend/shared/src/components/pages/PageNotFound.tsx
+++ b/frontend/shared/src/components/pages/PageNotFound.tsx
@@ -1,32 +1,23 @@
-import Head from 'next/head';
 import { Trans, useTranslation } from 'next-i18next';
 import React from 'react';
-import Container from 'shared/components/container/Container';
 import LinkText from 'shared/components/link-text/LinkText';
-import { $Notification } from 'shared/components/notification/Notification.sc';
+import NotificationPage from 'shared/components/pages/NotificationPage';
 
 const PageNotFound: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <Container>
-      <Head>
-        <title>
-          {t(`common:404Page.pageNotFoundLabel`)} | {t(`common:appName`)}
-        </title>
-      </Head>
-      <$Notification
-        label={t(`common:404Page.pageNotFoundLabel`)}
-        type="alert"
-        size="large"
-      >
+    <NotificationPage
+      type="alert"
+      title={t(`common:404Page.pageNotFoundLabel`)}
+      message={
         <Trans
           i18nKey="common:404Page.pageNotFoundContent"
           components={{
             lnk: <LinkText href="/">{}</LinkText>,
           }}
         />
-      </$Notification>
-    </Container>
+      }
+    />
   );
 };
 


### PR DESCRIPTION
Use NotificationPage as base component for all activation,thank you - and error pages

## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
