### PR TITLE
YJDH-418 | KS-Backend: Add detail view for YouthApplication

### DIFF
--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -1,3 +1,5 @@
+import json
+
 import filetype
 from django.conf import settings
 from django.db import transaction
@@ -467,8 +469,24 @@ class YouthApplicationSerializer(serializers.ModelSerializer):
             "phone_number",
             "language",
             "receipt_confirmed_at",
+            "encrypted_vtj_json",
         ]
         read_only_fields = [
             "id",
             "created_at",
+            "encrypted_vtj_json",
         ]
+
+    encrypted_vtj_json = serializers.SerializerMethodField("get_encrypted_vtj_json")
+
+    def get_encrypted_vtj_json(self, obj):
+        """
+        Return encrypted_vtj_json as JSON object, converting None & empty string to {}.
+
+        The reason for this function is that encrypted_vtj_json field is
+        EncryptedCharField, not JSONField.
+        """
+        if obj.encrypted_vtj_json in [None, ""]:
+            return {}
+        else:
+            return json.loads(obj.encrypted_vtj_json)

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -34,7 +34,7 @@ from applications.models import (
     School,
     YouthApplication,
 )
-from common.utils import DenyAll
+from common.permissions import DenyAll, IsHandler
 
 
 class SchoolListView(ListAPIView):
@@ -118,6 +118,8 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
         """
         if self.action in ["activate", "create"]:
             permission_classes = [AllowAny]
+        elif self.action in ["retrieve"]:
+            permission_classes = [IsHandler]
         else:
             permission_classes = [DenyAll]
         return [permission() for permission in permission_classes]

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -1,5 +1,6 @@
+import json
 from datetime import timedelta
-from typing import Optional
+from typing import List, Optional
 
 import factory.random
 import langdetect
@@ -21,14 +22,23 @@ from common.tests.factories import (
 )
 
 
-def get_required_fields():
+def get_required_fields() -> List[str]:
     return [
         "first_name",
         "last_name",
         "social_security_number",
         "school",
         "is_unlisted_school",
+        "email",
         "phone_number",
+    ]
+
+
+def get_handler_fields() -> List[str]:
+    return get_required_fields() + [
+        "language",
+        "receipt_confirmed_at",
+        "encrypted_vtj_json",
     ]
 
 
@@ -40,11 +50,58 @@ def get_activation_url(pk):
     return reverse("v1:youthapplication-activate", kwargs={"pk": pk})
 
 
+def get_detail_url(pk):
+    return reverse("v1:youthapplication-detail", kwargs={"pk": pk})
+
+
+def get_test_vtj_json() -> dict:
+    return {"first_name": "Maija", "last_name": "Meikäläinen"}
+
+
 @pytest.mark.django_db
 def test_youth_applications_list(api_client):
     response = api_client.get(get_list_url())
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_youth_applications_detail_valid_pk(api_client, youth_application):
+    response = api_client.get(get_detail_url(pk=youth_application.pk))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_youth_applications_detail_invalid_pk(api_client):
+    response = api_client.get(get_detail_url(pk="invalid value"))
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("field", get_handler_fields())
+def test_youth_applications_detail_response_field(api_client, youth_application, field):
+    response = api_client.get(get_detail_url(pk=youth_application.pk))
+    assert field in response.data
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "input_encrypted_vtj_json,expected_output_encrypted_vtj_json",
+    [
+        (None, {}),
+        ("", {}),
+        (json.dumps(get_test_vtj_json()), get_test_vtj_json()),
+    ],
+)
+def test_youth_applications_detail_encrypted_vtj_json(
+    api_client,
+    input_encrypted_vtj_json,
+    expected_output_encrypted_vtj_json,
+):
+    app = YouthApplicationFactory.create(encrypted_vtj_json=input_encrypted_vtj_json)
+    response = api_client.get(get_detail_url(pk=app.pk))
+    output_encrypted_vtj_json = response.data["encrypted_vtj_json"]
+    assert output_encrypted_vtj_json == expected_output_encrypted_vtj_json
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/common/permissions.py
+++ b/backend/kesaseteli/common/permissions.py
@@ -1,0 +1,20 @@
+from rest_framework.permissions import BasePermission
+
+
+class DenyAll(BasePermission):
+    """
+    Deny all access (the opposite of AllowAny).
+    """
+
+    def has_permission(self, request, view):
+        return False
+
+
+class IsHandler(BasePermission):
+    """
+    Is the user a youth application / youth summer voucher handler?
+    """
+
+    def has_permission(self, request, view):
+        # TODO: Implement
+        return True

--- a/backend/kesaseteli/common/utils.py
+++ b/backend/kesaseteli/common/utils.py
@@ -3,17 +3,7 @@ from datetime import date
 from django.core.exceptions import ValidationError
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
-from rest_framework.permissions import BasePermission
 from stdnum.fi.hetu import is_valid as is_valid_finnish_social_security_number
-
-
-class DenyAll(BasePermission):
-    """
-    Deny all access (the opposite of AllowAny).
-    """
-
-    def has_permission(self, request, view):
-        return False
 
 
 def has_whitespace(value):


### PR DESCRIPTION
## Description :sparkles:

YouthApplication's detail view is accessible now using:
 - reverse("v1:youthapplication-detail", kwargs={"pk": pk})
   - e.g. locally `https://localhost:8000/v1/youthapplications/<pk>/`

The detail view returns the YouthApplication's information for the
youth application / youth summer voucher handler.

Also:
 - Add encrypted_vtj_json to YouthApplicationSerializer so it is sent to
   the handler through the detail view. Convert it from string to JSON
   and convert None and empty string to {}.
 - Create backend/kesaseteli/common/permissions.py
   - Add stub for IsHandler permission
     - TODO: Implement, split to ticket YJDH-435
   - Move DenyAll from backend/kesaseteli/common/utils.py here
 - test_youth_applications_api.py tests:
   - Add email to required fields
   - Add tests:
     - test_youth_applications_detail_valid_pk
     - test_youth_applications_detail_invalid_pk
     - test_youth_applications_detail_response_field
     - test_youth_applications_detail_encrypted_vtj_json

## Issues :bug:

YJDH-418 (Add detail view for YouthApplication)
YJDH-435 (TODO / Implementing IsHandler)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
