### PR TITLE
YJDH-509 | KS-Backend: Send additional info request email

### DIFF
--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -229,11 +229,30 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
         list(same_persons_apps)  # Force evaluation of queryset to lock its rows
 
         if same_persons_apps.active().exists():
-            return HttpResponseRedirect(youth_application.already_activated_page_url())
+            if youth_application.is_active and youth_application.need_additional_info:
+                return HttpResponseRedirect(
+                    youth_application.additional_info_page_url(pk=youth_application.pk)
+                )
+            else:  # not the active one or does not need additional info
+                return HttpResponseRedirect(
+                    youth_application.already_activated_page_url()
+                )
         elif youth_application.has_activation_link_expired:
             return HttpResponseRedirect(youth_application.expired_page_url())
         elif youth_application.activate():
-            if settings.DISABLE_VTJ:
+            if youth_application.need_additional_info:
+                LOGGER.info(
+                    f"Activated youth application {youth_application.pk}: "
+                    "Additional info is needed, redirecting user to page to provide it"
+                )
+                youth_application.status = (
+                    YouthApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED
+                )
+                youth_application.save()
+                return HttpResponseRedirect(
+                    youth_application.additional_info_page_url(pk=youth_application.pk)
+                )
+            elif settings.DISABLE_VTJ:
                 LOGGER.info(
                     f"Activated youth application {youth_application.pk}: "
                     "VTJ is disabled, sending application to be processed by a handler"
@@ -309,17 +328,23 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
             # Data was valid and other criteria passed too, so let's create the object
             self.perform_create(serializer)
 
-            # Send the localized activation email
+            # Send the localized activation/additional info request email
             youth_application = serializer.instance
-            was_email_sent = youth_application.send_activation_email(
-                request, youth_application.language
-            )
+
+            if youth_application.need_additional_info:
+                was_email_sent = youth_application.send_additional_info_request_email(
+                    request, youth_application.language
+                )
+            else:
+                was_email_sent = youth_application.send_activation_email(
+                    request, youth_application.language
+                )
 
             if not was_email_sent:
                 transaction.set_rollback(True)
                 with translation.override(youth_application.language):
                     return HttpResponse(
-                        _("Failed to send activation email"),
+                        _("Failed to send activation/additional info request email"),
                         status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     )
 

--- a/backend/kesaseteli/applications/enums.py
+++ b/backend/kesaseteli/applications/enums.py
@@ -94,7 +94,6 @@ class YouthApplicationStatus(models.TextChoices):
         """
         return [
             YouthApplicationStatus.AWAITING_MANUAL_PROCESSING.value,
-            YouthApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED.value,
             YouthApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED.value,
         ]
 

--- a/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-07 13:53+0200\n"
-"PO-Revision-Date: 2022-03-07 09:05+0200\n"
+"POT-Creation-Date: 2022-03-28 16:15+0300\n"
+"PO-Revision-Date: 2022-03-28 16:22+0300\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
 "Language: en\n"
@@ -58,7 +58,24 @@ msgstr ""
 msgid "Attachments missing with types: {attachment_types}"
 msgstr ""
 
-msgid "Social security number must be set"
+msgid "Must be set"
+msgstr ""
+
+#, python-format
+msgid "additional_info_user_reasons must be a list, was %(type)s"
+msgstr ""
+
+msgid "Invalid type input values for additional_info_user_reasons"
+msgstr ""
+
+#, python-format
+msgid ""
+"additional_info_user_reasons must contain only values from "
+"AdditionalInfoUserReason, contained invalid values %(invalid_values)s"
+msgstr ""
+
+#, python-format
+msgid "Invalid status %(status)s for setting additional info"
 msgstr ""
 
 msgid "Failed to send youth summer voucher email"
@@ -70,7 +87,7 @@ msgstr ""
 msgid "VTJ integration is not implemented"
 msgstr ""
 
-msgid "Failed to send activation email"
+msgid "Failed to send activation/additional info request email"
 msgstr ""
 
 msgid "File not found."
@@ -101,6 +118,26 @@ msgid "Deleted by customer"
 msgstr ""
 
 msgid "Awaiting manual processing"
+msgstr ""
+
+msgid "Student in Helsinki but not resident"
+msgstr ""
+
+#, fuzzy
+#| msgid "Helsinki"
+msgid "Moving to Helsinki"
+msgstr "Helsinki"
+
+msgid "Underage or overage"
+msgstr ""
+
+msgid "Personal info differs from VTJ"
+msgstr ""
+
+msgid "Unlisted school"
+msgstr ""
+
+msgid "Other"
 msgstr ""
 
 msgid "employment contract"
@@ -316,6 +353,15 @@ msgstr ""
 msgid "time handled"
 msgstr ""
 
+msgid "time additional info was provided"
+msgstr ""
+
+msgid "additional info user reasons"
+msgstr ""
+
+msgid "additional info description"
+msgstr ""
+
 msgid "Aktivoi Kesäseteli"
 msgstr "Activate your Summer Job Voucher"
 
@@ -335,6 +381,24 @@ msgstr ""
 "\n"
 "Kind regards, the Summer Job Voucher Team"
 
+msgid "Lisätietopyyntö"
+msgstr "Request for additional information"
+
+#, python-format
+msgid ""
+"Täydennäthän kesäsetelihakemuksesi tietoja alla olevasta linkistä:\n"
+"\n"
+"%(activation_link)s\n"
+"\n"
+"Kiitos! Ystävällisin terveisin, Kesäseteli-tiimi"
+msgstr ""
+"Please complete your Summer Job Voucher application's information using the "
+"link below:\n"
+"\n"
+"%(activation_link)s\n"
+"\n"
+"Thank you! Kind regards, the Summer Job Voucher Team"
+
 #, python-format
 msgid "Nuoren kesäsetelihakemus: %(first_name)s %(last_name)s"
 msgstr ""
@@ -350,6 +414,9 @@ msgid ""
 "Sähköposti: %(email)s\n"
 "\n"
 "%(processing_link)s"
+msgstr ""
+
+msgid "Unable to send youth application's additional info request email"
 msgstr ""
 
 msgid "Unable to send youth application's activation email"

--- a/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-03-28 16:15+0300\n"
-"PO-Revision-Date: 2022-03-28 16:22+0300\n"
+"PO-Revision-Date: 2022-03-29 08:40+0300\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
 "Language: en\n"
@@ -123,10 +123,8 @@ msgstr ""
 msgid "Student in Helsinki but not resident"
 msgstr ""
 
-#, fuzzy
-#| msgid "Helsinki"
 msgid "Moving to Helsinki"
-msgstr "Helsinki"
+msgstr "Moving to Helsinki"
 
 msgid "Underage or overage"
 msgstr ""
@@ -168,22 +166,22 @@ msgid "Already assigned"
 msgstr ""
 
 msgid "Järjestys"
-msgstr ""
+msgstr "Order"
 
 msgid "Saatu pvm"
-msgstr ""
+msgstr "Received date"
 
 msgid "Hakemuksen kieli"
-msgstr ""
+msgstr "Application language"
 
 msgid "Setelin numero"
-msgstr ""
+msgstr "Voucher number"
 
 msgid "Erikoistapaus (esim yhdeksäsluokkalainen)"
-msgstr ""
+msgstr "Special case (e.g. 9th grader)"
 
 msgid "Nuoren nimi"
-msgstr ""
+msgstr "Youth's name"
 
 msgid "Henkilötunnus"
 msgstr ""

--- a/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-03-28 16:15+0300\n"
-"PO-Revision-Date: 2022-02-08 14:52+0200\n"
+"PO-Revision-Date: 2022-03-29 08:43+0300\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
 "Language: fi\n"
@@ -78,23 +78,18 @@ msgstr ""
 msgid "Invalid status %(status)s for setting additional info"
 msgstr ""
 
-#, fuzzy
-#| msgid "Failed to send activation email"
 msgid "Failed to send youth summer voucher email"
-msgstr "Aktivointisähköpostin lähettäminen epäonnistui"
+msgstr "Nuoren kesäsetelisähköpostin lähettäminen epäonnistui"
 
-#, fuzzy
-#| msgid "Failed to send activation email"
 msgid "Failed to send manual processing email to handler"
-msgstr "Aktivointisähköpostin lähettäminen epäonnistui"
+msgstr ""
+"Manuaaliprosessointisähköpostin lähettäminen käsittelijälle epäonnistui"
 
 msgid "VTJ integration is not implemented"
 msgstr ""
 
-#, fuzzy
-#| msgid "Failed to send activation email"
 msgid "Failed to send activation/additional info request email"
-msgstr "Aktivointisähköpostin lähettäminen epäonnistui"
+msgstr "Aktivointi/lisätietopyyntösähköpostin lähettäminen epäonnistui"
 
 msgid "File not found."
 msgstr ""

--- a/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-07 13:53+0200\n"
+"POT-Creation-Date: 2022-03-28 16:15+0300\n"
 "PO-Revision-Date: 2022-02-08 14:52+0200\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
@@ -58,7 +58,24 @@ msgstr ""
 msgid "Attachments missing with types: {attachment_types}"
 msgstr ""
 
-msgid "Social security number must be set"
+msgid "Must be set"
+msgstr ""
+
+#, python-format
+msgid "additional_info_user_reasons must be a list, was %(type)s"
+msgstr ""
+
+msgid "Invalid type input values for additional_info_user_reasons"
+msgstr ""
+
+#, python-format
+msgid ""
+"additional_info_user_reasons must contain only values from "
+"AdditionalInfoUserReason, contained invalid values %(invalid_values)s"
+msgstr ""
+
+#, python-format
+msgid "Invalid status %(status)s for setting additional info"
 msgstr ""
 
 #, fuzzy
@@ -74,7 +91,9 @@ msgstr "Aktivointisähköpostin lähettäminen epäonnistui"
 msgid "VTJ integration is not implemented"
 msgstr ""
 
-msgid "Failed to send activation email"
+#, fuzzy
+#| msgid "Failed to send activation email"
+msgid "Failed to send activation/additional info request email"
 msgstr "Aktivointisähköpostin lähettäminen epäonnistui"
 
 msgid "File not found."
@@ -105,6 +124,24 @@ msgid "Deleted by customer"
 msgstr ""
 
 msgid "Awaiting manual processing"
+msgstr ""
+
+msgid "Student in Helsinki but not resident"
+msgstr ""
+
+msgid "Moving to Helsinki"
+msgstr ""
+
+msgid "Underage or overage"
+msgstr ""
+
+msgid "Personal info differs from VTJ"
+msgstr ""
+
+msgid "Unlisted school"
+msgstr ""
+
+msgid "Other"
 msgstr ""
 
 msgid "employment contract"
@@ -320,6 +357,15 @@ msgstr ""
 msgid "time handled"
 msgstr ""
 
+msgid "time additional info was provided"
+msgstr ""
+
+msgid "additional info user reasons"
+msgstr ""
+
+msgid "additional info description"
+msgstr ""
+
 msgid "Aktivoi Kesäseteli"
 msgstr ""
 
@@ -331,6 +377,18 @@ msgid ""
 "%(activation_link)s\n"
 "\n"
 "Ystävällisin terveisin, Kesäseteli-tiimi"
+msgstr ""
+
+msgid "Lisätietopyyntö"
+msgstr ""
+
+#, python-format
+msgid ""
+"Täydennäthän kesäsetelihakemuksesi tietoja alla olevasta linkistä:\n"
+"\n"
+"%(activation_link)s\n"
+"\n"
+"Kiitos! Ystävällisin terveisin, Kesäseteli-tiimi"
 msgstr ""
 
 #, python-format
@@ -348,6 +406,9 @@ msgid ""
 "Sähköposti: %(email)s\n"
 "\n"
 "%(processing_link)s"
+msgstr ""
+
+msgid "Unable to send youth application's additional info request email"
 msgstr ""
 
 msgid "Unable to send youth application's activation email"

--- a/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-03-28 16:15+0300\n"
-"PO-Revision-Date: 2022-03-28 16:23+0300\n"
+"PO-Revision-Date: 2022-03-29 08:45+0300\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
 "Language: sv\n"
@@ -87,10 +87,8 @@ msgstr ""
 msgid "VTJ integration is not implemented"
 msgstr ""
 
-#, fuzzy
-#| msgid "Failed to send activation email"
 msgid "Failed to send activation/additional info request email"
-msgstr "Det gick inte att skicka aktiveringsmail"
+msgstr ""
 
 msgid "File not found."
 msgstr ""
@@ -125,10 +123,8 @@ msgstr ""
 msgid "Student in Helsinki but not resident"
 msgstr ""
 
-#, fuzzy
-#| msgid "Helsinki"
 msgid "Moving to Helsinki"
-msgstr "Helsingfors"
+msgstr ""
 
 msgid "Underage or overage"
 msgstr ""

--- a/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-07 13:53+0200\n"
-"PO-Revision-Date: 2022-03-07 09:16+0200\n"
+"POT-Creation-Date: 2022-03-28 16:15+0300\n"
+"PO-Revision-Date: 2022-03-28 16:23+0300\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
 "Language: sv\n"
@@ -58,7 +58,24 @@ msgstr ""
 msgid "Attachments missing with types: {attachment_types}"
 msgstr ""
 
-msgid "Social security number must be set"
+msgid "Must be set"
+msgstr ""
+
+#, python-format
+msgid "additional_info_user_reasons must be a list, was %(type)s"
+msgstr ""
+
+msgid "Invalid type input values for additional_info_user_reasons"
+msgstr ""
+
+#, python-format
+msgid ""
+"additional_info_user_reasons must contain only values from "
+"AdditionalInfoUserReason, contained invalid values %(invalid_values)s"
+msgstr ""
+
+#, python-format
+msgid "Invalid status %(status)s for setting additional info"
 msgstr ""
 
 msgid "Failed to send youth summer voucher email"
@@ -70,7 +87,9 @@ msgstr ""
 msgid "VTJ integration is not implemented"
 msgstr ""
 
-msgid "Failed to send activation email"
+#, fuzzy
+#| msgid "Failed to send activation email"
+msgid "Failed to send activation/additional info request email"
 msgstr "Det gick inte att skicka aktiveringsmail"
 
 msgid "File not found."
@@ -101,6 +120,26 @@ msgid "Deleted by customer"
 msgstr ""
 
 msgid "Awaiting manual processing"
+msgstr ""
+
+msgid "Student in Helsinki but not resident"
+msgstr ""
+
+#, fuzzy
+#| msgid "Helsinki"
+msgid "Moving to Helsinki"
+msgstr "Helsingfors"
+
+msgid "Underage or overage"
+msgstr ""
+
+msgid "Personal info differs from VTJ"
+msgstr ""
+
+msgid "Unlisted school"
+msgstr ""
+
+msgid "Other"
 msgstr ""
 
 msgid "employment contract"
@@ -316,6 +355,15 @@ msgstr ""
 msgid "time handled"
 msgstr ""
 
+msgid "time additional info was provided"
+msgstr ""
+
+msgid "additional info user reasons"
+msgstr ""
+
+msgid "additional info description"
+msgstr ""
+
 msgid "Aktivoi Kesäseteli"
 msgstr "Aktivera Sommarsedeln"
 
@@ -335,6 +383,23 @@ msgstr ""
 "\n"
 "Med vänliga hälsningar, Sommarsedeln-teamet"
 
+msgid "Lisätietopyyntö"
+msgstr "Begäran om ytterligare information"
+
+#, python-format
+msgid ""
+"Täydennäthän kesäsetelihakemuksesi tietoja alla olevasta linkistä:\n"
+"\n"
+"%(activation_link)s\n"
+"\n"
+"Kiitos! Ystävällisin terveisin, Kesäseteli-tiimi"
+msgstr ""
+"Fyll i informationen om din sommarsedelansökan från länken nedan:\n"
+"\n"
+"%(activation_link)s\n"
+"\n"
+"Tack! Med vänliga hälsningar, Sommarsedeln-teamet"
+
 #, python-format
 msgid "Nuoren kesäsetelihakemus: %(first_name)s %(last_name)s"
 msgstr ""
@@ -350,6 +415,9 @@ msgid ""
 "Sähköposti: %(email)s\n"
 "\n"
 "%(processing_link)s"
+msgstr ""
+
+msgid "Unable to send youth application's additional info request email"
 msgstr ""
 
 msgid "Unable to send youth application's activation email"

--- a/backend/kesaseteli/applications/tests/test_misc.py
+++ b/backend/kesaseteli/applications/tests/test_misc.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from applications.enums import get_supported_languages
@@ -5,13 +7,31 @@ from applications.enums import get_supported_languages
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "youth_url,url_function_name,language,expected_url",
+    "youth_url,url_function_name,url_function_kwargs,language,expected_url",
     [
-        (youth_url, url_function_name, language, f"{youth_url}/{language}/{page_name}")
-        for page_name, url_function_name in [
-            ("activated", "activated_page_url"),
-            ("already_activated", "already_activated_page_url"),
-            ("expired", "expired_page_url"),
+        (
+            youth_url,
+            url_function_name,
+            url_function_kwargs,
+            language,
+            f"{youth_url}/{language}/{page_name}",
+        )
+        for page_name, url_function_name, url_function_kwargs in [
+            ("activated", "activated_page_url", {}),
+            ("already_activated", "already_activated_page_url", {}),
+            ("expired", "expired_page_url", {}),
+            ("additional_info?id=10", "additional_info_page_url", {"pk": 10}),
+            ("additional_info?id=123", "additional_info_page_url", {"pk": "123"}),
+            (
+                "additional_info?id=5ab8c069-4e64-49e6-9140-d6407b105df2",
+                "additional_info_page_url",
+                {"pk": "5ab8c069-4e64-49e6-9140-d6407b105df2"},
+            ),
+            (
+                "additional_info?id=5ab8c069-4e64-49e6-9140-d6407b105df2",
+                "additional_info_page_url",
+                {"pk": uuid.UUID("5ab8c069-4e64-49e6-9140-d6407b105df2")},
+            ),
         ]
         for language in get_supported_languages()
         for youth_url in ["https://test.com:1234", "https://example.org"]
@@ -22,6 +42,7 @@ def test_youth_application_page_url_function(
     youth_application,
     youth_url,
     url_function_name,
+    url_function_kwargs,
     language,
     expected_url,
 ):
@@ -32,5 +53,5 @@ def test_youth_application_page_url_function(
     youth_application.language = language
     youth_application.save(update_fields=["language"])
     youth_application.refresh_from_db()
-    url = getattr(youth_application, url_function_name)()
+    url = getattr(youth_application, url_function_name)(**url_function_kwargs)
     assert url == expected_url

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -1636,6 +1636,7 @@ def test_youth_applications_set_excess_additional_info(
     application does not matter and does not change anything.
     """
     settings.NEXT_PUBLIC_MOCK_FLAG = mock_flag
+    settings.DISABLE_VTJ = True
     client_fixture = request.getfixturevalue(client_fixture_func.__name__)
 
     source_app = AdditionalInfoRequestedYouthApplicationFactory()
@@ -1714,6 +1715,7 @@ def test_youth_applications_set_valid_additional_info(
     additional_info_description,
 ):
     settings.NEXT_PUBLIC_MOCK_FLAG = mock_flag
+    settings.DISABLE_VTJ = True
     client_fixture = request.getfixturevalue(client_fixture_func.__name__)
 
     source_app = AdditionalInfoRequestedYouthApplicationFactory()
@@ -1780,6 +1782,7 @@ def test_youth_applications_set_invalid_additional_info(
     additional_info_description,
 ):
     settings.NEXT_PUBLIC_MOCK_FLAG = mock_flag
+    settings.DISABLE_VTJ = True
     client_fixture = request.getfixturevalue(client_fixture_func.__name__)
 
     source_app = AdditionalInfoRequestedYouthApplicationFactory()
@@ -1827,6 +1830,7 @@ def test_youth_applications_set_partial_additional_info(
     missing_fields,
 ):
     settings.NEXT_PUBLIC_MOCK_FLAG = mock_flag
+    settings.DISABLE_VTJ = True
     client_fixture = request.getfixturevalue(client_fixture_func.__name__)
 
     source_app = AdditionalInfoRequestedYouthApplicationFactory()

--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -110,9 +110,83 @@ class EmployerApplicationFactory(factory.django.DjangoModelFactory):
 
 def get_listed_test_schools() -> List[str]:
     return [
+        "Aleksis Kiven peruskoulu",
+        "Apollon yhteiskoulu",
         "Arabian peruskoulu",
+        "Aurinkolahden peruskoulu",
         "Botby grundskola",
+        "Elias-koulu",
+        "Englantilainen koulu",
+        "Grundskolan Norsen",
+        "Haagan peruskoulu",
+        "Helsingin Juutalainen Yhteiskoulu",
+        "Helsingin Kristillinen koulu",
+        "Helsingin Montessori-koulu",
+        "Helsingin Rudolf Steiner -koulu",
+        "Helsingin Saksalainen koulu",
+        "Helsingin Suomalainen yhteiskoulu",
+        "Helsingin Uusi yhteiskoulu",
+        "Helsingin eurooppalainen koulu",
+        "Helsingin normaalilyseo",
+        "Helsingin ranskalais-suomalainen koulu",
+        "Helsingin yhteislyseo",
+        "Helsingin yliopiston Viikin normaalikoulu",
+        "Herttoniemen yhteiskoulu",
+        "Hiidenkiven peruskoulu",
+        "Hoplaxskolan",
+        "International School of Helsinki",
+        "Itäkeskuksen peruskoulu",
+        "Jätkäsaaren peruskoulu",
+        "Kalasataman peruskoulu",
+        "Kankarepuiston peruskoulu",
+        "Kannelmäen peruskoulu",
+        "Karviaistien koulu",
+        "Kruununhaan yläasteen koulu",
+        "Kruunuvuorenrannan peruskoulu",
+        "Kulosaaren yhteiskoulu",
+        "Käpylän peruskoulu",
+        "Laajasalon peruskoulu",
+        "Latokartanon peruskoulu",
+        "Lauttasaaren yhteiskoulu",
+        "Maatullin peruskoulu",
+        "Malmin peruskoulu",
+        "Marjatta-koulu",
+        "Maunulan yhteiskoulu",
+        "Meilahden yläasteen koulu",
+        "Merilahden peruskoulu",
+        "Minervaskolan",
+        "Munkkiniemen yhteiskoulu",
+        "Myllypuron peruskoulu",
+        "Naulakallion koulu",
+        "Oulunkylän yhteiskoulu",
+        "Outamon koulu",
+        "Pakilan yläasteen koulu",
+        "Pasilan peruskoulu",
+        "Pitäjänmäen peruskoulu",
+        "Pohjois-Haagan yhteiskoulu",
+        "Porolahden peruskoulu",
+        "Puistolan peruskoulu",
+        "Puistopolun peruskoulu",
+        "Pukinmäenkaaren peruskoulu",
         "Ressu Comprehensive School",
+        "Ressun peruskoulu",
+        "Sakarinmäen peruskoulu",
+        "Solakallion koulu",
+        "Sophie Mannerheimin koulu",
+        "Suomalais-venäläinen koulu",
+        "Suutarinkylän peruskoulu",
+        "Taivallahden peruskoulu",
+        "Toivolan koulu",
+        "Torpparinmäen peruskoulu",
+        "Töölön yhteiskoulu",
+        "Valteri-koulu",
+        "Vartiokylän yläasteen koulu",
+        "Vesalan peruskoulu",
+        "Vuoniityn peruskoulu",
+        "Yhtenäiskoulu",
+        "Zacharias Topeliusskolan",
+        "Åshöjdens grundskola",
+        "Östersundom skola",
     ]
 
 
@@ -123,12 +197,12 @@ def get_unlisted_test_schools() -> List[str]:
     ]
 
 
-def get_all_test_schools() -> List[str]:
-    return get_listed_test_schools() + get_unlisted_test_schools()
-
-
-def uses_unlisted_test_school(youth_application) -> bool:
-    return youth_application.school not in get_listed_test_schools()
+def determine_school(youth_application) -> str:
+    return Faker().random_element(
+        get_unlisted_test_schools()
+        if youth_application.is_unlisted_school
+        else get_listed_test_schools()
+    )
 
 
 def get_test_phone_number() -> str:
@@ -201,8 +275,8 @@ class AbstractYouthApplicationFactory(factory.django.DjangoModelFactory):
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
     social_security_number = factory.Faker("ssn", locale="fi")  # Must be Finnish
-    school = factory.Faker("random_element", elements=get_all_test_schools())
-    is_unlisted_school = factory.LazyAttribute(uses_unlisted_test_school)
+    school = factory.LazyAttribute(determine_school)
+    is_unlisted_school = factory.Faker("boolean")
     email = factory.Faker("email")
     phone_number = factory.LazyFunction(get_test_phone_number)
     postcode = factory.Faker("postcode", locale="fi")
@@ -239,8 +313,24 @@ class ActiveYouthApplicationFactory(AbstractYouthApplicationFactory):
     )
 
 
+class ActiveListedSchoolYouthApplicationFactory(ActiveYouthApplicationFactory):
+    is_unlisted_school = False
+
+
+class ActiveUnlistedSchoolYouthApplicationFactory(ActiveYouthApplicationFactory):
+    is_unlisted_school = True
+
+
 class InactiveYouthApplicationFactory(AbstractYouthApplicationFactory):
     status = YouthApplicationStatus.SUBMITTED.value
+
+
+class InactiveListedSchoolYouthApplicationFactory(InactiveYouthApplicationFactory):
+    is_unlisted_school = False
+
+
+class InactiveUnlistedSchoolYouthApplicationFactory(InactiveYouthApplicationFactory):
+    is_unlisted_school = True
 
 
 class AcceptableYouthApplicationFactory(AbstractYouthApplicationFactory):

--- a/backend/shared/shared/common/tests/test_utils.py
+++ b/backend/shared/shared/common/tests/test_utils.py
@@ -1,7 +1,14 @@
+from datetime import date
+
 import pytest
+import stdnum.exceptions
 from django.db.models import Q
 
-from shared.common.utils import _ALWAYS_FALSE_Q_FILTER, any_of_q_filter
+from shared.common.utils import (
+    _ALWAYS_FALSE_Q_FILTER,
+    any_of_q_filter,
+    social_security_number_birthdate,
+)
 
 
 @pytest.mark.parametrize(
@@ -18,3 +25,48 @@ from shared.common.utils import _ALWAYS_FALSE_Q_FILTER, any_of_q_filter
 )
 def test_any_of_q_filter(input_kwargs, expected_q_filter):
     assert any_of_q_filter(**input_kwargs) == expected_q_filter
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "test_value,expected_result",
+    [
+        ("010203-1230", date(year=1903, month=2, day=1)),
+        ("121212A899H", date(year=2012, month=12, day=12)),
+        ("111111-002V", date(year=1911, month=11, day=11)),
+        ("111111-111C", date(year=1911, month=11, day=11)),
+        ("111111A111C", date(year=2011, month=11, day=11)),
+        ("111111-900U", date(year=1911, month=11, day=11)),
+        ("111111-9991", date(year=1911, month=11, day=11)),
+        ("300522A0024", date(year=2022, month=5, day=30)),
+        # Case-insensitive and leading/trailing whitespace allowed
+        ("  111111a111c   ", date(year=2011, month=11, day=11)),
+    ],
+)
+def test_valid_social_security_number_birthdate(test_value, expected_result):
+    assert social_security_number_birthdate(test_value) == expected_result
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "test_value",
+    [
+        "111111-000T",  # Invalid number after dash, must be 002-999
+        "111111-001U",  # Invalid number after dash, must be 002-999
+        "30052 2A0025",  # Inner whitespace
+        "111111 -111x",  # Invalid checksum, inner whitespace
+        "320522A002T",  # Invalid date because no 32 days in any month
+        "311322A002E",  # Invalid date because no 13 months in any year
+        # Invalid checksum
+        "111111-111X",  # "111111-111C" would be valid
+        "111111A111W",  # "111111A111C" would be valid
+        "010203-123A",  # "010203-1230" would be valid
+        "121212A899F",  # "121212A899H" would be valid
+        "111111-900X",  # "111111-900U" would be valid
+        "111111-9996",  # "111111-9991" would be valid
+        "300522A0025",  # "300522A0024" would be valid
+    ],
+)
+def test_invalid_social_security_number_birthdate(test_value):
+    with pytest.raises(stdnum.exceptions.ValidationError):
+        social_security_number_birthdate(test_value)


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Send additional info request email 

Changes to YouthApplicationViewSet:
 - activate action i.e. activating a submitted youth application:
   - If an active youth application already exists then:
     - If the youth application to be activated is already active and it
       initially needs additional info then redirect to frontend's
       additional info page
     - If the youth application to be activated is not the already
       activated one or it does not initially need additional info then
       then redirect to already activated page i.e. as was done before
       this commit
  - If activated an inactive youth application then:
    - If additional info is needed then set youth application's status
      to "additional_information_requested" and redirect to frontend's
      additional info page. Otherwise do as before.
  - create action i.e. submitting a new youth application:
    - If youth application needs additional info then send additional
      info request email to the applicant
    - If youth application does not need additional info then send an
      activation email to the applicant

Changes to YouthApplication:
 - Add additional_info_page_url function generating the redirection
   URL to the frontend's additional info page, for an example
   https://localhost:3100/fi/additional_info?id=123
 - Add send_additional_info_request_email for sending the additional
   info request email to the applicant
 - Add birthdate property for calculating the applicant's birthdate
   based on their social security number. This is not used yet but will
   very likely be used for determining whether the applicant is a ninth
   grader or not.
 - Add need_additional_info property for determining whether the youth
   application initially needs additional info or not.
   - NOTE: This is at the moment only checking whether the school is
     unlisted and that's it.
 - Add has_additional_info property

Changes to tests:
 - Add test cases for additional_info_page_url function to
   test_youth_application_page_url_function
 - Take the need_additional_info function's current implementation and
   its repercussions into account in the youth application tests
 - Add new tests:
   - test_youth_application_additional_info_request_email_language
   - test_youth_application_additional_info_request_email_sending
   - test_youth_application_additional_info_request_email_link_path

Changes to factories:
 - Use current real school list in factories
 - Add factories
   - ActiveListedSchoolYouthApplicationFactory
   - ActiveUnlistedSchoolYouthApplicationFactory
   - InactiveListedSchoolYouthApplicationFactory
   - InactiveUnlistedSchoolYouthApplicationFactory

Changes to translations:
 - Ran "python manage.py makemessages --no-location -l fi -l sv -l en"
 - Added preliminary translations for additional info request email
   subject and body texts

Shared code changes:
 - Add social_security_number_birthdate function and tests for
   calculating the birthdate based on a Finnish social security number

Refs YJDH-509 (Sending additional info request email to applicant)
Refs YJDH-510 (Redirecting to frontend's additional info page)
 
### KS-Backend: Send processing email after additional info 

Refs YJDH-429 (Send processing email to handler after additional info)

## Issues :bug:

YJDH-429 (Send processing email to handler after additional info)
YJDH-509 (Sending additional info request email to applicant)
YJDH-510 (Redirecting to frontend's additional info page)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

TODO:
 - More tests—reason for skipping some of them now is to make something usable for the frontend browser tests faster
   - This has been split to ticket [YJDH-515](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-515)