### PR TITLE
HL-480: csv export fails when override_monthly_benefit_amount is set

### DIFF
--- a/backend/benefit/calculator/models.py
+++ b/backend/benefit/calculator/models.py
@@ -135,9 +135,14 @@ class Calculation(UUIDModel, TimeStampedModel, DurationMixin):
 
         if rows.count() > 0:
             return rows
-        return SalaryBenefitTotalRow.objects.filter(
-            calculation=self, row_type=RowType.HELSINKI_BENEFIT_TOTAL_EUR
-        )
+        if self.override_monthly_benefit_amount is not None:
+            return ManualOverrideTotalRow.objects.filter(
+                calculation=self, row_type=RowType.HELSINKI_BENEFIT_TOTAL_EUR
+            )
+        else:
+            return SalaryBenefitTotalRow.objects.filter(
+                calculation=self, row_type=RowType.HELSINKI_BENEFIT_TOTAL_EUR
+            )
 
     history = HistoricalRecords(table_name="bf_calculator_calculator_history")
 


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug: HL-480

## Testing :alembic:
backend/benefit/applications/tests/test_applications_csv_report.py:test_applications_csv_monthly_amount_override

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
