### PR TITLE
HL-450: add duration_in_months_rounded to the application API

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -565,6 +565,7 @@ class BaseApplicationSerializer(serializers.ModelSerializer):
             "ahjo_decision",
             "unread_messages_count",
             "warnings",
+            "duration_in_months_rounded",
         ]
         read_only_fields = [
             "submitted_at",
@@ -586,6 +587,7 @@ class BaseApplicationSerializer(serializers.ModelSerializer):
             "status_last_changed_at",
             "unread_messages_count",
             "warnings",
+            "duration_in_months_rounded",
         ]
         extra_kwargs = {
             "company_name": {

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -4,6 +4,7 @@ import os
 import re
 import tempfile
 from datetime import date, datetime
+from decimal import Decimal
 from unittest import mock
 
 import pytest
@@ -27,6 +28,7 @@ from applications.tests.factories import ApplicationFactory
 from calculator.models import Calculation
 from common.tests.conftest import *  # noqa
 from common.tests.conftest import get_client_user
+from common.utils import duration_in_months
 from companies.tests.conftest import *  # noqa
 from companies.tests.factories import CompanyFactory
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -133,6 +135,9 @@ def test_application_single_read_as_applicant(api_client, application):
     assert response.data["ahjo_decision"] is None
     assert response.data["application_number"] is not None
     assert "batch" not in response.data
+    assert Decimal(response.data["duration_in_months_rounded"]) == duration_in_months(
+        application.start_date, application.end_date, decimal_places=2
+    )
     assert response.status_code == 200
 
 

--- a/backend/benefit/calculator/tests/test_models.py
+++ b/backend/benefit/calculator/tests/test_models.py
@@ -8,6 +8,7 @@ from calculator.models import (
     TrainingCompensation,
 )
 from common.exceptions import BenefitAPIException
+from common.utils import duration_in_months
 from helsinkibenefit.tests.conftest import *  # noqa
 
 
@@ -15,6 +16,13 @@ def test_calculation_model(calculation):
     assert Calculation.objects.count() == 1
     assert calculation.application
     assert calculation.rows.count() == 4
+    assert calculation.start_date is not None and calculation.end_date is not None
+    assert calculation.duration_in_months == duration_in_months(
+        calculation.start_date, calculation.end_date
+    )
+    calculation.start_date = None
+    assert calculation.duration_in_months is None
+    assert calculation.duration_in_months_rounded is None
 
 
 def test_pay_subsidy(pay_subsidy):

--- a/backend/benefit/common/utils.py
+++ b/backend/benefit/common/utils.py
@@ -155,13 +155,21 @@ class DurationMixin:
 
     @property
     def duration_in_months(self):
-        return duration_in_months(self.start_date, self.end_date)
+        return self._get_duration_in_months()
 
     @property
     def duration_in_months_rounded(self):
         # The handler's Excel file uses the number of months rounded to two decimals
         # in many calculations
-        return duration_in_months(self.start_date, self.end_date, decimal_places=2)
+        return self._get_duration_in_months(decimal_places=2)
+
+    def _get_duration_in_months(self, decimal_places=None):
+        if self.start_date and self.end_date:
+            return duration_in_months(
+                self.start_date, self.end_date, decimal_places=decimal_places
+            )
+        else:
+            return None
 
 
 # defensive programming to avoid infinite loops


### PR DESCRIPTION
## Description :sparkles:

The field is needed for display in the UI

## Issues :bug: HL-450

## Testing :alembic:
backend/benefit/applications/tests/test_applications_api.py:test_application_single_read_as_applicant

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
