### PR TITLE
HL-474: fix submitted_at field in application api

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -866,7 +866,7 @@ class BaseApplicationSerializer(serializers.ModelSerializer):
         }
 
     def get_submitted_at(self, obj):
-        return obj.get_log_entry_field(ApplicationStatus.RECEIVED, "created_at")
+        return obj.get_log_entry_field([ApplicationStatus.RECEIVED], "created_at")
 
     def get_last_modified_at(self, obj):
         if not self.logged_in_user_is_admin() and obj.status != ApplicationStatus.DRAFT:

--- a/backend/benefit/applications/tests/factories.py
+++ b/backend/benefit/applications/tests/factories.py
@@ -127,6 +127,13 @@ class ReceivedApplicationFactory(ApplicationFactory):
     )
 
     @factory.post_generation
+    def received_log_event(self, created, extracted, **kwargs):
+        self.log_entries.create(
+            from_status=ApplicationStatus.DRAFT,
+            to_status=ApplicationStatus.RECEIVED,
+        )
+
+    @factory.post_generation
     def calculation(self, created, extracted, **kwargs):
         self.calculation = Calculation.objects.create_for_application(self)
         self.calculation.init_calculator()

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -179,6 +179,17 @@ def test_application_single_read_as_handler(handler_api_client, application):
     assert response.status_code == 200
 
 
+def test_application_submitted_at(
+    api_client, application, received_application, handling_application
+):
+    response = api_client.get(get_detail_url(application))
+    assert response.data["submitted_at"] is None
+    response = api_client.get(get_detail_url(received_application))
+    assert response.data["submitted_at"].isoformat() == "2021-06-04T00:00:00+00:00"
+    response = api_client.get(get_detail_url(handling_application))
+    assert response.data["submitted_at"].isoformat() == "2021-06-04T00:00:00+00:00"
+
+
 def test_application_template(api_client):
     response = api_client.get(
         reverse("v1:applicant-application-get-application-template")


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug: HL-474
submitted_at was always null in API responses

## Testing :alembic:
backend/benefit/applications/tests/test_applications_api.py:test_application_submitted_at

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
