### PR TITLE
YJDH-515 | KS-Backend: Add more additional info related tests

### DIFF
--- a/backend/kesaseteli/applications/enums.py
+++ b/backend/kesaseteli/applications/enums.py
@@ -115,6 +115,26 @@ class YouthApplicationStatus(models.TextChoices):
         """
         return [YouthApplicationStatus.ACCEPTED, YouthApplicationStatus.REJECTED]
 
+    @staticmethod
+    def unhandled_values():
+        """
+        Youth application statuses which have not been handled.
+        """
+        return sorted(
+            set(YouthApplicationStatus.values)
+            - set(YouthApplicationStatus.handled_values())
+        )
+
+    @staticmethod
+    def active_unhandled_values():
+        """
+        Active youth application statuses which have not been handled.
+        """
+        return sorted(
+            set(YouthApplicationStatus.unhandled_values())
+            - {YouthApplicationStatus.SUBMITTED.value}
+        )
+
 
 class AdditionalInfoUserReason(models.TextChoices):
     STUDENT_IN_HELSINKI_BUT_NOT_RESIDENT = "student_in_helsinki_but_not_resident", _(

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -274,7 +274,7 @@ class YouthApplication(LockForUpdateMixin, TimeStampedModel, UUIDModel):
                 "Kiitos! Ystävällisin terveisin, Kesäseteli-tiimi"
             ) % {"activation_link": activation_link}
 
-    def _processing_email_subject(self):
+    def processing_email_subject(self):
         with translation.override("fi"):
             return gettext("Nuoren kesäsetelihakemus: %(first_name)s %(last_name)s") % {
                 "first_name": self.first_name,
@@ -352,7 +352,7 @@ class YouthApplication(LockForUpdateMixin, TimeStampedModel, UUIDModel):
         :return: True if email was sent, otherwise False.
         """
         return send_mail_with_error_logging(
-            subject=self._processing_email_subject(),
+            subject=self.processing_email_subject(),
             message=self._processing_email_message(self._processing_link(request)),
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[settings.HANDLER_EMAIL],
@@ -597,7 +597,7 @@ class YouthSummerVoucher(HistoricalModel, TimeStampedModel, UUIDModel):
     def year(self) -> int:
         return self.youth_application.created_at.year
 
-    def _email_subject(self, language):
+    def email_subject(self, language):
         with translation.override(language):
             return gettext("Vuoden %(year)s Kesäsetelisi") % {"year": self.year}
 
@@ -641,7 +641,7 @@ class YouthSummerVoucher(HistoricalModel, TimeStampedModel, UUIDModel):
                 "year": self.year,
             }
             return send_mail_with_error_logging(
-                subject=self._email_subject(language),
+                subject=self.email_subject(language),
                 message=get_template("youth_summer_voucher_email.txt").render(context),
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=[self.youth_application.email],

--- a/backend/kesaseteli/applications/tests/test_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_applications_api.py
@@ -9,7 +9,10 @@ from applications.api.v1.serializers import (
 )
 from applications.enums import EmployerApplicationStatus
 from applications.models import EmployerApplication
-from common.tests.factories import EmployerApplicationFactory, SummerVoucherFactory
+from common.tests.factories import (
+    EmployerApplicationFactory,
+    EmployerSummerVoucherFactory,
+)
 
 
 def get_list_url():
@@ -156,7 +159,7 @@ def test_update_summer_voucher_with_invalid_data(
 
 @pytest.mark.django_db
 def test_remove_single_summer_voucher(api_client, application, summer_voucher):
-    SummerVoucherFactory(application=application)  # Add a second voucher
+    EmployerSummerVoucherFactory(application=application)  # Add a second voucher
     application.refresh_from_db()
     original_summer_voucher_count = application.summer_vouchers.count()
 
@@ -179,7 +182,7 @@ def test_remove_single_summer_voucher(api_client, application, summer_voucher):
 
 @pytest.mark.django_db
 def test_remove_all_summer_vouchers(api_client, application):
-    SummerVoucherFactory.create_batch(size=3, application=application)
+    EmployerSummerVoucherFactory.create_batch(size=3, application=application)
     data = EmployerApplicationSerializer(application).data
     data.pop("summer_vouchers")
     response = api_client.put(

--- a/backend/kesaseteli/applications/tests/test_models.py
+++ b/backend/kesaseteli/applications/tests/test_models.py
@@ -3,14 +3,16 @@ from django.db import transaction
 from django.db.utils import IntegrityError
 
 from applications.models import YouthSummerVoucher
-from common.tests.factories import AcceptedYouthApplicationFactory
+from common.tests.factories import AwaitingManualProcessingYouthApplicationFactory
 
 
 @pytest.mark.django_db(transaction=True, reset_sequences=True)
 def test_youth_summer_voucher_sequentiality():
     assert YouthSummerVoucher.objects.count() == 0
     for ordinal_number in range(1, 10):
-        summer_voucher = AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+        summer_voucher = (
+            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
+        )
         assert YouthSummerVoucher.objects.count() == ordinal_number
         assert YouthSummerVoucher.objects.last() == summer_voucher
         assert summer_voucher.summer_voucher_serial_number == ordinal_number
@@ -20,7 +22,7 @@ def test_youth_summer_voucher_sequentiality():
 def test_youth_summer_voucher_sequentiality_duplicate_create():
     assert YouthSummerVoucher.objects.count() == 0
 
-    app_1 = AcceptedYouthApplicationFactory()
+    app_1 = AwaitingManualProcessingYouthApplicationFactory()
     app_1.create_youth_summer_voucher()
     assert YouthSummerVoucher.objects.count() == 1
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
@@ -30,7 +32,7 @@ def test_youth_summer_voucher_sequentiality_duplicate_create():
     assert YouthSummerVoucher.objects.count() == 1
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
 
-    AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
     assert YouthSummerVoucher.objects.count() == 2
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 2
 
@@ -45,19 +47,19 @@ def test_youth_summer_voucher_sequentiality_duplicate_create():
 def test_youth_summer_voucher_sequentiality_failing_transaction():
     assert YouthSummerVoucher.objects.count() == 0
 
-    AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
     assert YouthSummerVoucher.objects.count() == 1
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
 
     with transaction.atomic():
-        AcceptedYouthApplicationFactory().create_youth_summer_voucher()
-        AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+        AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
+        AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
         transaction.set_rollback(True)
 
     assert YouthSummerVoucher.objects.count() == 1
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
 
-    AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
     assert YouthSummerVoucher.objects.count() == 2
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 2
 
@@ -72,21 +74,21 @@ def test_youth_summer_voucher_sequentiality_failing_transaction():
 def test_youth_summer_voucher_sequentiality_failing_nested_transaction():
     assert YouthSummerVoucher.objects.count() == 0
 
-    AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
     assert YouthSummerVoucher.objects.count() == 1
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
 
     with transaction.atomic():
-        AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+        AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
         with transaction.atomic():
-            AcceptedYouthApplicationFactory().create_youth_summer_voucher()
-            AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
+            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
             transaction.set_rollback(True)
 
     assert YouthSummerVoucher.objects.count() == 2
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 2
 
-    AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
     assert YouthSummerVoucher.objects.count() == 3
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 3
 
@@ -101,22 +103,22 @@ def test_youth_summer_voucher_sequentiality_failing_nested_transaction():
 def test_youth_summer_voucher_sequentiality_failing_nested_transactions():
     assert YouthSummerVoucher.objects.count() == 0
 
-    AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
     assert YouthSummerVoucher.objects.count() == 1
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
 
     with transaction.atomic():
-        AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+        AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
         with transaction.atomic():
-            AcceptedYouthApplicationFactory().create_youth_summer_voucher()
-            AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
+            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
             transaction.set_rollback(True)
         transaction.set_rollback(True)
 
     assert YouthSummerVoucher.objects.count() == 1
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
 
-    AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
     assert YouthSummerVoucher.objects.count() == 2
     assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 2
 
@@ -133,7 +135,7 @@ def test_youth_summer_voucher_sequentiality_complex_transaction_nesting():
 
     def create_youth_summer_vouchers(count: int):
         for i in range(count):
-            AcceptedYouthApplicationFactory().create_youth_summer_voucher()
+            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
 
     create_youth_summer_vouchers(count=1)
     assert YouthSummerVoucher.objects.count() == 1

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -46,10 +46,10 @@ from common.tests.conftest import (
 from common.tests.factories import (
     AcceptableYouthApplicationFactory,
     AcceptedYouthApplicationFactory,
-    ActiveListedSchoolYouthApplicationFactory,
     AdditionalInfoRequestedYouthApplicationFactory,
-    InactiveListedSchoolYouthApplicationFactory,
-    InactiveUnlistedSchoolYouthApplicationFactory,
+    AwaitingManualProcessingYouthApplicationFactory,
+    InactiveNeedAdditionalInfoYouthApplicationFactory,
+    InactiveNoNeedAdditionalInfoYouthApplicationFactory,
     RejectedYouthApplicationFactory,
     YouthApplicationFactory,
 )
@@ -83,6 +83,13 @@ class RedirectTo(Enum):
 
 def get_random_pk() -> uuid.UUID:
     return uuid.uuid4()
+
+
+def test_additional_info() -> dict:
+    return {
+        "additional_info_user_reasons": [AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE],
+        "additional_info_description": "Test text",
+    }
 
 
 def get_required_fields() -> List[str]:
@@ -533,7 +540,7 @@ def test_youth_applications_activate_unexpired_inactive(
     expected_status_code,
 ):
     settings.DISABLE_VTJ = disable_vtj
-    inactive_youth_application = InactiveListedSchoolYouthApplicationFactory(
+    inactive_youth_application = InactiveNoNeedAdditionalInfoYouthApplicationFactory(
         language=language
     )
     assert not inactive_youth_application.has_youth_summer_voucher
@@ -567,11 +574,20 @@ def test_youth_applications_activate_unexpired_inactive(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "language,disable_vtj",
+    "language,disable_vtj,youth_application_factory,need_additional_info",
     [
-        (language, disable_vtj)
+        (
+            language,
+            disable_vtj,
+            youth_application_factory,
+            need_additional_info,
+        )
         for language in get_supported_languages()
         for disable_vtj in [False, True]
+        for youth_application_factory, need_additional_info in [
+            (AwaitingManualProcessingYouthApplicationFactory, False),
+            (AdditionalInfoRequestedYouthApplicationFactory, True),
+        ]
     ],
 )
 def test_youth_applications_activate_unexpired_active(
@@ -580,24 +596,33 @@ def test_youth_applications_activate_unexpired_active(
     settings,
     language,
     disable_vtj,
+    youth_application_factory,
+    need_additional_info,
 ):
     settings.DISABLE_VTJ = disable_vtj
-    active_youth_application = ActiveListedSchoolYouthApplicationFactory(
-        language=language
-    )
-    assert not active_youth_application.has_youth_summer_voucher
+    active_youth_application = youth_application_factory(language=language)
     old_status = active_youth_application.status
     old_handler = active_youth_application.handler
     old_handled_at = active_youth_application.handled_at
 
+    # Make sure the source object is set up correctly
     assert active_youth_application.is_active
     assert not active_youth_application.has_activation_link_expired
     assert active_youth_application.language == language
+    assert active_youth_application.need_additional_info == need_additional_info
+    assert not active_youth_application.has_additional_info
+    assert not active_youth_application.has_youth_summer_voucher
 
     response = api_client.get(get_activation_url(active_youth_application.pk))
 
     assert response.status_code == status.HTTP_302_FOUND
-    assert response.url == active_youth_application.already_activated_page_url()
+
+    if need_additional_info:
+        assert response.url == active_youth_application.additional_info_page_url(
+            pk=active_youth_application.pk
+        )
+    else:
+        assert response.url == active_youth_application.already_activated_page_url()
 
     active_youth_application.refresh_from_db()
     assert not active_youth_application.has_youth_summer_voucher
@@ -609,11 +634,20 @@ def test_youth_applications_activate_unexpired_active(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "language,disable_vtj",
+    "language,disable_vtj,youth_application_factory,need_additional_info",
     [
-        (language, disable_vtj)
+        (
+            language,
+            disable_vtj,
+            youth_application_factory,
+            need_additional_info,
+        )
         for language in get_supported_languages()
         for disable_vtj in [False, True]
+        for youth_application_factory, need_additional_info in [
+            (InactiveNoNeedAdditionalInfoYouthApplicationFactory, False),
+            (InactiveNeedAdditionalInfoYouthApplicationFactory, True),
+        ]
     ],
 )
 def test_youth_applications_activate_expired_inactive(
@@ -622,17 +656,21 @@ def test_youth_applications_activate_expired_inactive(
     settings,
     language,
     disable_vtj,
+    youth_application_factory,
+    need_additional_info,
 ):
     settings.DISABLE_VTJ = disable_vtj
-    inactive_youth_application = InactiveListedSchoolYouthApplicationFactory(
-        language=language
-    )
-    assert not inactive_youth_application.has_youth_summer_voucher
+    inactive_youth_application = youth_application_factory(language=language)
+
     old_status = inactive_youth_application.status
 
+    # Make sure the source object is set up correctly
     assert not inactive_youth_application.is_active
     assert inactive_youth_application.has_activation_link_expired
     assert inactive_youth_application.language == language
+    assert inactive_youth_application.need_additional_info == need_additional_info
+    assert not inactive_youth_application.has_additional_info
+    assert not inactive_youth_application.has_youth_summer_voucher
 
     response = api_client.get(get_activation_url(inactive_youth_application.pk))
 
@@ -649,11 +687,20 @@ def test_youth_applications_activate_expired_inactive(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "language,disable_vtj",
+    "language,disable_vtj,youth_application_factory,need_additional_info",
     [
-        (language, disable_vtj)
+        (
+            language,
+            disable_vtj,
+            youth_application_factory,
+            need_additional_info,
+        )
         for language in get_supported_languages()
         for disable_vtj in [False, True]
+        for youth_application_factory, need_additional_info in [
+            (AwaitingManualProcessingYouthApplicationFactory, False),
+            (AdditionalInfoRequestedYouthApplicationFactory, True),
+        ]
     ],
 )
 def test_youth_applications_activate_expired_active(
@@ -662,24 +709,33 @@ def test_youth_applications_activate_expired_active(
     settings,
     language,
     disable_vtj,
+    youth_application_factory,
+    need_additional_info,
 ):
     settings.DISABLE_VTJ = disable_vtj
-    active_youth_application = ActiveListedSchoolYouthApplicationFactory(
-        language=language
-    )
-    assert not active_youth_application.has_youth_summer_voucher
+    active_youth_application = youth_application_factory(language=language)
     old_status = active_youth_application.status
     old_handler = active_youth_application.handler
     old_handled_at = active_youth_application.handled_at
 
+    # Make sure the source object is set up correctly
     assert active_youth_application.is_active
     assert active_youth_application.has_activation_link_expired
     assert active_youth_application.language == language
+    assert active_youth_application.need_additional_info == need_additional_info
+    assert not active_youth_application.has_additional_info
+    assert not active_youth_application.has_youth_summer_voucher
 
     response = api_client.get(get_activation_url(active_youth_application.pk))
 
     assert response.status_code == status.HTTP_302_FOUND
-    assert response.url == active_youth_application.already_activated_page_url()
+
+    if need_additional_info:
+        assert response.url == active_youth_application.additional_info_page_url(
+            pk=active_youth_application.pk
+        )
+    else:
+        assert response.url == active_youth_application.already_activated_page_url()
 
     active_youth_application.refresh_from_db()
     assert not active_youth_application.has_youth_summer_voucher
@@ -695,8 +751,8 @@ def test_youth_applications_dual_activate_unexpired_inactive(
     api_client,
     make_youth_application_activation_link_unexpired,
 ):
-    app_1 = InactiveListedSchoolYouthApplicationFactory()
-    app_2 = InactiveListedSchoolYouthApplicationFactory(
+    app_1 = InactiveNoNeedAdditionalInfoYouthApplicationFactory()
+    app_2 = InactiveNoNeedAdditionalInfoYouthApplicationFactory(
         social_security_number=app_1.social_security_number
     )
     app_2_old_status = app_2.status
@@ -949,7 +1005,7 @@ def test_youth_application_post_valid_language(
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 @pytest.mark.parametrize("language", get_supported_languages())
 def test_youth_application_activation_email_language(api_client, language):
-    youth_application = InactiveListedSchoolYouthApplicationFactory.build(
+    youth_application = InactiveNoNeedAdditionalInfoYouthApplicationFactory.build(
         language=language
     )
     data = YouthApplicationSerializer(youth_application).data
@@ -964,7 +1020,7 @@ def test_youth_application_activation_email_language(api_client, language):
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 @pytest.mark.parametrize("language", get_supported_languages())
 def test_youth_application_additional_info_request_email_language(api_client, language):
-    youth_application = InactiveUnlistedSchoolYouthApplicationFactory.build(
+    youth_application = InactiveNeedAdditionalInfoYouthApplicationFactory.build(
         language=language
     )
     data = YouthApplicationSerializer(youth_application).data
@@ -982,7 +1038,7 @@ def test_youth_application_additional_info_request_email_language(api_client, la
 )
 @pytest.mark.parametrize("language", get_supported_languages())
 def test_youth_application_activation_email_sending(api_client, language):
-    youth_application = InactiveListedSchoolYouthApplicationFactory.build(
+    youth_application = InactiveNoNeedAdditionalInfoYouthApplicationFactory.build(
         language=language
     )
     data = YouthApplicationSerializer(youth_application).data
@@ -1004,7 +1060,7 @@ def test_youth_application_activation_email_sending(api_client, language):
 )
 @pytest.mark.parametrize("language", get_supported_languages())
 def test_youth_application_additional_info_request_email_sending(api_client, language):
-    youth_application = InactiveUnlistedSchoolYouthApplicationFactory.build(
+    youth_application = InactiveNeedAdditionalInfoYouthApplicationFactory.build(
         language=language
     )
     data = YouthApplicationSerializer(youth_application).data
@@ -1023,7 +1079,7 @@ def test_youth_application_additional_info_request_email_sending(api_client, lan
 @pytest.mark.django_db
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 def test_youth_application_activation_email_link_path(api_client):
-    youth_application = InactiveListedSchoolYouthApplicationFactory.build()
+    youth_application = InactiveNoNeedAdditionalInfoYouthApplicationFactory.build()
     data = YouthApplicationSerializer(youth_application).data
     response = api_client.post(reverse("v1:youthapplication-list"), data)
     assert len(mail.outbox) > 0
@@ -1041,7 +1097,7 @@ def test_youth_application_activation_email_link_path(api_client):
 @pytest.mark.django_db
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 def test_youth_application_additional_info_request_email_link_path(api_client):
-    youth_application = InactiveUnlistedSchoolYouthApplicationFactory.build()
+    youth_application = InactiveNeedAdditionalInfoYouthApplicationFactory.build()
     data = YouthApplicationSerializer(youth_application).data
     response = api_client.post(reverse("v1:youthapplication-list"), data)
     assert len(mail.outbox) > 0
@@ -1058,47 +1114,161 @@ def test_youth_application_additional_info_request_email_link_path(api_client):
 
 @pytest.mark.django_db
 @override_settings(
-    DISABLE_VTJ=True,
     EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
     DEFAULT_FROM_EMAIL="Test sender <testsender@hel.fi>",
     HANDLER_EMAIL="Test handler <testhandler@hel.fi>",
 )
-def test_youth_application_processing_email_sending_without_vtj(
+@pytest.mark.parametrize(
+    "disable_vtj,expect_success",
+    [(disable_vtj, disable_vtj is True) for disable_vtj in [False, True]],
+)
+def test_youth_application_processing_email_sending_on_activate(
+    settings,
     api_client,
     make_youth_application_activation_link_unexpired,
+    disable_vtj,
+    expect_success,
 ):
-    inactive_youth_application = InactiveListedSchoolYouthApplicationFactory()
+    settings.DISABLE_VTJ = disable_vtj
+    youth_application = InactiveNoNeedAdditionalInfoYouthApplicationFactory()
+    assert not youth_application.is_active
+    assert not youth_application.has_activation_link_expired
+    assert not youth_application.need_additional_info
     start_mail_count = len(mail.outbox)
-    api_client.get(get_activation_url(inactive_youth_application.pk))
-    assert len(mail.outbox) == start_mail_count + 1
-    processing_email = mail.outbox[-1]
-    assert processing_email.from_email == "Test sender <testsender@hel.fi>"
-    assert processing_email.to == ["Test handler <testhandler@hel.fi>"]
+    api_client.get(get_activation_url(youth_application.pk))
+
+    if expect_success:
+        assert len(mail.outbox) == start_mail_count + 1
+        processing_email = mail.outbox[-1]
+        assert processing_email.subject == youth_application.processing_email_subject()
+        assert processing_email.from_email == "Test sender <testsender@hel.fi>"
+        assert processing_email.to == ["Test handler <testhandler@hel.fi>"]
+    else:
+        assert len(mail.outbox) == start_mail_count
 
 
 @pytest.mark.django_db
 @override_settings(
-    DISABLE_VTJ=True,
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DEFAULT_FROM_EMAIL="Test sender <testsender@hel.fi>",
+    HANDLER_EMAIL="Test handler <testhandler@hel.fi>",
+)
+@pytest.mark.parametrize(
+    "disable_vtj,expect_success",
+    [(disable_vtj, disable_vtj is True) for disable_vtj in [False, True]],
+)
+def test_youth_application_processing_email_sending_after_additional_info(
+    settings,
+    api_client,
+    disable_vtj,
+    expect_success,
+):
+    settings.DISABLE_VTJ = disable_vtj
+    youth_application = AdditionalInfoRequestedYouthApplicationFactory()
+    assert youth_application.need_additional_info
+    assert youth_application.can_set_additional_info
+    start_mail_count = len(mail.outbox)
+    api_client.post(
+        get_additional_info_url(youth_application.pk),
+        data=json.dumps(test_additional_info()),
+        content_type="application/json",
+    )
+    if expect_success:
+        assert len(mail.outbox) == start_mail_count + 1
+        processing_email = mail.outbox[-1]
+        assert processing_email.subject == youth_application.processing_email_subject()
+        assert processing_email.from_email == "Test sender <testsender@hel.fi>"
+        assert processing_email.to == ["Test handler <testhandler@hel.fi>"]
+    else:
+        assert len(mail.outbox) == start_mail_count
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+@pytest.mark.parametrize(
+    "disable_vtj,youth_application_language,expected_email_language,expect_success",
+    [
+        (
+            disable_vtj,
+            language,
+            "fi",
+            disable_vtj is True,
+        )
+        for disable_vtj in [False, True]
+        for language in get_supported_languages()
+    ],
+)
+def test_youth_application_processing_email_language_on_activate(
+    settings,
+    api_client,
+    make_youth_application_activation_link_unexpired,
+    disable_vtj,
+    youth_application_language,
+    expected_email_language,
+    expect_success,
+):
+    settings.DISABLE_VTJ = disable_vtj
+    youth_application = InactiveNoNeedAdditionalInfoYouthApplicationFactory(
+        language=youth_application_language
+    )
+    assert not youth_application.is_active
+    assert not youth_application.has_activation_link_expired
+    assert not youth_application.need_additional_info
+    start_mail_count = len(mail.outbox)
+    api_client.get(get_activation_url(youth_application.pk))
+    if expect_success:
+        assert len(mail.outbox) == start_mail_count + 1
+        processing_email = mail.outbox[-1]
+        assert_email_subject_language(processing_email.subject, expected_email_language)
+        assert_email_body_language(processing_email.body, expected_email_language)
+    else:
+        assert len(mail.outbox) == start_mail_count
+
+
+@pytest.mark.django_db
+@override_settings(
     EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
 )
 @pytest.mark.parametrize(
-    "youth_application_language,expected_email_language",
-    [(language, "fi") for language in get_supported_languages()],
+    "disable_vtj,youth_application_language,expected_email_language,expect_success",
+    [
+        (
+            disable_vtj,
+            language,
+            "fi",
+            disable_vtj is True,
+        )
+        for disable_vtj in [False, True]
+        for language in get_supported_languages()
+    ],
 )
-def test_youth_application_processing_email_language(
+def test_youth_application_processing_email_language_after_additional_info(
+    settings,
     api_client,
-    make_youth_application_activation_link_unexpired,
+    disable_vtj,
     youth_application_language,
     expected_email_language,
+    expect_success,
 ):
-    inactive_youth_application = InactiveListedSchoolYouthApplicationFactory(
+    settings.DISABLE_VTJ = disable_vtj
+    youth_application = AdditionalInfoRequestedYouthApplicationFactory(
         language=youth_application_language
     )
-    api_client.get(get_activation_url(inactive_youth_application.pk))
-    assert len(mail.outbox) > 0
-    processing_email = mail.outbox[-1]
-    assert_email_subject_language(processing_email.subject, expected_email_language)
-    assert_email_body_language(processing_email.body, expected_email_language)
+    assert youth_application.need_additional_info
+    assert youth_application.can_set_additional_info
+    start_mail_count = len(mail.outbox)
+    api_client.post(
+        get_additional_info_url(youth_application.pk),
+        data=json.dumps(test_additional_info()),
+        content_type="application/json",
+    )
+    if expect_success:
+        assert len(mail.outbox) == start_mail_count + 1
+        processing_email = mail.outbox[-1]
+        assert_email_subject_language(processing_email.subject, expected_email_language)
+        assert_email_body_language(processing_email.body, expected_email_language)
+    else:
+        assert len(mail.outbox) == start_mail_count
 
 
 @pytest.mark.django_db
@@ -1147,6 +1317,12 @@ def test_youth_summer_voucher_email_sending(api_client, language):
     api_client.patch(get_accept_url(acceptable_youth_application.pk))
     assert len(mail.outbox) == start_mail_count + 1
     youth_summer_voucher_email = mail.outbox[-1]
+    assert (
+        youth_summer_voucher_email.subject
+        == acceptable_youth_application.youth_summer_voucher.email_subject(
+            language=language
+        )
+    )
     assert youth_summer_voucher_email.from_email == "Test sender <testsender@hel.fi>"
     assert youth_summer_voucher_email.to == [acceptable_youth_application.email]
 
@@ -1616,27 +1792,38 @@ def test_youth_applications_reject_rejectable(
 @pytest.mark.parametrize("mock_flag", [False, True])
 @pytest.mark.parametrize("client_fixture_func", [unauth_api_client, staff_client])
 @pytest.mark.parametrize(
-    "extra_field_name,extra_field_value",
+    "disable_vtj,extra_field_name,extra_field_value,expected_status_code",
     [
-        ("additional_info_provided_at", "2021-01-01"),
-        ("social_security_number", "111111-111C"),
-        ("inexistent field name", 3.14),
+        (
+            disable_vtj,
+            extra_field_name,
+            extra_field_value,
+            status.HTTP_201_CREATED if disable_vtj else status.HTTP_501_NOT_IMPLEMENTED,
+        )
+        for disable_vtj in [False, True]
+        for extra_field_name, extra_field_value in [
+            ("additional_info_provided_at", "2021-01-01"),
+            ("social_security_number", "111111-111C"),
+            ("inexistent field name", 3.14),
+        ]
     ],
 )
 def test_youth_applications_set_excess_additional_info(
     request,
     settings,
     mock_flag,
+    disable_vtj,
     client_fixture_func,
     extra_field_name,
     extra_field_value,
+    expected_status_code,
 ):
     """
     Test that providing excess POST data when setting additional info for a youth
     application does not matter and does not change anything.
     """
     settings.NEXT_PUBLIC_MOCK_FLAG = mock_flag
-    settings.DISABLE_VTJ = True
+    settings.DISABLE_VTJ = disable_vtj
     client_fixture = request.getfixturevalue(client_fixture_func.__name__)
 
     source_app = AdditionalInfoRequestedYouthApplicationFactory()
@@ -1648,11 +1835,8 @@ def test_youth_applications_set_excess_additional_info(
     assert source_app.can_set_additional_info
     old_extra_field_value = getattr(source_app, extra_field_name, None)
 
-    post_data = {
-        "additional_info_user_reasons": [AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE],
-        "additional_info_description": "Test text",
-        extra_field_name: extra_field_value,
-    }
+    post_data = test_additional_info()
+    post_data[extra_field_name] = extra_field_value
 
     response = client_fixture.post(
         get_additional_info_url(source_app.pk),
@@ -1660,23 +1844,24 @@ def test_youth_applications_set_excess_additional_info(
         content_type="application/json",
     )
 
-    assert response.status_code == status.HTTP_201_CREATED
+    assert response.status_code == expected_status_code
 
-    expected_fields_to_change = [
-        "additional_info_user_reasons",
-        "additional_info_description",
-        "additional_info_provided_at",
-    ]
+    if expected_status_code != status.HTTP_501_NOT_IMPLEMENTED:
+        expected_fields_to_change = [
+            "additional_info_user_reasons",
+            "additional_info_description",
+            "additional_info_provided_at",
+        ]
 
-    source_app.refresh_from_db()
-    assert source_app.additional_info_user_reasons == [
-        AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE
-    ]
-    assert source_app.additional_info_description == "Test text"
-    assert source_app.additional_info_provided_at == timezone.now()
-    if extra_field_name not in expected_fields_to_change:
-        assert getattr(source_app, extra_field_name, None) == old_extra_field_value
-    assert not source_app.can_set_additional_info
+        source_app.refresh_from_db()
+        assert source_app.additional_info_user_reasons == [
+            AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE
+        ]
+        assert source_app.additional_info_description == "Test text"
+        assert source_app.additional_info_provided_at == timezone.now()
+        if extra_field_name not in expected_fields_to_change:
+            assert getattr(source_app, extra_field_name, None) == old_extra_field_value
+        assert not source_app.can_set_additional_info
 
 
 @freeze_time()
@@ -1684,38 +1869,49 @@ def test_youth_applications_set_excess_additional_info(
 @pytest.mark.parametrize("mock_flag", [False, True])
 @pytest.mark.parametrize("client_fixture_func", [unauth_api_client, staff_client])
 @pytest.mark.parametrize(
-    "additional_info_user_reasons,additional_info_description",
+    "disable_vtj,additional_info_user_reasons,additional_info_description,expected_status_code",
     [
         (
-            [AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE],
-            unicodedata.lookup("person with folded hands"),
-        ),
-        ([AdditionalInfoUserReason.MOVING_TO_HELSINKI], "Test text"),
-        (
-            [
-                AdditionalInfoUserReason.STUDENT_IN_HELSINKI_BUT_NOT_RESIDENT,
-                AdditionalInfoUserReason.MOVING_TO_HELSINKI,
-                AdditionalInfoUserReason.PERSONAL_INFO_DIFFERS_FROM_VTJ,
-            ],
-            "Test text",
-        ),
-        (AdditionalInfoUserReason.values, "1st line.\n2nd line.\n3rd line."),
-        (
-            [AdditionalInfoUserReason.OTHER],
-            " \tLeading\n and trailing whitespace should get removed \n\t ",
-        ),
+            disable_vtj,
+            additional_info_user_reasons,
+            additional_info_description,
+            status.HTTP_201_CREATED if disable_vtj else status.HTTP_501_NOT_IMPLEMENTED,
+        )
+        for disable_vtj in [False, True]
+        for additional_info_user_reasons, additional_info_description in [
+            (
+                [AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE],
+                unicodedata.lookup("person with folded hands"),
+            ),
+            ([AdditionalInfoUserReason.MOVING_TO_HELSINKI], "Test text"),
+            (
+                [
+                    AdditionalInfoUserReason.STUDENT_IN_HELSINKI_BUT_NOT_RESIDENT,
+                    AdditionalInfoUserReason.MOVING_TO_HELSINKI,
+                    AdditionalInfoUserReason.PERSONAL_INFO_DIFFERS_FROM_VTJ,
+                ],
+                "Test text",
+            ),
+            (AdditionalInfoUserReason.values, "1st line.\n2nd line.\n3rd line."),
+            (
+                [AdditionalInfoUserReason.OTHER],
+                " \tLeading\n and trailing whitespace should get removed \n\t ",
+            ),
+        ]
     ],
 )
 def test_youth_applications_set_valid_additional_info(
     request,
     settings,
     mock_flag,
+    disable_vtj,
     client_fixture_func,
     additional_info_user_reasons,
     additional_info_description,
+    expected_status_code,
 ):
     settings.NEXT_PUBLIC_MOCK_FLAG = mock_flag
-    settings.DISABLE_VTJ = True
+    settings.DISABLE_VTJ = disable_vtj
     client_fixture = request.getfixturevalue(client_fixture_func.__name__)
 
     source_app = AdditionalInfoRequestedYouthApplicationFactory()
@@ -1737,52 +1933,70 @@ def test_youth_applications_set_valid_additional_info(
         content_type="application/json",
     )
 
-    assert response.status_code == status.HTTP_201_CREATED
+    assert response.status_code == expected_status_code
 
-    source_app.refresh_from_db()
-    assert source_app.additional_info_user_reasons == additional_info_user_reasons
-    assert source_app.additional_info_description == additional_info_description.strip()
-    assert source_app.additional_info_provided_at == timezone.now()
-    assert not source_app.can_set_additional_info
+    if expected_status_code != status.HTTP_501_NOT_IMPLEMENTED:
+        source_app.refresh_from_db()
+        assert source_app.additional_info_user_reasons == additional_info_user_reasons
+        assert (
+            source_app.additional_info_description
+            == additional_info_description.strip()
+        )
+        assert source_app.additional_info_provided_at == timezone.now()
+        assert not source_app.can_set_additional_info
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("mock_flag", [False, True])
 @pytest.mark.parametrize("client_fixture_func", [unauth_api_client, staff_client])
 @pytest.mark.parametrize(
-    "additional_info_user_reasons,additional_info_description",
+    "disable_vtj,additional_info_user_reasons,additional_info_description,expected_status_code",
     [
-        ([AdditionalInfoUserReason.OTHER, "Invalid user reason"], "Valid description"),
-        (list(AdditionalInfoUserReason.values) + [""], "Valid description"),
-        (list(AdditionalInfoUserReason.values) + [[]], "Valid description"),
-        ([AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE], ""),
-        ([AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE], None),
-        ([AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE], "   \n  "),
-        (["Invalid user reason"], "Valid description"),
-        ([""], "Valid description"),
-        ([" \n   "], "Valid description"),
-        ([None], "Valid description"),
-        # additional_info_user_reasons must be a list:
-        (AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE, "Valid description"),
-        ("Invalid user reason", "Valid description"),
-        ("", "Valid description"),
-        (" \n   ", "Valid description"),
-        (None, "Valid description"),
-        (8, "Valid description"),
-        (dict(), "Valid description"),
-        ({AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE: True}, "Valid description"),
+        (
+            disable_vtj,
+            additional_info_user_reasons,
+            additional_info_description,
+            status.HTTP_400_BAD_REQUEST,
+        )
+        for disable_vtj in [False, True]
+        for additional_info_user_reasons, additional_info_description in [
+            (
+                [AdditionalInfoUserReason.OTHER, "Invalid user reason"],
+                "Valid description",
+            ),
+            (list(AdditionalInfoUserReason.values) + [""], "Valid description"),
+            (list(AdditionalInfoUserReason.values) + [[]], "Valid description"),
+            ([AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE], ""),
+            ([AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE], None),
+            ([AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE], "   \n  "),
+            (["Invalid user reason"], "Valid description"),
+            ([""], "Valid description"),
+            ([" \n   "], "Valid description"),
+            ([None], "Valid description"),
+            # additional_info_user_reasons must be a list:
+            (AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE, "Valid description"),
+            ("Invalid user reason", "Valid description"),
+            ("", "Valid description"),
+            (" \n   ", "Valid description"),
+            (None, "Valid description"),
+            (8, "Valid description"),
+            (dict(), "Valid description"),
+            ({AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE: True}, "Valid description"),
+        ]
     ],
 )
 def test_youth_applications_set_invalid_additional_info(
     request,
     settings,
     mock_flag,
+    disable_vtj,
     client_fixture_func,
     additional_info_user_reasons,
     additional_info_description,
+    expected_status_code,
 ):
     settings.NEXT_PUBLIC_MOCK_FLAG = mock_flag
-    settings.DISABLE_VTJ = True
+    settings.DISABLE_VTJ = disable_vtj
     client_fixture = request.getfixturevalue(client_fixture_func.__name__)
 
     source_app = AdditionalInfoRequestedYouthApplicationFactory()
@@ -1802,7 +2016,7 @@ def test_youth_applications_set_invalid_additional_info(
         content_type="application/json",
     )
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == expected_status_code
 
     source_app.refresh_from_db()
     assert source_app.additional_info_user_reasons == old_additional_info_user_reasons
@@ -1815,22 +2029,32 @@ def test_youth_applications_set_invalid_additional_info(
 @pytest.mark.parametrize("mock_flag", [False, True])
 @pytest.mark.parametrize("client_fixture_func", [unauth_api_client, staff_client])
 @pytest.mark.parametrize(
-    "missing_fields",
+    "disable_vtj,missing_fields,expected_status_code",
     [
-        ["additional_info_user_reasons"],
-        ["additional_info_description"],
-        ["additional_info_user_reasons", "additional_info_description"],
+        (
+            disable_vtj,
+            missing_fields,
+            status.HTTP_400_BAD_REQUEST,
+        )
+        for disable_vtj in [False, True]
+        for missing_fields in [
+            ["additional_info_user_reasons"],
+            ["additional_info_description"],
+            ["additional_info_user_reasons", "additional_info_description"],
+        ]
     ],
 )
 def test_youth_applications_set_partial_additional_info(
     request,
     settings,
     mock_flag,
+    disable_vtj,
     client_fixture_func,
     missing_fields,
+    expected_status_code,
 ):
     settings.NEXT_PUBLIC_MOCK_FLAG = mock_flag
-    settings.DISABLE_VTJ = True
+    settings.DISABLE_VTJ = disable_vtj
     client_fixture = request.getfixturevalue(client_fixture_func.__name__)
 
     source_app = AdditionalInfoRequestedYouthApplicationFactory()
@@ -1839,10 +2063,7 @@ def test_youth_applications_set_partial_additional_info(
     old_additional_info_provided_at = source_app.additional_info_provided_at
     old_modified_at = source_app.modified_at
 
-    post_data = {
-        "additional_info_user_reasons": [AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE],
-        "additional_info_description": "Test text",
-    }
+    post_data = test_additional_info()
 
     for missing_field in missing_fields:
         del post_data[missing_field]
@@ -1853,7 +2074,7 @@ def test_youth_applications_set_partial_additional_info(
         content_type="application/json",
     )
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == expected_status_code
     source_app.refresh_from_db()
     assert source_app.additional_info_user_reasons == old_additional_info_user_reasons
     assert source_app.additional_info_description == old_additional_info_description

--- a/backend/kesaseteli/common/tests/conftest.py
+++ b/backend/kesaseteli/common/tests/conftest.py
@@ -13,10 +13,10 @@ from common.tests.factories import (
     AttachmentFactory,
     CompanyFactory,
     EmployerApplicationFactory,
+    EmployerSummerVoucherFactory,
     InactiveYouthApplicationFactory,
     RejectableYouthApplicationFactory,
     RejectedYouthApplicationFactory,
-    SummerVoucherFactory,
     YouthApplicationFactory,
 )
 
@@ -49,7 +49,7 @@ def submitted_application(company, user):
 
 @pytest.fixture
 def summer_voucher(application):
-    summer_voucher = SummerVoucherFactory(application=application)
+    summer_voucher = EmployerSummerVoucherFactory(application=application)
     yield summer_voucher
     for attachment in summer_voucher.attachments.all():
         attachment.attachment_file.delete(save=False)
@@ -57,7 +57,7 @@ def summer_voucher(application):
 
 @pytest.fixture
 def submitted_summer_voucher(submitted_application):
-    summer_voucher = SummerVoucherFactory(application=submitted_application)
+    summer_voucher = EmployerSummerVoucherFactory(application=submitted_application)
     yield summer_voucher
     for attachment in summer_voucher.attachments.all():
         attachment.attachment_file.delete(save=False)

--- a/backend/kesaseteli/common/tests/test_factories.py
+++ b/backend/kesaseteli/common/tests/test_factories.py
@@ -1,0 +1,170 @@
+import pytest
+
+from applications.enums import YouthApplicationStatus
+from applications.models import YouthApplication
+from applications.tests.conftest import *  # noqa
+from common.tests.factories import (
+    AcceptableYouthApplicationFactory,
+    AcceptedYouthApplicationFactory,
+    ActiveUnhandledYouthApplicationFactory,
+    ActiveYouthApplicationFactory,
+    AdditionalInfoProvidedYouthApplicationFactory,
+    AdditionalInfoRequestedYouthApplicationFactory,
+    AwaitingManualProcessingYouthApplicationFactory,
+    InactiveNeedAdditionalInfoYouthApplicationFactory,
+    InactiveNoNeedAdditionalInfoYouthApplicationFactory,
+    InactiveYouthApplicationFactory,
+    RejectableYouthApplicationFactory,
+    RejectedYouthApplicationFactory,
+    UnhandledYouthApplicationFactory,
+    YouthApplicationFactory,
+    YouthSummerVoucherFactory,
+)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "youth_application_factory,expected_statuses,expected_attribute_values",
+    [
+        (YouthApplicationFactory, YouthApplicationStatus.values, {}),
+        (ActiveYouthApplicationFactory, YouthApplicationStatus.active_values(), {}),
+        (
+            InactiveYouthApplicationFactory,
+            [YouthApplicationStatus.SUBMITTED.value],
+            {},
+        ),
+        (
+            AcceptableYouthApplicationFactory,
+            YouthApplicationStatus.acceptable_values(),
+            {},
+        ),
+        (
+            AcceptedYouthApplicationFactory,
+            [YouthApplicationStatus.ACCEPTED.value],
+            {},
+        ),
+        (
+            ActiveUnhandledYouthApplicationFactory,
+            YouthApplicationStatus.active_unhandled_values(),
+            {},
+        ),
+        (
+            AdditionalInfoRequestedYouthApplicationFactory,
+            [YouthApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED.value],
+            {"need_additional_info": True},
+        ),
+        (
+            AdditionalInfoProvidedYouthApplicationFactory,
+            [YouthApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED.value],
+            {"need_additional_info": True},
+        ),
+        (
+            RejectableYouthApplicationFactory,
+            YouthApplicationStatus.rejectable_values(),
+            {},
+        ),
+        (
+            RejectedYouthApplicationFactory,
+            [YouthApplicationStatus.REJECTED.value],
+            {},
+        ),
+        (
+            UnhandledYouthApplicationFactory,
+            YouthApplicationStatus.unhandled_values(),
+            {},
+        ),
+        (
+            AwaitingManualProcessingYouthApplicationFactory,
+            [YouthApplicationStatus.AWAITING_MANUAL_PROCESSING.value],
+            {"need_additional_info": False},
+        ),
+        (
+            InactiveNoNeedAdditionalInfoYouthApplicationFactory,
+            [YouthApplicationStatus.SUBMITTED.value],
+            {"need_additional_info": False},
+        ),
+        (
+            InactiveNeedAdditionalInfoYouthApplicationFactory,
+            [YouthApplicationStatus.SUBMITTED.value],
+            {"need_additional_info": True},
+        ),
+    ],
+)
+def test_youth_application_factory(
+    make_youth_application_activation_link_unexpired,
+    youth_application_factory,
+    expected_statuses,
+    expected_attribute_values: dict,
+):
+    for _ in range(20):  # Run more than once because factories generate random data
+        youth_application: YouthApplication = youth_application_factory()
+        status = youth_application.status
+        assert status in expected_statuses
+        is_active_status = status in YouthApplicationStatus.active_values()
+        is_handled_status = status in YouthApplicationStatus.handled_values()
+        is_accepted_status = status == YouthApplicationStatus.ACCEPTED.value
+        is_rejected_status = status == YouthApplicationStatus.REJECTED.value
+        is_additional_information_requested_status = (
+            status == YouthApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED.value
+        )
+        assert youth_application.is_active == is_active_status
+        assert youth_application.can_activate == (not is_active_status)
+        assert youth_application.is_accepted == is_accepted_status
+        assert youth_application.is_rejected == is_rejected_status
+        assert (
+            youth_application.can_set_additional_info
+            == is_additional_information_requested_status
+        )
+        assert (youth_application.handler is not None) == is_handled_status
+        assert (youth_application.handled_at is not None) == is_handled_status
+        assert youth_application.has_youth_summer_voucher == is_accepted_status
+
+        if status not in YouthApplicationStatus.can_have_additional_info_values():
+            assert not youth_application.has_additional_info
+
+        if status in YouthApplicationStatus.must_have_additional_info_values():
+            assert youth_application.has_additional_info
+
+        if status == YouthApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED:
+            assert youth_application.need_additional_info
+            assert youth_application.can_set_additional_info
+            assert not youth_application.has_additional_info
+        elif status == YouthApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED:
+            assert youth_application.need_additional_info
+            assert not youth_application.can_set_additional_info
+            assert youth_application.has_additional_info
+
+        # If additional info has been provided it must have been initially needed
+        if youth_application.has_additional_info:
+            assert youth_application.need_additional_info
+
+        # Test expected attribute values
+        for attribute_name, expected_value in expected_attribute_values.items():
+            assert hasattr(youth_application, attribute_name)
+            assert getattr(youth_application, attribute_name) == expected_value
+
+
+@pytest.mark.django_db
+def test_youth_summer_voucher_factory():
+    # Run more than once because factories generate random data
+    youth_summer_vouchers = YouthSummerVoucherFactory.create_batch(size=20)
+
+    for youth_summer_voucher in youth_summer_vouchers:
+        assert youth_summer_voucher.summer_voucher_serial_number >= 1
+        assert youth_summer_voucher.summer_voucher_exception_reason == ""
+
+    summer_voucher_serial_numbers = [
+        youth_summer_voucher.summer_voucher_serial_number
+        for youth_summer_voucher in youth_summer_vouchers
+    ]
+    assert len(set(summer_voucher_serial_numbers)) == len(
+        summer_voucher_serial_numbers
+    ), "Duplicates in youth summer voucher serial numbers"
+
+    youth_application_pks = [
+        youth_summer_voucher.youth_application_id
+        for youth_summer_voucher in youth_summer_vouchers
+    ]
+    assert len(set(youth_application_pks)) == len(
+        youth_application_pks
+    ), "Duplicates in youth application primary keys"


### PR DESCRIPTION
## Description :sparkles:

Tests in test_models.py:
 - Use AwaitingManualProcessingYouthApplicationFactory instead of
   AcceptedYouthApplicationFactory because the former factory generates
   youth applications without youth summer vouchers now but the latter
   generates youth applications with youth summer vouchers. These tests
   need youth applications without youth summer vouchers.

YouthApplicationStatus:
 - Add active_unhandled_values function
   - Active youth application statuses which have not been handled.
 - Add unhandled_values function
   - Youth application statuses which have not been handled.

Expose email subject functions for testing by removing underscore
prefixes from the function names:
 - YouthApplication._processing_email_subject
 - YouthSummerVoucher._email_subject

Tests in test_youth_applications_api.py:
 - Move shared additional info test POST data into test_additional_info
   function
 - Revamp tests related to activation/additional info,
   add parametrization on DISABLE_VTJ
 - Test sent emails' subjects

Revamp factories:
 - Rename SummerVoucherFactory to EmployerSummerVoucherFactory for
   clarity
 - Add support for generating youth applications that do/don't need
   additional info i.e. YouthApplication.need_additional_info returns
   True/False
 - Add ActiveUnhandledYouthApplicationFactory
 - Add AwaitingManualProcessingYouthApplicationFactory
 - Add InactiveNoNeedAdditionalInfoYouthApplicationFactory
 - Add InactiveNeedAdditionalInfoYouthApplicationFactory
 - Add UnhandledYouthApplicationFactory
 - Add YouthSummerVoucherFactory
 - Add YouthSummerVoucher linking to YouthApplication objects generated
   by different youth application factories

Add test_factories.py:
 - Add test_youth_application_factory
   - Test that different youth application factories generate
     YouthApplication instances with certain qualities
 - Add test_youth_summer_voucher_factory
   - Test that youth summer voucher factories generated
     YouthSummerVoucher instances with certain qualities

## Issues :bug:

YJDH-515

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
