### PR TITLE
YJDH-497 | KS-Backend: Add youth application status endpoint

### DIFF
--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -512,3 +512,11 @@ class YouthApplicationSerializer(serializers.ModelSerializer):
             return {}
         else:
             return json.loads(obj.encrypted_vtj_json)
+
+
+class YouthApplicationStatusSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = YouthApplication
+        fields = read_only_fields = [
+            "status",
+        ]

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -34,6 +34,7 @@ from applications.api.v1.serializers import (
     EmployerSummerVoucherSerializer,
     SchoolSerializer,
     YouthApplicationSerializer,
+    YouthApplicationStatusSerializer,
 )
 from applications.enums import (
     EmployerApplicationStatus,
@@ -125,6 +126,15 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
     def destroy(self, request, *args, **kwargs):
         self._log_permission_denied()
         return Response(status=status.HTTP_403_FORBIDDEN)
+
+    @action(methods=["get"], detail=True)
+    def status(self, request, *args, **kwargs) -> HttpResponse:
+        with self.record_action(additional_information="status"):
+            serializer = YouthApplicationStatusSerializer(
+                self.get_object(),
+                context=self.get_serializer_context(),
+            )
+            return Response(serializer.data)
 
     @enforce_handler_view_adfs_login
     def retrieve(self, request, *args, **kwargs):


### PR DESCRIPTION
## Description :sparkles:

The added endpoint:
 - URL: `/v1/youthapplications/<pk>/status/`
 - Access control: None, so this is a public endpoint
 - Output: {"status": "<youth application's status>"}

Add YouthApplicationStatusSerializer for serializing only the youth
application's status.

Add tests for status endpoint:
 - test_youth_applications_public_action_unused_pk
   - Combine test_youth_applications_activate_unused_pk into this
 - test_youth_applications_status_valid_pk

## Issues :bug:

YJDH-497

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
