### PR TITLE
TETP-208: Add support for mocked suomi.fi authentication

### DIFF
--- a/backend/tet/events/api/v1/permissions.py
+++ b/backend/tet/events/api/v1/permissions.py
@@ -18,7 +18,7 @@ class TetAPIPermission(BasePermission):
          the postings of their company.
       3. Users logged in via AD NOT belonging to a group listed in `settings.ADFS_CONTROLLER_GROUP_UUIDS`.
          This could be anyone with a Microsoft account. The ADFS setup might prevent these logins,
-         but we cannot be sure about this, so we need to check that not anyone is allowed to creating
+         but we cannot be sure about this, so we need to check that they aren't allowed to create
          a TET posting as an employee of the city of Helsinki.
 
          This permission prevents case 3 from accessing the service.

--- a/backend/tet/events/api/v1/permissions.py
+++ b/backend/tet/events/api/v1/permissions.py
@@ -1,12 +1,41 @@
+from django.conf import settings
+from django.http import HttpRequest
 from rest_framework.permissions import BasePermission
 
 
-class TetAdminPermission(BasePermission):
+class TetAPIPermission(BasePermission):
     """
-    Permission check for managing city TET postings.
+    Permission to access the Linked Events API as authorized.
+
+    There are three kinds of possible logins:
+
+      1. Users logged in via AD belonging to a group listed in `settings.ADFS_CONTROLLER_GROUP_UUIDS`.
+         This group should contain all City of Helsinki users needing to use this servicing.
+         These users are logged in as staff users and should be allowed access to their own
+         TET postings.
+      2. Users logged in via suomi.fi (puolesta asiointi)
+         The service works if we can find a business_id for the user and the user is allowed access to
+         the postings of their company.
+      3. Users logged in via AD NOT belonging to a group listed in `settings.ADFS_CONTROLLER_GROUP_UUIDS`.
+         This could be anyone with a Microsoft account. The ADFS setup might prevent these logins,
+         but we cannot be sure about this, so we need to check that not anyone is allowed to creating
+         a TET posting as an employee of the city of Helsinki.
+
+         This permission prevents case 3 from accessing the service.
+
+         For cases 1 and 2, `ServiceClient` is responsible to further check the authorization
+         based on user actions.
     """
 
-    def has_permission(self, request, view):
+    def has_permission(self, request: HttpRequest, view):
+        # Allow all authenticated access when logins are mocked
+        if settings.NEXT_PUBLIC_MOCK_FLAG:
+            return bool(request.user)
+
         return bool(
-            request.user and (request.user.is_staff or request.user.is_superuser)
+            request.user
+            and (
+                (request.user.is_staff or request.user.is_superuser)
+                or (request.session.get("eauth_id_token") is not None)
+            )
         )

--- a/backend/tet/events/api/v1/views.py
+++ b/backend/tet/events/api/v1/views.py
@@ -3,7 +3,7 @@ from rest_framework.generics import UpdateAPIView
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
-from events.api.v1.permissions import TetAdminPermission
+from events.api.v1.permissions import TetAPIPermission
 from events.api.v1.serializers import TetUpsertEventSerializer
 from events.services import ServiceClient
 
@@ -13,30 +13,28 @@ from events.services import ServiceClient
 class JobPostingsViewSet(ViewSet):
     """CRUD operations for TET job postings"""
 
-    permission_classes = [TetAdminPermission]
+    permission_classes = [TetAPIPermission]
 
     def list(self, request):
-        job_postings = ServiceClient().list_job_postings_for_user(request.user)
+        job_postings = ServiceClient().list_job_postings_for_user(request)
         return Response(job_postings)
 
     def retrieve(self, request, pk=None):
         if pk is not None:
-            return Response(ServiceClient().get_tet_event(pk, request.user))
+            return Response(ServiceClient().get_tet_event(pk, request))
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
     def create(self, request):
         serializer = TetUpsertEventSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        event = ServiceClient().add_tet_event(serializer.data, request.user)
+        event = ServiceClient().add_tet_event(serializer.data, request)
         return Response(event, status=status.HTTP_201_CREATED)
 
     def update(self, request, pk=None):
         serializer = TetUpsertEventSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        updated_event = ServiceClient().update_tet_event(
-            pk, serializer.data, request.user
-        )
+        updated_event = ServiceClient().update_tet_event(pk, serializer.data, request)
         if pk is not None:
             return Response(updated_event)
         else:
@@ -44,18 +42,18 @@ class JobPostingsViewSet(ViewSet):
 
     def destroy(self, request, pk=None):
         if pk is not None:
-            response_status = ServiceClient().delete_event(pk, request.user)
+            response_status = ServiceClient().delete_event(pk, request)
             return Response(status=response_status)
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
 
 class PublishTetPostingView(UpdateAPIView):
-    permission_classes = [TetAdminPermission]
+    permission_classes = [TetAPIPermission]
 
     def update(self, request, pk=None):
         if pk is not None:
-            event = ServiceClient().publish_job_posting(pk, request.user)
+            event = ServiceClient().publish_job_posting(pk, request)
             return Response(event)
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)

--- a/backend/tet/events/linkedevents.py
+++ b/backend/tet/events/linkedevents.py
@@ -81,7 +81,7 @@ class LinkedEventsClient:
         else:
             return r.json()
 
-    def list_ongoing_events_authenticated(self, publisher=None):
+    def list_ongoing_events_authenticated(self, publisher=None, text=None):
         events = []
         nexturl = None
         while True:
@@ -98,6 +98,9 @@ class LinkedEventsClient:
                 }
                 if publisher:
                     params["publisher_ancestor"] = publisher
+
+                if text:
+                    params["text"] = text
 
                 r = requests.get(
                     urljoin(settings.LINKEDEVENTS_URL, "event/"),

--- a/backend/tet/events/tests/data/linked_events_responses.py
+++ b/backend/tet/events/tests/data/linked_events_responses.py
@@ -476,10 +476,10 @@ EVENT_RESPONSE_OTHERUSER = json.loads(
 )
 
 
-EVENT_RESPONSE_NO_USER = json.loads(
+EVENT_RESPONSE_TEST_COMPANY = json.loads(
     """
         {
-            "id": "tet:nouser",
+            "id": "tet:companyuser",
             "location": {
                 "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/place/tprek:352/"
             },
@@ -523,14 +523,14 @@ EVENT_RESPONSE_NO_USER = json.loads(
             "audience": [],
             "created_time": "2022-02-22T11:44:17.966052Z",
             "last_modified_time": "2022-03-07T14:00:01.981206Z",
-            "date_published": null,
+            "date_published": "2022-03-07T14:00:01.981206Z",
             "start_time": "2022-04-11",
             "end_time": "2022-04-15",
             "created_by": " - ",
             "last_modified_by": " - ",
             "custom_data": {
                 "spots": "4",
-                "org_name": "Päiväkoti Susanna",
+                "org_name": "Test Company",
                 "contact_email": "yrjo@ef.fi",
                 "contact_phone": "040585766832",
                 "contact_language": "fi",
@@ -551,7 +551,8 @@ EVENT_RESPONSE_NO_USER = json.loads(
             "search_vector_sv": "",
             "replaced_by": null,
             "provider": {
-                "fi": "Päiväkoti"
+                "fi": "Test company",
+                "sv": "654321-5"
             },
             "name": {
                 "fi": "Avustaja"
@@ -668,7 +669,7 @@ SAMPLE_EVENTS = {
         EVENT_RESPONSE_TESTUSER_EMAIL,
         EVENT_RESPONSE_TESTUSER_OID,
         EVENT_RESPONSE_OTHERUSER,
-        EVENT_RESPONSE_NO_USER,
+        EVENT_RESPONSE_TEST_COMPANY,
         EVENT_RESPONSE_NO_CUSTOM_DATA,
     ],
 }

--- a/backend/tet/events/tests/data/linked_events_responses.py
+++ b/backend/tet/events/tests/data/linked_events_responses.py
@@ -1,5 +1,7 @@
 import json
 
+from events.utils import PROVIDER_BUSINESS_ID_FIELD, PROVIDER_NAME_FIELD
+
 ADD_EVENT_PAYLOAD = json.loads(
     """
 {
@@ -550,10 +552,7 @@ EVENT_RESPONSE_TEST_COMPANY = json.loads(
             "search_vector_en": "",
             "search_vector_sv": "",
             "replaced_by": null,
-            "provider": {
-                "fi": "Test company",
-                "sv": "654321-5"
-            },
+            "provider": {},
             "name": {
                 "fi": "Avustaja"
             },
@@ -572,6 +571,11 @@ EVENT_RESPONSE_TEST_COMPANY = json.loads(
         }
 """
 )
+
+EVENT_RESPONSE_TEST_COMPANY["provider"] = {
+    PROVIDER_NAME_FIELD: "Test company",
+    PROVIDER_BUSINESS_ID_FIELD: "654321-5",
+}
 
 
 EVENT_RESPONSE_NO_CUSTOM_DATA = json.loads(

--- a/backend/tet/events/tests/test_services.py
+++ b/backend/tet/events/tests/test_services.py
@@ -11,40 +11,51 @@ from events.tests.data.linked_events_responses import (
     ADD_EVENT_PAYLOAD,
     ADD_EVENT_RESPONSE,
     EVENT_RESPONSE_NO_CUSTOM_DATA,
-    EVENT_RESPONSE_NO_USER,
     EVENT_RESPONSE_OTHERUSER,
+    EVENT_RESPONSE_TEST_COMPANY,
     EVENT_RESPONSE_TESTUSER_EMAIL,
     EVENT_RESPONSE_TESTUSER_OID,
     SAMPLE_EVENTS,
 )
 
 LOGGER = logging.getLogger(__name__)
+TEST_COMPANY_BUSINESS_ID = (
+    "654321-5"  # Needs to match linked_events_responses.EVENT_RESPONSE_TEST_COMPANY
+)
 
 
-def mock_request(is_staff=True, email=None, username=None):
+def mock_django_request(is_staff=True, email=None, username=None):
+    factory = RequestFactory()
+    request = factory.get("/")
+
     if is_staff:
         user = StaffUserFactory()
     else:
         user = UserFactory()
+
+        # We need to set organization_roles in session
+        # Otherwise the code tries to fetch them from the eauthorizations API
+        request.session = {
+            "organization_roles": {"identifier": TEST_COMPANY_BUSINESS_ID}
+        }
 
     if email:
         user.email = email
     if username:
         user.username = username
 
-    factory = RequestFactory()
-    request = factory.get("/")
     request.user = user
 
     return request
 
 
 # We expect to have a user that is properly authenticated and is authorized to access Linked Events services.
-# This can mean either a city user logged via AD or a company user logged via suomi.fi. The latter case is
-# not yet designed/implemented, so currently this test only tests for city users, but it needs to be
-# adapted to all users eventually.
-
-# Currently the expectation is that all users getting access to `ServicesClient` have is_staff set.
+# This can mean either a city user logged via AD or a company user logged via suomi.fi (OIDC). For the first
+# case the user is logged in as a staff user. For the second case we set the company business id in Django
+# request's session.
+#
+# It's important to run these test with `NEXT_PUBLIC_MOCK_FLAG=False`, because we want to test that
+# the access control works in production.
 
 
 @pytest.mark.django_db
@@ -57,22 +68,35 @@ def test_get_postings(requests_mock):
     """Test that posts are filtered by user's email and divide into published/draft works"""
     requests_mock.get("http://localhost/event/", json=SAMPLE_EVENTS)
 
-    request = mock_request(
+    request_with_adfs_auth = mock_django_request(
         is_staff=True, email="testuser@example.org", username="test-oid"
     )
-    postings = ServiceClient().list_job_postings_for_user(request)
+    postings = ServiceClient().list_job_postings_for_user(request_with_adfs_auth)
 
     assert len(postings["published"]) == 1
     assert len(postings["draft"]) == 1
 
-    request = mock_request(is_staff=True, email="hasnopostings@example.org")
-    postings = ServiceClient().list_job_postings_for_user(request)
+    request_with_adfs_auth = mock_django_request(
+        is_staff=True, email="hasnopostings@example.org"
+    )
+    postings = ServiceClient().list_job_postings_for_user(request_with_adfs_auth)
 
     assert len(postings["published"]) == 0
     assert len(postings["draft"]) == 0
 
-    request = mock_request(is_staff=True, email="otheruser@example.org")
-    postings = ServiceClient().list_job_postings_for_user(request)
+    request_with_adfs_auth = mock_django_request(
+        is_staff=True, email="otheruser@example.org"
+    )
+    postings = ServiceClient().list_job_postings_for_user(request_with_adfs_auth)
+
+    assert len(postings["published"]) == 1
+    assert len(postings["draft"]) == 0
+
+    # Test request for a company user should find published posting
+    # linked_events_responses.EVENT_RESPONSE_TEST_COMPANY
+
+    request_with_oidc_auth = mock_django_request(is_staff=False)
+    postings = ServiceClient().list_job_postings_for_user(request_with_oidc_auth)
 
     assert len(postings["published"]) == 1
     assert len(postings["draft"]) == 0
@@ -86,8 +110,15 @@ def test_get_postings(requests_mock):
 )
 def test_add_posting(requests_mock):
     requests_mock.post("http://localhost/event/", json=ADD_EVENT_RESPONSE)
-    event = ServiceClient().add_tet_event(ADD_EVENT_PAYLOAD, mock_request())
+    request_with_adfs_auth = mock_django_request(is_staff=True)
+    request_with_oidc_auth = mock_django_request(is_staff=False)
+
+    event = ServiceClient().add_tet_event(ADD_EVENT_PAYLOAD, request_with_adfs_auth)
     assert event["id"] == "tet:af7w5v5m6e"
+
+    # Adding TET postings for suomi.fi logged in users is not yet implemented when mock flag is False
+    with pytest.raises(PermissionDenied):
+        ServiceClient().add_tet_event(ADD_EVENT_PAYLOAD, request_with_oidc_auth)
 
 
 @pytest.mark.django_db
@@ -112,12 +143,14 @@ def test_edit_tet_posting(requests_mock):
     requests_mock.get(
         "http://localhost/event/tet:other-user/", json=EVENT_RESPONSE_OTHERUSER
     )
-    requests_mock.get("http://localhost/event/tet:nouser/", json=EVENT_RESPONSE_NO_USER)
+    requests_mock.get(
+        "http://localhost/event/tet:companyuser/", json=EVENT_RESPONSE_TEST_COMPANY
+    )
     requests_mock.get(
         "http://localhost/event/tet:no-custom-data/", json=EVENT_RESPONSE_NO_CUSTOM_DATA
     )
 
-    request = mock_request(
+    request_with_adfs_auth = mock_django_request(
         is_staff=True, email="testuser@example.org", username="test-oid"
     )
 
@@ -125,19 +158,59 @@ def test_edit_tet_posting(requests_mock):
 
     # Updating shouldn't raise when either `editor_email` or `editor_oid` is correctly set in event `custom_data`
 
-    client.update_tet_event("tet:test-user-email-set", ADD_EVENT_PAYLOAD, request)
-    client.update_tet_event("tet:test-user-oid-set", ADD_EVENT_PAYLOAD, request)
+    client.update_tet_event(
+        "tet:test-user-email-set", ADD_EVENT_PAYLOAD, request_with_adfs_auth
+    )
+    client.update_tet_event(
+        "tet:test-user-oid-set", ADD_EVENT_PAYLOAD, request_with_adfs_auth
+    )
 
     # Updating other events should always raise PermissionDenied
 
     with pytest.raises(PermissionDenied):
-        client.update_tet_event("tet:other-user", ADD_EVENT_PAYLOAD, request)
+        client.update_tet_event(
+            "tet:other-user", ADD_EVENT_PAYLOAD, request_with_adfs_auth
+        )
 
     with pytest.raises(PermissionDenied):
-        client.update_tet_event("tet:nouser", ADD_EVENT_PAYLOAD, request)
+        client.update_tet_event(
+            "tet:companyuser", ADD_EVENT_PAYLOAD, request_with_adfs_auth
+        )
 
     with pytest.raises(PermissionDenied):
-        client.update_tet_event("tet:no-custom-data", ADD_EVENT_PAYLOAD, request)
+        client.update_tet_event(
+            "tet:no-custom-data", ADD_EVENT_PAYLOAD, request_with_adfs_auth
+        )
+
+    request_with_oidc_auth = mock_django_request(is_staff=False)
+
+    # Updating shouldn't raise when business_id is correct set in provider
+
+    client.update_tet_event(
+        "tet:companyuser", ADD_EVENT_PAYLOAD, request_with_oidc_auth
+    )
+
+    # Updating other events should always raise PermissionDenied
+
+    with pytest.raises(PermissionDenied):
+        client.update_tet_event(
+            "tet:test-user-email-set", ADD_EVENT_PAYLOAD, request_with_oidc_auth
+        )
+
+    with pytest.raises(PermissionDenied):
+        client.update_tet_event(
+            "tet:no-custom-data", ADD_EVENT_PAYLOAD, request_with_oidc_auth
+        )
+
+    with pytest.raises(PermissionDenied):
+        client.update_tet_event(
+            "tet:test-user-oid-set", ADD_EVENT_PAYLOAD, request_with_oidc_auth
+        )
+
+    with pytest.raises(PermissionDenied):
+        client.update_tet_event(
+            "tet:other-user", ADD_EVENT_PAYLOAD, request_with_oidc_auth
+        )
 
 
 # TODO add tests for delete and publish

--- a/backend/tet/events/tests/test_services.py
+++ b/backend/tet/events/tests/test_services.py
@@ -17,11 +17,9 @@ from events.tests.data.linked_events_responses import (
     EVENT_RESPONSE_TESTUSER_OID,
     SAMPLE_EVENTS,
 )
+from events.utils import PROVIDER_BUSINESS_ID_FIELD
 
 LOGGER = logging.getLogger(__name__)
-TEST_COMPANY_BUSINESS_ID = (
-    "654321-5"  # Needs to match linked_events_responses.EVENT_RESPONSE_TEST_COMPANY
-)
 
 
 def mock_django_request(is_staff=True, email=None, username=None):
@@ -36,7 +34,11 @@ def mock_django_request(is_staff=True, email=None, username=None):
         # We need to set organization_roles in session
         # Otherwise the code tries to fetch them from the eauthorizations API
         request.session = {
-            "organization_roles": {"identifier": TEST_COMPANY_BUSINESS_ID}
+            "organization_roles": {
+                "identifier": EVENT_RESPONSE_TEST_COMPANY["provider"][
+                    PROVIDER_BUSINESS_ID_FIELD
+                ]
+            }
         }
 
     if email:

--- a/backend/tet/events/utils.py
+++ b/backend/tet/events/utils.py
@@ -1,0 +1,48 @@
+# Common utils used by services and transformations
+
+from django.conf import settings
+from django.http import HttpRequest
+from requests import RequestException
+from rest_framework.exceptions import PermissionDenied
+from shared.oidc.utils import get_organization_roles
+
+# TET service uses Linked Events `provider` field to store data that needs to be searchable
+# We can then filter events with the `text` criterion to reduced matches
+PROVIDER_NAME_FIELD = "fi"
+PROVIDER_BUSINESS_ID_FIELD = "sv"
+
+# AD users get this as the company name
+# while for suomi.fi users the company name is fetched via YTJ
+# TODO we need to localize this based on user's locale
+CITY_OF_HELSINKI = "Helsingin kaupunki"
+
+
+def get_business_id(request: HttpRequest):
+    if settings.NEXT_PUBLIC_MOCK_FLAG:
+        return "123456-7"
+
+    try:
+        organization_roles = get_organization_roles(request)
+    except RequestException:
+        raise PermissionDenied(
+            detail="Unable to fetch organization roles from eauthorizations API"
+        )
+
+    business_id = organization_roles.get("identifier")
+
+    if not business_id:
+        raise PermissionDenied(detail="Empty business id, not able to use the service")
+
+    return business_id
+
+
+def get_organization_name(request: HttpRequest):
+    if request.user.is_staff:
+        return CITY_OF_HELSINKI
+
+    if settings.NEXT_PUBLIC_MOCK_FLAG:
+        return "Test Company"
+
+    # TODO using the YTJ API will be implemented in TETP-214
+
+    raise PermissionDenied(detail="Fetching company name not implemented")

--- a/backend/tet/events/utils.py
+++ b/backend/tet/events/utils.py
@@ -7,7 +7,12 @@ from rest_framework.exceptions import PermissionDenied
 from shared.oidc.utils import get_organization_roles
 
 # TET service uses Linked Events `provider` field to store data that needs to be searchable
-# We can then filter events with the `text` criterion to reduced matches
+# We can then filter events with the `text` criterion to reduce matches
+#
+# Normally we use the field `custom_data` for this, but this field is not searchable.
+# `provider` is a localized object with keys like "fi" or "sv". Here we use them to store
+# different data, which can be very counterintuitive. This is why the code always refers
+# to the fields by these constants.
 PROVIDER_NAME_FIELD = "fi"
 PROVIDER_BUSINESS_ID_FIELD = "sv"
 

--- a/backend/tet/tet/views.py
+++ b/backend/tet/tet/views.py
@@ -16,7 +16,8 @@ class UserInfoView(View):
                 "email": user.email,
                 "name": f"{user.first_name} {user.last_name}",
                 "industry": "",
-                "username": user.username,
+                "username": user.username,  # TODO check if this can be removed
+                "is_ad_login": user.is_staff,
             }
 
             if not (userinfo["given_name"] or userinfo["family_name"]):


### PR DESCRIPTION
## Description :sparkles:

The purpose of this PR is that login from path `/oidc/authenticate` logs in a "company user" (suomi.fi puolesta asiointi) instead of city of Helsinki user (login via /oauth2/authenticate). We can currently test when the logins are mocked (localhost or review environment). Setup for testing suomi.fi login is still underway by Helsinki profiili.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
