### PR TITLE
HL-421: reduce review environment build failures by limiting concurrency of jobs

### DIFF
--- a/.github/workflows/bf-review.yml
+++ b/.github/workflows/bf-review.yml
@@ -60,6 +60,9 @@ jobs:
             context: ./frontend
             dockerfile: ./frontend/benefit/handler/Dockerfile
             port: 3100
+    concurrency:
+      group: ${{ github.event.pull_request.number }}-${{ matrix.service }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     name: Build
     steps:
@@ -97,6 +100,9 @@ jobs:
             dockerfile: ./frontend/benefit/handler/Dockerfile
             database: false
             port: 3100
+    concurrency:
+      group: ${{ github.event.pull_request.number }}-${{ matrix.service }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     needs: build
     name: Review
@@ -113,7 +119,6 @@ jobs:
           K8S_SECRET_ENCRYPTION_KEY: ${{ secrets.K8S_SECRET_ENCRYPTION_KEY_REVIEW }}
           K8S_SECRET_SOCIAL_SECURITY_NUMBER_HASH_KEY: ${{ secrets.K8S_SECRET_SOCIAL_SECURITY_NUMBER_HASH_KEY_REVIEW }}
           K8S_SECRET_PREVIOUS_BENEFITS_SOCIAL_SECURITY_NUMBER_HASH_KEY: ${{ secrets.K8S_SECRET_SOCIAL_SECURITY_NUMBER_HASH_KEY_REVIEW }}
-
         run: |
           echo "K8S_SECRET_ALLOWED_HOSTS=*" >> $GITHUB_ENV
           echo "K8S_SECRET_CREATE_SUPERUSER=${{ secrets.K8S_SECRET_CREATE_SUPERUSER_REVIEW }}" >> $GITHUB_ENV

--- a/.github/workflows/ks-review.yml
+++ b/.github/workflows/ks-review.yml
@@ -66,6 +66,9 @@ jobs:
             context: ./frontend
             dockerfile: ./frontend/kesaseteli/handler/Dockerfile
             port: 3200
+    concurrency:
+      group: ${{ github.event.pull_request.number }}-${{ matrix.service }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     name: Build
     steps:
@@ -111,6 +114,9 @@ jobs:
             dockerfile: ./frontend/kesaseteli/handler/Dockerfile
             database: false
             port: 3200
+    concurrency:
+      group: ${{ github.event.pull_request.number }}-${{ matrix.service }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     needs: build
     name: Review

--- a/.github/workflows/te-review.yml
+++ b/.github/workflows/te-review.yml
@@ -69,6 +69,9 @@ jobs:
             context: ./frontend
             dockerfile: ./frontend/tet/admin/Dockerfile
             port: 3000
+    concurrency:
+      group: ${{ github.event.pull_request.number }}-${{ matrix.service }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     name: Build
     steps:
@@ -114,6 +117,9 @@ jobs:
             dockerfile: ./frontend/tet/admin/Dockerfile
             database: false
             port: 3000
+    concurrency:
+      group: ${{ github.event.pull_request.number }}-${{ matrix.service }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     needs: build
     name: Review


### PR DESCRIPTION
## Description :sparkles:
Juho Saarinen commented in Slack: "Basically lock should be namespace + service"

NOTE: If this seems to work, I'll add the same config for other YJDH subprojects

## Issues :bug: HL-421

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
