### PR TITLE
TET: add ADFS claims givenName and familyName

### DIFF
--- a/backend/tet/tet/settings.py
+++ b/backend/tet/tet/settings.py
@@ -280,7 +280,11 @@ AUTH_ADFS = {
     "AUDIENCE": ADFS_CLIENT_ID,
     "CLIENT_ID": ADFS_CLIENT_ID,
     "CLIENT_SECRET": ADFS_CLIENT_SECRET,
-    "CLAIM_MAPPING": {"email": "email"},
+    "CLAIM_MAPPING": {
+        "email": "email",
+        "first_name": "givenName",
+        "last_name": "familyName",
+    },
     "USERNAME_CLAIM": "oid",
     "TENANT_ID": ADFS_TENANT_ID,
     "RELYING_PARTY_ID": ADFS_CLIENT_ID,


### PR DESCRIPTION
## Description :sparkles:

TET backend tries to read user's name from ADFS claim. If givenName or familyName is empty, it will produce the following warning but no error: `Claim 'givenName' for user field 'first_name' was not found in the access token for user '6928cf58-4791-480c-b848-1272de20c124'. Field is not required and will be left empty`

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
