### PR TITLE
YJDH-448/YJDH-453: Accept and Reject -button to handler-ui

### DIFF
--- a/frontend/kesaseteli/handler/public/locales/fi/common.json
+++ b/frontend/kesaseteli/handler/public/locales/fi/common.json
@@ -33,7 +33,16 @@
     "is_unlisted_school": "(Koulua ei löytynyt listalta)",
     "phone_number": "Puhelinnumero",
     "email": "Sähköposti",
-    "notFound": "Hakemusta ei löytynyt"
+    "notFound": "Hakemusta ei löytynyt",
+    "accept": "Hyväksy",
+    "reject": "Hylkää",
+    "saving": "Tallennetaan...",
+    "notification": {
+      "submitted": "Nuori ei ole vielä aktivoinut hakemusta",
+      "additional_information_requested": "Nuori ei ole vielä täyttänyt lisätietohakemusta",
+      "accepted": "Hyväksytty",
+      "rejected": "Hylätty"
+    }
   },
   "errors": {
     "required": "Tieto puuttuu",

--- a/frontend/kesaseteli/handler/src/__tests__/utils/backend/backend-nocks.ts
+++ b/frontend/kesaseteli/handler/src/__tests__/utils/backend/backend-nocks.ts
@@ -49,17 +49,19 @@ export const expectToGetYouthApplicationError = (
     );
 };
 
-export const expectToPostYouthApplication = (
+export const expectToPatchYouthApplication = (
   operation: 'accept' | 'reject',
-  expectedApplication: CreatedYouthApplication
+  id: CreatedYouthApplication['id']
 ): nock.Scope =>
   nock(getBackendDomain())
-    .post(
-      `${BackendEndpoint.YOUTH_APPLICATIONS}${expectedApplication.id}/${operation}`
-    )
-    .reply(200, expectedApplication, { 'Access-Control-Allow-Origin': '*' });
+    .post(`${BackendEndpoint.YOUTH_APPLICATIONS}${id}/${operation}`)
+    .reply(
+      200,
+      { status: operation === 'accept' ? 'accepted' : 'rejected' },
+      { 'Access-Control-Allow-Origin': '*' }
+    );
 
-export const expectToPostYouthApplicationError = (
+export const expectToPatchYouthApplicationError = (
   operation: 'accept' | 'reject',
   id: CreatedYouthApplication['id'],
   errorCode: 400 | 404 | 500

--- a/frontend/kesaseteli/handler/src/__tests__/utils/backend/backend-nocks.ts
+++ b/frontend/kesaseteli/handler/src/__tests__/utils/backend/backend-nocks.ts
@@ -42,9 +42,33 @@ export const expectToGetYouthApplicationError = (
 ): nock.Scope => {
   consoleSpy = jest.spyOn(console, 'error').mockImplementation();
   return nock(getBackendDomain())
-    .get(`${BackendEndpoint.YOUTH_APPLICATIONS}${String(id)}/`)
+    .get(`${BackendEndpoint.YOUTH_APPLICATIONS}${id}/`)
     .reply(
       errorCode,
       'This is a youthapplications backend test error. Please ignore this error message.'
+    );
+};
+
+export const expectToPostYouthApplication = (
+  operation: 'accept' | 'reject',
+  expectedApplication: CreatedYouthApplication
+): nock.Scope =>
+  nock(getBackendDomain())
+    .post(
+      `${BackendEndpoint.YOUTH_APPLICATIONS}${expectedApplication.id}/${operation}`
+    )
+    .reply(200, expectedApplication, { 'Access-Control-Allow-Origin': '*' });
+
+export const expectToPostYouthApplicationError = (
+  operation: 'accept' | 'reject',
+  id: CreatedYouthApplication['id'],
+  errorCode: 400 | 404 | 500
+): nock.Scope => {
+  consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+  return nock(getBackendDomain())
+    .post(`${BackendEndpoint.YOUTH_APPLICATIONS}${id}/${operation}`)
+    .reply(
+      errorCode,
+      `This is a youthapplications ${operation} backend test error. Please ignore this error message.`
     );
 };

--- a/frontend/kesaseteli/handler/src/__tests__/utils/components/get-index-page-api.ts
+++ b/frontend/kesaseteli/handler/src/__tests__/utils/components/get-index-page-api.ts
@@ -1,7 +1,7 @@
 import {
   expectToGetYouthApplication,
-  expectToPostYouthApplication,
-  expectToPostYouthApplicationError,
+  expectToPatchYouthApplication,
+  expectToPatchYouthApplicationError,
 } from 'kesaseteli/handler/__tests__/utils/backend/backend-nocks';
 import { YOUTH_APPLICATION_STATUS_HANDLER_CANNOT_PROCEED } from 'kesaseteli-shared/constants/status-constants';
 import CreatedYouthApplication from 'kesaseteli-shared/types/created-youth-application';
@@ -105,13 +105,13 @@ const getIndexPageApi = (expectedApplication?: CreatedYouthApplication) => ({
         );
       }
       if (errorCode) {
-        expectToPostYouthApplicationError(
+        expectToPatchYouthApplicationError(
           type,
           expectedApplication.id,
           errorCode
         );
       } else {
-        expectToPostYouthApplication(type, expectedApplication);
+        expectToPatchYouthApplication(type, expectedApplication.id);
         expectToGetYouthApplication({
           ...expectedApplication,
           status: type === 'accept' ? 'accepted' : 'rejected',

--- a/frontend/kesaseteli/handler/src/__tests__/utils/components/get-index-page-api.ts
+++ b/frontend/kesaseteli/handler/src/__tests__/utils/components/get-index-page-api.ts
@@ -1,6 +1,13 @@
+import {
+  expectToGetYouthApplication,
+  expectToPostYouthApplication,
+  expectToPostYouthApplicationError,
+} from 'kesaseteli/handler/__tests__/utils/backend/backend-nocks';
+import { YOUTH_APPLICATION_STATUS_HANDLER_CANNOT_PROCEED } from 'kesaseteli-shared/constants/status-constants';
 import CreatedYouthApplication from 'kesaseteli-shared/types/created-youth-application';
-import { screen } from 'shared/__tests__/utils/test-utils';
+import { screen, userEvent } from 'shared/__tests__/utils/test-utils';
 import { escapeRegExp } from 'shared/utils/regex.utils';
+import { assertUnreachable } from 'shared/utils/typescript.utils';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
 const getIndexPageApi = (expectedApplication?: CreatedYouthApplication) => ({
@@ -39,8 +46,80 @@ const getIndexPageApi = (expectedApplication?: CreatedYouthApplication) => ({
         escapeRegExp(`${first_name} ${last_name}`)
       );
     },
+    actionButtonsArePresent: async (): Promise<void> => {
+      await screen.findByRole('button', {
+        name: /hyväksy/i,
+      });
+      await screen.findByRole('button', {
+        name: /hylkää/i,
+      });
+    },
+    actionButtonsAreNotPresent: (): void => {
+      expect(
+        screen.queryByRole('button', {
+          name: /hyväksy/i,
+        })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {
+          name: /hylkää/i,
+        })
+      ).not.toBeInTheDocument();
+    },
+
+    // eslint-disable-next-line consistent-return
+    statusNotificationIsPresent: async (
+      status: typeof YOUTH_APPLICATION_STATUS_HANDLER_CANNOT_PROCEED[number]
+    ): Promise<HTMLElement | undefined> => {
+      switch (status) {
+        case 'submitted':
+          return screen.findByRole('heading', {
+            name: /nuori ei ole vielä aktivoinut hakemusta/i,
+          });
+
+        case 'additional_information_requested':
+          return screen.findByRole('heading', {
+            name: /nuori ei ole vielä täyttänyt lisätietohakemusta/i,
+          });
+
+        case 'accepted':
+          return screen.findByRole('heading', {
+            name: /hyväksytty/i,
+          });
+
+        case 'rejected':
+          return screen.findByRole('heading', {
+            name: /hylätty/i,
+          });
+
+        default:
+          assertUnreachable(status, 'Unknown status');
+      }
+    },
   },
-  actions: {},
+  actions: {
+    clickButton: (type: 'accept' | 'reject', errorCode?: 400 | 500): void => {
+      if (!expectedApplication) {
+        throw new Error(
+          'you forgot to give expected application values for the test'
+        );
+      }
+      if (errorCode) {
+        expectToPostYouthApplicationError(
+          type,
+          expectedApplication.id,
+          errorCode
+        );
+      } else {
+        expectToPostYouthApplication(type, expectedApplication);
+        expectToGetYouthApplication({
+          ...expectedApplication,
+          status: type === 'accept' ? 'accepted' : 'rejected',
+        });
+      }
+      userEvent.click(screen.getByTestId(`${type}-button`));
+    },
+  },
 });
 
 export default getIndexPageApi;

--- a/frontend/kesaseteli/handler/src/__tests__/utils/components/get-index-page-api.ts
+++ b/frontend/kesaseteli/handler/src/__tests__/utils/components/get-index-page-api.ts
@@ -67,9 +67,9 @@ const getIndexPageApi = (expectedApplication?: CreatedYouthApplication) => ({
       ).not.toBeInTheDocument();
     },
 
-    // eslint-disable-next-line consistent-return
     statusNotificationIsPresent: async (
       status: typeof YOUTH_APPLICATION_STATUS_HANDLER_CANNOT_PROCEED[number]
+      // eslint-disable-next-line consistent-return
     ): Promise<HTMLElement | undefined> => {
       switch (status) {
         case 'submitted':

--- a/frontend/kesaseteli/handler/src/components/form/ActionButtons.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/ActionButtons.tsx
@@ -1,0 +1,51 @@
+import { Button, IconCheck, IconCross } from 'hds-react';
+import useCompleteYouthApplicationQuery from 'kesaseteli/handler/hooks/backend/useCompleteYouthApplicationQuery';
+import CreatedYouthApplication from 'kesaseteli-shared/types/created-youth-application';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { useTheme } from 'styled-components';
+
+type Props = {
+  id: CreatedYouthApplication['id'];
+};
+
+const HandlerForm: React.FC<Props> = ({ id }) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const { isLoading, mutate } = useCompleteYouthApplicationQuery(id);
+  const accept = React.useCallback(() => mutate('accept'), [mutate]);
+  const reject = React.useCallback(() => mutate('reject'), [mutate]);
+
+  return (
+    <$GridCell>
+      <Button
+        theme="coat"
+        data-testid="accept-button"
+        iconLeft={<IconCheck />}
+        onClick={accept}
+        isLoading={isLoading}
+        disabled={isLoading}
+        css={`
+          margin-right: ${theme.spacing.l};
+        `}
+      >
+        {t(`common:handlerApplication.accept`)}
+      </Button>
+      <Button
+        variant="secondary"
+        theme="black"
+        data-testid="reject-button"
+        iconLeft={<IconCross />}
+        onClick={reject}
+        loadingText={t(`common:handlerApplication.saving`)}
+        isLoading={isLoading}
+        disabled={isLoading}
+      >
+        {t(`common:handlerApplication.reject`)}
+      </Button>
+    </$GridCell>
+  );
+};
+
+export default HandlerForm;

--- a/frontend/kesaseteli/handler/src/components/form/HandlerForm.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/HandlerForm.tsx
@@ -1,16 +1,30 @@
+import { NotificationType } from 'hds-react';
+import ActionButtons from 'kesaseteli/handler/components/form/ActionButtons';
 import Field from 'kesaseteli/handler/components/form/Field';
+import {
+  YOUTH_APPLICATION_STATUS_COMPLETED,
+  YOUTH_APPLICATION_STATUS_WAITING_FOR_HANDLER_ACTION,
+  YOUTH_APPLICATION_STATUS_WAITING_FOR_YOUTH_ACTION,
+} from 'kesaseteli-shared/constants/status-constants';
 import CreatedYouthApplication from 'kesaseteli-shared/types/created-youth-application';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { $Notification } from 'shared/components/notification/Notification.sc';
 import { convertToUIDateAndTimeFormat } from 'shared/utils/date.utils';
+import { useTheme } from 'styled-components';
 
 type Props = {
   application: CreatedYouthApplication;
 };
 
+type MessageType = NotificationType | undefined;
+
 const HandlerForm: React.FC<Props> = ({ application }) => {
   const { t } = useTranslation();
+  const theme = useTheme();
   const {
+    id,
     receipt_confirmed_at,
     first_name,
     last_name,
@@ -20,7 +34,46 @@ const HandlerForm: React.FC<Props> = ({ application }) => {
     is_unlisted_school,
     phone_number,
     email,
+    status,
   } = application;
+
+  const waitingForUserAction = React.useMemo(
+    () =>
+      (
+        YOUTH_APPLICATION_STATUS_WAITING_FOR_YOUTH_ACTION as ReadonlyArray<string>
+      ).includes(status),
+    [status]
+  );
+  const waitingForHandlerAction = React.useMemo(
+    () =>
+      (
+        YOUTH_APPLICATION_STATUS_WAITING_FOR_HANDLER_ACTION as ReadonlyArray<string>
+      ).includes(status),
+    [status]
+  );
+  const isCompleted = React.useMemo(
+    () =>
+      (YOUTH_APPLICATION_STATUS_COMPLETED as ReadonlyArray<string>).includes(
+        status
+      ),
+    [status]
+  );
+
+  // eslint-disable-next-line consistent-return
+  const notificationType: MessageType = React.useMemo(() => {
+    if (!status || waitingForUserAction) {
+      return 'error';
+    }
+    if (status === 'accepted') {
+      return 'success';
+    }
+    if (status === 'rejected') {
+      return 'alert';
+    }
+  }, [status, waitingForUserAction]);
+
+  const statusId = React.useMemo(() => String(status || 'submitted'), [status]);
+
   return (
     <>
       <Field
@@ -39,7 +92,26 @@ const HandlerForm: React.FC<Props> = ({ application }) => {
         }`}
       />
       <Field type="phone_number" value={phone_number} />
-      <Field type="email" value={email} />
+      <Field
+        type="email"
+        value={email}
+        css={`
+          padding-bottom: ${theme.spacing.m};
+        `}
+      />
+      {waitingForHandlerAction ? (
+        <ActionButtons id={id} />
+      ) : (
+        <$GridCell $colSpan={2}>
+          <$Notification
+            data-testid={`status-notification-${statusId}`}
+            label={t(`common:handlerApplication.notification.${statusId}`)}
+            type={notificationType}
+          >
+            {isCompleted && email && <a href={`mailto:${email}`}>{email}</a>}
+          </$Notification>
+        </$GridCell>
+      )}
     </>
   );
 };

--- a/frontend/kesaseteli/handler/src/hooks/backend/useCompleteYouthApplicationQuery.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/useCompleteYouthApplicationQuery.ts
@@ -1,0 +1,40 @@
+import {
+  BackendEndpoint,
+  getYouthApplicationQueryKey,
+} from 'kesaseteli-shared/backend-api/backend-api';
+import CreatedYouthApplication from 'kesaseteli-shared/types/created-youth-application';
+import {
+  useMutation,
+  UseMutationOptions,
+  UseMutationResult,
+  useQueryClient,
+} from 'react-query';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+import useErrorHandler from 'shared/hooks/useErrorHandler';
+
+type Operation = 'accept' | 'reject';
+
+const useCompleteYouthApplicationQuery = (
+  id: CreatedYouthApplication['id'],
+  options?: UseMutationOptions<CreatedYouthApplication, unknown, Operation>
+): UseMutationResult<CreatedYouthApplication, unknown, Operation> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+  return useMutation({
+    mutationFn: (operation: Operation) =>
+      handleResponse<CreatedYouthApplication>(
+        axios.post(`${BackendEndpoint.YOUTH_APPLICATIONS}${id}/${operation}`)
+      ),
+    onSuccess: (data, operation, context) => {
+      void queryClient.invalidateQueries(getYouthApplicationQueryKey(id));
+      if (onSuccess) {
+        void onSuccess(data, operation, context);
+      }
+    },
+    onError: useErrorHandler(false),
+    ...restOptions,
+  });
+};
+
+export default useCompleteYouthApplicationQuery;

--- a/frontend/kesaseteli/handler/src/hooks/backend/useYouthApplicationQuery.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/useYouthApplicationQuery.ts
@@ -1,11 +1,6 @@
-import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
+import { getYouthApplicationQueryKey } from 'kesaseteli-shared/backend-api/backend-api';
 import CreatedYouthApplication from 'kesaseteli-shared/types/created-youth-application';
-import {
-  QueryKey,
-  useQuery,
-  UseQueryOptions,
-  UseQueryResult,
-} from 'react-query';
+import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
 import useErrorHandler from 'shared/hooks/useErrorHandler';
 import { isError } from 'shared/utils/type-guards';
 
@@ -15,7 +10,7 @@ const useYouthApplicationQuery = (
 ): UseQueryResult<CreatedYouthApplication> => {
   const handleError = useErrorHandler(false);
   return useQuery({
-    queryKey: `${BackendEndpoint.YOUTH_APPLICATIONS}${String(id)}/` as QueryKey,
+    queryKey: id ? getYouthApplicationQueryKey(id) : undefined,
     enabled: Boolean(id),
     staleTime: Infinity,
     onError: (error: unknown) => {

--- a/frontend/kesaseteli/shared/browser-tests/handler-form-page/handlerFormPage.components.ts
+++ b/frontend/kesaseteli/shared/browser-tests/handler-form-page/handlerFormPage.components.ts
@@ -26,6 +26,36 @@ export const getHandlerFormPageComponents = async (
     applicationField(id: keyof YouthApplication | 'name') {
       return screen.findByTestId(`handlerApplication-${id}`);
     },
+    acceptButton() {
+      return screen.findByRole('button', {
+        name: /hyväksy/i,
+      });
+    },
+    rejectButton() {
+      return screen.findByRole('button', {
+        name: /hylkää/i,
+      });
+    },
+    notYetActivated() {
+      return screen.findByRole('heading', {
+        name: /nuori ei ole vielä aktivoinut hakemusta/i,
+      });
+    },
+    additionalInformationRequested() {
+      return screen.findByRole('heading', {
+        name: /nuori ei ole vielä täyttänyt lisätietohakemusta/i,
+      });
+    },
+    applicationIsAccepted() {
+      return screen.findByRole('heading', {
+        name: /hyväksytty/i,
+      });
+    },
+    applicationIsRejected() {
+      return screen.findByRole('heading', {
+        name: /hylätty/i,
+      });
+    },
   };
   const expectations = {
     async isLoaded() {
@@ -53,8 +83,35 @@ export const getHandlerFormPageComponents = async (
         .expect(selectors.applicationField(key).textContent)
         .contains(value, await getErrorMessage(t));
     },
+    async applicationIsNotYetActivated() {
+      await t
+        .expect(selectors.notYetActivated().exists)
+        .ok(await getErrorMessage(t));
+    },
+    async additionalInformationRequested() {
+      await t
+        .expect(selectors.additionalInformationRequested().exists)
+        .ok(await getErrorMessage(t));
+    },
+    async applicationIsAccepted() {
+      await t
+        .expect(selectors.applicationIsAccepted().exists)
+        .ok(await getErrorMessage(t));
+    },
+    async applicationIsRejected() {
+      await t
+        .expect(selectors.applicationIsRejected().exists)
+        .ok(await getErrorMessage(t));
+    },
   };
-  const actions = {};
+  const actions = {
+    clickAcceptButton() {
+      return t.click(selectors.acceptButton());
+    },
+    clickRejectButton() {
+      return t.click(selectors.rejectButton());
+    },
+  };
   await expectations.isLoaded();
   return {
     selectors,

--- a/frontend/kesaseteli/shared/src/__tests__/utils/fake-objects.ts
+++ b/frontend/kesaseteli/shared/src/__tests__/utils/fake-objects.ts
@@ -92,39 +92,45 @@ export const fakeSchools: string[] = [
   'Östersundom skola',
 ];
 
-export const fakeYouthFormData = (isUnlistedSchool = false): YouthFormData => ({
-  first_name: faker.name.findName(),
-  last_name: faker.name.findName(),
-  social_security_number: FinnishSSN.createWithAge(
-    faker.datatype.number({ min: 15, max: 16 })
-  ),
-  postcode: faker.datatype.number({ min: 10_000, max: 99_999 }).toString(),
-  selectedSchool: { name: faker.random.arrayElement(fakeSchools) },
-  unlistedSchool: isUnlistedSchool ? faker.commerce.department() : undefined,
-  is_unlisted_school: isUnlistedSchool,
-  phone_number: faker.phone.phoneNumber('+358#########'),
-  email: faker.internet.email(),
-  termsAndConditions: true,
-});
+export const fakeYouthFormData = (
+  override?: Partial<YouthApplication>
+): YouthFormData => {
+  const { isUnlistedSchool } = { isUnlistedSchool: false, ...override };
+  return {
+    first_name: faker.name.findName(),
+    last_name: faker.name.findName(),
+    social_security_number: FinnishSSN.createWithAge(
+      faker.datatype.number({ min: 15, max: 16 })
+    ),
+    postcode: faker.datatype.number({ min: 10_000, max: 99_999 }).toString(),
+    selectedSchool: { name: faker.random.arrayElement(fakeSchools) },
+    unlistedSchool: isUnlistedSchool ? faker.commerce.department() : undefined,
+    is_unlisted_school: isUnlistedSchool,
+    phone_number: faker.phone.phoneNumber('+358#########'),
+    email: faker.internet.email(),
+    termsAndConditions: true,
+    ...override,
+  };
+};
 
 export const fakeYouthApplication = (language?: Language): YouthApplication =>
   convertFormDataToApplication(fakeYouthFormData(), language);
 
-type Options = { activated?: boolean; isUnlistedSchool?: boolean };
-
 export const fakeCreatedYouthApplication = (
-  options?: Options
+  override?: Partial<CreatedYouthApplication>
 ): CreatedYouthApplication => {
-  const { activated, isUnlistedSchool } = {
-    activated: true,
-    isUnlistedSchool: false,
-    ...options,
+  const { status } = {
+    status: 'submitted' as CreatedYouthApplication['status'],
+    ...override,
   };
   return {
     id: faker.datatype.uuid(),
-    receipt_confirmed_at: activated
-      ? convertToBackendDateFormat(faker.date.past())
-      : undefined,
-    ...convertFormDataToApplication(fakeYouthFormData(isUnlistedSchool)),
+    status,
+    receipt_confirmed_at:
+      override?.status !== 'submitted'
+        ? convertToBackendDateFormat(faker.date.past())
+        : undefined,
+    ...convertFormDataToApplication(fakeYouthFormData(override)),
+    ...override,
   };
 };

--- a/frontend/kesaseteli/shared/src/backend-api/backend-api.ts
+++ b/frontend/kesaseteli/shared/src/backend-api/backend-api.ts
@@ -18,3 +18,6 @@ export const getBackendDomain = (): string =>
 
 export const getBackendUrl = (path: BackendPath): string =>
   `${getBackendDomain()}${path}`;
+
+export const getYouthApplicationQueryKey = (id: string): string =>
+  `${BackendEndpoint.YOUTH_APPLICATIONS}${id}/`;

--- a/frontend/kesaseteli/shared/src/constants/status-constants.ts
+++ b/frontend/kesaseteli/shared/src/constants/status-constants.ts
@@ -1,0 +1,20 @@
+export const YOUTH_APPLICATION_STATUS_WAITING_FOR_YOUTH_ACTION = [
+  'submitted',
+  'additional_information_requested',
+] as const;
+export const YOUTH_APPLICATION_STATUS_WAITING_FOR_HANDLER_ACTION = [
+  'awaiting_manual_processing',
+  'additional_information_provided',
+] as const;
+export const YOUTH_APPLICATION_STATUS_COMPLETED = [
+  'accepted',
+  'rejected',
+] as const;
+export const YOUTH_APPLICATION_STATUS_HANDLER_CANNOT_PROCEED = [
+  ...YOUTH_APPLICATION_STATUS_WAITING_FOR_YOUTH_ACTION,
+  ...YOUTH_APPLICATION_STATUS_COMPLETED,
+] as const;
+export const YOUTH_APPLICATION_STATUS = [
+  ...YOUTH_APPLICATION_STATUS_HANDLER_CANNOT_PROCEED,
+  ...YOUTH_APPLICATION_STATUS_WAITING_FOR_HANDLER_ACTION,
+] as const;

--- a/frontend/kesaseteli/shared/src/constants/status-constants.ts
+++ b/frontend/kesaseteli/shared/src/constants/status-constants.ts
@@ -2,18 +2,22 @@ export const YOUTH_APPLICATION_STATUS_WAITING_FOR_YOUTH_ACTION = [
   'submitted',
   'additional_information_requested',
 ] as const;
+
 export const YOUTH_APPLICATION_STATUS_WAITING_FOR_HANDLER_ACTION = [
   'awaiting_manual_processing',
   'additional_information_provided',
 ] as const;
+
 export const YOUTH_APPLICATION_STATUS_COMPLETED = [
   'accepted',
   'rejected',
 ] as const;
+
 export const YOUTH_APPLICATION_STATUS_HANDLER_CANNOT_PROCEED = [
   ...YOUTH_APPLICATION_STATUS_WAITING_FOR_YOUTH_ACTION,
   ...YOUTH_APPLICATION_STATUS_COMPLETED,
 ] as const;
+
 export const YOUTH_APPLICATION_STATUS = [
   ...YOUTH_APPLICATION_STATUS_HANDLER_CANNOT_PROCEED,
   ...YOUTH_APPLICATION_STATUS_WAITING_FOR_HANDLER_ACTION,

--- a/frontend/kesaseteli/shared/src/types/created-youth-application.d.ts
+++ b/frontend/kesaseteli/shared/src/types/created-youth-application.d.ts
@@ -1,10 +1,10 @@
-import { YOUTH_APPLICATION_STATUS } from '../constants/status-constants';
 import YouthApplication from './youth-application';
+import YouthApplicationStatus from './youth-application-status';
 
 type CreatedYouthApplication = YouthApplication & {
   receipt_confirmed_at?: string;
   id: string;
-  status: typeof YOUTH_APPLICATION_STATUS[number];
+  status: YouthApplicationStatus;
 };
 
 export default CreatedYouthApplication;

--- a/frontend/kesaseteli/shared/src/types/created-youth-application.d.ts
+++ b/frontend/kesaseteli/shared/src/types/created-youth-application.d.ts
@@ -1,8 +1,10 @@
+import { YOUTH_APPLICATION_STATUS } from '../constants/status-constants';
 import YouthApplication from './youth-application';
 
 type CreatedYouthApplication = YouthApplication & {
   receipt_confirmed_at?: string;
   id: string;
+  status: typeof YOUTH_APPLICATION_STATUS[number];
 };
 
 export default CreatedYouthApplication;

--- a/frontend/kesaseteli/shared/src/types/youth-application-status.d.ts
+++ b/frontend/kesaseteli/shared/src/types/youth-application-status.d.ts
@@ -1,0 +1,5 @@
+import { YOUTH_APPLICATION_STATUS } from '../constants/status-constants';
+
+type YouthApplicationStatus = typeof YOUTH_APPLICATION_STATUS[number];
+
+export default YouthApplicationStatus;

--- a/frontend/kesaseteli/youth/browser-tests/youth-application.testcafe.ts
+++ b/frontend/kesaseteli/youth/browser-tests/youth-application.testcafe.ts
@@ -219,4 +219,20 @@ if (!isRealIntegrationsEnabled()) {
     await handlerFormPage.expectations.applicationFieldHasValue('phone_number');
     await handlerFormPage.expectations.applicationFieldHasValue('email');
   });
+
+  test('As a handler I can open non-activated application, but I will see "youth has not yet activated the application" -error message ', async (t) => {
+    const indexPage = await getIndexPageComponents(t);
+    await indexPage.expectations.isLoaded();
+    const formData = fakeYouthFormData();
+    await sendYouthApplication(t, formData);
+    await getThankYouPageComponents(t);
+    const applicationId = await getUrlParam('id');
+    if (!applicationId) {
+      throw new Error('cannot complete test without application id');
+    }
+    await goToHandlerUrl(t, `?id=${applicationId}`);
+    const handlerFormPage = await getHandlerFormPageComponents(t);
+    await handlerFormPage.expectations.isLoaded();
+    await handlerFormPage.expectations.applicationIsNotYetActivated();
+  });
 }


### PR DESCRIPTION
## Description :sparkles:
Accept and Reject -button to handler-ui. Backend is not yeat implemented but ui functionality is already done. Component tests shows that it works correctly. After backend is done, browser tests for accepting/rejecting should be added.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
