### PR TITLE
YJDH-405 | Fix ks-pytest.yml by not using Finnish Postgres

### DIFF
--- a/.github/workflows/ks-pytest.yml
+++ b/.github/workflows/ks-pytest.yml
@@ -20,10 +20,7 @@ jobs:
 
     services:
       postgres:
-        build:
-          context: ../../backend
-          dockerfile: ./docker/kesaseteli.Dockerfile
-          target: finnish_postgres
+        image: postgres:12
         ports:
           - 5432:5432
         options: >-
@@ -35,8 +32,6 @@ jobs:
           POSTGRES_USER: kesaseteli
           POSTGRES_PASSWORD: kesaseteli
           POSTGRES_DB: kesaseteli
-          LC_COLLATE: 'fi_FI.UTF-8'
-          LC_CTYPE: 'fi_FI.UTF-8'
 
     steps:
       - name: Check out repository

--- a/backend/docker/finnish_postgres.Dockerfile
+++ b/backend/docker/finnish_postgres.Dockerfile
@@ -1,0 +1,8 @@
+# ==============================
+FROM postgres:12 as finnish_postgres
+# ==============================
+RUN sed -i -e 's/# fi_FI.UTF-8 UTF-8/fi_FI.UTF-8 UTF-8/' /etc/locale.gen \
+    && locale-gen
+ENV LANG fi_FI.UTF-8
+ENV LANGUAGE fi_FI:fi
+ENV LC_ALL fi_FI.UTF-8

--- a/backend/docker/kesaseteli.Dockerfile
+++ b/backend/docker/kesaseteli.Dockerfile
@@ -1,13 +1,4 @@
 # ==============================
-FROM postgres:12 as finnish_postgres
-# ==============================
-RUN sed -i -e 's/# fi_FI.UTF-8 UTF-8/fi_FI.UTF-8 UTF-8/' /etc/locale.gen \
-    && locale-gen
-ENV LANG fi_FI.UTF-8
-ENV LANGUAGE fi_FI:fi
-ENV LC_ALL fi_FI.UTF-8
-
-# ==============================
 FROM helsinkitest/python:3.8-slim as appbase
 # ==============================
 RUN mkdir /entrypoint

--- a/docker-compose.youth.yml
+++ b/docker-compose.youth.yml
@@ -3,8 +3,7 @@ services:
   postgres:
     build:
       context: ./backend
-      dockerfile: ./docker/kesaseteli.Dockerfile
-      target: finnish_postgres
+      dockerfile: ./docker/finnish_postgres.Dockerfile
     restart: on-failure
     environment:
       POSTGRES_USER: kesaseteli


### PR DESCRIPTION
## Description :sparkles:

Revert the changes from PR #582 related to GitHub Actions.

Also:
 - Move Finnish Postgres to own Dockerfile and use it from there
 - Add back PostgreSQL specific custom sorter to SchoolListView because
   otherwise the backend tests won't pass using GitHub Actions.

NOTE:
 - Hotfixing YJDH-405 to get "(KS) Python tests" working again in pull
   requests while looking for a way to use Finnish Postgres in GitHub
   Actions.

## Issues :bug:

YJDH-405

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
