### PR TITLE
HL-457: fix de_minimis_aid validation when submitting application

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -1091,7 +1091,6 @@ class BaseApplicationSerializer(serializers.ModelSerializer):
         "company_contact_person_last_name",
         "co_operation_negotiations",
         "pay_subsidy_granted",
-        "de_minimis_aid",
         "benefit_type",
         "start_date",
         "end_date",
@@ -1104,16 +1103,19 @@ class BaseApplicationSerializer(serializers.ModelSerializer):
         # newly created applications are always DRAFT
         required_fields = self.REQUIRED_FIELDS_FOR_SUBMITTED_APPLICATIONS[:]
         if (
-            OrganizationType.resolve_organization_type(
+            organization_type := OrganizationType.resolve_organization_type(
                 self.get_company(data).company_form
             )
-            == OrganizationType.ASSOCIATION
-        ):
+        ) == OrganizationType.ASSOCIATION:
             required_fields.append("association_has_business_activities")
 
             # For associations, validate() already limits the association_immediate_manager_check value to [None, True]
             # at submit time, only True is allowed.
             required_fields.append("association_immediate_manager_check")
+        elif organization_type == OrganizationType.COMPANY:
+            required_fields.append("de_minimis_aid")
+        else:
+            assert False, "unreachable"
 
         # if pay_subsidy_granted is selected, then the applicant needs to also select if
         # it's an apprenticeship_program or not


### PR DESCRIPTION
## Description :sparkles:

Association applicants need not specify the de_minimis_aid parameter

## Issues :bug: HL-457

## Testing :alembic:
backend/benefit/applications/tests/test_applications_api.py:test_submit_application_without_de_minimis_aid

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
