### PR TITLE
HL-494: allow modification of granted_as_de_minimis_aid when accepting application

### DIFF
--- a/backend/benefit/common/utils.py
+++ b/backend/benefit/common/utils.py
@@ -9,10 +9,12 @@ from phonenumber_field.serializerfields import (
 )
 
 
-def update_object(obj, data):
+def update_object(obj, data, limit_to_fields=None):
     if not data:
         return
     for k, v in data.items():
+        if limit_to_fields is not None and k not in limit_to_fields:
+            continue
         if v is None and not obj.__class__._meta.get_field(k).null:
             raise ValueError(f"{k} cannot be null.")
         setattr(obj, k, v)


### PR DESCRIPTION

## Description :sparkles:

When application is accepted, the handler needs to be able to set the granted_as_de_minimis_aid value.

## Issues :bug: HL-494

## Testing :alembic:
backend/benefit/applications/tests/test_applications_api.py:test_application_accept

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
