### PR TITLE
HL-488: state_aid_max_percentage not required for employment_benefit

### DIFF
--- a/backend/benefit/calculator/rules.py
+++ b/backend/benefit/calculator/rules.py
@@ -124,13 +124,9 @@ class HelsinkiBenefitCalculator:
             [
                 self.calculation.start_date,
                 self.calculation.end_date,
-                self.calculation.state_aid_max_percentage,
             ]
         ):
             return False
-        for pay_subsidy in self.calculation.application.pay_subsidies.all():
-            if not all([pay_subsidy.start_date, pay_subsidy.end_date]):
-                return False
         return True
 
     @transaction.atomic
@@ -188,6 +184,20 @@ class SalaryBenefitCalculator2021(HelsinkiBenefitCalculator):
     PAY_SUBSIDY_MAX_FOR_100_PERCENT = 1800
     DEFAULT_PAY_SUBSIDY_MAX = 1400
     SALARY_BENEFIT_MAX = 800
+
+    def can_calculate(self):
+        if not all(
+            [
+                self.calculation.start_date,
+                self.calculation.end_date,
+                self.calculation.state_aid_max_percentage,
+            ]
+        ):
+            return False
+        for pay_subsidy in self.calculation.application.pay_subsidies.all():
+            if not all([pay_subsidy.start_date, pay_subsidy.end_date]):
+                return False
+        return True
 
     def get_maximum_monthly_pay_subsidy(self, pay_subsidy):
         if pay_subsidy.pay_subsidy_percent == 100:

--- a/backend/benefit/calculator/tests/test_models.py
+++ b/backend/benefit/calculator/tests/test_models.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 from applications.enums import ApplicationStatus, BenefitType
 from applications.tests.conftest import *  # noqa
@@ -88,3 +90,148 @@ def test_pay_subsidy_maximum(handling_application, pay_subsidy_percent, max_subs
         )
         == max_subsidy
     )
+
+
+@pytest.mark.parametrize(
+    (
+        "benefit_type,start_date,end_date,state_aid_max_percentage,"
+        "pay_subsidy_start_date,pay_subsidy_end_date,can_calculate"
+    ),
+    [
+        (
+            BenefitType.SALARY_BENEFIT,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            100,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            True,
+        ),
+        (
+            BenefitType.SALARY_BENEFIT,
+            None,
+            date(2022, 1, 31),
+            100,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            False,
+        ),
+        (
+            BenefitType.SALARY_BENEFIT,
+            date(2022, 1, 1),
+            None,
+            100,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            False,
+        ),
+        (
+            BenefitType.SALARY_BENEFIT,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            None,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            False,
+        ),
+        (
+            BenefitType.SALARY_BENEFIT,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            100,
+            None,
+            date(2022, 1, 31),
+            False,
+        ),
+        (
+            BenefitType.SALARY_BENEFIT,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            100,
+            date(2022, 1, 1),
+            None,
+            False,
+        ),
+        (
+            BenefitType.EMPLOYMENT_BENEFIT,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            100,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            True,
+        ),
+        (
+            BenefitType.EMPLOYMENT_BENEFIT,
+            None,
+            date(2022, 1, 31),
+            100,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            False,
+        ),
+        (
+            BenefitType.EMPLOYMENT_BENEFIT,
+            date(2022, 1, 1),
+            None,
+            100,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            False,
+        ),
+        (
+            BenefitType.EMPLOYMENT_BENEFIT,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            None,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            True,
+        ),
+        (
+            BenefitType.EMPLOYMENT_BENEFIT,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            100,
+            None,
+            date(2022, 1, 31),
+            True,
+        ),
+        (
+            BenefitType.EMPLOYMENT_BENEFIT,
+            date(2022, 1, 1),
+            date(2022, 1, 31),
+            100,
+            date(2022, 1, 1),
+            None,
+            True,
+        ),
+    ],
+)
+def test_calculation_required_fields(
+    handling_application,
+    benefit_type,
+    start_date,
+    end_date,
+    state_aid_max_percentage,
+    pay_subsidy_start_date,
+    pay_subsidy_end_date,
+    can_calculate,
+):
+    handling_application.calculation.start_date = start_date
+    handling_application.calculation.end_date = end_date
+    handling_application.calculation.state_aid_max_percentage = state_aid_max_percentage
+    assert handling_application.pay_subsidies.count() == 1
+    handling_application.pay_subsidies.update(
+        start_date=pay_subsidy_start_date, end_date=pay_subsidy_end_date
+    )
+    handling_application.benefit_type = benefit_type
+    handling_application.save()
+    handling_application.calculation.save()
+    handling_application.calculation.calculate()
+    if can_calculate:
+        assert handling_application.calculation.calculated_benefit_amount is not None
+        assert handling_application.calculation.rows.count() > 0
+    else:
+        assert handling_application.calculation.calculated_benefit_amount is None
+        assert handling_application.calculation.rows.count() == 0


### PR DESCRIPTION
## Description :sparkles:

state_aid_max_percentage is not needed to calculate employment_benefit, so don't require it

## Issues :bug: HL-488

## Testing :alembic:
backend/benefit/calculator/tests/test_models.py:test_calculation_required_fields

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
