### PR TITLE
YJDH-432: improve docker image build times: remove write access

### DIFF
--- a/frontend/benefit/applicant/Dockerfile
+++ b/frontend/benefit/applicant/Dockerfile
@@ -88,15 +88,6 @@ RUN yarn install --production --frozen-lockfile --check-files
 # install lerna
 RUN yarn add -W lerna
 
-USER root
-# Use non-root user and add it to the root group (0)
-RUN usermod -a -G 0 appuser
-# Sets the directory and file permissions to allow users in the root group to access them in the built image (for OpenShift)
-# https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
-RUN chgrp -R 0 . \
-  && chmod -R g+rwX .
-USER appuser
-
 # Expose port
 EXPOSE 3000
 

--- a/frontend/benefit/handler/Dockerfile
+++ b/frontend/benefit/handler/Dockerfile
@@ -88,15 +88,6 @@ RUN yarn install --production --frozen-lockfile --check-files
 # install lerna
 RUN yarn add -W lerna
 
-USER root
-# Use non-root user and add it to the root group (0)
-RUN usermod -a -G 0 appuser
-# Sets the directory and file permissions to allow users in the root group to access them in the built image (for OpenShift)
-# https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
-RUN chgrp -R 0 . \
-  && chmod -R g+rwX .
-USER appuser
-
 # Expose port
 EXPOSE 3100
 

--- a/frontend/kesaseteli/employer/Dockerfile
+++ b/frontend/kesaseteli/employer/Dockerfile
@@ -90,15 +90,6 @@ RUN yarn install --production --frozen-lockfile --check-files
 # install lerna
 RUN yarn add -W lerna
 
-USER root
-# Use non-root user and add it to the root group (0)
-RUN usermod -a -G 0 appuser
-# Sets the directory and file permissions to allow users in the root group to access them in the built image (for OpenShift)
-# https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
-RUN chgrp -R 0 . \
-  && chmod -R g+rwX .
-USER appuser
-
 # Expose port
 EXPOSE 3000
 

--- a/frontend/kesaseteli/handler/Dockerfile
+++ b/frontend/kesaseteli/handler/Dockerfile
@@ -90,15 +90,6 @@ RUN yarn install --production --frozen-lockfile --check-files
 # install lerna
 RUN yarn add -W lerna
 
-USER root
-# Use non-root user and add it to the root group (0)
-RUN usermod -a -G 0 appuser
-# Sets the directory and file permissions to allow users in the root group to access them in the built image (for OpenShift)
-# https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
-RUN chgrp -R 0 . \
-  && chmod -R g+rwX .
-USER appuser
-
 # Expose port
 EXPOSE 3200
 

--- a/frontend/kesaseteli/youth/Dockerfile
+++ b/frontend/kesaseteli/youth/Dockerfile
@@ -91,15 +91,6 @@ RUN yarn install --production --frozen-lockfile --check-files
 # install lerna
 RUN yarn add -W lerna
 
-USER root
-# Use non-root user and add it to the root group (0)
-RUN usermod -a -G 0 appuser
-# Sets the directory and file permissions to allow users in the root group to access them in the built image (for OpenShift)
-# https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
-RUN chgrp -R 0 . \
-  && chmod -R g+rwX .
-USER appuser
-
 # Expose port
 EXPOSE 3100
 

--- a/frontend/tet/admin/Dockerfile
+++ b/frontend/tet/admin/Dockerfile
@@ -90,14 +90,6 @@ RUN yarn install --production --frozen-lockfile --check-files
 # install lerna
 RUN yarn add -W lerna
 
-USER root
-# Use non-root user and add it to the root group (0)
-RUN usermod -a -G 0 appuser
-# Sets the directory and file permissions to allow users in the root group to access them in the built image (for OpenShift)
-# https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
-RUN chgrp -R 0 . \
-  && chmod -R g+rwX .
-USER appuser
 
 # Expose port
 EXPOSE 3000

--- a/frontend/tet/employer/Dockerfile
+++ b/frontend/tet/employer/Dockerfile
@@ -88,14 +88,6 @@ RUN yarn install --production --frozen-lockfile --check-files
 # install lerna
 RUN yarn add -W lerna
 
-USER root
-# Use non-root user and add it to the root group (0)
-RUN usermod -a -G 0 appuser
-# Sets the directory and file permissions to allow users in the root group to access them in the built image (for OpenShift)
-# https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
-RUN chgrp -R 0 . \
-  && chmod -R g+rwX .
-USER appuser
 
 # Expose port
 EXPOSE 3000

--- a/frontend/tet/youth/Dockerfile
+++ b/frontend/tet/youth/Dockerfile
@@ -88,15 +88,6 @@ RUN yarn install --production --frozen-lockfile --check-files
 # install lerna
 RUN yarn add -W lerna
 
-USER root
-# Use non-root user and add it to the root group (0)
-RUN usermod -a -G 0 appuser
-# Sets the directory and file permissions to allow users in the root group to access them in the built image (for OpenShift)
-# https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
-RUN chgrp -R 0 . \
-  && chmod -R g+rwX .
-USER appuser
-
 # Expose port
 EXPOSE 3000
 


### PR DESCRIPTION
## Description :sparkles:
docker command `RUN chgrp -R 0 . && chmod -R g+rwX .` takes 23 minutes. Let's change it so that it doesnt try to change recursively every file in the `node_modules` folder. Let's add the user group earlier and change mode only for excutable files in the `node_modules/.bin` folder. 

After quick check it seems that the build time for example for ks-youth has dropped from 9.5 minutes to 6 minutes.

new docker file build time: https://github.com/City-of-Helsinki/yjdh/runs/4935611018?check_suite_focus=true
old docker file build time (from another pr):
https://github.com/City-of-Helsinki/yjdh/runs/4933217802?check_suite_focus=true

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
