### PR TITLE
HL-378: Add extra explanation row for salary related expenses

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -175,6 +175,7 @@
         "heading5Employment": "Työsuhde",
         "heading5Assignment": "Toimeksianto",
         "heading5EmploymentSub1": "Palkkauskustannukset",
+        "salaryExpensesExplanation": "Bruttopalkka ja sivukulut ilmoitetaan euroina kuukaudessa, lomaraha kertasummana ",
         "tooltips": {
           "heading5Employment": "Työsuhde tooltip text",
           "heading5EmploymentSub1": "Työsuhde sub header tooltip message 1",
@@ -263,12 +264,12 @@
             "placeholder": "Työehtosopimus"
           },
           "monthlyPay": {
-            "label": "Bruttopalkka €/kk",
+            "label": "Bruttopalkka",
             "placeholder": "Palkka",
             "view": "Bruttopalkka {{monthlyPay}} €/kk"
           },
           "otherExpenses": {
-            "label": "Sivukulut €/kk",
+            "label": "Sivukulut",
             "placeholder": "Sivukulut",
             "view": "Sivukulut {{otherExpenses}} €/kk"
           },

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -175,6 +175,7 @@
         "heading5Employment": "Työsuhde",
         "heading5Assignment": "Toimeksianto",
         "heading5EmploymentSub1": "Palkkauskustannukset",
+        "salaryExpensesExplanation": "Bruttopalkka ja sivukulut ilmoitetaan euroina kuukaudessa, lomaraha kertasummana ",
         "tooltips": {
           "heading5Employment": "Työsuhde tooltip text",
           "heading5EmploymentSub1": "Työsuhde sub header tooltip message 1",
@@ -263,12 +264,12 @@
             "placeholder": "Työehtosopimus"
           },
           "monthlyPay": {
-            "label": "Bruttopalkka €/kk",
+            "label": "Bruttopalkka",
             "placeholder": "Palkka",
             "view": "Bruttopalkka {{monthlyPay}} €/kk"
           },
           "otherExpenses": {
-            "label": "Sivukulut €/kk",
+            "label": "Sivukulut",
             "placeholder": "Sivukulut",
             "view": "Sivukulut {{otherExpenses}} €/kk"
           },

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -175,6 +175,7 @@
         "heading5Employment": "Työsuhde",
         "heading5Assignment": "Toimeksianto",
         "heading5EmploymentSub1": "Palkkauskustannukset",
+        "salaryExpensesExplanation": "Bruttopalkka ja sivukulut ilmoitetaan euroina kuukaudessa, lomaraha kertasummana ",
         "tooltips": {
           "heading5Employment": "Työsuhde tooltip text",
           "heading5EmploymentSub1": "Työsuhde sub header tooltip message 1",
@@ -263,12 +264,12 @@
             "placeholder": "Työehtosopimus"
           },
           "monthlyPay": {
-            "label": "Bruttopalkka €/kk",
+            "label": "Bruttopalkka",
             "placeholder": "Palkka",
             "view": "Bruttopalkka {{monthlyPay}} €/kk"
           },
           "otherExpenses": {
-            "label": "Sivukulut €/kk",
+            "label": "Sivukulut",
             "placeholder": "Sivukulut",
             "view": "Sivukulut {{otherExpenses}} €/kk"
           },

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -374,27 +374,32 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           </SelectionGroup>
         </$GridCell>
 
-        {formik.values.benefitType === BENEFIT_TYPES.SALARY 
-          && formik.values.apprenticeshipProgram === true && (
-          <$GridCell $colSpan={6}>
-            <$Notification
-              label={t(`${translationsBase}.notifications.salaryBenefit.label`)}
-            >
-              {t(`${translationsBase}.notifications.salaryBenefit.content`)}
-            </$Notification>
-          </$GridCell>
-        )}
+        {formik.values.benefitType === BENEFIT_TYPES.SALARY &&
+          formik.values.apprenticeshipProgram === true && (
+            <$GridCell $colSpan={6}>
+              <$Notification
+                label={t(
+                  `${translationsBase}.notifications.salaryBenefit.label`
+                )}
+              >
+                {t(`${translationsBase}.notifications.salaryBenefit.content`)}
+              </$Notification>
+            </$GridCell>
+          )}
       </FormSection>
 
       <FormSection header={t(`${translationsBase}.heading4`)}>
         <$GridCell $colSpan={8}>
           {!formik.values.benefitType
             ? t(`${translationsBase}.messages.selectBenefitType`)
-            : formik.values.benefitType === BENEFIT_TYPES.SALARY 
-              && formik.values.apprenticeshipProgram === false
+            : formik.values.benefitType === BENEFIT_TYPES.SALARY &&
+              formik.values.apprenticeshipProgram === false
             ? ''
-            : t(`${translationsBase}.messages.${camelCase(formik.values.benefitType)}Selected`
-          )}
+            : t(
+                `${translationsBase}.messages.${camelCase(
+                  formik.values.benefitType
+                )}Selected`
+              )}
         </$GridCell>
         <$GridCell $colStart={1} $colSpan={2}>
           <DateInput
@@ -558,6 +563,10 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
                   `${translationsBase}.tooltips.heading5EmploymentSub1`
                 )}
               />
+            </$GridCell>
+
+            <$GridCell $colSpan={12}>
+              {t(`${translationsBase}.salaryExpensesExplanation`)}
             </$GridCell>
 
             <$GridCell $colSpan={2}>


### PR DESCRIPTION
## Description :sparkles:
Add extra explanation row for salary related expenses

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
<img width="1097" alt="Screenshot 2022-01-27 at 11 01 49" src="https://user-images.githubusercontent.com/23077311/151326203-af00d7be-b6ec-4911-8b61-2296aec98ee5.png">

## Additional notes :spiral_notepad:
