### PR TITLE
YJDH-459 | KS-Backend: Compile messages in Docker image build

### DIFF
--- a/backend/docker/kesaseteli.Dockerfile
+++ b/backend/docker/kesaseteli.Dockerfile
@@ -41,6 +41,11 @@ ENV DEV_SERVER=1
 COPY --chown=appuser:appuser /kesaseteli/ /app/
 
 USER appuser
+
+# Compile messages as a part of Docker image build so it doesn't have to be done during
+# container startup. This removes the need for writeable localization directories.
+RUN django-admin compilemessages
+
 EXPOSE 8000/tcp
 
 # ==============================
@@ -52,4 +57,9 @@ COPY --chown=appuser:appuser /kesaseteli/ /app/
 RUN SECRET_KEY="only-used-for-collectstatic" python manage.py collectstatic
 
 USER appuser
+
+# Compile messages as a part of Docker image build so it doesn't have to be done during
+# container startup. This removes the need for writeable localization directories.
+RUN django-admin compilemessages
+
 EXPOSE 8000/tcp

--- a/backend/kesaseteli/docker-entrypoint.sh
+++ b/backend/kesaseteli/docker-entrypoint.sh
@@ -30,9 +30,6 @@ if [[ "$CREATE_SUPERUSER" = "1" ]]; then
     fi
 fi
 
-# Compile messages to make translations work
-python ./manage.py compilemessages
-
 # Start server
 if [[ ! -z "$@" ]]; then
     "$@"

--- a/docker-compose.employer.yml
+++ b/docker-compose.employer.yml
@@ -20,6 +20,11 @@ services:
       context: ./backend
       dockerfile: ./docker/kesaseteli.Dockerfile
       target: development
+    # Entrypoint is overridden because although "django-admin compilemessages" is run as
+    # a part of Docker image build, the resulting files are overridden by volume mount
+    # in this docker-compose file and thus have to be regenerated.
+    entrypoint:
+      bash -c "django-admin compilemessages && /entrypoint/docker-entrypoint.sh"
     env_file:
       - .env.kesaseteli
     environment:

--- a/docker-compose.handler.yml
+++ b/docker-compose.handler.yml
@@ -22,6 +22,11 @@ services:
       context: ./backend
       dockerfile: ./docker/kesaseteli.Dockerfile
       target: development
+    # Entrypoint is overridden because although "django-admin compilemessages" is run as
+    # a part of Docker image build, the resulting files are overridden by volume mount
+    # in this docker-compose file and thus have to be regenerated.
+    entrypoint:
+      bash -c "django-admin compilemessages && /entrypoint/docker-entrypoint.sh"
     env_file:
       - .env.kesaseteli
     environment:

--- a/docker-compose.youth.yml
+++ b/docker-compose.youth.yml
@@ -22,6 +22,11 @@ services:
       context: ./backend
       dockerfile: ./docker/kesaseteli.Dockerfile
       target: development
+    # Entrypoint is overridden because although "django-admin compilemessages" is run as
+    # a part of Docker image build, the resulting files are overridden by volume mount
+    # in this docker-compose file and thus have to be regenerated.
+    entrypoint:
+      bash -c "django-admin compilemessages && /entrypoint/docker-entrypoint.sh"
     env_file:
       - .env.kesaseteli
     environment:


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Compile messages in Docker image build

Compile messages in Docker image build in kesaseteli.Dockerfile to
remove the need for writeable localization directories in the Docker
container. This should fix the error in Platta environment about not
being able to write the generated django.mo files.

Also override the entrypoints in the docker-compose files using the
Kesäseteli backend because although "django-admin compilemessages" is
now run as a part of Docker image build, the resulting files are
overridden by the volume mounts in the docker-compose files and thus
have to regenerated.

## Issues :bug:

YJDH-459

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
