### PR TITLE
HL-514: change CSRF_COOKIE_NAME to avoid conflict with Tunnistamo

### DIFF
--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -41,6 +41,7 @@ env = environ.Env(
     CORS_ALLOW_ALL_ORIGINS=(bool, False),
     CSRF_COOKIE_DOMAIN=(str, "localhost"),
     CSRF_TRUSTED_ORIGINS=(list, []),
+    CSRF_COOKIE_NAME=(str, "benefitcsrftoken"),
     YTJ_BASE_URL=(str, "http://avoindata.prh.fi/opendata/tr/v1"),
     YTJ_TIMEOUT=(int, 30),
     # Source: YTJ-rajapinnan koodiston kuvaus, available at https://liityntakatalogi.suomi.fi/dataset/xroadytj-services
@@ -232,6 +233,7 @@ CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS")
 CORS_ALLOW_ALL_ORIGINS = env.bool("CORS_ALLOW_ALL_ORIGINS")
 CSRF_COOKIE_DOMAIN = env.str("CSRF_COOKIE_DOMAIN")
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS")
+CSRF_COOKIE_NAME = env.str("CSRF_COOKIE_NAME")
 CSRF_COOKIE_SECURE = True
 
 # Audit logging


### PR DESCRIPTION
## Description :sparkles:
[mikkovihonen](https://app.slack.com/team/U017Z6SEH70) [Mar 17th at 3:11 PM]
@here Does anyone have any clue why csrftoken would be set two times, first for .[hel.fi](http://hel.fi/) domain and the latter for .[arodevtest.hel.fi](http://arodevtest.hel.fi/)? We noticed that two csrftokens on a call will cause an error which will disappear once the “wrong” csrftoken expires. I witnessed this yesterday in Kesäseteli and today in TET project.

## Issues :bug: HL-514

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
