### PR TITLE
HL-379: time range validation errors should be warnings.

### DIFF
--- a/backend/benefit/applications/tests/test_benefit_aggregation.py
+++ b/backend/benefit/applications/tests/test_benefit_aggregation.py
@@ -13,15 +13,17 @@ from calculator.models import PreviousBenefit
 from calculator.tests.factories import PreviousBenefitFactory
 from common.tests.conftest import *  # noqa
 from companies.tests.conftest import *  # noqa
+from django.utils import translation
 from helsinkibenefit.tests.conftest import *  # noqa
 from terms.tests.conftest import *  # noqa
 
 APPRENTICESHIP = True
 NO_APPRENTICESHIP = False
+NO_WARNINGS = None
 
 
 @pytest.mark.parametrize(
-    "previous_benefits, benefit_type, apprenticeship_program, expected_result, months_used, months_remaining",
+    "previous_benefits, benefit_type, apprenticeship_program, expected_warning, months_used, months_remaining",
     [
         (
             [
@@ -33,7 +35,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            400,
+            "Benefit can not be granted before 24-month waiting period expires",
             12,
             0,
         ),  # 12 months of benefit used, 24 months not elapsed
@@ -47,7 +49,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            400,
+            "Benefit can not be granted before 24-month waiting period expires",
             12,
             0,
         ),  # 12 months of benefit used, 24 months not elapsed
@@ -61,7 +63,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             APPRENTICESHIP,
-            200,
+            NO_WARNINGS,
             12,
             None,
         ),  # As an exception, apprenticeship may be granted
@@ -75,7 +77,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            400,
+            "Benefit can not be granted before 24-month waiting period expires",
             12,
             0,
         ),  # 12 months of benefit used, 24 months not elapsed
@@ -89,7 +91,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.EMPLOYMENT_BENEFIT,
             NO_APPRENTICESHIP,
-            400,
+            "Benefit can not be granted before 24-month waiting period expires",
             12,
             0,
         ),  # same as above, employment_benefit/salary_benefit are treated the same
@@ -103,7 +105,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.EMPLOYMENT_BENEFIT,
             NO_APPRENTICESHIP,
-            400,
+            "Benefit can not be granted before 24-month waiting period expires",
             12,
             0,
         ),  # 12 months of benefit used, 24 months not elapsed
@@ -117,7 +119,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.EMPLOYMENT_BENEFIT,
             NO_APPRENTICESHIP,
-            200,
+            NO_WARNINGS,
             0,
             12,
         ),  # 24 months is elapsed
@@ -131,7 +133,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            200,
+            NO_WARNINGS,
             6,
             6,
         ),  # only 6 months of benefit used
@@ -145,7 +147,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            400,
+            "Benefit can not be granted before 24-month waiting period expires",
             Decimal("6.03"),
             Decimal("5.97"),
         ),
@@ -165,7 +167,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            400,
+            "Benefit can not be granted before 24-month waiting period expires",
             12,
             0,
         ),  # 24 months not elapsed
@@ -184,7 +186,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            400,
+            "Benefit can not be granted before 24-month waiting period expires",
             12,
             0,
         ),  # 24 months not elapsed - both Application and PreviousBenefit
@@ -203,7 +205,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             APPRENTICESHIP,
-            200,
+            NO_WARNINGS,
             12,
             None,
         ),  # 24 months not elapsed - but apprenticeship may be granted
@@ -222,7 +224,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            400,
+            "Benefit can not be granted before 24-month waiting period expires",
             12,
             0,
         ),  # 24 months not elapsed
@@ -241,7 +243,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            200,
+            NO_WARNINGS,
             0,
             12,
         ),  # 24 months elapsed
@@ -260,7 +262,7 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            200,
+            NO_WARNINGS,
             6,
             6,
         ),
@@ -285,11 +287,25 @@ NO_APPRENTICESHIP = False
             ],
             BenefitType.SALARY_BENEFIT,
             NO_APPRENTICESHIP,
-            400,
+            "Benefit can not be granted before 24-month waiting period expires",
             9,
             3,
         ),
         # several previously granted benefits that don't have a 24-month gap
+        (
+            [
+                (
+                    Application,
+                    "2021-06-01",
+                    "2021-08-31",
+                )
+            ],
+            BenefitType.EMPLOYMENT_BENEFIT,
+            NO_APPRENTICESHIP,
+            "There's already an accepted application or previous benefit with overlapping date range",
+            3,
+            9,
+        ),  # a benefit has been previously granted that overlaps the new application
     ],
 )
 def test_application_with_previously_accepted_applications_and_previous_benefits(
@@ -300,7 +316,7 @@ def test_application_with_previously_accepted_applications_and_previous_benefits
     apprenticeship_program,
     months_used,
     months_remaining,
-    expected_result,
+    expected_warning,
 ):
     # the type of the previous benefit and the apprenticeship_program value do not matter when
     # calculating the remaining available benefit time (Teams discussion)
@@ -342,10 +358,10 @@ def test_application_with_previously_accepted_applications_and_previous_benefits
 
     response_before_update = api_client.get(get_detail_url(application))
     assert (
-        response_before_update.data["past_benefit_info"]["months_used"] == months_used
+        response_before_update.data["former_benefit_info"]["months_used"] == months_used
     )
     assert (
-        response_before_update.data["past_benefit_info"]["months_remaining"]
+        response_before_update.data["former_benefit_info"]["months_remaining"]
         == months_remaining
     )
 
@@ -357,13 +373,16 @@ def test_application_with_previously_accepted_applications_and_previous_benefits
     data["pay_subsidy_granted"] = True
     data["pay_subsidy_percent"] = 50
 
-    response = api_client.put(
-        get_detail_url(application),
-        data,
-    )
-    assert response.status_code == expected_result
-    if expected_result == 200:
+    with translation.override("en"):
+        response = api_client.put(
+            get_detail_url(application),
+            data,
+        )
+        assert response.status_code == 200
         assert response.data["start_date"] == "2021-07-01"
         assert response.data["end_date"] == "2021-12-31"
-    else:
-        assert response.data.keys() == {"start_date"}
+        if expected_warning:
+            assert expected_warning in response.data["warnings"]["former_benefits"][0]
+            assert len(response.data["warnings"]["former_benefits"]) == 1
+        else:
+            assert "former_benefits" not in response.data["warnings"]


### PR DESCRIPTION

## Description :sparkles:

Add new "warnings" element to the API that can be used for other kinds of warnings, too.
Rename past_benefit_info.
Add tests for overlapping previously granted benefit.

## Issues :bug: HL-379

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
