### PR TITLE
HL-348: Not saving application with default apprenticeship program value

### DIFF
--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -117,7 +117,7 @@ const useFormActions = (application: Application): FormActions => {
       endDate: currentValues.endDate
         ? convertToBackendDateFormat(parseDate(currentValues.endDate))
         : undefined,
-      apprenticeshipProgram: currentValues.apprenticeshipProgram || false,
+      apprenticeshipProgram: currentValues.apprenticeshipProgram,
     };
 
     const deMinimisAidSet =


### PR DESCRIPTION
## Description :sparkles:
When creating application, we set default value for apprenticeship program as false, fixing because we don't want default value for this

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
<img width="937" alt="Screenshot 2022-01-27 at 11 09 16" src="https://user-images.githubusercontent.com/23077311/151327496-c63b59b4-0fb7-4237-a366-7354faa1e273.png">
<img width="915" alt="Screenshot 2022-01-27 at 11 08 55" src="https://user-images.githubusercontent.com/23077311/151327514-10a11eda-f177-413d-b70b-3347b7f68863.png">


## Additional notes :spiral_notepad:
