### PR TITLE
YJDH-482 | KS-Backend: Reduce data sent to Sentry by default

### DIFF
--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -36,6 +36,11 @@ env = environ.Env(
     MAIL_MAILGUN_API=(str, ""),
     SENTRY_DSN=(str, ""),
     SENTRY_ENVIRONMENT=(str, ""),
+    SENTRY_ATTACH_STACKTRACE=(bool, False),
+    SENTRY_MAX_BREADCRUMBS=(int, 0),
+    SENTRY_REQUEST_BODIES=(str, "never"),
+    SENTRY_SEND_DEFAULT_PII=(bool, False),
+    SENTRY_WITH_LOCALS=(bool, False),
     CORS_ALLOWED_ORIGINS=(list, []),
     CORS_ALLOW_ALL_ORIGINS=(bool, False),
     CSRF_COOKIE_DOMAIN=(str, "localhost"),
@@ -122,7 +127,18 @@ DATABASES = {"default": env.db()}
 
 CACHES = {"default": env.cache()}
 
+SENTRY_ATTACH_STACKTRACE = env.bool("SENTRY_ATTACH_STACKTRACE")
+SENTRY_MAX_BREADCRUMBS = env.int("SENTRY_MAX_BREADCRUMBS")
+SENTRY_REQUEST_BODIES = env.str("SENTRY_REQUEST_BODIES")
+SENTRY_SEND_DEFAULT_PII = env.bool("SENTRY_SEND_DEFAULT_PII")
+SENTRY_WITH_LOCALS = env.bool("SENTRY_WITH_LOCALS")
+
 sentry_sdk.init(
+    attach_stacktrace=SENTRY_ATTACH_STACKTRACE,
+    max_breadcrumbs=SENTRY_MAX_BREADCRUMBS,
+    request_bodies=SENTRY_REQUEST_BODIES,
+    send_default_pii=SENTRY_SEND_DEFAULT_PII,
+    with_locals=SENTRY_WITH_LOCALS,
     dsn=env.str("SENTRY_DSN"),
     release="n/a",
     environment=env("SENTRY_ENVIRONMENT"),


### PR DESCRIPTION
## Description :sparkles:

To reduce risk of GDPR violation reduce data sent to Sentry by default:
  - Remove stacktraces from messages but not from exceptions by default
  - Remove breadcrumbs by default
  - Remove request bodies by default
  - Remove local variables from stackframes by default
  - Turn off the adding of personally identifiable information (PII) by
    active integrations by default

Add environment variables:
 - SENTRY_ATTACH_STACKTRACE
   - Mapped to Sentry option: attach_stacktrace
   - Default: False
   - Sentry documentation:
     - "When enabled, stack traces are automatically attached to all
       messages logged. Stack traces are always attached to exceptions;
       however, when this option is set, stack traces are also sent with
       messages. This option, for instance, means that stack traces
       appear next to all log messages."
     - "This option is off by default."
     - "Grouping in Sentry is different for events with stack traces and
       without. As a result, you will get new groups as you enable or
       disable this flag for certain events."
 - SENTRY_MAX_BREADCRUMBS
   - Mapped to Sentry option: max_breadcrumbs
   - Default: 0
   - Sentry documentation:
     - "This variable controls the total amount of breadcrumbs that
       should be captured. This defaults to 100."
 - SENTRY_REQUEST_BODIES
   - Mapped to Sentry option: request_bodies
   - Default: "never"
   - Sentry documentation:
     - "This parameter controls if integrations should capture HTTP
       request bodies. It can be set to one of the following values:"
       - "never: request bodies are never sent"
       - "small: only small request bodies will be captured where the
         cutoff for small depends on the SDK (typically 4KB)"
       - "medium: medium and small requests will be captured (typically
         10KB)"
       - "always: the SDK will always capture the request body for as
         long as Sentry can make sense of it"
 - SENTRY_SEND_DEFAULT_PII
   - Mapped to Sentry option: send_default_pii
   - Default: False
   - Sentry documentation:
     - "If this flag is enabled, certain personally identifiable
       information (PII) is added by active integrations. By default, no
       such data is sent."
 - SENTRY_WITH_LOCALS
   - Mapped to Sentry option: with_locals
   - Default: False
   - Sentry documentation:
     - "When enabled, local variables are sent along with stackframes.
       This can have a performance and PII impact. Enabled by default on
       platforms where this is available."
     - "If possible, we recommended turning on this feature to send all
       such data by default, and manually removing what you don't want
       to send using our features for managing Sensitive Data."

Source of Sentry documentation:
  - https://docs.sentry.io/platforms/python/configuration/options/

## Issues :bug:

YJDH-482

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
