### PR TITLE
HL-313: Handler logo url

### DIFF
--- a/frontend/benefit/handler/src/components/header/Header.tsx
+++ b/frontend/benefit/handler/src/components/header/Header.tsx
@@ -1,3 +1,4 @@
+import { ROUTES } from 'benefit/handler/constants';
 import * as React from 'react';
 import BaseHeader from 'shared/components/header/Header';
 
@@ -16,6 +17,7 @@ const Header: React.FC = () => {
   return (
     <BaseHeader
       title={t('common:appName')}
+      titleUrl={ROUTES.HOME}
       menuToggleAriaLabel={t('common:menuToggleAriaLabel')}
       languages={languageOptions}
       locale={locale}

--- a/frontend/shared/src/components/header/Header.tsx
+++ b/frontend/shared/src/components/header/Header.tsx
@@ -14,6 +14,7 @@ import { useHeader } from './useHeader';
 
 export type HeaderProps = {
   title?: string;
+  titleUrl?: string;
   skipToContentLabel?: string;
   menuToggleAriaLabel?: string;
   locale: string;
@@ -41,6 +42,7 @@ export type HeaderProps = {
 const Header: React.FC<HeaderProps> = ({
   skipToContentLabel,
   title,
+  titleUrl,
   menuToggleAriaLabel,
   languages,
   locale,
@@ -83,6 +85,7 @@ const Header: React.FC<HeaderProps> = ({
       skipToContentLabel={skipToContentLabel}
       logoLanguage={logoLang as LogoLanguage}
       title={title}
+      titleUrl={titleUrl}
       titleAriaLabel={title}
     >
       {isNavigationVisible && navigationItems && (


### PR DESCRIPTION
## Description :sparkles:
Adds the handler logo url
Adds optional titleUrl param to the shared header

Note: applicant logo url is not needed

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
