### PR TITLE
HL-544: Round the amount of employment benefit to full euros

### DIFF
--- a/backend/benefit/calculator/models.py
+++ b/backend/benefit/calculator/models.py
@@ -779,20 +779,19 @@ class EmployeeBenefitMonthlyRow(CalculationRow):
 
 class EmployeeBenefitTotalRow(CalculationRow, TotalRowMixin):
     """
-    SalaryBenefitTotalRow for the simple cases where
-    * there is a single pay subsidy decision for the duration of the benefit
-    * or there is no pay subsidy decision
+    Calculate the total based on the monthly amount and the duration
     """
 
     proxy_row_type = RowType.HELSINKI_BENEFIT_TOTAL_EUR
     description_fi_template = "Helsinki-lisä yhteensä"
 
     def calculate_amount(self):
-        return (
+        return to_decimal(
             self.calculation.duration_in_months
             * self.calculation.calculator.get_amount(
                 RowType.HELSINKI_BENEFIT_MONTHLY_EUR
-            )
+            ),
+            0,
         )
 
     class Meta:

--- a/backend/benefit/calculator/tests/test_models.py
+++ b/backend/benefit/calculator/tests/test_models.py
@@ -206,6 +206,15 @@ def test_pay_subsidy_maximum(handling_application, pay_subsidy_percent, max_subs
             None,
             True,
         ),
+        (
+            BenefitType.EMPLOYMENT_BENEFIT,
+            date(2022, 1, 1),
+            date(2022, 1, 16),
+            100,
+            date(2022, 1, 1),
+            None,
+            True,
+        ),
     ],
 )
 def test_calculation_required_fields(
@@ -232,6 +241,11 @@ def test_calculation_required_fields(
     if can_calculate:
         assert handling_application.calculation.calculated_benefit_amount is not None
         assert handling_application.calculation.rows.count() > 0
+        # The result must be rounded to full euros
+        assert (
+            int(handling_application.calculation.calculated_benefit_amount)
+            == handling_application.calculation.calculated_benefit_amount
+        )
     else:
         assert handling_application.calculation.calculated_benefit_amount is None
         assert handling_application.calculation.rows.count() == 0


### PR DESCRIPTION
## Description :sparkles:

The amount of benefit was not rounded

## Issues :bug: HL-544

## Testing :alembic:

backend/benefit/calculator/tests/test_models.py

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
