### PR TITLE
Increase V8 max heap size in development

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,6 +32,11 @@ COPY --chown=appuser:appuser . .
 # =============================
 FROM appbase as development
 # =============================
+
+# Set V8 max heap size to 2GB (default is 512MB)
+# This prevents Docker Compose from crashing due to out of memory errors
+ENV NODE_OPTIONS="--max_old_space_size=2048"
+
 ARG SERVICE
 # Use non-root user
 USER appuser


### PR DESCRIPTION
## Description :sparkles:

When running TET project locally Docker Compose has been crashing often due to `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
