### PR TITLE
Yjdh-350: Show creation error pages

### DIFF
--- a/frontend/kesaseteli/youth/browser-tests/actions/send-youth-application.ts
+++ b/frontend/kesaseteli/youth/browser-tests/actions/send-youth-application.ts
@@ -3,7 +3,6 @@ import TestController from 'testcafe';
 
 import YouthFormData from '../../src/types/youth-form-data';
 import { getIndexPageComponents } from '../index-page/indexPage.components';
-import { getThankYouPageComponents } from '../thank-you-page/thankYouPage.components';
 
 const sendYouthApplication = async (
   t: TestController,
@@ -33,8 +32,6 @@ const sendYouthApplication = async (
   await indexPage.actions.typeInput('email', formData.email);
   await indexPage.actions.toggleAcceptTermsAndConditions();
   await indexPage.actions.clickSendButton();
-  const thankYouPage = await getThankYouPageComponents(t);
-  await thankYouPage.expectations.isLoaded();
 };
 
 export default sendYouthApplication;

--- a/frontend/kesaseteli/youth/browser-tests/index-page/indexPage.testcafe.ts
+++ b/frontend/kesaseteli/youth/browser-tests/index-page/indexPage.testcafe.ts
@@ -11,7 +11,7 @@ import sendYouthApplication from '../actions/send-youth-application';
 import { getActivatedPageComponents } from '../notification-page/activatedPage.components';
 import { getAlreadyActivatedPageComponents } from '../notification-page/alreadyActivatedPage.components';
 import { getAlreadyAssignedPageComponents } from '../notification-page/alreadyAssignedPage.components';
-import { getEmailInUsePaegComponents } from '../notification-page/emailInUsePage.components';
+import { getEmailInUsePageComponents } from '../notification-page/emailInUsePage.components';
 import { getExpiredPageComponents } from '../notification-page/expiredPage.components';
 import { getThankYouPageComponents } from '../thank-you-page/thankYouPage.components';
 import {
@@ -50,7 +50,7 @@ test('sending two applications with same email redirects latter to email_in_use 
   await indexPage.expectations.isLoaded();
   const secondFormData = { ...fakeYouthFormData(), email: formData.email };
   await sendYouthApplication(t, secondFormData);
-  const emailInUsePage = await getEmailInUsePaegComponents(t);
+  const emailInUsePage = await getEmailInUsePageComponents(t);
   await emailInUsePage.expectations.isLoaded();
 });
 

--- a/frontend/kesaseteli/youth/browser-tests/index-page/indexPage.testcafe.ts
+++ b/frontend/kesaseteli/youth/browser-tests/index-page/indexPage.testcafe.ts
@@ -40,7 +40,7 @@ test('can send application and return to front page', async (t) => {
   await indexPage.expectations.isLoaded();
 });
 
-test.skip('sending two applications with same email redirects latter to email_in_use page', async (t) => {
+test('sending two applications with same email redirects latter to email_in_use page', async (t) => {
   const indexPage = await getIndexPageComponents(t);
   await indexPage.expectations.isLoaded();
   const formData = fakeYouthFormData();
@@ -86,7 +86,7 @@ if (!isRealIntegrationsEnabled()) {
     await alreadyActivatedPage.expectations.isLoaded();
   });
 
-  test.only('shows expiration page if kesäseteli is activated too late', async (t) => {
+  test('shows expiration page if kesäseteli is activated too late', async (t) => {
     const indexPage = await getIndexPageComponents(t);
     await indexPage.expectations.isLoaded();
     const formData = fakeYouthFormData();

--- a/frontend/kesaseteli/youth/browser-tests/notification-page/alreadyAssignedPage.components.ts
+++ b/frontend/kesaseteli/youth/browser-tests/notification-page/alreadyAssignedPage.components.ts
@@ -1,0 +1,8 @@
+import TestController from 'testcafe';
+
+import { getNotificationPageComponents } from './notificationPage.components';
+
+export const getAlreadyAssignedPageComponents = async (t: TestController) =>
+  getNotificationPageComponents(t, {
+    headerText: /hups! antamallasi tiedoilla on jo myönnetty kesäseteli/i,
+  });

--- a/frontend/kesaseteli/youth/browser-tests/notification-page/emailInUsePage.components.ts
+++ b/frontend/kesaseteli/youth/browser-tests/notification-page/emailInUsePage.components.ts
@@ -1,0 +1,8 @@
+import TestController from 'testcafe';
+
+import { getNotificationPageComponents } from './notificationPage.components';
+
+export const getEmailInUsePaegComponents = async (t: TestController) =>
+  getNotificationPageComponents(t, {
+    headerText: /hups!/i,
+  });

--- a/frontend/kesaseteli/youth/browser-tests/notification-page/emailInUsePage.components.ts
+++ b/frontend/kesaseteli/youth/browser-tests/notification-page/emailInUsePage.components.ts
@@ -2,7 +2,7 @@ import TestController from 'testcafe';
 
 import { getNotificationPageComponents } from './notificationPage.components';
 
-export const getEmailInUsePaegComponents = async (t: TestController) =>
+export const getEmailInUsePageComponents = async (t: TestController) =>
   getNotificationPageComponents(t, {
     headerText: /hups!/i,
   });

--- a/frontend/kesaseteli/youth/browser-tests/utils/url.utils.ts
+++ b/frontend/kesaseteli/youth/browser-tests/utils/url.utils.ts
@@ -1,10 +1,14 @@
 import { getUrl } from '@frontend/shared/browser-tests/utils/url.utils';
-import { ClientFunction } from 'testcafe';
+import TestController, { ClientFunction } from 'testcafe';
 
 const goBack = ClientFunction(() => window.history.back());
 
 export const getFrontendUrl = (path = ''): string =>
   getUrl(process.env.YOUTH_URL ?? 'https://localhost:3100', path);
+
+export const goToFrontPage = async (t: TestController): Promise<void> => {
+  t.navigateTo(getFrontendUrl());
+};
 
 export const clickBrowserBackButton = async (): Promise<void> => {
   await goBack();

--- a/frontend/kesaseteli/youth/browser-tests/utils/url.utils.ts
+++ b/frontend/kesaseteli/youth/browser-tests/utils/url.utils.ts
@@ -7,7 +7,7 @@ export const getFrontendUrl = (path = ''): string =>
   getUrl(process.env.YOUTH_URL ?? 'https://localhost:3100', path);
 
 export const goToFrontPage = async (t: TestController): Promise<void> => {
-  t.navigateTo(getFrontendUrl());
+  await t.navigateTo(getFrontendUrl());
 };
 
 export const clickBrowserBackButton = async (): Promise<void> => {

--- a/frontend/kesaseteli/youth/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/index.test.tsx
@@ -7,13 +7,13 @@ import {
 } from 'kesaseteli/youth/__tests__/utils/backend/backend-nocks';
 import getIndexPageApi from 'kesaseteli/youth/__tests__/utils/components/get-index-page-api';
 import renderPage from 'kesaseteli/youth/__tests__/utils/components/render-page';
+import CREATION_ERROR_TYPES from 'kesaseteli/youth/components/constants/creation-error-types';
 import YouthIndex from 'kesaseteli/youth/pages';
 import headerApi from 'kesaseteli-shared/__tests__/utils/component-apis/header-api';
 import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
 import React from 'react';
 import { waitFor } from 'shared/__tests__/utils/test-utils';
 import { DEFAULT_LANGUAGE, Language } from 'shared/i18n/i18n';
-import CREATION_ERROR_TYPES from 'kesaseteli/youth/components/constants/creation-error-types';
 
 const texts = {
   required: /tieto puuttuu/i,

--- a/frontend/kesaseteli/youth/src/__tests__/utils/backend/backend-nocks.ts
+++ b/frontend/kesaseteli/youth/src/__tests__/utils/backend/backend-nocks.ts
@@ -1,6 +1,7 @@
 import faker from 'faker';
 import { fakeSchools } from 'kesaseteli/youth/__tests__/utils/fake-objects';
 import YouthApplication from 'kesaseteli/youth/types/youth-application';
+import { ErrorType } from 'kesaseteli/youth/types/youth-application-creation-error';
 import {
   BackendEndpoint,
   getBackendDomain,
@@ -60,13 +61,15 @@ export const expectToCreateYouthApplication = (
     );
 
 export const expectToReplyErrorWhenCreatingYouthApplication =
-  (errorCode: 400 | 404 | 500) =>
+  (errorCode: 400 | 404 | 500, errorType?: ErrorType) =>
   (application: YouthApplication): nock.Scope => {
     consoleSpy = jest.spyOn(console, 'error').mockImplementation();
     return nock(getBackendDomain())
       .post(BackendEndpoint.YOUTH_APPLICATIONS, application)
       .reply(
         errorCode,
-        'This is a create youth application backend test error. Please ignore this error message.'
+        errorType
+          ? () => ({ code: errorType })
+          : 'This is a create youth application backend test error. Please ignore this error message.'
       );
   };

--- a/frontend/kesaseteli/youth/src/components/constants/creation-error-codes.ts
+++ b/frontend/kesaseteli/youth/src/components/constants/creation-error-codes.ts
@@ -1,3 +1,0 @@
-const CREATION_ERROR_CODES = ['already_assigned', 'email_in_use'] as const;
-
-export default CREATION_ERROR_CODES;

--- a/frontend/kesaseteli/youth/src/components/constants/creation-error-codes.ts
+++ b/frontend/kesaseteli/youth/src/components/constants/creation-error-codes.ts
@@ -1,0 +1,3 @@
+const CREATION_ERROR_CODES = ['already_assigned', 'email_in_use'] as const;
+
+export default CREATION_ERROR_CODES;

--- a/frontend/kesaseteli/youth/src/components/constants/creation-error-types.ts
+++ b/frontend/kesaseteli/youth/src/components/constants/creation-error-types.ts
@@ -1,0 +1,3 @@
+const CREATION_ERROR_TYPES = ['already_assigned', 'email_in_use'] as const;
+
+export default CREATION_ERROR_TYPES;

--- a/frontend/kesaseteli/youth/src/components/forms/YouthForm.tsx
+++ b/frontend/kesaseteli/youth/src/components/forms/YouthForm.tsx
@@ -3,6 +3,7 @@ import useCreateYouthApplicationQuery from 'kesaseteli/youth/hooks/backend/useCr
 import useRegisterInput from 'kesaseteli/youth/hooks/useRegisterInput';
 import YouthApplication from 'kesaseteli/youth/types/youth-application';
 import YouthFormData from 'kesaseteli/youth/types/youth-form-data';
+import { useRouter } from 'next/router';
 import { Trans, useTranslation } from 'next-i18next';
 import React from 'react';
 import SaveFormButton from 'shared/components/forms/buttons/SaveFormButton';
@@ -19,11 +20,18 @@ import {
   POSTAL_CODE_REGEX,
 } from 'shared/constants';
 import isRealIntegrationsEnabled from 'shared/flags/is-real-integrations-enabled';
+import useErrorHandler from 'shared/hooks/useErrorHandler';
 import useGoToPage from 'shared/hooks/useGoToPage';
+import useLocale from 'shared/hooks/useLocale';
+import { isYouthApplicationCreationError } from 'kesaseteli/youth/utils/type-guards';
+import { assertUnreachable } from 'shared/utils/typescript.utils';
 
 const YouthForm: React.FC = () => {
   const { t } = useTranslation();
+  const router = useRouter();
+  const locale = useLocale();
   const register = useRegisterInput<YouthFormData>();
+  const handleDefaultError = useErrorHandler(false);
 
   const goToPage = useGoToPage();
   const handleSaveSuccess = React.useCallback(
@@ -35,6 +43,26 @@ const YouthForm: React.FC = () => {
       goToPage(url);
     },
     [goToPage]
+  );
+
+  const handleErrorResponse = React.useCallback(
+    (error: Error | unknown) => {
+      if (isYouthApplicationCreationError(error)) {
+        const errorCode = error.response.data.code;
+        switch (errorCode) {
+          case 'already_assigned':
+          case 'email_in_use':
+            void router.push(`${locale}/${encodeURIComponent(errorCode)}`);
+            return;
+
+          default:
+            assertUnreachable(errorCode);
+        }
+      } else {
+        handleDefaultError(error);
+      }
+    },
+    [handleDefaultError, locale, router]
   );
 
   return (
@@ -114,6 +142,7 @@ const YouthForm: React.FC = () => {
             <SaveFormButton
               saveQuery={useCreateYouthApplicationQuery()}
               onSuccess={handleSaveSuccess}
+              onError={handleErrorResponse}
             >
               {t(`common:youthApplication.form.sendButton`)}
             </SaveFormButton>

--- a/frontend/kesaseteli/youth/src/components/forms/YouthForm.tsx
+++ b/frontend/kesaseteli/youth/src/components/forms/YouthForm.tsx
@@ -3,6 +3,7 @@ import useCreateYouthApplicationQuery from 'kesaseteli/youth/hooks/backend/useCr
 import useRegisterInput from 'kesaseteli/youth/hooks/useRegisterInput';
 import YouthApplication from 'kesaseteli/youth/types/youth-application';
 import YouthFormData from 'kesaseteli/youth/types/youth-form-data';
+import { isYouthApplicationCreationError } from 'kesaseteli/youth/utils/type-guards';
 import { useRouter } from 'next/router';
 import { Trans, useTranslation } from 'next-i18next';
 import React from 'react';
@@ -23,7 +24,6 @@ import isRealIntegrationsEnabled from 'shared/flags/is-real-integrations-enabled
 import useErrorHandler from 'shared/hooks/useErrorHandler';
 import useGoToPage from 'shared/hooks/useGoToPage';
 import useLocale from 'shared/hooks/useLocale';
-import { isYouthApplicationCreationError } from 'kesaseteli/youth/utils/type-guards';
 import { assertUnreachable } from 'shared/utils/typescript.utils';
 
 const YouthForm: React.FC = () => {

--- a/frontend/kesaseteli/youth/src/types/youth-application-creation-error.d.ts
+++ b/frontend/kesaseteli/youth/src/types/youth-application-creation-error.d.ts
@@ -1,0 +1,12 @@
+import CREATION_ERROR_CODES from 'kesaseteli/youth/components/constants/creation-error-codes';
+
+type YouthApplicationCreationError = {
+  response: {
+    data: {
+      message: string;
+      code: typeof CREATION_ERROR_CODES[number];
+    };
+  };
+};
+
+export default YouthApplicationCreationError;

--- a/frontend/kesaseteli/youth/src/types/youth-application-creation-error.d.ts
+++ b/frontend/kesaseteli/youth/src/types/youth-application-creation-error.d.ts
@@ -1,10 +1,12 @@
-import CREATION_ERROR_CODES from 'kesaseteli/youth/components/constants/creation-error-codes';
+import CREATION_ERROR_TYPES from 'kesaseteli/youth/components/constants/creation-error-types';
+
+export type ErrorType = typeof CREATION_ERROR_TYPES[number];
 
 type YouthApplicationCreationError = {
   response: {
     data: {
       message: string;
-      code: typeof CREATION_ERROR_CODES[number];
+      code: ErrorType;
     };
   };
 };

--- a/frontend/kesaseteli/youth/src/utils/type-guards.ts
+++ b/frontend/kesaseteli/youth/src/utils/type-guards.ts
@@ -1,8 +1,6 @@
 import Axios from 'axios';
 import CREATION_ERROR_TYPES from 'kesaseteli/youth/components/constants/creation-error-types';
-import YouthApplicationCreationError, {
-  ErrorType,
-} from 'kesaseteli/youth/types/youth-application-creation-error';
+import YouthApplicationCreationError from 'kesaseteli/youth/types/youth-application-creation-error';
 
 export const isYouthApplicationCreationError = (
   error: unknown

--- a/frontend/kesaseteli/youth/src/utils/type-guards.ts
+++ b/frontend/kesaseteli/youth/src/utils/type-guards.ts
@@ -1,0 +1,11 @@
+import Axios from 'axios';
+import CREATION_ERROR_CODES from 'kesaseteli/youth/components/constants/creation-error-codes';
+import YouthApplicationCreationError from 'kesaseteli/youth/types/youth-application-creation-error';
+
+export const isYouthApplicationCreationError = (
+  error: unknown
+): error is YouthApplicationCreationError =>
+  Axios.isAxiosError(error) &&
+  Boolean(
+    error.response && CREATION_ERROR_CODES.includes(error.response.data.code)
+  );

--- a/frontend/kesaseteli/youth/src/utils/type-guards.ts
+++ b/frontend/kesaseteli/youth/src/utils/type-guards.ts
@@ -1,11 +1,16 @@
 import Axios from 'axios';
 import CREATION_ERROR_TYPES from 'kesaseteli/youth/components/constants/creation-error-types';
-import YouthApplicationCreationError from 'kesaseteli/youth/types/youth-application-creation-error';
+import YouthApplicationCreationError, {
+  ErrorType,
+} from 'kesaseteli/youth/types/youth-application-creation-error';
 
 export const isYouthApplicationCreationError = (
   error: unknown
 ): error is YouthApplicationCreationError =>
   Axios.isAxiosError(error) &&
   Boolean(
-    error.response && CREATION_ERROR_TYPES.includes(error.response.data.code)
+    error.response &&
+      CREATION_ERROR_TYPES.includes(
+        (error as YouthApplicationCreationError).response.data.code
+      )
   );

--- a/frontend/kesaseteli/youth/src/utils/type-guards.ts
+++ b/frontend/kesaseteli/youth/src/utils/type-guards.ts
@@ -1,5 +1,5 @@
 import Axios from 'axios';
-import CREATION_ERROR_CODES from 'kesaseteli/youth/components/constants/creation-error-codes';
+import CREATION_ERROR_TYPES from 'kesaseteli/youth/components/constants/creation-error-types';
 import YouthApplicationCreationError from 'kesaseteli/youth/types/youth-application-creation-error';
 
 export const isYouthApplicationCreationError = (
@@ -7,5 +7,5 @@ export const isYouthApplicationCreationError = (
 ): error is YouthApplicationCreationError =>
   Axios.isAxiosError(error) &&
   Boolean(
-    error.response && CREATION_ERROR_CODES.includes(error.response.data.code)
+    error.response && CREATION_ERROR_TYPES.includes(error.response.data.code)
   );

--- a/frontend/shared/src/components/forms/buttons/SaveFormButton.tsx
+++ b/frontend/shared/src/components/forms/buttons/SaveFormButton.tsx
@@ -11,10 +11,11 @@ import useErrorHandler from 'shared/hooks/useErrorHandler';
 
 type Props<FormData, BackendResponseData> = Omit<
   CommonButtonProps,
-  'onClick'
+  'onClick' | 'onError'
 > & {
   saveQuery: UseMutationResult<BackendResponseData, unknown, FormData>;
   onSuccess: (response: BackendResponseData) => void | Promise<void>;
+  onError?: (error: Error | unknown) => void;
   onInvalidForm?: SubmitErrorHandler<FormData>;
 };
 
@@ -24,6 +25,7 @@ const SaveFormButton = <
 >({
   saveQuery,
   onSuccess,
+  onError,
   onInvalidForm,
   children,
   disabled,
@@ -33,7 +35,7 @@ const SaveFormButton = <
 }: Props<FormData, BackendResponseData>): React.ReactElement => {
   const { handleSubmit, formState } = useFormContext<FormData>();
 
-  const onError = useErrorHandler(false);
+  const onDefaultError = useErrorHandler(false);
 
   const isSaving = React.useMemo(
     () => saveQuery.isLoading || formState.isSubmitting,
@@ -47,7 +49,7 @@ const SaveFormButton = <
             void onSuccess(responseData);
           }
         },
-        onError,
+        onError: onError ?? onDefaultError,
       });
     },
     [saveQuery, onSuccess, onError]
@@ -68,6 +70,7 @@ const SaveFormButton = <
 
 SaveFormButton.defaultProps = {
   onInvalidForm: noop,
+  onError: undefined,
 };
 
 export default SaveFormButton;

--- a/frontend/shared/src/components/forms/buttons/SaveFormButton.tsx
+++ b/frontend/shared/src/components/forms/buttons/SaveFormButton.tsx
@@ -52,7 +52,7 @@ const SaveFormButton = <
         onError: onError ?? onDefaultError,
       });
     },
-    [saveQuery, onSuccess, onError]
+    [saveQuery, onError, onDefaultError, onSuccess]
   );
 
   return (

--- a/frontend/shared/src/utils/typescript.utils.ts
+++ b/frontend/shared/src/utils/typescript.utils.ts
@@ -1,0 +1,3 @@
+export const assertUnreachable = (param: never, message?: string): never => {
+  throw new Error(`${message || 'Unknown parameter'}: ${param as string}`);
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -13129,7 +13129,7 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-testcafe-browser-tools@2.0.21, testcafe-browser-tools@^2.0.21:
+testcafe-browser-tools@2.0.21:
   version "2.0.21"
   resolved "https://registry.yarnpkg.com/testcafe-browser-tools/-/testcafe-browser-tools-2.0.21.tgz#0e15e15dea4b5132b345386047f3a17acf9b10d9"
   integrity sha512-dsaUgUY4i/VLKSexh0w8ZyvDGWd3+LfoEysN/nFCUufseiwGvvbBpsNSAV7XZN12GpExG3mCilaQDuJNBKs4CQ==


### PR DESCRIPTION
## Description :sparkles:
Show specific error pages when
-  email is already in use in other application  
- there is an already registered kesaseteli with same ssn or email

Also including browser tests to these special cases
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
