### PR TITLE
Update tet-shared to React 18

### DIFF
--- a/frontend/tet/shared/package.json
+++ b/frontend/tet/shared/package.json
@@ -20,7 +20,8 @@
     "next": "^11.1.4",
     "next-i18next": "^10.5.0",
     "react-query": "^3.34.0",
-    "react": "17.0.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "styled-components": "^5.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description :sparkles:

The production build was failing with error message`ModuleNotFoundError: Module not found: Error: Can't resolve 'react-dom' in '/app/node_modules/next/dist/client'` due to this.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
