### PR TITLE
Fix showing error for no available benefit types

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -93,7 +93,9 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
   const isAbleToSelectSalaryBenefit = formik.values.paySubsidyGranted === true;
 
   const isNoAvailableBenefitTypes =
-    !isAbleToSelectEmploymentBenefit && !isAbleToSelectSalaryBenefit;
+    formik.values.paySubsidyGranted !== null &&
+    !isAbleToSelectEmploymentBenefit &&
+    !isAbleToSelectSalaryBenefit;
 
   return (
     <form onSubmit={handleSubmit} noValidate>


### PR DESCRIPTION
Fix applicant form step 2 so that error for no available benefit types is shown only when user has chosen no for paySubsidyGranted

## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
