### PR TITLE
Backends: Escape string literals in tests' regular expressions

### DIFF
--- a/backend/benefit/companies/tests/conftest.py
+++ b/backend/benefit/companies/tests/conftest.py
@@ -31,14 +31,14 @@ ASSOCIATION_ROLE_JSON = [
 
 @pytest.fixture()
 def mock_get_organisation_roles_and_create_company(requests_mock):
-    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    matcher = re.compile(re.escape(settings.EAUTHORIZATIONS_BASE_URL))
     requests_mock.get(matcher, json=COMPANY_ROLE_JSON)
     return CompanyFactory(business_id=COMPANY_ROLE_JSON[0]["identifier"])
 
 
 @pytest.fixture()
 def mock_get_organisation_roles_and_create_association(requests_mock):
-    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    matcher = re.compile(re.escape(settings.EAUTHORIZATIONS_BASE_URL))
     requests_mock.get(matcher, json=ASSOCIATION_ROLE_JSON)
     return CompanyFactory(
         business_id=ASSOCIATION_ROLE_JSON[0]["identifier"], company_form="association"

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -71,7 +71,7 @@ def test_get_company_from_service_bus_invalid_response(
     response = deepcopy(DUMMY_SERVICE_BUS_RESPONSE)
     response["GetCompanyResult"]["Company"]["PostalAddress"] = {}
 
-    matcher = re.compile(settings.SERVICE_BUS_INFO_PATH)
+    matcher = re.compile(re.escape(settings.SERVICE_BUS_INFO_PATH))
     requests_mock.post(matcher, json=response)
     response = api_client.get(get_company_api_url())
 
@@ -89,7 +89,7 @@ def test_get_organisation_from_service_bus(
     requests_mock,
     mock_get_organisation_roles_and_create_company,
 ):
-    matcher = re.compile(settings.SERVICE_BUS_INFO_PATH)
+    matcher = re.compile(re.escape(settings.SERVICE_BUS_INFO_PATH))
     requests_mock.post(matcher, json=DUMMY_SERVICE_BUS_RESPONSE)
     response = api_client.get(get_company_api_url())
     assert response.status_code == 200
@@ -117,9 +117,9 @@ def test_get_company_from_yrtti(
         company=mock_get_organisation_roles_and_create_association,
         terms=terms_of_service,
     )
-    matcher = re.compile(settings.SERVICE_BUS_INFO_PATH)
+    matcher = re.compile(re.escape(settings.SERVICE_BUS_INFO_PATH))
     requests_mock.post(matcher, text="Error", status_code=404)
-    matcher = re.compile(settings.YRTTI_BASIC_INFO_PATH)
+    matcher = re.compile(re.escape(settings.YRTTI_BASIC_INFO_PATH))
     requests_mock.post(matcher, json=DUMMY_YRTTI_RESPONSE)
     response = api_client.get(get_company_api_url())
     assert response.status_code == 200
@@ -136,9 +136,9 @@ def test_get_company_from_yrtti(
 def test_get_company_from_service_bus_and_yrtti_results_in_error(
     api_client, requests_mock, mock_get_organisation_roles_and_create_company
 ):
-    matcher = re.compile(settings.SERVICE_BUS_INFO_PATH)
+    matcher = re.compile(re.escape(settings.SERVICE_BUS_INFO_PATH))
     requests_mock.post(matcher, text="Error", status_code=404)
-    matcher = re.compile(settings.YRTTI_BASIC_INFO_PATH)
+    matcher = re.compile(re.escape(settings.YRTTI_BASIC_INFO_PATH))
     requests_mock.post(matcher, text="Error", status_code=404)
     # Delete company so that API cannot return object from DB
     mock_get_organisation_roles_and_create_company.delete()
@@ -151,7 +151,7 @@ def test_get_company_from_service_bus_and_yrtti_results_in_error(
 def test_get_company_from_service_bus_and_yrtti_with_fallback_data(
     api_client, requests_mock, mock_get_organisation_roles_and_create_company
 ):
-    matcher = re.compile(settings.SERVICE_BUS_INFO_PATH)
+    matcher = re.compile(re.escape(settings.SERVICE_BUS_INFO_PATH))
     requests_mock.post(matcher, json=DUMMY_SERVICE_BUS_RESPONSE)
     response = api_client.get(get_company_api_url())
 
@@ -160,9 +160,9 @@ def test_get_company_from_service_bus_and_yrtti_with_fallback_data(
     assert Company.objects.count() == 1
 
     # Now assuming request to YTJ & YRTTI doesn't return any data
-    matcher = re.compile(settings.SERVICE_BUS_INFO_PATH)
+    matcher = re.compile(re.escape(settings.SERVICE_BUS_INFO_PATH))
     requests_mock.post(matcher, text="Error", status_code=404)
-    matcher = re.compile(settings.YRTTI_BASIC_INFO_PATH)
+    matcher = re.compile(re.escape(settings.YRTTI_BASIC_INFO_PATH))
     requests_mock.post(matcher, text="Error", status_code=404)
 
     response = api_client.get(get_company_api_url())

--- a/backend/kesaseteli/companies/tests/test_company_api.py
+++ b/backend/kesaseteli/companies/tests/test_company_api.py
@@ -71,7 +71,7 @@ def test_get_company_organization_roles_error(api_client, requests_mock, user):
     session.pop("organization_roles")
     session.save()
 
-    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    matcher = re.compile(re.escape(settings.EAUTHORIZATIONS_BASE_URL))
     requests_mock.get(matcher, text="Error", status_code=401)
 
     response = api_client.get(get_company_api_url())
@@ -130,7 +130,7 @@ def test_get_company_from_ytj(api_client, requests_mock):
     YTJ_BASE_URL="http://example.com",
 )
 def test_get_company_not_found_from_ytj(api_client, requests_mock, user):
-    matcher = re.compile(settings.YTJ_BASE_URL)
+    matcher = re.compile(re.escape(settings.YTJ_BASE_URL))
     requests_mock.get(matcher, text="Error", status_code=404)
 
     org_roles_json = {

--- a/backend/shared/shared/azure_adfs/tests/test_adfs_login.py
+++ b/backend/shared/shared/azure_adfs/tests/test_adfs_login.py
@@ -30,7 +30,7 @@ def test_get_member_objects(requests_mock):
         ],
     }
 
-    matcher = re.compile("https://graph.microsoft.com/")
+    matcher = re.compile(re.escape("https://graph.microsoft.com/"))
     requests_mock.post(matcher, json=member_objects_response)
 
     groups = auth_backend.get_member_objects_from_graph_api("test", "test")
@@ -59,7 +59,7 @@ def test_update_user_groups_from_graph_api(requests_mock, user):
         ],
     }
 
-    matcher = re.compile("https://graph.microsoft.com/")
+    matcher = re.compile(re.escape("https://graph.microsoft.com/"))
     requests_mock.post(matcher, json=member_objects_response)
 
     auth_backend.update_user_groups_from_graph_api(user, "test", "test")
@@ -89,7 +89,7 @@ def test_get_graph_api_access_token(requests_mock):
         "refresh_token": "OAQABAAAAAABnfiG-mA6NTae7CdWW7QfdAALzDWjw6qSn4GUDfxWzJDZ6lk9qRw4An",
     }
 
-    matcher = re.compile("https://login.microsoftonline.com/")
+    matcher = re.compile(re.escape("https://login.microsoftonline.com/"))
     requests_mock.post(matcher, json=token_endpoint_response)
 
     with mock.patch.object(

--- a/backend/shared/shared/oidc/tests/test_auth_backend.py
+++ b/backend/shared/shared/oidc/tests/test_auth_backend.py
@@ -59,7 +59,7 @@ def test_authenticate(requests_mock):
         "email": "test_email",
     }
 
-    matcher = re.compile(settings.OIDC_OP_USER_ENDPOINT)
+    matcher = re.compile(re.escape(settings.OIDC_OP_USER_ENDPOINT))
     requests_mock.get(matcher, json=claims)
 
     state = "test"
@@ -158,7 +158,7 @@ def test_refresh_token(session_request, requests_mock):
         "refresh_expires_in": 1800,
     }
 
-    matcher = re.compile(settings.OIDC_OP_TOKEN_ENDPOINT)
+    matcher = re.compile(re.escape(settings.OIDC_OP_TOKEN_ENDPOINT))
     requests_mock.post(matcher, json=token_info)
 
     auth_backend.refresh_tokens(session_request)

--- a/backend/shared/shared/oidc/tests/test_eauth_views.py
+++ b/backend/shared/shared/oidc/tests/test_eauth_views.py
@@ -60,7 +60,7 @@ def test_get_organization_roles(session_request, requests_mock):
         }
     ]
 
-    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    matcher = re.compile(re.escape(settings.EAUTHORIZATIONS_BASE_URL))
     requests_mock.get(matcher, json=organization_roles_json)
 
     organization_roles = get_organization_roles(session_request)
@@ -83,7 +83,7 @@ def test_eauth_authentication_init_view(requests_mock, user_client, user):
         "userId": "test_user",
     }
 
-    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    matcher = re.compile(re.escape(settings.EAUTHORIZATIONS_BASE_URL))
     requests_mock.get(matcher, json=register_user_info)
 
     authentication_url = reverse("eauth_authentication_init")
@@ -115,7 +115,7 @@ def test_eauth_callback_view(requests_mock, user_client, user):
         "expires_in": 600,
         "refresh_token": "test3",
     }
-    matcher = re.compile(settings.EAUTHORIZATIONS_BASE_URL)
+    matcher = re.compile(re.escape(settings.EAUTHORIZATIONS_BASE_URL))
     requests_mock.post(matcher, json=token_info)
 
     organization_roles_json = [

--- a/backend/shared/shared/oidc/tests/test_oidc_views.py
+++ b/backend/shared/shared/oidc/tests/test_oidc_views.py
@@ -59,7 +59,7 @@ def test_logout_view_without_oidc_info(user_client, user):
     MOCK_FLAG=False,
 )
 def test_logout_callback_view(requests_mock, user_client, user):
-    matcher = re.compile(settings.OIDC_OP_LOGOUT_ENDPOINT)
+    matcher = re.compile(re.escape(settings.OIDC_OP_LOGOUT_ENDPOINT))
     requests_mock.post(matcher)
 
     logout_url = reverse("oidc_logout_callback")
@@ -90,7 +90,7 @@ def test_userinfo_view(requests_mock, user_client, user):
         "name": userinfo["name"],
     }
 
-    matcher = re.compile(settings.OIDC_OP_USER_ENDPOINT)
+    matcher = re.compile(re.escape(settings.OIDC_OP_USER_ENDPOINT))
     requests_mock.get(matcher, json=userinfo)
 
     userinfo_url = reverse("oidc_userinfo")
@@ -127,7 +127,7 @@ def test_userinfo_view_without_oidc_info(user_client):
     NEXT_PUBLIC_MOCK_FLAG=False,
 )
 def test_userinfo_view_with_userinfo_returning_401(requests_mock, user_client, user):
-    matcher = re.compile(settings.OIDC_OP_USER_ENDPOINT)
+    matcher = re.compile(re.escape(settings.OIDC_OP_USER_ENDPOINT))
     requests_mock.get(matcher, status_code=401)
 
     userinfo_url = reverse("oidc_userinfo")


### PR DESCRIPTION
## Description :sparkles:

GitHub Code Scanning / CodeQL found "Incomplete regular expression for
hostnames" problems in code in develop to main branch merging on
7th of March, 2022, for an example:
 - "This regular expression has an unescaped '.' before 'microsoft.com',
   so it might match more hosts than expected."

Fix uses of re.compile in tests with string literals by escaping the
input i.e. by changing re.compile(text) to re.compile(re.escape(text)).

## Issues :bug:

`-`

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
