### PR TITLE
HL-449: hide draft applications from handler API

### DIFF
--- a/backend/benefit/applications/tests/test_application_batch_api.py
+++ b/backend/benefit/applications/tests/test_application_batch_api.py
@@ -64,7 +64,6 @@ def test_applications_batch_list_with_filter(handler_api_client, application_bat
 @pytest.mark.parametrize(
     "status,batch_status,expected_decision",
     [
-        (ApplicationStatus.DRAFT, ApplicationBatchStatus.DRAFT, None),
         (
             ApplicationStatus.ACCEPTED,
             ApplicationBatchStatus.AWAITING_AHJO_DECISION,

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -172,12 +172,29 @@ def test_application_single_read_as_applicant(
     assert response.status_code == 200
 
 
-def test_application_single_read_as_handler(handler_api_client, application):
+@pytest.mark.parametrize(
+    "status, expected_result",
+    [
+        (ApplicationStatus.DRAFT, 404),
+        (ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED, 200),
+        (ApplicationStatus.RECEIVED, 200),
+        (ApplicationStatus.HANDLING, 200),
+        (ApplicationStatus.ACCEPTED, 200),
+        (ApplicationStatus.REJECTED, 200),
+        (ApplicationStatus.CANCELLED, 200),
+    ],
+)
+def test_application_single_read_as_handler(
+    handler_api_client, application, status, expected_result
+):
+    application.status = status
+    application.save()
     response = handler_api_client.get(get_handler_detail_url(application))
-    assert response.data["ahjo_decision"] is None
-    assert response.data["application_number"] is not None
-    assert "batch" in response.data
-    assert response.status_code == 200
+    assert response.status_code == expected_result
+    if response.status_code == 200:
+        assert response.data["ahjo_decision"] is None
+        assert response.data["application_number"] is not None
+        assert "batch" in response.data
 
 
 def test_application_submitted_at(
@@ -996,7 +1013,7 @@ def test_application_status_change_as_applicant(
 @pytest.mark.parametrize(
     "from_status,to_status,expected_code",
     [
-        (ApplicationStatus.DRAFT, ApplicationStatus.RECEIVED, 200),
+        (ApplicationStatus.DRAFT, ApplicationStatus.RECEIVED, 404),
         (
             ApplicationStatus.HANDLING,
             ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED,
@@ -1103,7 +1120,6 @@ def test_application_status_change_as_handler(
 @pytest.mark.parametrize(
     "from_status, to_status, auto_assign",
     [
-        (ApplicationStatus.DRAFT, ApplicationStatus.RECEIVED, False),
         (
             ApplicationStatus.HANDLING,
             ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED,
@@ -1462,7 +1478,7 @@ def test_pdf_attachment_upload_and_download_as_applicant(
 @pytest.mark.parametrize(
     "status,upload_result",
     [
-        (ApplicationStatus.DRAFT, 201),
+        (ApplicationStatus.DRAFT, 404),
         (ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED, 201),
         (ApplicationStatus.HANDLING, 201),
         (ApplicationStatus.ACCEPTED, 403),
@@ -1483,7 +1499,7 @@ def test_pdf_attachment_upload_and_download_as_handler(
     assert response.status_code == upload_result
     if upload_result != 201:
         return
-    response = handler_api_client.get(get_detail_url(application))
+    response = handler_api_client.get(get_handler_detail_url(application))
     assert len(response.data["attachments"]) == 1
     assert response.data["attachments"][0]["attachment_file"]
     # the URL must point to the handler API

--- a/backend/benefit/common/permissions.py
+++ b/backend/benefit/common/permissions.py
@@ -13,6 +13,18 @@ class BFIsAuthenticated(permissions.IsAuthenticated):
         return super().has_permission(request, view)
 
 
+class BFIsApplicant(BFIsAuthenticated):
+    def has_permission(self, request, view):
+        # FIXME: Remove this permission when FE implemented authentication
+        if settings.DISABLE_AUTHENTICATION:
+            return True
+        if request.user and request.user.is_staff:
+            # Handlers are never applicants. This restriction is needed in order to limit
+            # handler's access to draft applications.
+            return False
+        return super().has_permission(request, view)
+
+
 class BFIsHandler(permissions.IsAdminUser):
     def has_permission(self, request, view):
         # FIXME: Remove this permission when FE implemented authentication

--- a/backend/benefit/messages/views.py
+++ b/backend/benefit/messages/views.py
@@ -1,5 +1,5 @@
 from applications.models import Application
-from common.permissions import BFIsAuthenticated, BFIsHandler, TermsOfServiceAccepted
+from common.permissions import BFIsApplicant, BFIsHandler, TermsOfServiceAccepted
 from django.conf import settings
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
@@ -17,7 +17,7 @@ class ApplicantMessageViewSet(AuditLoggingModelViewSet):
 
     serializer_class = MessageSerializer
     permission_classes = [
-        BFIsAuthenticated,
+        BFIsApplicant,
         TermsOfServiceAccepted,
         HasMessagePermission,
     ]

--- a/backend/benefit/requirements.in
+++ b/backend/benefit/requirements.in
@@ -26,4 +26,5 @@ pdfkit
 Babel
 factory-boy # TODO: added temporarily so that NEXT_PUBLIC_MOCK_FLAG can be set on dev env, remove when authentication done
 drf-nested-routers
+django-sql-utils
 -e file:../shared

--- a/backend/benefit/requirements.txt
+++ b/backend/benefit/requirements.txt
@@ -58,6 +58,8 @@ django-searchable-encrypted-fields==0.1.9
     # via -r requirements.in
 django-simple-history==3.0.0
     # via -r requirements.in
+django-sql-utils==0.6.1
+    # via -r requirements.in
 django-storages[azure]==1.11.1
     # via -r requirements.in
 django==3.2.4
@@ -70,6 +72,7 @@ django==3.2.4
     #   django-localflavor
     #   django-phonenumber-field
     #   django-searchable-encrypted-fields
+    #   django-sql-utils
     #   django-storages
     #   djangorestframework
     #   drf-nested-routers
@@ -157,7 +160,9 @@ six==1.16.0
     #   pyopenssl
     #   python-dateutil
 sqlparse==0.4.1
-    # via django
+    # via
+    #   django
+    #   django-sql-utils
 text-unidecode==1.3
     # via faker
 uritemplate==3.0.1

--- a/backend/benefit/terms/api/v1/views.py
+++ b/backend/benefit/terms/api/v1/views.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from common.permissions import BFIsAuthenticated
+from common.permissions import BFIsApplicant
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema
@@ -17,7 +17,7 @@ from users.utils import get_company_from_request
 
 
 class ApproveTermsOfServiceView(APIView):
-    permission_classes = [BFIsAuthenticated]
+    permission_classes = [BFIsApplicant]
 
     @extend_schema(
         description=(


### PR DESCRIPTION
Also
* Deny handler's access to applicant applications API
* Fix tests where handler was accessing draft applications
  or using the applicant API
* Force the rest framework to use English error messages in tests

## Description :sparkles: HL-449

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
