### PR TITLE
HL-372: Message indicator

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -19,7 +19,9 @@
         "applicationNumber": "Hakemusnumero",
         "status": "Tila",
         "check": "Tarkastele",
-        "editEndDate": "Muokkaa viimeistään"
+        "editEndDate": "Muokkaa viimeistään",
+        "newMessages": "uusi viesti",
+        "newMessagesMult": "uutta viestiä"
       }
     },
     "pageHeaders": {

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -20,8 +20,8 @@
         "status": "Tila",
         "check": "Tarkastele",
         "editEndDate": "Muokkaa viimeistään",
-        "newMessages": "uusi viesti",
-        "newMessagesMult": "uutta viestiä"
+        "newMessages_one": "{{count}} uusi viesti",
+        "newMessages_other": "{{count}} uutta viestiä"
       }
     },
     "pageHeaders": {

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -19,7 +19,9 @@
         "applicationNumber": "Hakemusnumero",
         "status": "Tila",
         "check": "Tarkastele",
-        "editEndDate": "Muokkaa viimeistään"
+        "editEndDate": "Muokkaa viimeistään",
+        "newMessages": "uusi viesti",
+        "newMessagesMult": "uutta viestiä"
       }
     },
     "pageHeaders": {

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -20,8 +20,8 @@
         "status": "Tila",
         "check": "Tarkastele",
         "editEndDate": "Muokkaa viimeistään",
-        "newMessages": "uusi viesti",
-        "newMessagesMult": "uutta viestiä"
+        "newMessages_one": "{{count}} uusi viesti",
+        "newMessages_other": "{{count}} uutta viestiä"
       }
     },
     "pageHeaders": {

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -19,7 +19,9 @@
         "applicationNumber": "Hakemusnumero",
         "status": "Tila",
         "check": "Tarkastele",
-        "editEndDate": "Muokkaa viimeistään"
+        "editEndDate": "Muokkaa viimeistään",
+        "newMessages": "uusi viesti",
+        "newMessagesMult": "uutta viestiä"
       }
     },
     "pageHeaders": {

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -20,8 +20,8 @@
         "status": "Tila",
         "check": "Tarkastele",
         "editEndDate": "Muokkaa viimeistään",
-        "newMessages": "uusi viesti",
-        "newMessagesMult": "uutta viestiä"
+        "newMessages_one": "{{count}} uusi viesti",
+        "newMessages_other": "{{count}} uutta viestiä"
       }
     },
     "pageHeaders": {

--- a/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.sc.ts
@@ -12,5 +12,23 @@ export const $ListWrapper = styled.ul`
   list-style: none;
   padding: 0;
   margin: 0;
+`;
+
+export const $ListInfo = styled.div`
+  display: grid;
+  grid-template-columns: 60px 3fr;
+  grid-gap: ${(props) => props.theme.spacing.m};
+  background-color: ${(props) => props.theme.colors.coatOfArms};
+  padding: ${(props) => props.theme.spacing.xs2};
+  color: ${(props) => props.theme.colors.white};
   margin-bottom: ${(props) => props.theme.spacing.l};
+`;
+
+export const $ListInfoInner = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const $ListInfoText = styled.div`
+  padding: 0 ${(props) => props.theme.spacing.xs2};
 `;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.tsx
@@ -49,11 +49,9 @@ const ApplicationsList: React.FC<ApplicationListProps> = ({
             <$ListInfoInner>
               <IconSpeechbubbleText />
               <$ListInfoText>
-                {`${newMessagesCount} ${t(
-                  `common:applications.list.common.newMessages${
-                    newMessagesCount > 1 ? 'Mult' : ''
-                  }`
-                )}`}
+                {t('common:applications.list.common.newMessages', {
+                  count: newMessagesCount,
+                })}
               </$ListInfoText>
             </$ListInfoInner>
           </$GridCell>

--- a/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.tsx
@@ -1,9 +1,18 @@
+import { IconSpeechbubbleText } from 'hds-react';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import LoadingSkeleton from 'react-loading-skeleton';
 import Container from 'shared/components/container/Container';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import theme from 'shared/styles/theme';
 
-import { $Heading, $ListWrapper } from './ApplicationList.sc';
+import {
+  $Heading,
+  $ListInfo,
+  $ListInfoInner,
+  $ListInfoText,
+  $ListWrapper,
+} from './ApplicationList.sc';
 import ListItem from './listItem/ListItem';
 import useApplicationList from './useApplicationList';
 
@@ -16,9 +25,9 @@ const ApplicationsList: React.FC<ApplicationListProps> = ({
   heading,
   status,
 }) => {
-  const { list, shouldShowSkeleton, shouldHideList } = useApplicationList(
-    status
-  );
+  const { t } = useTranslation();
+  const { list, shouldShowSkeleton, shouldHideList, newMessagesCount } =
+    useApplicationList(status);
 
   const items = shouldShowSkeleton ? (
     <ListItem isLoading />
@@ -34,6 +43,22 @@ const ApplicationsList: React.FC<ApplicationListProps> = ({
         {shouldShowSkeleton ? <LoadingSkeleton width="20%" /> : heading}
       </$Heading>
       <$ListWrapper>{items}</$ListWrapper>
+      {newMessagesCount > 0 && (
+        <$ListInfo>
+          <$GridCell $colStart={2}>
+            <$ListInfoInner>
+              <IconSpeechbubbleText />
+              <$ListInfoText>
+                {`${newMessagesCount} ${t(
+                  `common:applications.list.common.newMessages${
+                    newMessagesCount > 1 ? 'Mult' : ''
+                  }`
+                )}`}
+              </$ListInfoText>
+            </$ListInfoInner>
+          </$GridCell>
+        </$ListInfo>
+      )}
     </Container>
   );
 };

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
@@ -64,21 +64,3 @@ export const $ItemActions = styled.div`
   width: 160px;
   min-width: 160px;
 `;
-
-export const $ItemInfo = styled.div`
-  display: grid;
-  grid-template-columns: 60px 3fr;
-  grid-gap: ${(props) => props.theme.spacing.m};
-  background-color: ${(props) => props.theme.colors.coatOfArms};
-  padding: ${(props) => props.theme.spacing.xs2};
-  color: ${(props) => props.theme.colors.white};
-`;
-
-export const $ItemInfoInner = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-export const $ItemInfoText = styled.div`
-  padding: 0 ${(props) => props.theme.spacing.xs2};
-`;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.tsx
@@ -2,10 +2,9 @@ import { APPLICATION_STATUSES } from 'benefit/applicant/constants';
 import { useTranslation } from 'benefit/applicant/i18n';
 import { ApplicationListItemData } from 'benefit/applicant/types/application';
 import { Loading } from 'benefit/applicant/types/common';
-import { Button, IconSpeechbubbleText, StatusLabel } from 'hds-react';
+import { Button, StatusLabel } from 'hds-react';
 import React from 'react';
 import LoadingSkeleton from 'react-loading-skeleton';
-import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 
 import {
   $Avatar,
@@ -14,9 +13,6 @@ import {
   $DataValue,
   $ItemActions,
   $ItemContent,
-  $ItemInfo,
-  $ItemInfoInner,
-  $ItemInfoText,
   $ListItem,
   $ListItemWrapper,
 } from './ListItem.sc';
@@ -100,7 +96,15 @@ const ListItem: React.FC<ListItemProps> = (props) => {
               <$DataHeader>
                 {t(`${translationBase}.common.editEndDate`)}
               </$DataHeader>
-              <StatusLabel type="alert">{editEndDate}</StatusLabel>
+              <StatusLabel
+                css={`
+                  font-weight: 600;
+                  text-align: center;
+                `}
+                type="alert"
+              >
+                {editEndDate}
+              </StatusLabel>
             </$DataColumn>
           )}
         </$ItemContent>
@@ -122,16 +126,6 @@ const ListItem: React.FC<ListItemProps> = (props) => {
           </Button>
         </$ItemActions>
       </$ListItem>
-      {status === APPLICATION_STATUSES.INFO_REQUIRED && (
-        <$ItemInfo>
-          <$GridCell $colStart={2}>
-            <$ItemInfoInner>
-              <IconSpeechbubbleText />
-              <$ItemInfoText>1 uusi viesti</$ItemInfoText>
-            </$ItemInfoInner>
-          </$GridCell>
-        </$ItemInfo>
-      )}
     </$ListItemWrapper>
   );
 };

--- a/frontend/benefit/applicant/src/components/applications/applicationList/useApplicationList.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/useApplicationList.ts
@@ -28,6 +28,7 @@ interface ApplicationListProps {
   list: ApplicationListItemData[];
   shouldShowSkeleton: boolean;
   shouldHideList: boolean;
+  newMessagesCount: number;
 }
 
 const getAvatarBGColor = (
@@ -109,6 +110,7 @@ const useApplicationList = (status: string[]): ApplicationListProps => {
       submitted_at,
       application_number: applicationNum,
       additional_information_needed_by,
+      unread_messages_count,
     } = application;
 
     const statusText = getStatusTranslation(appStatus);
@@ -127,7 +129,7 @@ const useApplicationList = (status: string[]): ApplicationListProps => {
       last_modified_at && convertToUIDateFormat(last_modified_at);
     const editEndDate =
       additional_information_needed_by &&
-      convertToUIDateAndTimeFormat(additional_information_needed_by);
+      convertToUIDateFormat(additional_information_needed_by);
     const commonProps = {
       id,
       name,
@@ -135,6 +137,7 @@ const useApplicationList = (status: string[]): ApplicationListProps => {
       modifiedAt,
       allowedAction,
       status: appStatus,
+      unreadMessagesCount: unread_messages_count ?? 0,
     };
     const draftProps = { createdAt, applicationNum };
     const submittedProps = {
@@ -169,6 +172,10 @@ const useApplicationList = (status: string[]): ApplicationListProps => {
     list: list || [],
     shouldShowSkeleton,
     shouldHideList,
+    newMessagesCount:
+      list?.filter(
+        (application) => Number(application?.unreadMessagesCount) > 0
+      ).length ?? 0,
   };
 };
 

--- a/frontend/benefit/applicant/src/types/application.d.ts
+++ b/frontend/benefit/applicant/src/types/application.d.ts
@@ -214,6 +214,7 @@ export type ApplicationData = {
   applicant_terms_approval_needed?: boolean;
   applicant_terms_in_effect?: ApplicantTermsData;
   approve_terms?: ApproveTermsData;
+  unread_messages_count?: number;
 };
 
 interface ApplicationAllowedAction {
@@ -237,6 +238,7 @@ export interface ApplicationListItemData {
   applicationNum?: number;
   editEndDate?: string;
   allowedAction: ApplicationAllowedAction;
+  unreadMessagesCount?: number;
 }
 
 export interface Step1 {
@@ -301,6 +303,7 @@ export type Application = {
   applicantTermsApprovalNeeded?: boolean;
   applicantTermsInEffect?: ApplicantTerms;
   approveTerms?: ApproveTerms;
+  unreadMessagesCount?: number;
 } & Step1 &
   Step2;
 


### PR DESCRIPTION
## Description :sparkles:
![image](https://user-images.githubusercontent.com/16116141/150534372-53227b80-9de8-40cd-bb4b-01e275826700.png)
- The new messages indicators shows for the applicant if there are new messages in the application
IMPORTANT: BY SPEX: the count is not showing the count of the actual unread messages in all applications in the list, but the NUMBER OF APPLICATIONS which have unread messages.

Currently there is no way to check in which application the unread messages are. This feature is planned for future development as "notification center functionality"

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
