### PR TITLE
HL-501: Fix start_date, end_date in new Ahjo "current row" columns

### DIFF
--- a/backend/benefit/applications/services/applications_csv_report.py
+++ b/backend/benefit/applications/services/applications_csv_report.py
@@ -135,7 +135,7 @@ class ApplicationsCsvService(CsvExportBase):
                 str,
             ),
             CsvColumn(
-                "Yhdistys jolla yritystoimintaa?",
+                "Yhdistys jolla taloudellista toimintaa?",
                 "association_has_business_activities",
                 format_bool,
             ),

--- a/backend/benefit/applications/tests/test_applications_csv_report.py
+++ b/backend/benefit/applications/tests/test_applications_csv_report.py
@@ -230,6 +230,12 @@ def test_applications_csv_output(applications_csv_service):  # noqa: C901
     )
     application1 = applications_csv_service.get_applications()[0]
     application2 = applications_csv_service.get_applications()[1]
+
+    for application in [application1, application2]:
+        assert len(application.ahjo_rows) == 1
+        assert application.ahjo_rows[0].start_date == application.calculation.start_date
+        assert application.ahjo_rows[0].end_date == application.calculation.end_date
+
     for idx, col in enumerate(applications_csv_service.CSV_COLUMNS):
         assert csv_lines[0][idx] == f'"{col.heading}"'
 
@@ -245,6 +251,24 @@ def test_applications_csv_output(applications_csv_service):  # noqa: C901
             assert (
                 csv_lines[2][idx]
                 == f'"{application2.calculation.ahjo_rows[0].description_fi}"'
+            )
+        elif "Siirrettävä Ahjo-rivi / alkupäivä" in col.heading:
+            assert (
+                csv_lines[1][idx]
+                == f'"{application1.calculation.ahjo_rows[0].start_date.isoformat()}"'
+            )
+            assert (
+                csv_lines[2][idx]
+                == f'"{application2.calculation.ahjo_rows[0].start_date.isoformat()}"'
+            )
+        elif "Siirrettävä Ahjo-rivi / päättymispäivä" in col.heading:
+            assert (
+                csv_lines[1][idx]
+                == f'"{application1.calculation.ahjo_rows[0].end_date.isoformat()}"'
+            )
+            assert (
+                csv_lines[2][idx]
+                == f'"{application2.calculation.ahjo_rows[0].end_date.isoformat()}"'
             )
         elif "Käsittelypäivä" in col.heading:
             assert csv_lines[1][idx] == f'"{application1.handled_at.isoformat()}"'

--- a/backend/benefit/calculator/admin.py
+++ b/backend/benefit/calculator/admin.py
@@ -20,6 +20,7 @@ class CalculationRowInline(admin.StackedInline):
 class CalculationInline(admin.StackedInline):
     model = Calculation
     inlines = (CalculationRowInline,)
+    show_change_link = True
     list_display = (
         "id",
         "start_date",
@@ -52,8 +53,9 @@ class CalculationAdmin(admin.ModelAdmin):
     )
     search_fields = (
         "id",
-        "application__company__id",
+        "application__id",
         "application__application_number",
+        "application__company__id",
         "application__company_name",
         "application__company_contact_person_email",
     )

--- a/backend/benefit/calculator/rules.py
+++ b/backend/benefit/calculator/rules.py
@@ -97,6 +97,8 @@ class HelsinkiBenefitCalculator:
                     training_compensation,
                 )
             )
+        assert ranges[0].start_date == self.calculation.start_date
+        assert ranges[-1].end_date == self.calculation.end_date
         return ranges
 
     def get_amount(self, row_type, default=None):
@@ -172,7 +174,11 @@ class DummyBenefitCalculator(HelsinkiBenefitCalculator):
 
 class ManualOverrideCalculator(HelsinkiBenefitCalculator):
     def create_rows(self):
-        self._create_row(ManualOverrideTotalRow)
+        self._create_row(
+            ManualOverrideTotalRow,
+            start_date=self.calculation.start_date,
+            end_date=self.calculation.end_date,
+        )
 
 
 class SalaryBenefitCalculator2021(HelsinkiBenefitCalculator):
@@ -278,13 +284,21 @@ class SalaryBenefitCalculator2021(HelsinkiBenefitCalculator):
         if len(date_ranges) > 1:
             self._create_row(
                 DateRangeDescriptionRow,
-                start_date=date_ranges[0].start_date,
-                end_date=date_ranges[-1].end_date,
+                start_date=self.calculation.start_date,
+                end_date=self.calculation.end_date,
                 prefix_text="Koko ajalta",
             )
-            self._create_row(SalaryBenefitSumSubTotalsRow)
+            self._create_row(
+                SalaryBenefitSumSubTotalsRow,
+                start_date=self.calculation.start_date,
+                end_date=self.calculation.end_date,
+            )
         else:
-            self._create_row(SalaryBenefitTotalRow)
+            self._create_row(
+                SalaryBenefitTotalRow,
+                start_date=self.calculation.start_date,
+                end_date=self.calculation.end_date,
+            )
 
 
 class EmployeeBenefitCalculator2021(HelsinkiBenefitCalculator):
@@ -296,4 +310,8 @@ class EmployeeBenefitCalculator2021(HelsinkiBenefitCalculator):
 
     def create_rows(self):
         self._create_row(EmployeeBenefitMonthlyRow)
-        self._create_row(EmployeeBenefitTotalRow)
+        self._create_row(
+            EmployeeBenefitTotalRow,
+            start_date=self.calculation.start_date,
+            end_date=self.calculation.end_date,
+        )

--- a/backend/benefit/calculator/tests/test_manual_override.py
+++ b/backend/benefit/calculator/tests/test_manual_override.py
@@ -39,6 +39,12 @@ def test_override_monthly_benefit_amount(
         handling_application.calculation.rows.first().row_type
         == RowType.HELSINKI_BENEFIT_TOTAL_EUR
     )
-    assert handling_application.calculation.rows.first().start_date is None
-    assert handling_application.calculation.rows.first().end_date is None
+    assert (
+        handling_application.calculation.rows.first().start_date
+        == handling_application.calculation.start_date
+    )
+    assert (
+        handling_application.calculation.rows.first().end_date
+        == handling_application.calculation.end_date
+    )
     assert handling_application.calculation.rows.first().amount == expected_amount


### PR DESCRIPTION
Also fix translation for association_has_business_activities

## Description :sparkles:

In some cases, the start_date and end_date were missing in Ahjo rows

## Issues :bug: HL-501

## Testing :alembic:

backend/benefit/applications/services/applications_csv_report.py
backend/benefit/applications/tests/test_applications_csv_report.py


## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
