### PR TITLE
HL-523: fix missing URLs in terms_of_service_in_effect

### DIFF
--- a/backend/benefit/terms/tests/test_terms_of_service_api.py
+++ b/backend/benefit/terms/tests/test_terms_of_service_api.py
@@ -47,6 +47,9 @@ def test_terms_of_service_in_effect(
         == mock_get_organisation_roles_and_create_company
     )
     assert response.data["terms_of_service_in_effect"]["id"] == str(current_terms.pk)
+    assert response.data["terms_of_service_in_effect"]["terms_pdf_fi"].startswith(
+        "http"
+    )
 
     assert {
         obj["id"]

--- a/backend/benefit/users/api/v1/serializers.py
+++ b/backend/benefit/users/api/v1/serializers.py
@@ -46,7 +46,9 @@ class UserSerializer(serializers.ModelSerializer):
     def get_terms_of_service_in_effect(self, obj):
         terms = Terms.objects.get_terms_in_effect(TermsType.TERMS_OF_SERVICE)
         if terms:
-            return TermsSerializer(terms).data
+            # If given the request in context, DRF will output the URL for FileFields
+            context = {"request": self.context.get("request")}
+            return TermsSerializer(terms, context=context).data
         else:
             return None
 


### PR DESCRIPTION
## Description :sparkles:

The response from server contained local fs paths

## Issues :bug: HL-523

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
