### PR TITLE
Fix applicant cannot choose 1.1 as start date

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
@@ -16,7 +16,10 @@ import startOfYear from 'date-fns/startOfYear';
 import { FinnishSSN } from 'finnish-ssn';
 import { TFunction } from 'next-i18next';
 import { NAMES_REGEX, PHONE_NUMBER_REGEX } from 'shared/constants';
-import { convertToUIDateFormat, parseDate } from 'shared/utils/date.utils';
+import {
+  convertToUIDateFormat,
+  validateDateIsFromCurrentYearOnwards,
+} from 'shared/utils/date.utils';
 import { getNumberValue } from 'shared/utils/string.utils';
 import * as Yup from 'yup';
 
@@ -73,10 +76,7 @@ export const getValidationSchema = (t: TFunction): Yup.SchemaOf<Step2> =>
         message: t(VALIDATION_MESSAGE_KEYS.DATE_MIN, {
           min: convertToUIDateFormat(startOfYear(new Date())),
         }),
-        test: (value = '') => {
-          const date = parseDate(value);
-          return date ? date >= startOfYear(new Date()) : false;
-        },
+        test: (value = '') => validateDateIsFromCurrentYearOnwards(value),
       }),
     [APPLICATION_FIELDS_STEP2_KEYS.END_DATE]: Yup.string().required(
       t(VALIDATION_MESSAGE_KEYS.REQUIRED)

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
@@ -76,7 +76,7 @@ export const getValidationSchema = (t: TFunction): Yup.SchemaOf<Step2> =>
         }),
         test: (value = '') => {
           const date = parseDate(value);
-          return date ? isAfter(date, startOfYear(new Date())) : false;
+          return date ? date >= startOfYear(new Date()) : false;
         },
       }),
     [APPLICATION_FIELDS_STEP2_KEYS.END_DATE]: Yup.string().required(

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
@@ -12,7 +12,6 @@ import {
 } from 'benefit/applicant/constants';
 import { Step2 } from 'benefit/applicant/types/application';
 import { VALIDATION_MESSAGE_KEYS } from 'benefit-shared/constants';
-import isAfter from 'date-fns/isAfter';
 import startOfYear from 'date-fns/startOfYear';
 import { FinnishSSN } from 'finnish-ssn';
 import { TFunction } from 'next-i18next';

--- a/frontend/shared/src/utils/__tests__/date.utils.test.ts
+++ b/frontend/shared/src/utils/__tests__/date.utils.test.ts
@@ -47,17 +47,25 @@ describe('dates', () => {
   });
 
   describe('validateDateIsFromCurrentYearOnwards', () => {
+    const currentYear = new Date().getFullYear();
     it('should return false', () => {
-      const validateDateIsFromCurrentYearOnwardsResult =
-        validateDateIsFromCurrentYearOnwards('31.12.2021');
-
-      expect(validateDateIsFromCurrentYearOnwardsResult).toBe(false);
+      expect(
+        validateDateIsFromCurrentYearOnwards(`31.12.${currentYear - 1}`)
+      ).toBe(false);
+      expect(
+        validateDateIsFromCurrentYearOnwards(`2.1.${currentYear - 4}`)
+      ).toBe(false);
+      expect(
+        validateDateIsFromCurrentYearOnwards(`4.8.${currentYear - 2}`)
+      ).toBe(false);
     });
     it('should return true', () => {
-      const validateDateIsFromCurrentYearOnwardsResult =
-        validateDateIsFromCurrentYearOnwards(`1.1.${new Date().getFullYear()}`);
-
-      expect(validateDateIsFromCurrentYearOnwardsResult).toBe(true);
+      expect(validateDateIsFromCurrentYearOnwards(`1.1.${currentYear}`)).toBe(
+        true
+      );
+      expect(
+        validateDateIsFromCurrentYearOnwards(`3.4.${currentYear + 5}`)
+      ).toBe(true);
     });
   });
 });

--- a/frontend/shared/src/utils/__tests__/date.utils.test.ts
+++ b/frontend/shared/src/utils/__tests__/date.utils.test.ts
@@ -1,4 +1,10 @@
-import { days360, diffMonths, isLeapYear, parseDate } from '../date.utils';
+import {
+  days360,
+  diffMonths,
+  isLeapYear,
+  parseDate,
+  validateDateIsFromCurrentYearOnwards,
+} from '../date.utils';
 
 describe('dates', () => {
   describe('isLeapYear', () => {
@@ -37,6 +43,21 @@ describe('dates', () => {
         parseDate('31.12.2021')
       );
       expect(diffMonthsResult).toBeLessThan(0);
+    });
+  });
+
+  describe('validateDateIsFromCurrentYearOnwards', () => {
+    it('should return false', () => {
+      const validateDateIsFromCurrentYearOnwardsResult =
+        validateDateIsFromCurrentYearOnwards('31.12.2021');
+
+      expect(validateDateIsFromCurrentYearOnwardsResult).toBe(false);
+    });
+    it('should return true', () => {
+      const validateDateIsFromCurrentYearOnwardsResult =
+        validateDateIsFromCurrentYearOnwards(`1.1.${new Date().getFullYear()}`);
+
+      expect(validateDateIsFromCurrentYearOnwardsResult).toBe(true);
     });
   });
 });

--- a/frontend/shared/src/utils/date.utils.ts
+++ b/frontend/shared/src/utils/date.utils.ts
@@ -1,3 +1,4 @@
+import { startOfYear } from 'date-fns';
 import formatDateStr from 'date-fns/format';
 import isFutureFn from 'date-fns/isFuture';
 import isValid from 'date-fns/isValid';
@@ -177,4 +178,11 @@ export const getCorrectEndDate = (
 ): string | undefined | Date => {
   if ((parseDate(startDate) ?? 0) > (parseDate(endDate) ?? 0)) return startDate;
   return endDate;
+};
+
+export const validateDateIsFromCurrentYearOnwards = (
+  date: string | undefined | null
+): boolean => {
+  const parsedDate = parseDate(date);
+  return parsedDate ? parsedDate >= startOfYear(new Date()) : false;
 };


### PR DESCRIPTION
## Description :sparkles:
Fix applicant cannot choose 1.1 as start date

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
