### PR TITLE
KS-Backend: Use transactions in test_models.py tests

### DIFF
--- a/backend/kesaseteli/applications/tests/test_models.py
+++ b/backend/kesaseteli/applications/tests/test_models.py
@@ -6,7 +6,7 @@ from applications.models import YouthSummerVoucher
 from common.tests.factories import AcceptedYouthApplicationFactory
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
 def test_youth_summer_voucher_sequentiality():
     assert YouthSummerVoucher.objects.count() == 0
     for ordinal_number in range(1, 10):
@@ -16,7 +16,7 @@ def test_youth_summer_voucher_sequentiality():
         assert summer_voucher.summer_voucher_serial_number == ordinal_number
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
 def test_youth_summer_voucher_sequentiality_duplicate_create():
     assert YouthSummerVoucher.objects.count() == 0
 
@@ -41,7 +41,7 @@ def test_youth_summer_voucher_sequentiality_duplicate_create():
     ) == list(range(1, 3))
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
 def test_youth_summer_voucher_sequentiality_failing_transaction():
     assert YouthSummerVoucher.objects.count() == 0
 
@@ -68,7 +68,7 @@ def test_youth_summer_voucher_sequentiality_failing_transaction():
     ) == list(range(1, 3))
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
 def test_youth_summer_voucher_sequentiality_failing_nested_transaction():
     assert YouthSummerVoucher.objects.count() == 0
 
@@ -97,7 +97,7 @@ def test_youth_summer_voucher_sequentiality_failing_nested_transaction():
     ) == list(range(1, 4))
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
 def test_youth_summer_voucher_sequentiality_failing_nested_transactions():
     assert YouthSummerVoucher.objects.count() == 0
 
@@ -127,7 +127,7 @@ def test_youth_summer_voucher_sequentiality_failing_nested_transactions():
     ) == list(range(1, 3))
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
 def test_youth_summer_voucher_sequentiality_complex_transaction_nesting():
     assert YouthSummerVoucher.objects.count() == 0
 


### PR DESCRIPTION
## Description :sparkles:

Enable use of transactions and reset sequences in all tests in
test_models.py. Previously the "with transaction.atomic()" clauses in
these tests did nothing besides having the code wrapped in a with clause
because the related default parameters to pytest.mark.django_db are:
 - transaction=False
   - "With transaction=False (the default when not specified),
     transaction operations are noops during the test."
 - reset_sequences=False
   - "The reset_sequences argument will ask to reset auto increment
     sequence values (e.g. primary keys) before running the test.
     Defaults to False. Must be used together with transaction=True to
     have an effect."

## Issues :bug:

`–`

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
