### PR TITLE
HL-366: add missing op_type parameter when sending audit logs to ES

### DIFF
--- a/backend/shared/shared/audit_log/tasks.py
+++ b/backend/shared/shared/audit_log/tasks.py
@@ -44,6 +44,7 @@ def send_audit_log_to_elastic_search():
             index=settings.ELASTICSEARCH_APP_AUDIT_LOG_INDEX,
             id=entry.id,
             body=message_body,
+            op_type="create",
         )
         if rs.get("result") == ES_STATUS_CREATED:
             entry.is_sent = True


### PR DESCRIPTION
## Description :sparkles:

Add op_type="create" that is required by ElasticSearch instance in Platta.
The issue causes errors like "elasticsearch.exceptions.RequestError: RequestError(400, 'illegal_argument_exception', 'only write ops with an op_type of create are allowed in data streams')" when running the cron job.

## Issues :bug: HL-366

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
