### PR TITLE
Include Django admin urls only when ENABLE_ADMIN is set

### DIFF
--- a/backend/tet/tet/urls.py
+++ b/backend/tet/tet/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import admin
 from django.http import HttpResponse, JsonResponse
 from django.urls import include, path
@@ -16,8 +17,10 @@ urlpatterns = [
     path("userinfo/", UserInfoView.as_view(), name="userinfo"),
     path("oidc/", include("shared.oidc.urls")),
     path("oauth2/", include("shared.azure_adfs.urls")),
-    path("admin/", admin.site.urls),
 ]
+
+if settings.ENABLE_ADMIN:
+    urlpatterns.append(path("admin/", admin.site.urls))
 
 
 @require_GET


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
