### PR TITLE
HL-443: hide some application statuses from the applicant

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -1530,7 +1530,33 @@ class BaseApplicationSerializer(serializers.ModelSerializer):
         return get_company_from_request(self.context.get("request"))
 
 
+class ApplicantApplicationStatusChoiceField(serializers.ChoiceField):
+    """
+    Some application processing statuses need to be hidden from the applicant
+    """
+
+    STATUS_OVERRIDES = {
+        ApplicationStatus.RECEIVED: ApplicationStatus.HANDLING,
+        ApplicationStatus.ACCEPTED: ApplicationStatus.HANDLING,
+        ApplicationStatus.REJECTED: ApplicationStatus.HANDLING,
+    }
+
+    def to_representation(self, value):
+        """
+        Transform the *outgoing* native value into primitive data.
+        """
+        value_shown_to_applicant = self.STATUS_OVERRIDES.get(value, value)
+        return super().to_representation(value_shown_to_applicant)
+
+
 class ApplicantApplicationSerializer(BaseApplicationSerializer):
+
+    status = ApplicantApplicationStatusChoiceField(
+        choices=ApplicationStatus.choices,
+        validators=[ApplicantApplicationStatusValidator()],
+        help_text="Status of the application, statuses that are visible to the applicant are limited",
+    )
+
     def get_company_for_new_application(self, validated_data):
         """
         Company field is read_only. When creating a new application, assign company.

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -131,10 +131,30 @@ def test_application_single_read_unauthorized(
     assert response.status_code == 404
 
 
-def test_application_single_read_as_applicant(api_client, application):
+@pytest.mark.parametrize(
+    "actual_status, visible_status",
+    [
+        (ApplicationStatus.DRAFT, ApplicationStatus.DRAFT),
+        (
+            ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED,
+            ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED,
+        ),
+        (ApplicationStatus.RECEIVED, ApplicationStatus.HANDLING),
+        (ApplicationStatus.HANDLING, ApplicationStatus.HANDLING),
+        (ApplicationStatus.ACCEPTED, ApplicationStatus.HANDLING),
+        (ApplicationStatus.REJECTED, ApplicationStatus.HANDLING),
+        (ApplicationStatus.CANCELLED, ApplicationStatus.CANCELLED),
+    ],
+)
+def test_application_single_read_as_applicant(
+    api_client, application, actual_status, visible_status
+):
+    application.status = actual_status
+    application.save()
     response = api_client.get(get_detail_url(application))
     assert response.data["ahjo_decision"] is None
     assert response.data["application_number"] is not None
+    assert response.data["status"] == visible_status
     assert "batch" not in response.data
     assert Decimal(response.data["duration_in_months_rounded"]) == duration_in_months(
         application.start_date, application.end_date, decimal_places=2

--- a/backend/benefit/terms/tests/test_api.py
+++ b/backend/benefit/terms/tests/test_api.py
@@ -48,10 +48,18 @@ def test_applicant_terms_in_effect(api_client, application, accept_tos):
 
 
 @pytest.mark.parametrize(
-    "from_status,to_status",
+    "from_status,to_status,status_visible_to_applicant",
     [
-        (ApplicationStatus.DRAFT, ApplicationStatus.RECEIVED),
-        (ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED, ApplicationStatus.HANDLING),
+        (
+            ApplicationStatus.DRAFT,
+            ApplicationStatus.RECEIVED,
+            ApplicationStatus.HANDLING,
+        ),
+        (
+            ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED,
+            ApplicationStatus.HANDLING,
+            ApplicationStatus.HANDLING,
+        ),
     ],
 )
 @pytest.mark.parametrize("previously_approved", [False, True])
@@ -62,6 +70,7 @@ def test_approve_terms_success(
     applicant_terms,
     from_status,
     to_status,
+    status_visible_to_applicant,
     previously_approved,
 ):
     application.status = from_status
@@ -94,9 +103,10 @@ def test_approve_terms_success(
         data,
     )
     application.refresh_from_db()
+    assert application.status == to_status
     assert response.status_code == 200
     assert response.data["applicant_terms_approval_needed"] is False
-    assert response.data["status"] == to_status
+    assert response.data["status"] == status_visible_to_applicant
     assert response.data["applicant_terms_approval"]["terms"]["id"] == str(
         applicant_terms.pk
     )


### PR DESCRIPTION
## Description :sparkles:
Some application processing statuses need to be hidden from the applicant

## Issues :bug: HL-443

## Testing :alembic:
backend/benefit/applications/tests/test_applications_api.py:test_application_single_read_as_applicant

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
