### PR TITLE
Use Finnish locale in postgres in local development

### DIFF
--- a/docker-compose.benefit.yml
+++ b/docker-compose.benefit.yml
@@ -1,12 +1,16 @@
 version: "3.8"
 services:
   postgres:
-    image: postgres:12
+    build:
+      context: ./backend
+      dockerfile: ./docker/finnish_postgres.Dockerfile
     restart: on-failure
     environment:
       POSTGRES_USER: benefit
       POSTGRES_PASSWORD: benefit
       POSTGRES_DB: benefit
+      LC_COLLATE: 'fi_FI.UTF-8'
+      LC_CTYPE: 'fi_FI.UTF-8'
     ports:
       - 5434:5432
     volumes:


### PR DESCRIPTION
## Description :sparkles:

Use Finnish locale for the Postgres instance used for local development

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
