### PR TITLE
HL-473: fix csv export of applications without calculation

### DIFF
--- a/backend/benefit/applications/services/applications_csv_report.py
+++ b/backend/benefit/applications/services/applications_csv_report.py
@@ -176,17 +176,21 @@ class ApplicationsCsvService(CsvExportBase):
             CsvDefaultColumn(
                 "Manuaalinen syöttö", "calculation.override_monthly_benefit_amount"
             ),
-            CsvColumn(
+            CsvDefaultColumn(
                 "Manuaalinen syöttö kommentti",
                 "calculation.override_monthly_benefit_amount_comment",
             ),
-            CsvColumn(
+            CsvDefaultColumn(
                 "Myönnetään de minimis -tukena?",
                 "calculation.granted_as_de_minimis_aid",
                 format_bool,
+                default_value=None,
             ),
-            CsvColumn(
-                "Kohderyhmätarkistus", "calculation.target_group_check", format_bool
+            CsvDefaultColumn(
+                "Kohderyhmätarkistus",
+                "calculation.target_group_check",
+                format_bool,
+                default_value=None,
             ),
             CsvDefaultColumn("Päättäjän nimike", "batch.decision_maker_title"),
             CsvDefaultColumn("Päättäjän nimi", "batch.decision_maker_name"),

--- a/backend/benefit/applications/services/csv_export_base.py
+++ b/backend/benefit/applications/services/csv_export_base.py
@@ -41,7 +41,10 @@ def nested_queryset_attr(
         try:
             nested_obj = operator.attrgetter(related_name)(item).all()[queryset_idx]
             return operator.attrgetter(nested_attr_name)(nested_obj)
-        except (AttributeError, IndexError):
+        except (
+            AttributeError,
+            IndexError,
+        ):
             return default_value
 
     return getter

--- a/backend/benefit/applications/tests/test_applications_csv_report.py
+++ b/backend/benefit/applications/tests/test_applications_csv_report.py
@@ -112,6 +112,19 @@ def test_applications_csv_export_new_applications(handler_api_client):
     assert ApplicationBatch.objects.all().count() == 2
 
 
+def test_applications_csv_export_without_calculation(
+    handler_api_client, received_application
+):
+    received_application.calculation.delete()
+    _get_csv(
+        handler_api_client,
+        reverse("v1:handler-application-list") + "export_csv/",
+        [
+            received_application.application_number,
+        ],
+    )
+
+
 def test_applications_csv_export_with_date_range(handler_api_client):
     (
         application1,


### PR DESCRIPTION
## Description :sparkles:

If application had no calculation, csv export would return a http 500 error.
Use empty/default values for the missing fields instead.

## Issues :bug: HL-473

## Testing :alembic:
backend/benefit/applications/tests/test_applications_csv_report.py:test_applications_csv_export_without_calculation

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
