### PR TITLE
HL-380: add duration_in_months_rounded and last_possible_end_date to API

### DIFF
--- a/backend/benefit/calculator/api/v1/serializers.py
+++ b/backend/benefit/calculator/api/v1/serializers.py
@@ -141,8 +141,13 @@ class CalculationSerializer(serializers.ModelSerializer):
             "rows",
             "handler_details",
             "handler",
+            "duration_in_months_rounded",
         ]
-        read_only_fields = ["id", "calculated_benefit_amount"]
+        read_only_fields = [
+            "id",
+            "calculated_benefit_amount",
+            "duration_in_months_rounded",
+        ]
 
 
 class UpdateOrderedListSerializer(serializers.ListSerializer):
@@ -191,8 +196,11 @@ class PaySubsidySerializer(serializers.ModelSerializer):
             "pay_subsidy_percent",
             "work_time_percent",
             "disability_or_illness",
+            "duration_in_months_rounded",
         ]
-        read_only_fields = []
+        read_only_fields = [
+            "duration_in_months_rounded",
+        ]
 
         list_serializer_class = UpdateOrderedListSerializer
 

--- a/backend/benefit/calculator/models.py
+++ b/backend/benefit/calculator/models.py
@@ -154,12 +154,6 @@ class Calculation(UUIDModel, TimeStampedModel, DurationMixin):
             setattr(self, target_field_name, value)
         PaySubsidy.reset_pay_subsidies(self.application)
 
-    @property
-    def duration_in_months_rounded(self):
-        # The handler's Excel file uses the number of months rounded to two decimals
-        # in all calculations
-        return duration_in_months(self.start_date, self.end_date, decimal_places=2)
-
     calculator = None
 
     def init_calculator(self):

--- a/backend/benefit/calculator/tests/test_calculator_api.py
+++ b/backend/benefit/calculator/tests/test_calculator_api.py
@@ -14,14 +14,30 @@ from applications.tests.test_applications_api import (
 from calculator.api.v1.serializers import CalculationSerializer
 from calculator.tests.factories import CalculationFactory, PaySubsidyFactory
 from common.tests.conftest import get_client_user
+from common.utils import duration_in_months, to_decimal
 
 
-def test_application_retrieve_calculation_as_handler(handler_api_client, application):
-    response = handler_api_client.get(get_handler_detail_url(application))
+def test_application_retrieve_calculation_as_handler(
+    handler_api_client, handling_application
+):
+    pay_subsidy = PaySubsidyFactory(application=handling_application)
+    response = handler_api_client.get(get_handler_detail_url(handling_application))
+    assert response.status_code == 200
     assert "calculation" in response.data
     assert "pay_subsidies" in response.data
     assert "training_compensations" in response.data
-    assert response.status_code == 200
+    assert decimal.Decimal(
+        response.data["calculation"]["duration_in_months_rounded"]
+    ) == to_decimal(
+        duration_in_months(
+            handling_application.calculation.start_date,
+            handling_application.calculation.end_date,
+        ),
+        2,
+    )
+    assert decimal.Decimal(
+        response.data["pay_subsidies"][0]["duration_in_months_rounded"]
+    ) == to_decimal(duration_in_months(pay_subsidy.start_date, pay_subsidy.end_date), 2)
 
 
 def test_application_try_retrieve_calculation_as_applicant(api_client, application):
@@ -224,7 +240,9 @@ def test_application_replace_pay_subsidy(handler_api_client, received_applicatio
     assert response.status_code == 200
     received_application.refresh_from_db()
     new_data = HandlerApplicationSerializer(received_application).data
-    del new_data["pay_subsidies"][0]["id"]
+    del new_data["pay_subsidies"][0]["id"]  # id is expected to change
+    # on-the-fly generated field that was not present in the PUT request
+    del new_data["pay_subsidies"][0]["duration_in_months_rounded"]
     assert new_data["pay_subsidies"] == data["pay_subsidies"]
 
 

--- a/backend/benefit/common/tests/test_utils.py
+++ b/backend/benefit/common/tests/test_utils.py
@@ -1,7 +1,15 @@
+import decimal
+import os
 from datetime import date
 
 import pytest
-from common.utils import date_range_overlap, days360
+from common.utils import (
+    date_range_overlap,
+    days360,
+    duration_in_months,
+    get_date_range_end_with_days360,
+)
+from dateutil.relativedelta import relativedelta
 
 
 @pytest.mark.parametrize(
@@ -51,3 +59,71 @@ def test_days360_errors(date1, date2):
 )
 def test_date_range_overlap(start_1, end_1, start_2, end_2, expected_result):
     assert date_range_overlap(start_1, end_1, start_2, end_2) == expected_result
+
+
+@pytest.mark.parametrize(
+    "date1,months,expected_result",
+    [
+        (date(2022, 1, 1), 0, None),
+        (date(2022, 1, 1), decimal.Decimal("0.01"), None),
+        (date(2022, 1, 1), decimal.Decimal("0.03"), date(2022, 1, 1)),
+        (date(2022, 1, 1), decimal.Decimal("0.92"), date(2022, 1, 28)),
+        (date(2022, 1, 1), decimal.Decimal("1"), date(2022, 1, 31)),
+        (date(2022, 1, 1), decimal.Decimal("1.04"), date(2022, 2, 1)),
+        (date(2022, 1, 20), decimal.Decimal("1.38"), date(2022, 2, 28)),
+        (date(2022, 1, 30), decimal.Decimal("6.99"), date(2022, 8, 30)),
+        (date(2022, 2, 28), decimal.Decimal("0.04"), None),
+        (date(2022, 2, 28), decimal.Decimal("0.05"), date(2022, 2, 28)),
+        (date(2022, 2, 28), decimal.Decimal("0.12"), date(2022, 3, 1)),
+        (date(2024, 2, 28), decimal.Decimal("0.04"), date(2024, 2, 28)),
+        (date(2024, 2, 28), decimal.Decimal("0.05"), date(2024, 2, 28)),
+        (date(2024, 2, 28), decimal.Decimal("0.12"), date(2024, 3, 1)),
+        (date(2024, 2, 29), decimal.Decimal("0.04"), date(2024, 2, 29)),
+        (date(2024, 2, 29), decimal.Decimal("0.05"), date(2024, 2, 29)),
+        (date(2024, 2, 29), decimal.Decimal("0.10"), date(2024, 3, 1)),
+        (date(2024, 2, 29), decimal.Decimal("0.12"), date(2024, 3, 2)),
+    ],
+)
+def test_get_date_range_end_with_days360(date1, months, expected_result):
+    assert get_date_range_end_with_days360(date1, months) == expected_result
+
+
+def test_get_date_range_end_with_days360_combinations():
+
+    if os.getenv("DAYS_360_FULL_TEST") == "1":
+        # The nested loops test a huge number of combinations. Takes a long time to run,
+        # only run this while debugging.
+        day_offsets = range(0, 100)  # offset from 2022-01-01
+        months_range = range(0, 1200)
+    else:
+        print(
+            "DAYS_360_FULL_TEST not set, test only a few combinations to make sure the test code doesn't rot"
+        )
+        day_offsets = range(0, 100, 20)  # offset from 2022-01-01
+        months_range = range(0, 1200, 100)
+
+    for initial_day_offset in day_offsets:
+        print(f"initial_day_offset={initial_day_offset}")
+        for months in [decimal.Decimal(m) / 100 for m in months_range]:
+            start_date = date(2022, 1, 1) + relativedelta(days=initial_day_offset)
+            end_date = get_date_range_end_with_days360(start_date, months)
+            if end_date is None:
+                # we are adding less than one day
+                if not (start_date.month == 2 and start_date.day in [28, 29]):
+                    # end of February produces interesting results
+                    assert months < (1 / 30)
+            else:
+                # verify that there is no date that would be closer
+                result_difference = abs(
+                    duration_in_months(start_date, end_date) - months
+                )
+                previous_day_difference = abs(
+                    duration_in_months(start_date, end_date - relativedelta(days=1))
+                    - months
+                )
+                next_day_difference = abs(
+                    duration_in_months(start_date, end_date + relativedelta(days=1))
+                    - months
+                )
+                assert result_difference <= previous_day_difference
+                assert result_difference <= next_day_difference


### PR DESCRIPTION
## Description :sparkles:

Add  duration in months field for PaySubsidy and Calculation objects in the API. The duration is rounded to two decimals, suitable for display in the UI.

Also add a last valid end_date for the calculation to the API, taking into account the previously accepted benefits.

## Issues :bug: HL-380

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
