### PR TITLE
Fix not showing calculation errors in salary calculator

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -21,6 +21,7 @@ import {
   $CalculatorText,
   $DateTimeDuration,
 } from '../ApplicationReview.sc';
+import CalculatorErrors from '../calculatorErrors/CalculatorErrors';
 import { useSalaryBenefitCalculatorData } from './useSalaryBenefitCalculatorData';
 
 const SalaryBenefitCalculatorView: React.FC<
@@ -42,6 +43,7 @@ const SalaryBenefitCalculatorView: React.FC<
     getStateAidMaxPercentageSelectValue,
     paySubsidyPercentageOptions,
     getPaySubsidyPercentageSelectValue,
+    calculationsErrors,
   } = useSalaryBenefitCalculatorData(data);
 
   return (
@@ -277,6 +279,7 @@ const SalaryBenefitCalculatorView: React.FC<
 
       <$GridCell $colStart={1} $colSpan={11}>
         <$CalculatorHr />
+        <CalculatorErrors data={calculationsErrors} />
       </$GridCell>
 
       <$GridCell $colSpan={7}>


### PR DESCRIPTION
## Description :sparkles:
Fix not showing calculation errors in salary calculator

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
<img width="917" alt="Screenshot 2022-02-07 at 15 40 33" src="https://user-images.githubusercontent.com/23077311/152798911-db226d04-6ec8-43c1-94cd-76d47be70984.png">


## Additional notes :spiral_notepad:
