### PR TITLE
Disable option Työllistämisen Helsinki-lisä if company is association…

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -204,6 +204,10 @@
           "commissionBenefitSelected": {
             "label": "Period",
             "content": "Varmista, että haettava kesto on sama kuin toimeksiantosopimuksessa."
+          },
+          "noAvailableBenefitTypes": {
+            "label": "No types of benefit available",
+            "content": "A company or an association that is not engaged in economic activity can only apply for the Helsinki benefit for salary. Pay subsidy granted for the employment relationship is a prerequisite for the Helsinki benefit for salary."
           }
         },
         "messages": {

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -204,6 +204,10 @@
           "commissionBenefitSelected": {
             "label": "Ajanjakso",
             "content": "Varmista, että haettava kesto on sama kuin toimeksiantosopimuksessa."
+          },
+          "noAvailableBenefitTypes": {
+            "label": "Ei haettavia tukimuotoja",
+            "content": "Yhteisö, joka ei harjoita taloudellista toimintaa voi hakea ainoastaan Palkan Helsinki-lisää. Palkan Helsinki-lisän edellytyksenä on työsuhteeseen myönnetty palkkatuki."
           }
         },
         "messages": {

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -204,6 +204,10 @@
           "commissionBenefitSelected": {
             "label": "Tidsperiod",
             "content": "Varmista, että haettava kesto on sama kuin toimeksiantosopimuksessa."
+          },
+          "noAvailableBenefitTypes": {
+            "label": "Inga ansökningsbara stödformer",
+            "content": "En sammanslutning som inte bedriver ekonomisk verksamhet kan endast ansöka om Helsingforstillägg för lön. Förutsättningen för att få Helsingforstillägg för lön är att lönesubvention har beviljats för anställningen."
           }
         },
         "messages": {

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -7,7 +7,6 @@ import {
 } from 'benefit/applicant/constants';
 import { useAlertBeforeLeaving } from 'benefit/applicant/hooks/useAlertBeforeLeaving';
 import { useDependentFieldsEffect } from 'benefit/applicant/hooks/useDependentFieldsEffect';
-import application from 'benefit/applicant/pages/application';
 import { DynamicFormStepComponentProps } from 'benefit/applicant/types/common';
 import { DateInput, Select, SelectionGroup, TextInput } from 'hds-react';
 import camelCase from 'lodash/camelCase';
@@ -368,7 +367,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
               disabled={
                 data?.company?.organizationType ===
                   ORGANIZATION_TYPES.ASSOCIATION &&
-                !Boolean(data?.associationHasBusinessActivities)
+                !data?.associationHasBusinessActivities
               }
             />
             <$RadioButton

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -87,8 +87,9 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
   const selectLabel = t('common:select');
 
   const isAbleToSelectEmploymentBenefit =
-    data?.company?.organizationType === ORGANIZATION_TYPES.ASSOCIATION &&
-    data?.associationHasBusinessActivities;
+    data?.company?.organizationType !== ORGANIZATION_TYPES.ASSOCIATION ||
+    (data?.company?.organizationType === ORGANIZATION_TYPES.ASSOCIATION &&
+      data?.associationHasBusinessActivities);
   const isAbleToSelectSalaryBenefit = formik.values.paySubsidyGranted === true;
 
   const isNoAvailableBenefitTypes =

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -86,6 +86,14 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
 
   const selectLabel = t('common:select');
 
+  const isAbleToSelectEmploymentBenefit =
+    data?.company?.organizationType === ORGANIZATION_TYPES.ASSOCIATION &&
+    data?.associationHasBusinessActivities;
+  const isAbleToSelectSalaryBenefit = formik.values.paySubsidyGranted === true;
+
+  const isNoAvailableBenefitTypes =
+    !isAbleToSelectEmploymentBenefit && !isAbleToSelectSalaryBenefit;
+
   return (
     <form onSubmit={handleSubmit} noValidate>
       <FormSection header={t(`${translationsBase}.heading1`)}>
@@ -364,11 +372,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
               onBlur={formik.handleBlur}
               onChange={formik.handleChange}
               checked={formik.values.benefitType === BENEFIT_TYPES.EMPLOYMENT}
-              disabled={
-                data?.company?.organizationType ===
-                  ORGANIZATION_TYPES.ASSOCIATION &&
-                !data?.associationHasBusinessActivities
-              }
+              disabled={!isAbleToSelectEmploymentBenefit}
             />
             <$RadioButton
               id={`${fields.benefitType.name}Salary`}
@@ -380,10 +384,24 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
               onBlur={formik.handleBlur}
               onChange={formik.handleChange}
               checked={formik.values.benefitType === BENEFIT_TYPES.SALARY}
-              disabled={formik.values.paySubsidyGranted !== true}
+              disabled={!isAbleToSelectSalaryBenefit}
             />
           </SelectionGroup>
         </$GridCell>
+        {isNoAvailableBenefitTypes && (
+          <$GridCell $colStart={7} $colSpan={6}>
+            <$Notification
+              type="error"
+              label={t(
+                `${translationsBase}.notifications.noAvailableBenefitTypes.label`
+              )}
+            >
+              {t(
+                `${translationsBase}.notifications.noAvailableBenefitTypes.content`
+              )}
+            </$Notification>
+          </$GridCell>
+        )}
       </FormSection>
 
       <FormSection header={t(`${translationsBase}.heading4`)}>
@@ -691,6 +709,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
         handleSave={handleSave}
         handleBack={handleBack}
         handleDelete={handleDelete}
+        disabledNext={isNoAvailableBenefitTypes}
       />
     </form>
   );

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -3,9 +3,11 @@ import {
   APPLICATION_FIELDS_STEP2,
   APPLICATION_START_DATE,
   BENEFIT_TYPES,
+  ORGANIZATION_TYPES,
 } from 'benefit/applicant/constants';
 import { useAlertBeforeLeaving } from 'benefit/applicant/hooks/useAlertBeforeLeaving';
 import { useDependentFieldsEffect } from 'benefit/applicant/hooks/useDependentFieldsEffect';
+import application from 'benefit/applicant/pages/application';
 import { DynamicFormStepComponentProps } from 'benefit/applicant/types/common';
 import { DateInput, Select, SelectionGroup, TextInput } from 'hds-react';
 import camelCase from 'lodash/camelCase';
@@ -363,6 +365,11 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
               onBlur={formik.handleBlur}
               onChange={formik.handleChange}
               checked={formik.values.benefitType === BENEFIT_TYPES.EMPLOYMENT}
+              disabled={
+                data?.company?.organizationType ===
+                  ORGANIZATION_TYPES.ASSOCIATION &&
+                !Boolean(data?.associationHasBusinessActivities)
+              }
             />
             <$RadioButton
               id={`${fields.benefitType.name}Salary`}


### PR DESCRIPTION
Applicant form step 2:
- Disable option Työllistämisen Helsinki-lisä if company is association and has no businessActivities
- Show error and disable next if there is no available benefit types

## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
<img width="1054" alt="Screenshot 2022-03-22 at 17 39 18" src="https://user-images.githubusercontent.com/23077311/159521069-67687d59-8a59-41aa-bb0d-c06642701550.png">

## Additional notes :spiral_notepad:
