### PR TITLE
HL-442: application can be returned from ACCEPTED and REJECTED statuses back to HANDLING

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -1601,7 +1601,9 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
     @transaction.atomic
     @do_delayed_calls_at_end()  # application recalculation
     def update(self, instance, validated_data):
-        if not ApplicationStatus.is_handler_editable_status(instance.status):
+        if not ApplicationStatus.is_handler_editable_status(
+            instance.status, validated_data["status"]
+        ):
             raise BenefitAPIException(
                 _("Application can not be changed in this status")
             )

--- a/backend/benefit/applications/api/v1/status_transition_validator.py
+++ b/backend/benefit/applications/api/v1/status_transition_validator.py
@@ -78,8 +78,8 @@ class HandlerApplicationStatusValidator(BaseApplicationStatusValidator):
             ApplicationStatus.CANCELLED,
         ),
         ApplicationStatus.CANCELLED: (),
-        ApplicationStatus.ACCEPTED: (),
-        ApplicationStatus.REJECTED: (),
+        ApplicationStatus.ACCEPTED: (ApplicationStatus.HANDLING,),
+        ApplicationStatus.REJECTED: (ApplicationStatus.HANDLING,),
     }
 
     ASSIGN_HANDLER_STATUSES = [

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -890,9 +890,12 @@ def test_application_status_change_as_applicant(
         (ApplicationStatus.HANDLING, ApplicationStatus.ACCEPTED, 200),
         (ApplicationStatus.HANDLING, ApplicationStatus.REJECTED, 200),
         (ApplicationStatus.HANDLING, ApplicationStatus.CANCELLED, 200),
+        (ApplicationStatus.ACCEPTED, ApplicationStatus.HANDLING, 200),
+        (ApplicationStatus.REJECTED, ApplicationStatus.HANDLING, 200),
         (ApplicationStatus.RECEIVED, ApplicationStatus.DRAFT, 400),
         (ApplicationStatus.ACCEPTED, ApplicationStatus.RECEIVED, 400),
         (ApplicationStatus.CANCELLED, ApplicationStatus.ACCEPTED, 400),
+        (ApplicationStatus.CANCELLED, ApplicationStatus.HANDLING, 400),
         (ApplicationStatus.REJECTED, ApplicationStatus.DRAFT, 400),
     ],
 )


### PR DESCRIPTION
## Description :sparkles:

The application handlers need to be able to revert their decision

## Issues :bug: HL-442

## Testing :alembic:
backend/benefit/applications/tests/test_applications_api.py:test_application_status_change_as_handler

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
