### PR TITLE
Fix applied dates and amount format in calculator views

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/employmentAppliedMoreView/EmploymentAppliedMoreView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentAppliedMoreView/EmploymentAppliedMoreView.tsx
@@ -9,6 +9,7 @@ import {
   $Grid,
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
+import { convertToUIDateFormat } from 'shared/utils/date.utils';
 import { formatStringFloatValue } from 'shared/utils/string.utils';
 
 import {
@@ -44,8 +45,8 @@ const EmploymentAppliedMoreView: React.FC<ApplicationReviewViewProps> = ({
             {data.startDate && data.endDate && (
               <>
                 {t(`${translationsBase}.startEndDates`, {
-                  startDate: data.startDate,
-                  endDate: data.endDate,
+                  startDate: convertToUIDateFormat(data.startDate),
+                  endDate: convertToUIDateFormat(data.endDate),
                   period: formatStringFloatValue(appliedPeriod),
                 })}
               </>
@@ -130,7 +131,7 @@ const EmploymentAppliedMoreView: React.FC<ApplicationReviewViewProps> = ({
                       </$ViewField>
                       <$ViewField isBold={isTotal}>
                         {t(`${translationsBase}.tableRowValue`, {
-                          amount: row.amount,
+                          amount: formatStringFloatValue(row.amount),
                         })}
                       </$ViewField>
                     </$CalculatorTableRow>

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -13,6 +13,7 @@ import DateFieldsSeparator from 'shared/components/forms/fields/dateFieldsSepara
 import { $Checkbox } from 'shared/components/forms/fields/Fields.sc';
 import { Option } from 'shared/components/forms/fields/types';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { convertToUIDateFormat } from 'shared/utils/date.utils';
 import { formatStringFloatValue } from 'shared/utils/string.utils';
 
 import {
@@ -63,8 +64,8 @@ const SalaryBenefitCalculatorView: React.FC<
         <$GridCell $colStart={1} $colSpan={3} style={{ alignSelf: 'center' }}>
           <$ViewField>
             {t(`${translationsBase}.startEndDates`, {
-              startDate: data.startDate,
-              endDate: data.endDate,
+              startDate: convertToUIDateFormat(data.startDate),
+              endDate: convertToUIDateFormat(data.endDate),
               period: formatStringFloatValue(appliedPeriod),
             })}
           </$ViewField>
@@ -299,7 +300,9 @@ const SalaryBenefitCalculatorView: React.FC<
                   </$ViewField>
                   {!isDescriptionRowType && (
                     <$ViewField isBold={isTotalRowType}>
-                      {row.amount}
+                      {t(`${translationsBase}.tableRowValue`, {
+                        amount: formatStringFloatValue(row.amount),
+                      })}
                     </$ViewField>
                   )}
                 </$CalculatorTableRow>


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
<img width="290" alt="Screenshot 2022-02-08 at 10 47 58" src="https://user-images.githubusercontent.com/23077311/152951072-7608a19a-6902-4d26-b6f0-560883de0d5d.png">
<img width="769" alt="Screenshot 2022-02-08 at 10 47 53" src="https://user-images.githubusercontent.com/23077311/152951089-1f83be8f-c879-4156-b776-7fb8f0b3067a.png">


## Additional notes :spiral_notepad:
