### PR TITLE
HL-506, YJDH-514, TETP-158: change CSRF_COOKIE_NAME to yjdhcsrftoken

### DIFF
--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -41,7 +41,7 @@ env = environ.Env(
     CORS_ALLOW_ALL_ORIGINS=(bool, False),
     CSRF_COOKIE_DOMAIN=(str, "localhost"),
     CSRF_TRUSTED_ORIGINS=(list, []),
-    CSRF_COOKIE_NAME=(str, "benefitcsrftoken"),
+    CSRF_COOKIE_NAME=(str, "yjdhcsrftoken"),
     YTJ_BASE_URL=(str, "http://avoindata.prh.fi/opendata/tr/v1"),
     YTJ_TIMEOUT=(int, 30),
     # Source: YTJ-rajapinnan koodiston kuvaus, available at https://liityntakatalogi.suomi.fi/dataset/xroadytj-services

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -46,6 +46,7 @@ env = environ.Env(
     CORS_ALLOW_ALL_ORIGINS=(bool, False),
     CSRF_COOKIE_DOMAIN=(str, "localhost"),
     CSRF_TRUSTED_ORIGINS=(list, []),
+    CSRF_COOKIE_NAME=(str, "yjdhcsrftoken"),
     YTJ_BASE_URL=(str, "http://avoindata.prh.fi/opendata/tr/v1"),
     YTJ_TIMEOUT=(int, 30),
     NEXT_PUBLIC_MOCK_FLAG=(bool, False),
@@ -235,6 +236,7 @@ CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS")
 CORS_ALLOW_ALL_ORIGINS = env.bool("CORS_ALLOW_ALL_ORIGINS")
 CSRF_COOKIE_DOMAIN = env.str("CSRF_COOKIE_DOMAIN")
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS")
+CSRF_COOKIE_NAME = env.str("CSRF_COOKIE_NAME")
 CSRF_COOKIE_SECURE = True
 
 # Audit logging

--- a/backend/tet/tet/settings.py
+++ b/backend/tet/tet/settings.py
@@ -47,6 +47,7 @@ django_env = environ.Env(
     CORS_ALLOW_ALL_ORIGINS=(bool, False),
     CSRF_COOKIE_DOMAIN=(str, "localhost"),
     CSRF_TRUSTED_ORIGINS=(list, []),
+    CSRF_COOKIE_NAME=(str, "yjdhcsrftoken"),
     NEXT_PUBLIC_MOCK_FLAG=(bool, False),
     SESSION_COOKIE_AGE=(int, 3600 * 2),
     OIDC_RP_CLIENT_ID=(str, ""),
@@ -183,6 +184,7 @@ CORS_ALLOWED_ORIGINS = django_env.list("CORS_ALLOWED_ORIGINS")
 CORS_ALLOW_ALL_ORIGINS = django_env.bool("CORS_ALLOW_ALL_ORIGINS")
 CSRF_COOKIE_DOMAIN = django_env.str("CSRF_COOKIE_DOMAIN")
 CSRF_TRUSTED_ORIGINS = django_env.list("CSRF_TRUSTED_ORIGINS")
+CSRF_COOKIE_NAME = django_env.str("CSRF_COOKIE_NAME")
 CSRF_COOKIE_SECURE = True
 
 # Audit log

--- a/frontend/kesaseteli/shared/src/query-client/create-query-client.ts
+++ b/frontend/kesaseteli/shared/src/query-client/create-query-client.ts
@@ -13,7 +13,7 @@ const createAxios = (): AxiosInstance =>
       'Content-Type': 'application/json',
     },
     withCredentials: true,
-    xsrfCookieName: 'csrftoken',
+    xsrfCookieName: 'yjdhcsrftoken',
     xsrfHeaderName: 'X-CSRFToken',
   });
 

--- a/frontend/shared/src/backend-api/BackendAPIProvider.tsx
+++ b/frontend/shared/src/backend-api/BackendAPIProvider.tsx
@@ -23,7 +23,7 @@ const BackendAPIProvider: React.FC<BackendAPIProviderProps> = ({
           ...headers,
         },
         withCredentials: true,
-        xsrfCookieName: 'csrftoken',
+        xsrfCookieName: 'yjdhcsrftoken',
         xsrfHeaderName: 'X-CSRFToken',
       }),
     [baseURL, headers]

--- a/frontend/tet/admin/src/query-client/create-query-client.ts
+++ b/frontend/tet/admin/src/query-client/create-query-client.ts
@@ -10,7 +10,7 @@ const createAxios = (): AxiosInstance =>
       'Content-Type': 'application/json',
     },
     withCredentials: true,
-    xsrfCookieName: 'csrftoken',
+    xsrfCookieName: 'yjdhcsrftoken',
     xsrfHeaderName: 'X-CSRFToken',
   });
 


### PR DESCRIPTION
## Description :sparkles:

Change CSRF_COOKIE_NAME to yjdhcsrftoken in all YJDH projects

## Issues :bug: HL-506, YJDH-514, TETP-158

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
