### PR TITLE
Yjdh-484: Don't accept fake finnish ssn + better feed input on ssn field

### DIFF
--- a/frontend/kesaseteli/youth/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/index.test.tsx
@@ -140,7 +140,9 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
 
       indexPageApi.actions.typeInput('first_name', '!#$%&()*+/:;<=>?@');
       indexPageApi.actions.typeInput('last_name', '~¡¿÷ˆ]+$');
-      indexPageApi.actions.typeInput('social_security_number', '111111-111D');
+      // Note! 170915-915L is a fake ssn. See more info (in finnish only):
+      // https://www.tuomas.salste.net/doc/tunnus/henkilotunnus.html#keinotunnus
+      indexPageApi.actions.typeInput('social_security_number', '170915-915L');
       indexPageApi.actions.typeInput('postcode', 'abcde');
       indexPageApi.actions.typeInput('phone_number', '+44-20-7011-5555');
       indexPageApi.actions.typeInput('email', 'aaaa@bbb');

--- a/frontend/shared/src/components/forms/inputs/SocialSecurityNumberInput.tsx
+++ b/frontend/shared/src/components/forms/inputs/SocialSecurityNumberInput.tsx
@@ -1,12 +1,12 @@
 import { FinnishSSN } from 'finnish-ssn';
 import React from 'react';
-import { useFormContext } from 'react-hook-form';
+import { FieldError, get, useFormContext } from 'react-hook-form';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { FINNISH_SSN_REGEX } from 'shared/constants';
 import InputProps from 'shared/types/input-props';
 import { isString } from 'shared/utils/type-guards';
 
 import { $TextInput } from './TextInput.sc';
-import { FINNISH_SSN_REGEX } from 'shared/constants';
 
 type Props<T> = Omit<InputProps<T>, 'onChange'> & {
   placeholder?: string;
@@ -21,7 +21,7 @@ const SocialSecurityNumberInput = <T,>({
   registerOptions = {},
   ...$gridCellProps
 }: Props<T>): React.ReactElement<T> => {
-  const { register } = useFormContext<T>();
+  const { register, formState, clearErrors } = useFormContext<T>();
 
   const capitalizeAndTrimSocialSecurityNumber = React.useCallback(
     (ssn: unknown) => {
@@ -48,6 +48,17 @@ const SocialSecurityNumberInput = <T,>({
     [capitalizeAndTrimSocialSecurityNumber]
   );
 
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> =
+    React.useCallback(
+      (event) => {
+        const error = get(formState.errors, id) as FieldError | undefined;
+        if (error && validateSocialSecurityNumber(event.target.value)) {
+          clearErrors(id);
+        }
+      },
+      [formState.errors, id, validateSocialSecurityNumber, clearErrors]
+    );
+
   return (
     <$GridCell {...$gridCellProps}>
       <$TextInput
@@ -66,6 +77,7 @@ const SocialSecurityNumberInput = <T,>({
         errorText={errorText}
         label={label}
         invalid={Boolean(errorText)}
+        onChange={handleChange}
         aria-invalid={Boolean(errorText)}
       />
     </$GridCell>

--- a/frontend/shared/src/components/forms/inputs/SocialSecurityNumberInput.tsx
+++ b/frontend/shared/src/components/forms/inputs/SocialSecurityNumberInput.tsx
@@ -6,6 +6,7 @@ import InputProps from 'shared/types/input-props';
 import { isString } from 'shared/utils/type-guards';
 
 import { $TextInput } from './TextInput.sc';
+import { FINNISH_SSN_REGEX } from 'shared/constants';
 
 type Props<T> = Omit<InputProps<T>, 'onChange'> & {
   placeholder?: string;
@@ -35,7 +36,11 @@ const SocialSecurityNumberInput = <T,>({
   const validateSocialSecurityNumber = React.useCallback(
     (ssn: unknown) => {
       const capitalizedSsn = capitalizeAndTrimSocialSecurityNumber(ssn);
-      if (capitalizedSsn && isString(capitalizedSsn)) {
+      if (
+        capitalizedSsn &&
+        isString(capitalizedSsn) &&
+        FINNISH_SSN_REGEX.test(capitalizedSsn)
+      ) {
         return FinnishSSN.validate(capitalizedSsn);
       }
       return false;

--- a/frontend/shared/src/constants.ts
+++ b/frontend/shared/src/constants.ts
@@ -19,3 +19,7 @@ export const DATE_UI_REGEX =
   /^(0?[1-9]|[12]\d|3[01])\.(0?[1-9]|1[0-2])\.\d{4}$/;
 export const DATE_BACKEND_REGEX =
   /^\d{4}-(0?[1-9]|1[0-2])-(0?[1-9]|[12]\d|3[01])$/;
+
+// a modification of finnish ssn regex https://regex101.com/library/HPFWw6 that does not accept "fake" (keinotunnus) ssn's:
+// https://www.tuomas.salste.net/doc/tunnus/henkilotunnus.html#keinotunnus (more info only in finnish)
+export const FINNISH_SSN_REGEX = /^\d{6}[+Aa-][0-8]\d{2}[\dA-z]$/;


### PR DESCRIPTION
## Description :sparkles:
Dont accept fake social security number having number nine in postfix part: `######A9##X`. More info about it in finnish: https://www.tuomas.salste.net/doc/tunnus/henkilotunnus.html#keinotunnus

Also better user experience on ssn field when there is already validation error on the field, it is cleared when getting valid.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
