### PR TITLE
YJDH-446 | KS-Backend: Set handler permission to mock flag state

### DIFF
--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -68,10 +68,7 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
 
     @action(methods=["get"], detail=True)
     def process(self, request, pk=None) -> HttpResponse:
-        try:
-            YouthApplication.objects.get(pk=pk)
-        except (exceptions.ValidationError, YouthApplication.DoesNotExist):
-            return HttpResponse(status=status.HTTP_404_NOT_FOUND)
+        youth_application: YouthApplication = self.get_object()  # noqa: F841
 
         # TODO: Implement
         return HttpResponse(status=status.HTTP_501_NOT_IMPLEMENTED)
@@ -79,10 +76,7 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
     @transaction.atomic
     @action(methods=["get"], detail=True)
     def activate(self, request, pk=None) -> HttpResponse:
-        try:
-            youth_application = YouthApplication.objects.select_for_update().get(pk=pk)
-        except (exceptions.ValidationError, YouthApplication.DoesNotExist):
-            return HttpResponse(status=status.HTTP_404_NOT_FOUND)
+        youth_application: YouthApplication = self.get_object()
 
         # Lock same person's applications to prevent activation of more than one of them
         same_persons_apps = YouthApplication.objects.select_for_update().filter(

--- a/backend/kesaseteli/common/permissions.py
+++ b/backend/kesaseteli/common/permissions.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework.permissions import BasePermission
 
 
@@ -13,8 +14,13 @@ class DenyAll(BasePermission):
 class IsHandler(BasePermission):
     """
     Is the user a youth application / youth summer voucher handler?
+
+    NOTE: If NEXT_PUBLIC_MOCK_FLAG is set then everyone is a handler.
     """
 
     def has_permission(self, request, view):
+        if settings.NEXT_PUBLIC_MOCK_FLAG:
+            return True
+
         # TODO: Implement
-        return True
+        return False

--- a/backend/shared/shared/common/tests/conftest.py
+++ b/backend/shared/shared/common/tests/conftest.py
@@ -45,6 +45,11 @@ def staff_user():
 
 
 @pytest.fixture()
+def superuser_user():
+    return UserFactory(is_superuser=True)
+
+
+@pytest.fixture()
 def other_user():
     return UserFactory()
 
@@ -59,6 +64,13 @@ def client():
 def staff_client(staff_user):
     client = Client()
     client.force_login(staff_user)
+    return client
+
+
+@pytest.fixture
+def superuser_client(superuser_user):
+    client = Client()
+    client.force_login(superuser_user)
     return client
 
 


### PR DESCRIPTION
## Description :sparkles:

Before everyone was a handler.
Now everyone is a handler if the mock flag is set, otherwise no one is.

Parametrize tests with/without mock flag and with different clients:
 - test_youth_applications_process_valid_pk
   - Should return 403 Forbidden for all without mock flag
   - Should return 501 Not implemented for all with mock flag
 - test_youth_applications_detail_valid_pk
   - Should return 403 Forbidden for all without mock flag
   - Should return 200 OK for all with mock flag

Rename invalid_pk->unused_pk & parametrize tests with/without mock flag:
 - test_youth_applications_process_unused_pk
   - Use random UUID rather than "invalid value" string as primary key
 - test_youth_applications_detail_unused_pk
   - Use random UUID rather than "invalid value" string as primary key

Test only with mock flag:
 - test_youth_applications_detail_response_field
 - test_youth_applications_detail_encrypted_vtj_json

Simplify YouthApplicationViewSet's process and activate functions by
making use of GenericAPIView.get_object().

## Issues :bug:

YJDH-446

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
