### PR TITLE
HL-387: send email notification to applicant about new messages

### DIFF
--- a/.env.benefit-backend.example
+++ b/.env.benefit-backend.example
@@ -65,4 +65,13 @@ SERVICE_BUS_AUTH_USERNAME=helsinkilisatest
 
 SEND_AUDIT_LOG=0
 
+# Email configuration
+EMAIL_USE_TLS=False
+EMAIL_HOST=
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=
+EMAIL_PORT=25
+EMAIL_TIMEOUT=15
+DEFAULT_FROM_EMAIL='Helsinki-lisä <helsinkilisa@hel.fi>'
+
 

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -36,6 +36,7 @@ from common.utils import duration_in_months
 from companies.tests.conftest import *  # noqa
 from companies.tests.factories import CompanyFactory
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from freezegun import freeze_time
 from helsinkibenefit.settings import MAX_UPLOAD_SIZE
 from helsinkibenefit.tests.conftest import *  # noqa
@@ -1145,6 +1146,7 @@ def test_application_status_change_as_applicant(
     ],
 )
 @pytest.mark.parametrize("log_entry_comment", [None, "", "comment"])
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 def test_application_status_change_as_handler(
     request,
     handler_api_client,
@@ -1153,6 +1155,7 @@ def test_application_status_change_as_handler(
     to_status,
     expected_code,
     log_entry_comment,
+    mailoutbox,
 ):
     """
     modify existing application
@@ -1206,6 +1209,8 @@ def test_application_status_change_as_handler(
                 "Please make the corrections by 18.06.2021"
                 in application.messages.first().content
             )
+            assert len(mailoutbox) == 1
+            assert "You have received a new message" in mailoutbox[0].subject
 
         if to_status in [
             ApplicationStatus.CANCELLED,

--- a/backend/benefit/common/tests/conftest.py
+++ b/backend/benefit/common/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from django.contrib.auth.models import Permission
 from django.utils.translation import activate
 from freezegun import freeze_time
+from langdetect import DetectorFactory
 from rest_framework.test import APIClient
 
 from shared.common.tests.conftest import *  # noqa
@@ -18,6 +19,7 @@ def _api_client():
 @pytest.fixture(autouse=True)
 def setup_test_environment(settings):
     factory.random.reseed_random("777")
+    DetectorFactory.seed = 0
     random.seed(777)
     activate("en")
     with freeze_time("2021-06-04"):

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -97,6 +97,13 @@ env = environ.Env(
     ELASTICSEARCH_PASSWORD=(str, ""),
     CLEAR_AUDIT_LOG_ENTRIES=(bool, False),
     ENABLE_SEND_AUDIT_LOG=(bool, False),
+    EMAIL_USE_TLS=(bool, False),
+    EMAIL_HOST=(str, "ema.platta-net.hel.fi"),
+    EMAIL_HOST_USER=(str, ""),
+    EMAIL_HOST_PASSWORD=(str, ""),
+    EMAIL_PORT=(int, 25),
+    EMAIL_TIMEOUT=(int, 15),
+    DEFAULT_FROM_EMAIL=(str, "Helsinki-lisä <helsinkilisa@hel.fi>"),
     WKHTMLTOPDF_BIN=(str, "/usr/bin/wkhtmltopdf"),
     DISABLE_AUTHENTICATION=(bool, False),
     DUMMY_COMPANY_FORM_CODE=(
@@ -229,6 +236,14 @@ TEMPLATES = [
     }
 ]
 
+EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS")
+EMAIL_HOST = env.str("EMAIL_HOST")
+EMAIL_HOST_USER = env.str("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = env.str("EMAIL_HOST_PASSWORD")
+EMAIL_PORT = env.int("EMAIL_PORT")
+EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT")
+DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL")
+
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS")
 CORS_ALLOW_ALL_ORIGINS = env.bool("CORS_ALLOW_ALL_ORIGINS")
@@ -300,6 +315,11 @@ YTJ_TIMEOUT = env.int("YTJ_TIMEOUT")
 NEXT_PUBLIC_MOCK_FLAG = env.bool("NEXT_PUBLIC_MOCK_FLAG")
 DUMMY_COMPANY_FORM_CODE = env.int("DUMMY_COMPANY_FORM_CODE")
 ENABLE_DEBUG_ENV = env.bool("ENABLE_DEBUG_ENV")
+
+if NEXT_PUBLIC_MOCK_FLAG:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
 # Authentication settings begin
 SESSION_COOKIE_AGE = env.int("SESSION_COOKIE_AGE")

--- a/backend/benefit/locale/en/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-21 08:20+0200\n"
+"POT-Creation-Date: 2022-03-31 13:26+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -849,6 +849,18 @@ msgid ""
 "Your application has been opened for editing. Please make the corrections by "
 "{additional_information_needed_by}, otherwise the application cannot be "
 "processed."
+msgstr ""
+
+#: messages/automatic_messages.py:44
+msgid "You have received a new message from Helsinki benefit"
+msgstr ""
+
+#: messages/automatic_messages.py:55
+#, python-format
+msgid ""
+"A new message has been added to the Helsinki-benefit application "
+"%(application_number)s (%(submitted_at_fmt)s). Open that application to see "
+"the message."
 msgstr ""
 
 #: messages/models.py:16

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-21 08:20+0200\n"
+"POT-Creation-Date: 2022-03-31 13:26+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -852,7 +852,22 @@ msgid ""
 "processed."
 msgstr ""
 "Hakemuksesi on avattu muokattavaksi. Tee korjaukset viimeistään "
-"{additional_information_needed_by} mennessä, muuten hakemusta ei voida käsitellä."
+"{additional_information_needed_by} mennessä, muuten hakemusta ei voida "
+"käsitellä."
+
+#: messages/automatic_messages.py:44
+msgid "You have received a new message from Helsinki benefit"
+msgstr "Olet saanut uuden viestin Helsinki-lisä -hakemukseen"
+
+#: messages/automatic_messages.py:55
+#, python-format
+msgid ""
+"A new message has been added to the Helsinki-benefit application "
+"%(application_number)s (%(submitted_at_fmt)s). Open that application to see "
+"the message."
+msgstr ""
+"Helsinki-lisä hakemukseen %(application_number)s (%(submitted_at_fmt)s) on tullut uusi viesti. "
+"Avaa kyseinen hakemus nähdäksesi viestin."
 
 #: messages/models.py:16
 msgid "Note"

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-21 08:20+0200\n"
+"POT-Creation-Date: 2022-03-31 13:26+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -855,6 +855,20 @@ msgid ""
 msgstr ""
 "Din ansökan har öppnats för redigering. Gör ändringarna senast "
 "{additional_information_needed_by}, annars kan ansökan inte behandlas."
+
+#: messages/automatic_messages.py:44
+msgid "You have received a new message from Helsinki benefit"
+msgstr "Du har fått ett nytt meddelande om Helsingforstilläg"
+
+#: messages/automatic_messages.py:55
+#, python-format
+msgid ""
+"A new message has been added to the Helsinki-benefit application "
+"%(application_number)s (%(submitted_at_fmt)s). Open that application to see "
+"the message."
+msgstr ""
+"Ett meddelande om Helsingforstillägg ansökan "
+"%(application_number)s (%(submitted_at_fmt)s) har inkommit. Öppna ansökan i fråga för att se meddelandet."
 
 #: messages/models.py:16
 msgid "Note"

--- a/backend/benefit/messages/automatic_messages.py
+++ b/backend/benefit/messages/automatic_messages.py
@@ -1,7 +1,15 @@
+import logging
+from smtplib import SMTPException
+
+from django.conf import settings
+from django.core.mail import send_mail
 from django.utils import translation
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 from messages.models import Message, MessageType
+from sentry_sdk import capture_message
+
+LOGGER = logging.getLogger(__name__)
 
 APPLICATION_REOPENED_MESSAGE = _(
     "Your application has been opened for editing. Please make the corrections by "
@@ -29,3 +37,67 @@ def send_application_reopened_message(
                 ),
             ),
         )
+    notify_applicant_by_email_about_new_message(application)
+
+
+def _message_notification_email_subject():
+    # force evaluation of lazy string so that the messages in local memory queue remain translated
+    # correctly during unit tests
+    return str(_("You have received a new message from Helsinki benefit"))
+
+
+def _message_notification_email_body(application):
+    if submitted_at := application.submitted_at:
+        submitted_at_fmt = submitted_at.strftime("%d.%m.%Y")
+    else:
+        # this should never happen in practice, as the applicants are not allowed to send messages
+        # while application remains draft, and the handlers don't see non-submitted applications
+        # at all.
+        submitted_at_fmt = "n/a"
+    return str(
+        _(
+            "A new message has been added to the Helsinki-benefit application "
+            "%(application_number)s (%(submitted_at_fmt)s). "
+            "Open that application to see the message."
+        )
+        % {
+            "application_number": application.application_number,
+            "submitted_at_fmt": submitted_at_fmt,
+        }
+    )
+
+
+def notify_applicant_by_email_about_new_message(application):
+    """
+    :param user: The handler who is setting the application to ADDITIONAL_INFORMATION_REQUESTED status
+    :param application: The application being reopened
+    :param application: The last response date
+    """
+    if not application.company_contact_person_email:
+        # company_contact_person_email is a required field for submitted applications
+        LOGGER.warning(
+            f"Application {application} does not have company_contact_person_email - unexpected"
+        )
+        return 0
+
+    with translation.override(application.applicant_language):
+        try:
+            return send_mail(
+                subject=_message_notification_email_subject(),
+                message=_message_notification_email_body(application),
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=[application.company_contact_person_email],
+                fail_silently=False,
+            )
+        except SMTPException:
+            email_domain = "n/a"
+            if "@" in application.company_contact_person_email:
+                email_domain = application.company_contact_person_email.split("@")[1]
+            capture_message(
+                (
+                    f"SMTPException while sending email to xxx@{email_domain}, "
+                    f"application number {application.application_number}"
+                ),
+                "error",
+            )
+            return 0

--- a/backend/benefit/messages/tests/test_api.py
+++ b/backend/benefit/messages/tests/test_api.py
@@ -10,9 +10,16 @@ from applications.tests.test_applications_api import (
 )
 from common.tests.conftest import get_client_user
 from companies.tests.factories import CompanyFactory
+from django.conf import settings
+from django.test import override_settings
 from messages.models import Message, MessageType
 from messages.tests.factories import MessageFactory
 from rest_framework.reverse import reverse
+
+from shared.common.lang_test_utils import (
+    assert_email_body_language,
+    assert_email_subject_language,
+)
 
 SAMPLE_MESSAGE_PAYLOAD = {
     "content": "Sample message",
@@ -262,13 +269,16 @@ def test_applicant_send_first_message(
 
 
 @pytest.mark.parametrize(
-    "view_name,msg_type",
+    "view_name,msg_type,email_language",
     [
-        ("applicant-message-list", MessageType.APPLICANT_MESSAGE),
-        ("handler-message-list", MessageType.HANDLER_MESSAGE),
-        ("handler-note-list", MessageType.NOTE),
+        ("applicant-message-list", MessageType.APPLICANT_MESSAGE, None),
+        ("handler-message-list", MessageType.HANDLER_MESSAGE, "fi"),
+        ("handler-message-list", MessageType.HANDLER_MESSAGE, "en"),
+        ("handler-message-list", MessageType.HANDLER_MESSAGE, "sv"),
+        ("handler-note-list", MessageType.NOTE, None),
     ],
 )
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 def test_create_message(
     api_client,
     handler_api_client,
@@ -276,6 +286,8 @@ def test_create_message(
     mock_get_organisation_roles_and_create_company,
     view_name,
     msg_type,
+    email_language,
+    mailoutbox,
 ):
     msg = deepcopy(SAMPLE_MESSAGE_PAYLOAD)
     msg["message_type"] = msg_type
@@ -290,13 +302,28 @@ def test_create_message(
             reverse(view_name, kwargs={"application_pk": handling_application.pk}),
             msg,
         )
-        assert result.status_code == 201
+        assert len(mailoutbox) == 0
     else:
         user = get_client_user(handler_api_client)
+        if email_language:
+            handling_application.applicant_language = email_language
+            handling_application.save()
         result = handler_api_client.post(
             reverse(view_name, kwargs={"application_pk": handling_application.pk}),
             msg,
         )
+        assert result.status_code == 201
+        if email_language:
+            assert len(mailoutbox) == 1
+            assert_email_subject_language(str(mailoutbox[0].subject), email_language)
+            assert_email_body_language(str(mailoutbox[0].body), email_language)
+            if email_language == "fi":
+                assert "Olet saanut uuden viestin" in mailoutbox[0].subject
+                assert "on tullut uusi viesti" in mailoutbox[0].body
+                assert mailoutbox[0].to == [
+                    handling_application.company_contact_person_email
+                ]
+                assert mailoutbox[0].from_email == settings.DEFAULT_FROM_EMAIL
 
     assert result.status_code == 201
     message_qs = Message.objects.filter(message_type=msg_type)

--- a/backend/benefit/messages/views.py
+++ b/backend/benefit/messages/views.py
@@ -3,6 +3,7 @@ from common.permissions import BFIsApplicant, BFIsHandler, TermsOfServiceAccepte
 from django.conf import settings
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
+from messages.automatic_messages import notify_applicant_by_email_about_new_message
 from messages.models import Message
 from messages.permissions import HasMessagePermission
 from messages.serializers import MessageSerializer, NoteSerializer
@@ -45,6 +46,10 @@ class ApplicantMessageViewSet(AuditLoggingModelViewSet):
 class HandlerMessageViewSet(ApplicantMessageViewSet):
     serializer_class = MessageSerializer
     permission_classes = [BFIsHandler, HasMessagePermission]
+
+    def perform_create(self, serializer):
+        message = serializer.save()
+        notify_applicant_by_email_about_new_message(message.application)
 
     def get_queryset(self):
         try:

--- a/backend/benefit/requirements-dev.in
+++ b/backend/benefit/requirements-dev.in
@@ -9,3 +9,4 @@ pytest-freezegun
 requests-mock
 Werkzeug
 openpyxl # for the Excel testcases from the handlers
+langdetect

--- a/backend/benefit/requirements-dev.txt
+++ b/backend/benefit/requirements-dev.txt
@@ -40,6 +40,8 @@ isort==5.8.0
     # via -r requirements-dev.in
 jedi==0.18.0
     # via ipython
+langdetect==1.0.9
+    # via -r requirements-dev.in
 matplotlib-inline==0.1.2
     # via ipython
 mccabe==0.6.1
@@ -96,6 +98,7 @@ requests==2.25.1
     # via requests-mock
 six==1.16.0
     # via
+    #   langdetect
     #   python-dateutil
     #   requests-mock
 toml==0.10.2

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 from urllib.parse import urlparse
 
 import factory.random
-import langdetect
 import pytest
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.models import AnonymousUser
@@ -23,6 +22,10 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 from shared.audit_log.models import AuditLogEntry
+from shared.common.lang_test_utils import (
+    assert_email_body_language,
+    assert_email_subject_language,
+)
 from shared.common.tests.conftest import (
     staff_client,
     staff_superuser_client,
@@ -214,24 +217,6 @@ def get_django_adfs_login_url(redirect_url):
 
 def get_test_vtj_json() -> dict:
     return {"first_name": "Maija", "last_name": "Meikäläinen"}
-
-
-def assert_email_subject_language(email_subject, expected_language):
-    detected_language = langdetect.detect(email_subject)
-    assert (
-        detected_language == expected_language
-    ), "Email subject '{}' used language {} instead of expected {}".format(
-        email_subject, detected_language, expected_language
-    )
-
-
-def assert_email_body_language(email_body, expected_language):
-    detected_language = langdetect.detect(email_body)
-    assert (
-        detected_language == expected_language
-    ), "Email body '{}' used language {} instead of expected {}".format(
-        email_body, detected_language, expected_language
-    )
 
 
 @pytest.mark.django_db

--- a/backend/shared/shared/common/lang_test_utils.py
+++ b/backend/shared/shared/common/lang_test_utils.py
@@ -1,0 +1,24 @@
+try:
+    import langdetect
+except ImportError:
+    # as of 2022-04, TET project doesn't have langdetect as dependency yet, and
+    # unit tests fail because pytest tries to import this file
+    pass
+
+
+def assert_email_subject_language(email_subject, expected_language):
+    detected_language = langdetect.detect(email_subject)
+    assert (
+        detected_language == expected_language
+    ), "Email subject '{}' used language {} instead of expected {}".format(
+        email_subject, detected_language, expected_language
+    )
+
+
+def assert_email_body_language(email_body, expected_language):
+    detected_language = langdetect.detect(email_body)
+    assert (
+        detected_language == expected_language
+    ), "Email body '{}' used language {} instead of expected {}".format(
+        email_body, detected_language, expected_language
+    )


### PR DESCRIPTION
## Description :sparkles:

Email sending is implemented in the same way as in Kesäseteli

Report email sending errors to Sentry so that the errors can be reported further to the handlers. Error while sending email should not block sending messages.

## Issues :bug: HL-387

## Testing :alembic:

backend/benefit/messages/tests/test_api.py

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
