### PR TITLE
HL-482: Add handled_at field in API

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -1580,6 +1580,7 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
     * training compensations
     * batch
     * latest_decision_comment
+    * handled_at
     """
 
     # more status transitions
@@ -1631,6 +1632,17 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
             )
         return Company.objects.get(validated_data["create_application_for_company"])
 
+    handled_at = serializers.SerializerMethodField(
+        "get_handled_at",
+        help_text="Timestamp when the application was handled (accepted/rejected/cancelled)",
+    )
+
+    def get_handled_at(self, obj):
+        if hasattr(obj, "handled_at"):
+            return obj.handled_at
+        else:
+            return None
+
     class Meta(BaseApplicationSerializer.Meta):
         fields = BaseApplicationSerializer.Meta.fields + [
             "calculation",
@@ -1639,9 +1651,11 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
             "batch",
             "create_application_for_company",
             "latest_decision_comment",
+            "handled_at",
         ]
         read_only_fields = BaseApplicationSerializer.Meta.read_only_fields + [
-            "latest_decision_comment"
+            "latest_decision_comment",
+            "handled_at",
         ]
 
     @transaction.atomic

--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -14,6 +14,7 @@ from companies.models import Company
 from django.conf import settings
 from django.core.validators import MaxLengthValidator, MinLengthValidator
 from django.db import connection, models
+from django.db.models import Max, Q
 from django.utils.translation import gettext_lazy as _
 from encrypted_fields.fields import EncryptedCharField, SearchField
 from localflavor.generic.models import IBANField
@@ -63,6 +64,26 @@ def address_property(field_suffix):
     return _address_property_getter
 
 
+class ApplicationManager(models.Manager):
+
+    HANDLED_STATUSES = [
+        ApplicationStatus.REJECTED,
+        ApplicationStatus.ACCEPTED,
+        ApplicationStatus.CANCELLED,
+    ]
+
+    def _annotate_handled_at(self, qs):
+        return qs.annotate(
+            handled_at=Max(
+                "log_entries__created_at",
+                filter=Q(log_entries__to_status__in=self.HANDLED_STATUSES),
+            )
+        )
+
+    def get_queryset(self):
+        return self._annotate_handled_at(super().get_queryset())
+
+
 class Application(UUIDModel, TimeStampedModel, DurationMixin):
     """
     Data model for Helsinki benefit applications
@@ -74,6 +95,8 @@ class Application(UUIDModel, TimeStampedModel, DurationMixin):
 
     For additional descriptions of the fields, see the API documentation (serializers.py)
     """
+
+    objects = ApplicationManager()
 
     BENEFIT_MAX_MONTHS = 12
 

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -1090,8 +1090,12 @@ def test_application_status_change_as_handler(
             assert (
                 response.data["latest_decision_comment"] == expected_log_entry_comment
             )
+            assert response.data["handled_at"] == datetime.now().replace(
+                tzinfo=pytz.utc
+            )
         else:
             assert response.data["latest_decision_comment"] is None
+            assert response.data["handled_at"] is None
     else:
         assert application.log_entries.all().count() == 0
 

--- a/backend/benefit/applications/tests/test_applications_csv_report.py
+++ b/backend/benefit/applications/tests/test_applications_csv_report.py
@@ -46,9 +46,9 @@ def _create_applications_for_csv_export():
         created_at=datetime(2022, 3, 1)
     )
     application4 = DecidedApplicationFactory(
-        status=ApplicationStatus.CANCELLED
+        status=ApplicationStatus.HANDLING
     )  # should be excluded
-    application4.log_entries.filter(to_status=ApplicationStatus.CANCELLED).update(
+    application4.log_entries.filter(to_status=ApplicationStatus.HANDLING).update(
         created_at=datetime(2022, 2, 1)
     )
     return (application1, application2, application3, application4)
@@ -156,14 +156,14 @@ def test_applications_csv_export_with_date_range(handler_api_client):
     _get_csv(
         handler_api_client,
         reverse("v1:handler-application-list")
-        + "export_csv/?date_handled_after=2022-01-02",
+        + "export_csv/?handled_at_after=2022-01-02",
         [application2.application_number, application3.application_number],
     )
 
     _get_csv(
         handler_api_client,
         reverse("v1:handler-application-list")
-        + "export_csv/?date_handled_after=2021-12-31&date_handled_before=2022-03-02",
+        + "export_csv/?handled_at_after=2021-12-31&handled_at_before=2022-03-02",
         [
             application1.application_number,
             application2.application_number,
@@ -173,7 +173,7 @@ def test_applications_csv_export_with_date_range(handler_api_client):
     _get_csv(
         handler_api_client,
         reverse("v1:handler-application-list")
-        + "export_csv/?date_handled_after=2022-01-01&date_handled_before=2022-03-01",
+        + "export_csv/?handled_at_after=2022-01-01&handled_at_before=2022-03-01",
         [
             application1.application_number,
             application2.application_number,
@@ -183,13 +183,13 @@ def test_applications_csv_export_with_date_range(handler_api_client):
     _get_csv(
         handler_api_client,
         reverse("v1:handler-application-list")
-        + "export_csv/?date_handled_after=2022-01-02&date_handled_before=2022-02-28",
+        + "export_csv/?handled_at_after=2022-01-02&handled_at_before=2022-02-28",
         [application2.application_number],
     )
     _get_csv(
         handler_api_client,
         reverse("v1:handler-application-list")
-        + "export_csv/?date_handled_after=2022-02-02&date_handled_before=2022-02-28",
+        + "export_csv/?handled_at_after=2022-02-02&handled_at_before=2022-02-28",
         [],
         expect_empty=True,
     )
@@ -197,25 +197,25 @@ def test_applications_csv_export_with_date_range(handler_api_client):
     _get_csv(
         handler_api_client,
         reverse("v1:handler-application-list")
-        + "export_csv/?date_handled_after=2022-02-01",
+        + "export_csv/?handled_at_after=2022-02-01",
         [application2.application_number, application3.application_number],
     )
     _get_csv(
         handler_api_client,
         reverse("v1:handler-application-list")
-        + "export_csv/?date_handled_before=2022-02-28",
+        + "export_csv/?handled_at_before=2022-02-28",
         [application1.application_number, application2.application_number],
     )
     _get_csv(
         handler_api_client,
         reverse("v1:handler-application-list")
-        + "export_csv/?date_handled_after=2022-02-01&status=rejected",
+        + "export_csv/?handled_at_after=2022-02-01&status=rejected",
         [application3.application_number],
     )
     _get_csv(
         handler_api_client,
         reverse("v1:handler-application-list")
-        + "export_csv/?date_handled_after=2022-02-01&status=cancelled",
+        + "export_csv/?handled_at_after=2022-02-01&status=handling",
         [],
         expect_empty=True,
     )


### PR DESCRIPTION
The field contains the timestamp when the application was cancelled/rejected/accepted

## Description :sparkles:
Add handled_at field in API
    
The field contains the timestamp when the application was cancelled/rejected/accepted

## Issues :bug: HL-482

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
