### PR TITLE
YJDH-251 | KS-Backend: Enforce youth application handler ADFS login

### DIFF
--- a/.github/workflows/bf-pytest.yml
+++ b/.github/workflows/bf-pytest.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   DEBUG: 1
+  OIDC_OP_BASE_URL: https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect
 
 jobs:
   pytest:

--- a/.github/workflows/ks-pytest.yml
+++ b/.github/workflows/ks-pytest.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   DEBUG: 1
+  OIDC_OP_BASE_URL: https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect
 
 jobs:
   pytest:

--- a/.github/workflows/te-pytest.yml
+++ b/.github/workflows/te-pytest.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   DEBUG: 1
+  OIDC_OP_BASE_URL: https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect
 
 jobs:
   pytest:

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -41,7 +41,7 @@ from applications.models import (
     School,
     YouthApplication,
 )
-from common.permissions import DenyAll, HandlerPermission
+from common.decorators import enforce_handler_view_adfs_login
 
 LOGGER = logging.getLogger(__name__)
 
@@ -101,11 +101,33 @@ class SchoolListView(ListAPIView):
 
 
 class YouthApplicationViewSet(AuditLoggingModelViewSet):
+    permission_classes = [AllowAny]  # Permissions are handled per function
     queryset = YouthApplication.objects.all()
     serializer_class = YouthApplicationSerializer
 
+    def list(self, request, *args, **kwargs):
+        self._log_permission_denied()
+        return Response(status=status.HTTP_403_FORBIDDEN)
+
+    def update(self, request, *args, **kwargs):
+        self._log_permission_denied()
+        return Response(status=status.HTTP_403_FORBIDDEN)
+
+    def partial_update(self, request, *args, **kwargs):
+        self._log_permission_denied()
+        return Response(status=status.HTTP_403_FORBIDDEN)
+
+    def destroy(self, request, *args, **kwargs):
+        self._log_permission_denied()
+        return Response(status=status.HTTP_403_FORBIDDEN)
+
+    @enforce_handler_view_adfs_login
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
+
     @action(methods=["get"], detail=True)
-    def process(self, request, pk=None) -> HttpResponse:
+    @enforce_handler_view_adfs_login
+    def process(self, request, *args, **kwargs) -> HttpResponse:
         youth_application: YouthApplication = self.get_object()  # noqa: F841
 
         # TODO: Implement
@@ -113,7 +135,7 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
 
     @transaction.atomic
     @action(methods=["get"], detail=True)
-    def activate(self, request, pk=None) -> HttpResponse:
+    def activate(self, request, *args, **kwargs) -> HttpResponse:
         youth_application: YouthApplication = self.get_object()
 
         # Lock same person's applications to prevent activation of more than one of them
@@ -183,18 +205,6 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
         return Response(
             serializer.data, status=status.HTTP_201_CREATED, headers=headers
         )
-
-    def get_permissions(self):
-        """
-        Instantiates and returns the list of permissions that this view requires.
-        """
-        if self.action in ["activate", "create"]:
-            permission_classes = [AllowAny]
-        elif self.action in ["process", "retrieve"]:
-            permission_classes = [HandlerPermission]
-        else:
-            permission_classes = [DenyAll]
-        return [permission() for permission in permission_classes]
 
 
 class EmployerApplicationViewSet(AuditLoggingModelViewSet):

--- a/backend/kesaseteli/common/decorators.py
+++ b/backend/kesaseteli/common/decorators.py
@@ -1,0 +1,29 @@
+from functools import partial
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect
+from rest_framework.reverse import reverse_lazy
+from shared.common.decorators import (
+    is_request_user_unauthenticated,
+    permit_view_if_permissions_or_redirect,
+    set_use_original_redirect_url_into_session,
+)
+
+from common.permissions import HandlerPermission
+from common.urls import handler_403_url
+
+
+def redirect_to_handler_403_url(request: HttpRequest) -> HttpResponse:
+    return redirect(handler_403_url())
+
+
+#: Decorator for enforcing handler view's ADFS login before permitting access
+enforce_handler_view_adfs_login = partial(
+    permit_view_if_permissions_or_redirect(
+        permission_classes=[HandlerPermission],
+        login_url=reverse_lazy("django_auth_adfs:login"),
+        redirect_only_if_func=is_request_user_unauthenticated,  # Don't loop redirect
+        run_before_redirect_func=set_use_original_redirect_url_into_session,
+        forbidden_response_func=redirect_to_handler_403_url,
+    )
+)

--- a/backend/kesaseteli/common/urls.py
+++ b/backend/kesaseteli/common/urls.py
@@ -1,0 +1,7 @@
+from urllib.parse import urljoin
+
+from django.conf import settings
+
+
+def handler_403_url():
+    return urljoin(settings.HANDLER_URL, "/fi/403")

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -24,6 +24,7 @@ env = environ.Env(
     MEDIA_URL=(str, "/media/"),
     STATIC_URL=(str, "/static/"),
     YOUTH_URL=(str, "https://localhost:3100"),
+    HANDLER_URL=(str, "https://localhost:3200"),
     ALLOWED_HOSTS=(list, ["*"]),
     USE_X_FORWARDED_HOST=(bool, False),
     DATABASE_URL=(
@@ -150,6 +151,7 @@ STATIC_ROOT = env("STATIC_ROOT")
 MEDIA_URL = env.str("MEDIA_URL")
 STATIC_URL = env.str("STATIC_URL")
 YOUTH_URL = env.str("YOUTH_URL")
+HANDLER_URL = env.str("HANDLER_URL")
 
 ROOT_URLCONF = "kesaseteli.urls"
 WSGI_APPLICATION = "kesaseteli.wsgi.application"

--- a/backend/shared/shared/azure_adfs/views.py
+++ b/backend/shared/shared/azure_adfs/views.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import parse_qs, urlparse
 
 from django.conf import settings
 from django.shortcuts import redirect
@@ -8,6 +9,42 @@ LOGGER = logging.getLogger(__name__)
 
 
 class HelsinkiOAuth2CallbackView(OAuth2CallbackView):
+    @classmethod
+    def is_response_adfs_authorization_redirect(cls, response):
+        """
+        Is the response a redirect to ADFS authorization URL?
+
+        NOTE: This is not a foolproof method of detecting if the redirect is to ADFS
+        authorization URL. The detection depends on the query parameters being set by
+        django_auth_adfs.config.ProviderConfig.build_authorization_endpoint, see
+        https://github.com/snok/django-auth-adfs/blob/1.7.0/django_auth_adfs/config.py#L321-L327
+
+        The build_authorization_endpoint function is called by the super class's
+        OAuth2CallbackView.get function when user authentication fails and multi-factor
+        authentication is required, see
+        https://github.com/snok/django-auth-adfs/blob/1.7.0/django_auth_adfs/views.py#L38
+
+        :return: True if response's status code is 302 i.e. redirect, response's URL
+                 contains query parameters response_type, client_id, resource,
+                 redirect_uri and state, and response_type query parameter's value is
+                 code, otherwise False.
+        """
+        return (
+            response.status_code == 302
+            and (url_query_parameters := parse_qs(urlparse(response.url).query))
+            and set(url_query_parameters.keys()).issuperset(
+                {
+                    # Require following URL query parameters:
+                    "response_type",
+                    "client_id",
+                    "resource",
+                    "redirect_uri",
+                    "state",
+                }
+            )
+            and url_query_parameters["response_type"] == ["code"]
+        )
+
     def get(self, request):
         """
         Override GET method to use custom redirect urls.
@@ -15,7 +52,21 @@ class HelsinkiOAuth2CallbackView(OAuth2CallbackView):
         response = super().get(request)
 
         if response.status_code == 302:
-            return redirect(settings.ADFS_LOGIN_REDIRECT_URL)
+            # OAuth2CallbackView.get may return two types of redirects:
+            # 1. Multi-factor authentication redirect:
+            # https://github.com/snok/django-auth-adfs/blob/1.7.0/django_auth_adfs/views.py#L38
+            # 2. After login page redirect:
+            # https://github.com/snok/django-auth-adfs/blob/1.7.0/django_auth_adfs/views.py#L56
+            if self.is_response_adfs_authorization_redirect(response):
+                # NOTE: This code path has not been tested.
+                # Previously if the super class returned a multi-factor authentication
+                # redirect the user was not redirected to it but to the URL specified
+                # by settings.ADFS_LOGIN_REDIRECT_URL.
+                return response  # Redirect to multi-factor authentication endpoint
+            if request.session.pop("USE_ORIGINAL_REDIRECT_URL", False):
+                return response  # Redirect to the original redirect URL
+            else:
+                return redirect(settings.ADFS_LOGIN_REDIRECT_URL)
         elif response.status_code == 400:
             error_message = "No authorization code was provided."
         elif response.status_code == 403:

--- a/backend/shared/shared/common/decorators.py
+++ b/backend/shared/shared/common/decorators.py
@@ -1,0 +1,87 @@
+from functools import wraps
+from typing import Callable, Iterable, Optional, Type
+
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.http.request import HttpRequest
+from django.http.response import HttpResponse, HttpResponseBase
+from rest_framework import status
+from rest_framework.permissions import BasePermission
+
+from shared.common.utils import redirect_to_login_using_request
+
+
+def set_use_original_redirect_url_into_session(request: HttpRequest) -> None:
+    """
+    Set request.session["USE_ORIGINAL_REDIRECT_URL"] to True
+    """
+    request.session["USE_ORIGINAL_REDIRECT_URL"] = True
+
+
+def is_request_user_unauthenticated(request: HttpRequest) -> bool:
+    """
+    Is the request's user unauthenticated i.e. not authenticated?
+
+    :return: True if request has no user or the user is not authenticated, otherwise
+             False.
+    """
+    return not bool(request.user and request.user.is_authenticated)
+
+
+def permit_view_if_permissions_or_redirect(
+    permission_classes: Iterable[Type[BasePermission]],
+    login_url=None,
+    redirect_field_name=REDIRECT_FIELD_NAME,
+    redirect_only_if_func: Optional[Callable[[HttpRequest], bool]] = None,
+    run_before_redirect_func: Optional[Callable[[HttpRequest], None]] = None,
+    forbidden_response_func: Optional[Callable[[HttpRequest], HttpResponseBase]] = None,
+):
+    """
+    Decorator for permitting a view if all permissions pass, otherwise redirecting to
+    login URL with optional check (e.g. to remove redirection loops) and side effect
+    (e.g. set session variables) function calls before redirection. If not all
+    permissions pass nor redirection is taken then returns 403 Forbidden.
+
+    :param permission_classes: The permission classes as in Django REST Framework, e.g.
+                               [IsAuthenticated | ReadOnly]
+    :param login_url: Login URL to be redirected to in case at least one permission
+                      doesn't pass
+    :param redirect_field_name: Name of the URL parameter to pass the current URL in
+    :param redirect_only_if_func: Function to check if redirecting should be done when
+                                  user does not pass all the permissions. The default
+                                  value is None which means redirecting should always be
+                                  done when user does not pass all the permissions.
+    :param run_before_redirect_func: Function to run before redirection, e.g. to set a
+                                     value in request's session.
+    :param forbidden_response_func: Function to generate the response to return if not
+                                    all permissions pass nor redirection is taken. The
+                                    default value is None which means that a response
+                                    with status 403 Forbidden is returned.
+    """
+
+    def decorator(view_func):
+        @wraps(view_func)
+        def _wrapped_view(view, request, *args, **kwargs):
+            # Instantiate the permissions
+            permissions = [permission() for permission in permission_classes]
+            is_authorized = all(
+                permission.has_permission(request, view) for permission in permissions
+            )
+            if is_authorized:
+                return view_func(view, request, *args, **kwargs)
+            elif redirect_only_if_func is None or redirect_only_if_func(request):
+                # Redirect
+                if callable(run_before_redirect_func):
+                    run_before_redirect_func(request)
+                return redirect_to_login_using_request(
+                    request, login_url, redirect_field_name
+                )
+            else:
+                # Forbidden
+                if callable(forbidden_response_func):
+                    return forbidden_response_func(request)
+                else:
+                    return HttpResponse(status=status.HTTP_403_FORBIDDEN)
+
+        return _wrapped_view
+
+    return decorator

--- a/backend/shared/shared/common/tests/__init__.py
+++ b/backend/shared/shared/common/tests/__init__.py
@@ -1,0 +1,5 @@
+from django.test import RequestFactory
+
+
+def get_default_test_host():
+    return RequestFactory().request().get_host()

--- a/backend/shared/shared/common/utils.py
+++ b/backend/shared/shared/common/utils.py
@@ -1,7 +1,12 @@
 import operator
 from functools import reduce
+from urllib.parse import urlparse
 
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.db.models import Q, QuerySet
+from django.http import HttpResponseRedirect
+from django.shortcuts import resolve_url
 
 _ALWAYS_FALSE_Q_FILTER = Q(pk=None)  # A hack but works as primary keys can't be null
 
@@ -65,3 +70,27 @@ class MatchesAnyOfQuerySet(QuerySet):
         :warning: Does not support multiple "not__" prefixes for a single field
         """
         return self.filter(any_of_q_filter(**kwargs))
+
+
+def redirect_to_login_using_request(
+    request, login_url=None, redirect_field_name=REDIRECT_FIELD_NAME
+) -> HttpResponseRedirect:
+    """
+    Redirect to login page similarly as in django.contrib.auth.decorators.user_passes_test.
+
+    See user_passes_test for reference:
+    https://github.com/django/django/blob/3.2.4/django/contrib/auth/decorators.py#L22-L33
+    """
+    path = request.build_absolute_uri()
+    resolved_login_url = resolve_url(login_url or settings.LOGIN_URL)
+    # If the login url is the same scheme and net location then just
+    # use the path as the "next" url.
+    login_scheme, login_netloc = urlparse(resolved_login_url)[:2]
+    current_scheme, current_netloc = urlparse(path)[:2]
+    if (not login_scheme or login_scheme == current_scheme) and (
+        not login_netloc or login_netloc == current_netloc
+    ):
+        path = request.get_full_path()
+    from django.contrib.auth.views import redirect_to_login
+
+    return redirect_to_login(path, resolved_login_url, redirect_field_name)


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Enforce youth application handler ADFS login 

Enforce youth application handler ADFS login by adding
@enforce_handler_view_adfs_login decorator to:
 - YouthApplicationViewSet.process
   - Handler's processing email contains a link to this action
 - YouthApplicationViewSet.detail
   - Used by frontend to get data for processing a youth application

Revamp permission handling in YouthApplicationViewSet.

Add tests:
 - test_youth_applications_forbidden_modification_methods
   - Test that forbidden methods in YouthApplicationViewSet return
     HTTP status 403 Forbidden which can also seen in the audit log
 - test_youth_application_post_valid_audit_log
   - Test that the posting of a valid youth application can be seen in
     the audit log

Extend test with more parametrizations and audit log entry testing:
 - test_youth_applications_list

Extend tests with more parametrizations and redirection target testing:
 - test_youth_applications_process_valid_pk
 - test_youth_applications_process_unused_pk
 - test_youth_applications_detail_valid_pk
 - test_youth_applications_detail_unused_pk

Shared code changes:
 - Change HelsinkiOAuth2CallbackView.get:
   - Add support for USE_ORIGINAL_REDIRECT_URL session key
     which in case of a redirect which is not a multi-factor
     authentication redirect redirects to the original redirect URL.
     Otherwise works as before i.e. redirects to
     settings.ADFS_LOGIN_REDIRECT_URL.
   - Re-enable multi-factor authentication redirect by trying to detect
     it and letting it pass through unchanged. This was previously
     suppressed, the user was instead redirected to
     settings.ADFS_LOGIN_REDIRECT_URL. NOTE: This code path is untested.
 - Add test test_adfs_callback_original_redirect
   - Test that HelsinkiOAuth2CallbackView callback function redirects
     to the original redirect URL if session's dictionary item
     USE_ORIGINAL_REDIRECT_URL is True and that the dictionary
     item gets removed.
 - Add get_default_test_host function
 - Add permit_view_if_permissions_or_redirect decorator
   - This is a decorator for permitting a view if all permissions pass,
     otherwise redirecting to login URL with optional check (e.g. to
     remove redirection loops) and side effect (e.g. set session
     variables) function calls before redirection. If not all
     permissions pass nor redirection is taken then returns 403
     Forbidden.
 - Add redirect_to_login_using_request function
   - Redirects to login page similarly as in
     django.contrib.auth.decorators.user_passes_test
 - Add set_use_original_redirect_url_into_session function
   - Sets request.session["USE_ORIGINAL_REDIRECT_URL"] to True
 - Add is_request_user_unauthenticated function
   - Tests if request's user is unauthenticated i.e. not authenticated

### Backends: Set OIDC_OP_BASE_URL in (bf|ks|te)-pytest.yml 

Set OIDC_OP_BASE_URL to
https://tunnistus.test.hel.ninja/auth/.../openid-connect
in benefit, kesaseteli and tet backends' pytest GitHub Actions.

Rationale:
 - If OIDC_OP_BASE_URL is not set OIDC_OP_TOKEN_ENDPOINT will be set to
   "/token" which will be used in
   shared.azure_adfs.tests.test_adfs_login's test
   test_adfs_callback_original_redirect. This will call the following:
   - HelsinkiOIDCAuthenticationBackend.authenticate ->
     - OIDCAuthenticationBackend.get_token ->
       - requests.post ->
         - ... ->
           - PreparedRequest.prepare_url which will reject "/token" with
             MissingSchema exception: "Invalid URL '/token': No schema
             supplied. Perhaps you meant http:///token?".

Fixes test_adfs_callback_original_redirect test from
shared.azure_adfs.tests.test_adfs_login.

## Issues :bug:

YJDH-251

## Testing :alembic:

Steps:
 - Set up handler service and keep it running for the whole test:
   - `docker-compose -f docker-compose.handler.yml down`
   - `yarn handler --build`
 - Set `NEXT_PUBLIC_MOCK_FLAG=1` in `.env.kesaseteli`
 - `docker-compose -f docker-compose.youth.yml down`
 - `yarn youth --build`
 - Open `https://localhost:3100/` in web browser
   - Input youth application with valid data and submit it
     - You can generate valid Finnish personal identity codes using https://www.telepartikkeli.net/tunnusgeneraattori
     - Postcode must be 5 digits
     - You can use the same gmail.com email address multiple times by suffixing `+number` e.g. `x+1@gmail.com` is sent to the same address as `x@gmail.com`
   - Copy the youth application's ID from the browser's address bar somewhere to be used later, e.g.
     - `https://localhost:3100/fi/thankyou?id=7930a20a-3808-479f-8bf0-507f80c0c220` → `7930a20a-3808-479f-8bf0-507f80c0c220`
   - Activate the sent youth application by clicking on `AKTIVOI` link
 - `docker-compose -f docker-compose.youth.yml down`
 - Set `NEXT_PUBLIC_MOCK_FLAG=0` in `.env.kesaseteli`
 - `yarn youth`
 - Open `https://localhost:8000/v1/youthapplications/<id you copied earlier>/process/` e.g. `https://localhost:8000/v1/youthapplications/7930a20a-3808-479f-8bf0-507f80c0c220/process/` in web browser
   - If you get a page with HTTP ERROR 501 i.e. Not implemented everything's ok, you have permission to view the page but it has not yet been implemented
   - If you have logged into Helsinki city's AD and get redirected to https://localhost:3200/fi/403 with "Your connection is not private" or "Sinulla ei ole oikeuksia" text then try first logging out by clicking on `https://localhost:8000/oauth2/logout`, open Django admin page using link `https://localhost:8000/admin/`, log out from it, log into it with admin/admin, open users, open the user with the email address you used in logging into Helsinki city's AD, look at the user's groups, pick one of the ones with `adfs-` prefix and write down its suffix, e.g. `adfs-c5c7fb45-c112-4589-b599-e17fec5c14a3` → `c5c7fb45-c112-4589-b599-e17fec5c14a3`
   - Open `.env.kesaseteli` and put the value you just wrote down into it into the `ADFS_CONTROLLER_GROUP_UUIDS`, e.g. `ADFS_CONTROLLER_GROUP_UUIDS=c5c7fb45-c112-4589-b599-e17fec5c14a3`
   - `docker-compose -f docker-compose.youth.yml down`
   - `yarn youth`
   - Reopen the `https://localhost:8000/v1/youthapplications/<id you copied earlier>/process/` page and now you should get a page saying HTTP ERROR 501 i.e. Not implemented which is correct.

## Screenshots :camera_flash:

### Youth application processing page without handler permission:
![handler_403_page](https://user-images.githubusercontent.com/77663720/155475224-70044b86-696d-44af-96f1-13fe2f2889cc.png)

### Youth application processing page with handler permission:
![screenshot2](https://user-images.githubusercontent.com/77663720/154905624-bcb62cf9-f5fa-468b-bddf-ac2fea9b8e55.png)

☝️ This is ok, HTTP status 501 means not implemented which the processing functionality in actuality is.

## Additional notes :spiral_notepad:
