### PR TITLE
YJDH-398 | KS-Backend: Add error handling to youth application creation

### DIFF
--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -442,13 +442,14 @@ class SchoolSerializer(serializers.ModelSerializer):
 class YouthApplicationSerializer(serializers.ModelSerializer):
     def validate_social_security_number(self, value):
         if value is None or str(value).strip() == "":
-            raise serializers.ValidationError(_("Social security number must be set"))
+            raise serializers.ValidationError(
+                {"social_security_number": _("Social security number must be set")}
+            )
         return value
 
     def validate(self, data):
         data = super().validate(data)
-        if "social_security_number" not in data:
-            raise serializers.ValidationError(_("Social security number must be set"))
+        self.validate_social_security_number(data.get("social_security_number", None))
         return data
 
     class Meta:

--- a/backend/kesaseteli/applications/enums.py
+++ b/backend/kesaseteli/applications/enums.py
@@ -56,3 +56,14 @@ class HiredWithoutVoucherAssessment(models.TextChoices):
     YES = "yes", _("yes")
     NO = "no", _("no")
     MAYBE = "maybe", _("maybe")
+
+
+class YouthApplicationRejectedReason(models.TextChoices):
+    EMAIL_IN_USE = "email_in_use", _("Email in use")
+    ALREADY_ASSIGNED = "already_assigned", _("Already assigned")
+
+    def json(self):
+        return {
+            "code": str(self.value),
+            "message": str(self.label),
+        }

--- a/backend/kesaseteli/applications/tests/test_enums.py
+++ b/backend/kesaseteli/applications/tests/test_enums.py
@@ -1,0 +1,23 @@
+import pytest
+
+from applications.enums import YouthApplicationRejectedReason
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "enum,expected_json_code,expected_json_message",
+    [
+        (enum, str(enum.value), str(enum.label))
+        for enum in YouthApplicationRejectedReason
+    ],
+)
+def test_youth_application_rejected_reason_json(
+    enum,
+    expected_json_code,
+    expected_json_message,
+):
+    assert "code" in enum.json()
+    assert "message" in enum.json()
+
+    assert enum.json()["code"] == expected_json_code
+    assert enum.json()["message"] == expected_json_message

--- a/backend/kesaseteli/applications/tests/test_querying.py
+++ b/backend/kesaseteli/applications/tests/test_querying.py
@@ -1,0 +1,247 @@
+from collections import namedtuple
+from datetime import timedelta
+from typing import List, Tuple
+
+import pytest
+from django.conf import settings as django_settings
+from django.db.models import Q
+from django.utils import timezone
+from freezegun import freeze_time
+
+from applications.models import YouthApplication
+from common.tests.factories import YouthApplicationFactory
+
+
+def get_two_test_emails():
+    return ["a@b.com", "test@example.org"]
+
+
+def get_two_test_social_security_numbers():
+    return ["111111A111C", "121212A899H"]
+
+
+Expiration = namedtuple(
+    "Expiration", ["limit_seconds", "test_seconds_list", "expected_expired_list"]
+)
+
+
+def get_test_expirations() -> List[Expiration]:
+    return [
+        Expiration(0, [0], [True]),
+        Expiration(43200, [43199], [False]),
+        Expiration(43200, [43200], [True]),
+        Expiration(5, [0, 4, 5, 6, 123456789], [False, False, True, True, True]),
+        Expiration(
+            43200, [0, 43199, 43200, 43201, 1234567], [False, False, True, True, True]
+        ),
+    ]
+
+
+def create_app(alive_seconds: int) -> YouthApplication:
+    app = YouthApplicationFactory.create()
+    app.created_at = timezone.now() - timedelta(seconds=alive_seconds)
+    app.save()
+    return app
+
+
+def set_active_state(
+    youth_application: YouthApplication, is_active: bool
+) -> YouthApplication:
+    """
+    Set youth application to active if is_active, otherwise set it to inactive.
+    """
+    youth_application.receipt_confirmed_at = timezone.now() if is_active else None
+    youth_application.save()
+    return youth_application
+
+
+def expired_error_message(app: YouthApplication, expected_expired: bool) -> str:
+    return (
+        "{alive_seconds}s alive ({limit_seconds}s expiration) "
+        "should be {expected_state}"
+    ).format(
+        alive_seconds=app.seconds_elapsed,
+        limit_seconds=django_settings.NEXT_PUBLIC_ACTIVATION_LINK_EXPIRATION_SECONDS,
+        expected_state="expired" if expected_expired else "unexpired",
+    )
+
+
+def unexpired_or_active_error_message(
+    app: YouthApplication, is_active: bool, expected_unexpired_or_active: bool
+) -> str:
+    return (
+        "{active_state} and {alive_seconds}s alive ({limit_seconds}s expiration) "
+        "should be {expected_state}"
+    ).format(
+        active_state="Active" if is_active else "Inactive",
+        alive_seconds=app.seconds_elapsed,
+        limit_seconds=django_settings.NEXT_PUBLIC_ACTIVATION_LINK_EXPIRATION_SECONDS,
+        expected_state=(
+            "unexpired or active"
+            if expected_unexpired_or_active
+            else "expired and inactive"
+        ),
+    )
+
+
+@freeze_time("2022-02-02")
+@pytest.mark.django_db
+@pytest.mark.parametrize("expiration", get_test_expirations())
+def test_youth_application_query_set_unexpired(
+    api_client, settings, expiration: Expiration
+):
+    settings.NEXT_PUBLIC_ACTIVATION_LINK_EXPIRATION_SECONDS = expiration.limit_seconds
+    apps = [create_app(alive_seconds) for alive_seconds in expiration.test_seconds_list]
+
+    unexpired_pks = YouthApplication.objects.unexpired().values_list("pk", flat=True)
+    assert len(unexpired_pks) == len(set(unexpired_pks)), "unexpired() gave duplicates"
+
+    for app, expected_expired in zip(apps, expiration.expected_expired_list):
+        expired = app.pk not in unexpired_pks
+        assert expired == expected_expired, expired_error_message(app, expected_expired)
+
+
+@freeze_time("2022-02-02")
+@pytest.mark.django_db
+@pytest.mark.parametrize("expiration", get_test_expirations())
+def test_youth_application_query_set_expired(
+    api_client, settings, expiration: Expiration
+):
+    settings.NEXT_PUBLIC_ACTIVATION_LINK_EXPIRATION_SECONDS = expiration.limit_seconds
+    apps = [create_app(alive_seconds) for alive_seconds in expiration.test_seconds_list]
+
+    expired_pks = YouthApplication.objects.expired().values_list("pk", flat=True)
+    assert len(expired_pks) == len(set(expired_pks)), "expired() gave duplicates"
+
+    for app, expected_expired in zip(apps, expiration.expected_expired_list):
+        expired = app.pk in expired_pks
+        assert expired == expected_expired, expired_error_message(app, expected_expired)
+
+
+@pytest.mark.django_db
+def test_youth_application_query_set_active(
+    api_client, active_youth_application, inactive_youth_application
+):
+    active_pks = YouthApplication.objects.active().values_list("pk", flat=True)
+    assert len(active_pks) == len(set(active_pks)), "active() gave duplicates"
+    assert active_youth_application.pk in active_pks, "active() did not return active"
+    assert inactive_youth_application.pk not in active_pks, "active() returned inactive"
+
+
+@freeze_time("2022-02-02")
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "expiration,is_active,expected_unexpired_or_active_list",
+    [
+        (
+            expiration,
+            is_active,
+            [
+                not expected_expired or is_active
+                for expected_expired in expiration.expected_expired_list
+            ],
+        )
+        for expiration in get_test_expirations()
+        for is_active in [False, True]
+    ],
+)
+def test_youth_application_query_set_unexpired_or_active(
+    api_client,
+    settings,
+    expiration: Expiration,
+    is_active: bool,
+    expected_unexpired_or_active_list: List[bool],
+):
+    settings.NEXT_PUBLIC_ACTIVATION_LINK_EXPIRATION_SECONDS = expiration.limit_seconds
+    apps = [
+        set_active_state(create_app(alive_seconds), is_active)
+        for alive_seconds in expiration.test_seconds_list
+    ]
+
+    unexpired_or_active_pks = (
+        YouthApplication.objects.unexpired_or_active().values_list("pk", flat=True)
+    )
+
+    assert len(unexpired_or_active_pks) == len(
+        set(unexpired_or_active_pks)
+    ), "unexpired_or_active() gave duplicates"
+
+    for app, expected_unexpired_or_active in zip(
+        apps, expected_unexpired_or_active_list
+    ):
+        unexpired_or_active = app.pk in unexpired_or_active_pks
+        assert (
+            unexpired_or_active == expected_unexpired_or_active
+        ), unexpired_or_active_error_message(
+            app, is_active, expected_unexpired_or_active
+        )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "email_ssn_pair_list",
+    [
+        [
+            (email, social_security_number)
+            for email in get_two_test_emails()
+            for social_security_number in get_two_test_social_security_numbers()
+        ]
+    ],
+)
+def test_youth_application_query_set_matches_email_or_social_security_number(
+    api_client, email_ssn_pair_list: List[Tuple[str, str]]
+):
+    # Create source queryset
+    apps = [
+        YouthApplicationFactory.create(email=email, social_security_number=ssn)
+        for email, ssn in email_ssn_pair_list
+    ]
+
+    # Check that each email and social security number combination is matched correctly
+    for email, ssn in email_ssn_pair_list:
+        matched_pks = YouthApplication.objects.matches_email_or_social_security_number(
+            email=email, social_security_number=ssn
+        ).values_list("pk", flat=True)
+
+        assert len(matched_pks) == len(
+            set(matched_pks)
+        ), "matches_email_or_social_security_number() gave duplicates"
+
+        for app in apps:
+            assert (app.pk in matched_pks) == (
+                email == app.email or ssn == app.social_security_number
+            )
+
+
+@pytest.mark.django_db
+def test_youth_application_query_set_matches_any_of_empty(api_client):
+    YouthApplicationFactory.create_batch(size=5)  # Just create something
+    assert len(YouthApplication.objects.matches_any_of()) == 0
+
+
+@pytest.mark.django_db
+def test_youth_application_query_set_matches_any_of(api_client):
+    # Create source queryset
+    [
+        YouthApplicationFactory.create(**overridden_attributes)
+        for overridden_attributes in [
+            {"first_name": "Peter", "last_name": "Pan", "email": "test@test.org"},
+            {"first_name": "Susan", "last_name": "Oliver", "email": "test@test.org"},
+            {"first_name": "Olivia", "last_name": "Oxen", "email": "veikko@test.org"},
+            {"first_name": "Peter", "last_name": "Nat", "email": "uolevi@test.org"},
+        ]
+    ]
+
+    matched_pks = YouthApplication.objects.matches_any_of(
+        not__first_name__gt="Onni",
+        last_name__in=["Oliver", "Oxen"],
+        email__gt="test@test.org",
+    ).values_list("pk", flat=True)
+
+    expected_matched_pks = YouthApplication.objects.filter(
+        ~Q(first_name__gt="Onni")
+        | Q(last_name__in=["Oliver", "Oxen"])
+        | Q(email__gt="test@test.org")
+    ).values_list("pk", flat=True)
+
+    assert sorted(matched_pks) == sorted(expected_matched_pks)

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -1,13 +1,19 @@
+from datetime import timedelta
+from typing import Optional
+
 import factory.random
 import langdetect
 import pytest
 from django.core import mail
 from django.test import override_settings
+from django.utils import timezone
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from applications.api.v1.serializers import YouthApplicationSerializer
-from applications.enums import get_supported_languages
+from applications.enums import get_supported_languages, YouthApplicationRejectedReason
+from applications.models import YouthApplication
 from common.tests.factories import (
     ActiveYouthApplicationFactory,
     InactiveYouthApplicationFactory,
@@ -338,3 +344,94 @@ def test_youth_application_post_invalid_social_security_number(api_client, test_
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "social_security_number" in response.data
+
+
+def get_expected_reason(
+    same_email,
+    same_social_security_number,
+    is_existing_active,
+    is_existing_expired,
+) -> Optional[YouthApplicationRejectedReason]:
+    if (same_email or same_social_security_number) and is_existing_active:
+        return YouthApplicationRejectedReason.ALREADY_ASSIGNED
+    elif same_email and (is_existing_active or not is_existing_expired):
+        return YouthApplicationRejectedReason.EMAIL_IN_USE
+    else:
+        return None
+
+
+@freeze_time("2022-02-02")
+@override_settings(NEXT_PUBLIC_ACTIVATION_LINK_EXPIRATION_SECONDS=60 * 60 * 12)  # 12h
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "same_email,"
+    "same_social_security_number,"
+    "is_existing_active,"
+    "is_existing_expired,"
+    "expected_reason",
+    [
+        (
+            same_email,
+            same_social_security_number,
+            is_existing_active,
+            is_existing_expired,
+            get_expected_reason(
+                same_email,
+                same_social_security_number,
+                is_existing_active,
+                is_existing_expired,
+            ),
+        )
+        for same_email in [False, True]
+        for same_social_security_number in [False, True]
+        for is_existing_active in [False, True]
+        for is_existing_expired in [False, True]
+    ],
+)
+def test_youth_application_post_error_codes(
+    api_client,
+    same_email,
+    same_social_security_number,
+    is_existing_active,
+    is_existing_expired,
+    expected_reason,
+):
+    now = timezone.now()
+
+    # Create the existing youth application
+    existing_app = YouthApplicationFactory.create()
+    existing_app.receipt_confirmed_at = now if is_existing_active else None
+    if is_existing_expired:
+        # Make the saved youth application expired
+        existing_app.created_at = (
+            now - YouthApplication.expiration_duration() - timedelta(hours=1)
+        )
+    else:
+        existing_app.created_at = now
+    existing_app.save()
+    existing_app.refresh_from_db()
+
+    # Create the new unsaved youth application
+    new_app = YouthApplicationFactory.build()
+    if same_email:
+        new_app.email = existing_app.email
+    if same_social_security_number:
+        new_app.social_security_number = existing_app.social_security_number
+
+    # Check that the test objects are set up correctly
+    assert is_existing_expired == existing_app.has_activation_link_expired
+    assert is_existing_active == existing_app.is_active
+    assert same_email == (new_app.email == existing_app.email)
+    assert same_social_security_number == (
+        new_app.social_security_number == existing_app.social_security_number
+    )
+
+    data = YouthApplicationSerializer(new_app).data
+    response = api_client.post(get_list_url(), data)
+
+    if expected_reason is None:
+        assert response.status_code == status.HTTP_201_CREATED
+    else:
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.headers.get("Content-Type") == "application/json"
+        assert response.json() == expected_reason.json()

--- a/backend/shared/setup.cfg
+++ b/backend/shared/setup.cfg
@@ -4,7 +4,12 @@ exclude = *migrations*
 ignore = E309
 
 [flake8]
-exclude = migrations,snapshots
+exclude = migrations,snapshots,*.egg-info/
+# E203 and W503 are disabled and W504 enabled for compatibility with Black.
+# For details see "Why are Flake8's E203 and W503 violated?" in Black FAQ at
+# https://black.readthedocs.io/en/stable/faq.html
+ignore = E203, W503
+extend-select = W504
 max-line-length = 120
 max-complexity = 10
 

--- a/backend/shared/shared/common/tests/test_utils.py
+++ b/backend/shared/shared/common/tests/test_utils.py
@@ -1,0 +1,20 @@
+import pytest
+from django.db.models import Q
+
+from shared.common.utils import _ALWAYS_FALSE_Q_FILTER, any_of_q_filter
+
+
+@pytest.mark.parametrize(
+    "input_kwargs,expected_q_filter",
+    [
+        ({}, _ALWAYS_FALSE_Q_FILTER),
+        ({"a": 1}, Q(a=1)),
+        ({"a__lt": 1}, Q(a__lt=1)),
+        ({"a": 1, "b": "test"}, Q(a=1) | Q(b="test")),
+        ({"a": 1, "b": "test", "c": None}, Q(a=1) | Q(b="test") | Q(c=None)),
+        ({"a__gte": 1, "b__isnull": True}, Q(a__gte=1) | Q(b__isnull=True)),
+        ({"a": 1, "b__lt": 2, "not__c__gte": 3}, Q(a=1) | Q(b__lt=2) | ~Q(c__gte=3)),
+    ],
+)
+def test_any_of_q_filter(input_kwargs, expected_q_filter):
+    assert any_of_q_filter(**input_kwargs) == expected_q_filter

--- a/backend/shared/shared/common/utils.py
+++ b/backend/shared/shared/common/utils.py
@@ -1,0 +1,67 @@
+import operator
+from functools import reduce
+
+from django.db.models import Q, QuerySet
+
+_ALWAYS_FALSE_Q_FILTER = Q(pk=None)  # A hack but works as primary keys can't be null
+
+
+def any_of_q_filter(**kwargs):
+    """
+    Return Q filters combined with | i.e. match any of the given keyword arguments.
+    Return an always false Q filter if no keyword arguments are given.
+
+    NOTE: Supports "not__" prefix to invert a particular Q expression i.e. ~Q().
+
+    Example:
+        any_of_q_filter(a=1, b__lt=2, not__c__gte=3)
+        returns
+            Q(a=1) | Q(b__lt=2) | ~Q(c__gte=3)
+
+    :warning: Does not support field with name "not"
+    :warning: Does not support multiple "not__" prefixes for a single field
+    """
+    if not kwargs:
+        return _ALWAYS_FALSE_Q_FILTER
+    return reduce(
+        operator.or_,
+        (
+            ~Q(**{key[len("not__") :]: value})
+            if key.startswith("not__")
+            else Q(**{key: value})
+            for key, value in kwargs.items()
+        ),
+    )
+
+
+class MatchesAnyOfQuerySet(QuerySet):
+    """
+    QuerySet which supports OR filtering using matches_any_of member function.
+    See matches_any_of function for details.
+
+    NOTE: Put left in class declaration to have consistent method resolution order i.e.
+          Test(MatchesAnyOfQuerySet, QuerySet) works
+          but Test(QuerySet, MatchesAnyOfQuerySet) does not
+
+    Example if TestClass used TestClassQuerySet(MatchesAnyOfQuerySet) as object manager:
+        TestClass.objects.matches_any_of(a=1, b__lt=2, not__c__gte=3) would match like
+            TestClass.objects.filter(Q(a=1) | Q(b__lt=2) | ~Q(c__gte=3))
+    """
+
+    def matches_any_of(self, **kwargs):
+        """
+        Do any of the given expressions match? If none match or there are no expressions
+        then return an empty queryset. If there is some match then return the queryset
+        with the objects that matched.
+
+        NOTE: Supports "not__" prefix to invert a particular expression.
+
+        Example:
+            self.matches_any_of(a=1, b__lt=2, not__c__gte=3)
+            returns
+                self.filter(Q(a=1) | Q(b__lt=2) | ~Q(c__gte=3))
+
+        :warning: Does not support field with name "not"
+        :warning: Does not support multiple "not__" prefixes for a single field
+        """
+        return self.filter(any_of_q_filter(**kwargs))


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Remove unnecessary savings from tests 

Remove unnecessary savings of YouthApplication model instances from
test_youth_applications_api.py tests. This is in preparation for the
YJDH-398 tests where existing saved YouthApplication instances would
make a difference.

Additionally:
 - Make YouthApplicationSerializer return more specific error by
   specifying the social_security_number field as the source of the
   validation error.
 - Update tests to check that returned error is field specific:
   - test_youth_application_post_missing_required_field
   - test_youth_application_post_empty_required_field
 
### KS-Backend: Add error handling to youth application creation

When creating/submitting a new youth application handle errors:
 - Activated youth application with same email or social security number
   already exists
   - Return 400 Bad Request and JSON:
     {"code": "already_assigned", "message": "<human readable error>"}
 - Email is already used by inactive unexpired or active youth
   application
   - Return 400 Bad Request and JSON:
     {"code": "email_in_use", "message": "<human readable error>"}
 - Add test_youth_application_post_error_codes tests for the above

Add YouthApplicationRejectedReason enum:
 - Values:
   - EMAIL_IN_USE
   - ALREADY_ASSIGNED
 - Add json function for outputting value and label of enum as JSON
   - Add test test_youth_application_rejected_reason_json for testing
     the output of this function

Add YouthApplicationQuerySet:
 - Add member functions for ease of use:
   - matches_email_or_social_security_number
   - expired
   - unexpired
   - unexpired_or_active
   - active
 - Add tests for the above member functions to test_querying.py
 - Use YouthApplicationQuerySet as object manager in YouthApplication

Additionally:
 - backend/shared/shared/common/utils.py:
   - Add any_of_q_filter(**kwargs) function
     - Return Q filters combined with | i.e. match any of the given
       keyword arguments. NOTE: Supports "not__" prefix to invert a
       particular Q expression i.e. ~Q().
     - Example: any_of_q_filter(a=1, b__lt=2, not__c__gte=3) returns
       Q(a=1) | Q(b__lt=2) | ~Q(c__gte=3)
   - Add MatchesAnyOfQuerySet class
     - QuerySet which supports OR filtering using matches_any_of member
       function
     - Example if TestClass used TestClassQuerySet(MatchesAnyOfQuerySet)
       based object manager:
       TestClass.objects.matches_any_of(a=1, b__lt=2, not__c__gte=3)
       would match like
       TestClass.objects.filter(Q(a=1) | Q(b__lt=2) | ~Q(c__gte=3))
 - backend/shared/shared/common/tests/test_utils.py:
   - Add test_any_of_q_filter test for testing any_of_q_filter function
 - Test the matches_any_of with YouthApplicationQuerySet

## Issues :bug:

YJDH-398

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
