### PR TITLE
HL-484: set default sorting of applications in the handler UI

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -823,8 +823,8 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
     ADDITIONAL_INFORMATION_DEADLINE = timedelta(days=14)
 
     def get_additional_information_needed_by(self, obj):
-        if info_asked_timestamp := getattr_safe(
-            obj, "additional_information_requested_at"
+        if info_asked_timestamp := getattr(
+            obj, "additional_information_requested_at", None
         ):
             return info_asked_timestamp.date() + self.ADDITIONAL_INFORMATION_DEADLINE
         else:
@@ -868,7 +868,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
         }
 
     def get_submitted_at(self, obj):
-        return getattr_safe(obj, "submitted_at")
+        return getattr(obj, "submitted_at", None)
 
     def get_last_modified_at(self, obj):
         if not self.logged_in_user_is_admin() and obj.status != ApplicationStatus.DRAFT:
@@ -1642,7 +1642,7 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
     )
 
     def get_handled_at(self, obj):
-        return getattr_safe(obj, "handled_at")
+        return getattr(obj, "handled_at", None)
 
     class Meta(BaseApplicationSerializer.Meta):
         fields = BaseApplicationSerializer.Meta.fields + [
@@ -1790,10 +1790,3 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
         if instance.status == ApplicationStatus.HANDLING and instance.batch:
             instance.batch = None
             instance.save()
-
-
-def getattr_safe(obj, param_name):
-    if hasattr(obj, param_name):
-        return getattr(obj, param_name)
-    else:
-        return None

--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -82,37 +82,6 @@ class ApplicationManager(models.Manager):
         )
         return qs.annotate(**{field_name: Subquery(subquery)})
 
-    def _annotate_handled_at(self, qs):
-        subquery = (
-            ApplicationLogEntry.objects.filter(
-                application=OuterRef("pk"), to_status__in=self.HANDLED_STATUSES
-            )
-            .order_by("-created_at")
-            .values("created_at")[:1]
-        )
-        return qs.annotate(handled_at=Subquery(subquery))
-
-    def _annotate_additional_information_requested_at(self, qs):
-        subquery = (
-            ApplicationLogEntry.objects.filter(
-                application=OuterRef("pk"),
-                to_status__in=[ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED],
-            )
-            .order_by("-created_at")
-            .values("created_at")[:1]
-        )
-        return qs.annotate(additional_information_requested_at=Subquery(subquery))
-
-    def _annotate_submitted_at(self, qs):
-        subquery = (
-            ApplicationLogEntry.objects.filter(
-                application=OuterRef("pk"), to_status__in=[ApplicationStatus.RECEIVED]
-            )
-            .order_by("-created_at")
-            .values("created_at")[:1]
-        )
-        return qs.annotate(submitted_at=Subquery(subquery))
-
     def get_queryset(self):
         """
         Annotate the queryset with information about timestamps of past status transitions.

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -7,6 +7,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from unittest import mock
 
+import faker
 import pytest
 import pytz
 from applications.api.v1.serializers import (
@@ -27,7 +28,13 @@ from applications.enums import (
 )
 from applications.models import Application, ApplicationLogEntry, Attachment, Employee
 from applications.tests.conftest import *  # noqa
-from applications.tests.factories import ApplicationBatchFactory, ApplicationFactory
+from applications.tests.factories import (
+    ApplicationBatchFactory,
+    ApplicationFactory,
+    DecidedApplicationFactory,
+    HandlingApplicationFactory,
+    ReceivedApplicationFactory,
+)
 from calculator.models import Calculation
 from calculator.tests.conftest import fill_empty_calculation_fields
 from common.tests.conftest import *  # noqa
@@ -1114,6 +1121,12 @@ def test_application_status_change_as_applicant(
         assert application.log_entries.all().count() == 1
         assert application.log_entries.all().first().from_status == from_status
         assert application.log_entries.all().first().to_status == to_status
+        if to_status == ApplicationStatus.RECEIVED:
+            assert response.data["submitted_at"] == datetime.now().replace(
+                tzinfo=pytz.utc
+            )
+        else:
+            assert response.data["submitted_at"] is None
     else:
         assert application.log_entries.all().count() == 0
 
@@ -2035,3 +2048,52 @@ def test_application_status_last_changed_at(api_client, handling_application):
     assert response.data["status_last_changed_at"] == datetime(
         2021, 12, 1, tzinfo=pytz.UTC
     )
+
+
+def test_handler_application_default_ordering(handler_api_client):
+    f = faker.Faker()
+    combos = [
+        (ReceivedApplicationFactory, ApplicationStatus.RECEIVED),
+        (HandlingApplicationFactory, ApplicationStatus.HANDLING),
+        (DecidedApplicationFactory, ApplicationStatus.ACCEPTED),
+    ]
+    for _ in range(5):
+        for class_name, status in combos:
+            application = class_name()
+            random_datetime = f.past_datetime()
+            application.log_entries.filter(to_status=status).update(
+                created_at=random_datetime
+            )
+            Calculation.objects.filter(application__id=application.pk).update(
+                modified_at=random_datetime
+            )
+
+    def _expected_sort_key(obj):
+        handled_at_key = None
+        if (
+            log_entry := obj.log_entries.filter(
+                to_status__in=[
+                    ApplicationStatus.REJECTED,
+                    ApplicationStatus.ACCEPTED,
+                    ApplicationStatus.CANCELLED,
+                ]
+            )
+            .order_by("-created_at")
+            .first()
+        ):
+            handled_at_key = log_entry.created_at.timestamp()
+
+        return (
+            -handled_at_key if handled_at_key else float("-inf"),
+            -obj.calculation.modified_at.timestamp(),
+        )
+
+    # in-memory sort using _expected_sort_key and the database sort must be the same
+    expected_sorting = sorted(Application.objects.all(), key=_expected_sort_key)
+    expected_application_ids = [str(elem.pk) for elem in expected_sorting]
+
+    response = handler_api_client.get(
+        reverse("v1:handler-application-simplified-application-list")
+    )
+    returned_application_ids = [elem["id"] for elem in response.data]
+    assert expected_application_ids == returned_application_ids


### PR DESCRIPTION
Also:
* move perform_update to BaseApplicationViewSet in order to avoid
  issues with stale submitted_at values
* remove dead code from ApplicationManager

## Description :sparkles:

The default ordering in the handling views:
* In the "received" table, ordering should be by the send time, most recent first
* In the "handling" table, ordering should be by the calculation modification time, most recent first
* In the archive page, ordering should be by handled_at, most recent first.

All these goals are achieved by ordering by first handled_at, then
modified_at.
* in the "received" and "handling" table, no application has handled_at set yet,
so applications will compare as equals
* For received applications, the send time is the same as application modification time

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
