### PR TITLE
HL-478: remove application from batch when moving back to handling

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -1772,6 +1772,10 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
             instance, previous_status, approve_terms, log_entry_comment
         )
         # Extend from base class function.
+        self._assign_handler_if_needed(instance)
+        self._remove_batch_if_needed(instance)
+
+    def _assign_handler_if_needed(self, instance):
         # Assign current user to the application.calculation.handler
         # NOTE: This handler might be overridden if there is a handler pk included in the request post data
         handler = get_request_user_from_context(self)
@@ -1780,3 +1784,8 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
         if instance.status in HandlerApplicationStatusValidator.ASSIGN_HANDLER_STATUSES:
             instance.calculation.handler = handler
             instance.calculation.save()
+
+    def _remove_batch_if_needed(self, instance):
+        if instance.status == ApplicationStatus.HANDLING and instance.batch:
+            instance.batch = None
+            instance.save()


### PR DESCRIPTION
## Description :sparkles:
Application.batch field needs to be set to null when moving back to handling

## Issues :bug: HL-478

## Testing :alembic:
backend/benefit/applications/tests/test_applications_api.py:test_application_with_batch_back_to_handling

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
