### PR TITLE
YJDH-538 | BF-Backend: Export CSVs using StreamingHttpResponse

### DIFF
--- a/.github/workflows/bf-py-coding-style.yml
+++ b/.github/workflows/bf-py-coding-style.yml
@@ -40,11 +40,20 @@ jobs:
       - name: Install dependencies
         run: cd backend/benefit && pip install -r requirements.txt -r requirements-dev.txt
 
-      - name: Formatting
+      - name: (BF) Formatting
         run: cd backend/benefit && black --check .
 
-      - name: Linting
-        run: cd backend/benefit && flake8 --config ../shared/precommit-setup.cfg
+      - name: (BF) Linting
+        run: cd backend/benefit && flake8
 
-      - name: Import sorting
-        run: cd backend/benefit && isort -c --settings-path ../shared/precommit-setup.cfg .
+      - name: (BF) Import sorting
+        run: cd backend/benefit && isort -c .
+
+      - name: (Shared) Formatting
+        run: cd backend/shared && black --check .
+
+      - name: (Shared) Linting
+        run: cd backend/shared && flake8
+
+      - name: (Shared) Import sorting
+        run: cd backend/shared && isort -c .

--- a/backend/benefit/applications/admin.py
+++ b/backend/benefit/applications/admin.py
@@ -1,3 +1,5 @@
+from django.contrib import admin
+
 from applications.models import (
     Application,
     ApplicationBasis,
@@ -8,7 +10,6 @@ from applications.models import (
     Employee,
 )
 from calculator.admin import CalculationInline
-from django.contrib import admin
 
 
 class ApplicationBasisInline(admin.TabularInline):

--- a/backend/benefit/applications/api/v1/application_batch_views.py
+++ b/backend/benefit/applications/api/v1/application_batch_views.py
@@ -1,10 +1,3 @@
-from applications.api.v1.serializers import ApplicationBatchSerializer
-from applications.enums import ApplicationBatchStatus
-from applications.models import ApplicationBatch
-from applications.services.ahjo_integration import export_application_batch
-from applications.services.talpa_integration import TalpaService
-from common.authentications import RobotBasicAuthentication
-from common.permissions import BFIsHandler
 from django.db import transaction
 from django.http import HttpResponse, StreamingHttpResponse
 from django.utils import timezone
@@ -17,8 +10,15 @@ from rest_framework import filters as drf_filters, status
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-
 from shared.audit_log.viewsets import AuditLoggingModelViewSet
+
+from applications.api.v1.serializers import ApplicationBatchSerializer
+from applications.enums import ApplicationBatchStatus
+from applications.models import ApplicationBatch
+from applications.services.ahjo_integration import export_application_batch
+from applications.services.talpa_integration import TalpaService
+from common.authentications import RobotBasicAuthentication
+from common.permissions import BFIsHandler
 
 
 class ApplicationBatchFilter(filters.FilterSet):

--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -3,6 +3,19 @@ from datetime import date, datetime, timedelta
 from typing import Dict, List
 
 import filetype
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.db import transaction
+from django.forms import ImageField, ValidationError as DjangoFormsValidationError
+from django.utils.text import format_lazy
+from django.utils.translation import gettext_lazy as _
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+from rest_framework.fields import FileField
+from rest_framework.reverse import reverse
+
 from applications.api.v1.status_transition_validator import (
     ApplicantApplicationStatusValidator,
     ApplicationBatchStatusValidator,
@@ -43,20 +56,8 @@ from common.utils import (
 )
 from companies.api.v1.serializers import CompanySerializer
 from companies.models import Company
-from dateutil.relativedelta import relativedelta
-from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
-from django.db import transaction
-from django.forms import ImageField, ValidationError as DjangoFormsValidationError
-from django.utils.text import format_lazy
-from django.utils.translation import gettext_lazy as _
-from drf_spectacular.utils import extend_schema_field
 from helsinkibenefit.settings import MAX_UPLOAD_SIZE, MINIMUM_WORKING_HOURS_PER_WEEK
 from messages.automatic_messages import send_application_reopened_message
-from rest_framework import serializers
-from rest_framework.fields import FileField
-from rest_framework.reverse import reverse
 from terms.api.v1.serializers import (
     ApplicantTermsApprovalSerializer,
     ApproveTermsSerializer,

--- a/backend/benefit/applications/api/v1/status_transition_validator.py
+++ b/backend/benefit/applications/api/v1/status_transition_validator.py
@@ -1,7 +1,8 @@
-from applications.enums import ApplicationBatchStatus, ApplicationStatus
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
+
+from applications.enums import ApplicationBatchStatus, ApplicationStatus
 
 
 class StatusTransitionValidator:

--- a/backend/benefit/applications/api/v1/views.py
+++ b/backend/benefit/applications/api/v1/views.py
@@ -1,12 +1,3 @@
-from applications.api.v1.serializers import (
-    ApplicantApplicationSerializer,
-    AttachmentSerializer,
-    HandlerApplicationSerializer,
-)
-from applications.enums import ApplicationBatchStatus, ApplicationStatus
-from applications.models import Application, ApplicationBatch
-from applications.services.applications_csv_report import ApplicationsCsvService
-from common.permissions import BFIsApplicant, BFIsHandler, TermsOfServiceAccepted
 from django.conf import settings
 from django.core import exceptions
 from django.db import transaction
@@ -18,15 +9,24 @@ from django.utils.translation import gettext_lazy as _
 from django_filters import DateFromToRangeFilter, rest_framework as filters
 from django_filters.widgets import CSVWidget
 from drf_spectacular.utils import extend_schema
-from messages.models import MessageType
 from rest_framework import filters as drf_filters, status
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
-from sql_util.aggregates import SubqueryCount
-from users.utils import get_company_from_request
-
 from shared.audit_log.viewsets import AuditLoggingModelViewSet
+from sql_util.aggregates import SubqueryCount
+
+from applications.api.v1.serializers import (
+    ApplicantApplicationSerializer,
+    AttachmentSerializer,
+    HandlerApplicationSerializer,
+)
+from applications.enums import ApplicationBatchStatus, ApplicationStatus
+from applications.models import Application, ApplicationBatch
+from applications.services.applications_csv_report import ApplicationsCsvService
+from common.permissions import BFIsApplicant, BFIsHandler, TermsOfServiceAccepted
+from messages.models import MessageType
+from users.utils import get_company_from_request
 
 
 class BaseApplicationFilter(filters.FilterSet):

--- a/backend/benefit/applications/benefit_aggregation.py
+++ b/backend/benefit/applications/benefit_aggregation.py
@@ -4,13 +4,14 @@ from decimal import Decimal
 from itertools import chain
 from typing import List, Optional, Union
 
+from dateutil.relativedelta import relativedelta
+from django.utils.text import format_lazy
+from django.utils.translation import gettext_lazy as _
+
 from applications.enums import ApplicationStatus
 from applications.models import Application
 from calculator.models import PreviousBenefit
 from common.utils import date_range_overlap, duration_in_months, pairwise
-from dateutil.relativedelta import relativedelta
-from django.utils.text import format_lazy
-from django.utils.translation import gettext_lazy as _
 
 
 @dataclass

--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -1,5 +1,15 @@
 from datetime import datetime
 
+from django.conf import settings
+from django.core.validators import MaxLengthValidator, MinLengthValidator
+from django.db import connection, models
+from django.db.models import OuterRef, Subquery
+from django.utils.translation import gettext_lazy as _
+from encrypted_fields.fields import EncryptedCharField, SearchField
+from phonenumber_field.modelfields import PhoneNumberField
+from shared.models.abstract_models import TimeStampedModel, UUIDModel
+from simple_history.models import HistoricalRecords
+
 from applications.enums import (
     AhjoDecision,
     ApplicationBatchStatus,
@@ -12,16 +22,6 @@ from applications.enums import (
 from common.localized_iban_field import LocalizedIBANField
 from common.utils import DurationMixin
 from companies.models import Company
-from django.conf import settings
-from django.core.validators import MaxLengthValidator, MinLengthValidator
-from django.db import connection, models
-from django.db.models import OuterRef, Subquery
-from django.utils.translation import gettext_lazy as _
-from encrypted_fields.fields import EncryptedCharField, SearchField
-from phonenumber_field.modelfields import PhoneNumberField
-from simple_history.models import HistoricalRecords
-
-from shared.models.abstract_models import TimeStampedModel, UUIDModel
 
 # todo: move to some better location?
 APPLICATION_LANGUAGE_CHOICES = (

--- a/backend/benefit/applications/services/ahjo_integration.py
+++ b/backend/benefit/applications/services/ahjo_integration.py
@@ -4,8 +4,9 @@ from io import BytesIO
 
 import jinja2
 import pdfkit
-from applications.enums import ApplicationStatus, OrganizationType
 from django.utils import timezone
+
+from applications.enums import ApplicationStatus, OrganizationType
 
 PDF_PATH = os.path.join(os.path.dirname(__file__) + "/pdf_templates")
 TEMPLATE_ID_BENEFIT_WITH_DE_MINIMIS_AID = "benefit_with_de_minimis_aid"

--- a/backend/benefit/applications/services/applications_csv_report.py
+++ b/backend/benefit/applications/services/applications_csv_report.py
@@ -1,3 +1,5 @@
+from django.utils import translation
+
 from applications.enums import BenefitType
 from applications.services.csv_export_base import (
     CsvColumn,
@@ -5,7 +7,6 @@ from applications.services.csv_export_base import (
     get_organization_type,
     nested_queryset_attr,
 )
-from django.utils import translation
 
 
 def CsvDefaultColumn(*args, **kwargs):

--- a/backend/benefit/applications/services/applications_csv_report.py
+++ b/backend/benefit/applications/services/applications_csv_report.py
@@ -356,13 +356,12 @@ class ApplicationsCsvService(CsvExportBase):
                     application.application_row_idx = application_row_idx + 1
                     yield application
 
-    def get_csv_lines(self):
+    def get_csv_cell_list_lines_generator(self):
         if self.get_applications():
-            return super().get_csv_lines()
+            yield from super().get_csv_cell_list_lines_generator()
         else:
             header_row = self._get_header_row()
-            return [
-                header_row,
-                ["Ei löytynyt ehdot täyttäviä hakemuksia"]
-                + [""] * (len(header_row) - 1),
-            ]
+            yield header_row
+            yield ["Ei löytynyt ehdot täyttäviä hakemuksia"] + [""] * (
+                len(header_row) - 1
+            )

--- a/backend/benefit/applications/tests/common.py
+++ b/backend/benefit/applications/tests/common.py
@@ -1,0 +1,52 @@
+import csv
+import datetime
+import decimal
+
+import pytest
+
+from applications.services.csv_export_base import CsvExportBase
+
+
+def check_csv_cell_list_lines_generator(
+    csv_export: CsvExportBase, expected_row_count_with_header
+):
+    assert expected_row_count_with_header >= 1
+    lines_generator = csv_export.get_csv_cell_list_lines_generator()
+
+    rows = [next(lines_generator) for _ in range(expected_row_count_with_header)]
+    with pytest.raises(StopIteration):
+        next(lines_generator)
+
+    for row in rows:
+        assert isinstance(row, list)
+        for column in row:
+            assert isinstance(column, (str, int, decimal.Decimal, datetime.date))
+
+    header_row = rows[0]
+    assert header_row == [column.heading for column in csv_export.CSV_COLUMNS]
+
+
+def check_csv_string_lines_generator(
+    csv_export: CsvExportBase, expected_row_count_with_header
+):
+    assert expected_row_count_with_header >= 1
+    lines_generator = csv_export.get_csv_string_lines_generator()
+
+    rows = [next(lines_generator) for _ in range(expected_row_count_with_header)]
+    with pytest.raises(StopIteration):
+        next(lines_generator)
+
+    default_csv_dialect = csv.get_dialect("excel")
+
+    for row in rows:
+        assert isinstance(row, str)
+        assert row.endswith(default_csv_dialect.lineterminator)
+
+    header_row = rows[0]
+    assert (
+        header_row
+        == csv_export.CSV_DELIMITER.join(
+            (f'"{column.heading}"' for column in csv_export.CSV_COLUMNS)
+        )
+        + default_csv_dialect.lineterminator
+    )

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -1,5 +1,7 @@
 import factory
 import pytest
+from shared.service_bus.enums import YtjOrganizationCode
+
 from applications.enums import BenefitType
 from applications.models import Application
 from applications.services.applications_csv_report import ApplicationsCsvService
@@ -17,8 +19,6 @@ from companies.tests.conftest import *  # noqa
 from helsinkibenefit.tests.conftest import *  # noqa
 from terms.tests.conftest import *  # noqa
 from terms.tests.factories import TermsOfServiceApprovalFactory
-
-from shared.service_bus.enums import YtjOrganizationCode
 
 
 @pytest.fixture

--- a/backend/benefit/applications/tests/factories.py
+++ b/backend/benefit/applications/tests/factories.py
@@ -3,6 +3,8 @@ import random
 from datetime import date, timedelta
 
 import factory
+from shared.service_bus.enums import YtjOrganizationCode
+
 from applications.enums import ApplicationStatus, ApplicationStep, BenefitType
 from applications.models import (
     AhjoDecision,
@@ -16,8 +18,6 @@ from applications.models import (
 from calculator.models import Calculation
 from companies.tests.factories import CompanyFactory
 from users.tests.factories import HandlerFactory
-
-from shared.service_bus.enums import YtjOrganizationCode
 
 
 class DeMinimisAidFactory(factory.django.DjangoModelFactory):

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -4,6 +4,8 @@ from datetime import date
 from unittest.mock import patch
 
 import pytest
+from shared.service_bus.enums import YtjOrganizationCode
+
 from applications.enums import ApplicationStatus, BenefitType
 from applications.services.ahjo_integration import (
     export_application_batch,
@@ -16,8 +18,6 @@ from calculator.models import Calculation
 from calculator.tests.factories import PaySubsidyFactory
 from companies.tests.factories import CompanyFactory
 from helsinkibenefit.tests.conftest import *  # noqa
-
-from shared.service_bus.enums import YtjOrganizationCode
 
 
 def _assert_html_content(html, include_keys=(), excluded_keys=()):

--- a/backend/benefit/applications/tests/test_application_batch_api.py
+++ b/backend/benefit/applications/tests/test_application_batch_api.py
@@ -6,14 +6,16 @@ from unittest.mock import patch
 
 import pytest
 import pytz
+from django.conf import settings
+from django.http import StreamingHttpResponse
+from rest_framework.reverse import reverse
+
 from applications.api.v1.serializers import ApplicationBatchSerializer
 from applications.enums import AhjoDecision, ApplicationBatchStatus, ApplicationStatus
 from applications.models import Application, ApplicationBatch
 from applications.tests.conftest import *  # noqa
 from applications.tests.factories import ApplicationBatchFactory, ApplicationFactory
 from applications.tests.test_applications_api import get_handler_detail_url
-from django.conf import settings
-from rest_framework.reverse import reverse
 
 
 def get_batch_detail_url(application_batch):
@@ -486,13 +488,7 @@ def test_application_batch_export(mock_export, handler_api_client, application_b
     assert response.status_code == 400
 
 
-@patch("applications.services.talpa_integration.TalpaService")
-def test_application_batches_talpa_export(
-    mock_talpa_service, anonymous_client, application_batch
-):
-    # Mock export pdf function to reduce test time, the unittest for the export feature will be run separately
-    mock_talpa_service.get_csv_string.return_value = ""
-
+def test_application_batches_talpa_export(anonymous_client, application_batch):
     response = anonymous_client.get(reverse("v1:applicationbatch-talpa-export-batch"))
     assert response.status_code == 401
 
@@ -517,10 +513,12 @@ def test_application_batches_talpa_export(
     )
     # Export accepted batches then change it status
     response = anonymous_client.get(reverse("v1:applicationbatch-talpa-export-batch"))
+
     application_batch.refresh_from_db()
     app_batch_2.refresh_from_db()
     assert application_batch.status == ApplicationBatchStatus.SENT_TO_TALPA
     assert app_batch_2.status == ApplicationBatchStatus.SENT_TO_TALPA
 
+    assert isinstance(response, StreamingHttpResponse)
     assert response.headers["Content-Type"] == "text/csv"
     assert response.status_code == 200

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -10,6 +10,14 @@ from unittest import mock
 import faker
 import pytest
 import pytz
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
+from freezegun import freeze_time
+from PIL import Image
+from rest_framework.reverse import reverse
+from shared.audit_log import models as audit_models
+from shared.service_bus.enums import YtjOrganizationCode
+
 from applications.api.v1.serializers import (
     ApplicantApplicationSerializer,
     AttachmentSerializer,
@@ -42,18 +50,10 @@ from common.tests.conftest import get_client_user
 from common.utils import duration_in_months
 from companies.tests.conftest import *  # noqa
 from companies.tests.factories import CompanyFactory
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import override_settings
-from freezegun import freeze_time
 from helsinkibenefit.settings import MAX_UPLOAD_SIZE
 from helsinkibenefit.tests.conftest import *  # noqa
-from PIL import Image
-from rest_framework.reverse import reverse
 from terms.models import TermsOfServiceApproval
 from terms.tests.conftest import *  # noqa
-
-from shared.audit_log import models as audit_models
-from shared.service_bus.enums import YtjOrganizationCode
 
 
 def get_detail_url(application):

--- a/backend/benefit/applications/tests/test_applications_api_breaking_changes.py
+++ b/backend/benefit/applications/tests/test_applications_api_breaking_changes.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 import pytest
+
 from applications.api.v1.serializers import ApplicantApplicationSerializer
 from applications.enums import BenefitType
 from applications.tests.conftest import *  # noqa

--- a/backend/benefit/applications/tests/test_benefit_aggregation.py
+++ b/backend/benefit/applications/tests/test_benefit_aggregation.py
@@ -3,6 +3,8 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+from django.utils import translation
+
 from applications.api.v1.serializers import ApplicantApplicationSerializer
 from applications.enums import BenefitType
 from applications.models import Application
@@ -14,7 +16,6 @@ from calculator.tests.factories import PreviousBenefitFactory
 from common.tests.conftest import *  # noqa
 from common.utils import duration_in_months, to_decimal
 from companies.tests.conftest import *  # noqa
-from django.utils import translation
 from helsinkibenefit.tests.conftest import *  # noqa
 from terms.tests.conftest import *  # noqa
 

--- a/backend/benefit/applications/tests/test_models.py
+++ b/backend/benefit/applications/tests/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+
 from applications.enums import AhjoDecision, ApplicationBatchStatus
 from applications.models import Application, ApplicationBatch, Employee
 from helsinkibenefit.tests.conftest import *  # noqa

--- a/backend/benefit/applications/tests/test_talpa_integration.py
+++ b/backend/benefit/applications/tests/test_talpa_integration.py
@@ -3,6 +3,10 @@ import decimal
 
 import pytest
 from applications.services.talpa_integration import TalpaService
+from applications.tests.common import (
+    check_csv_cell_list_lines_generator,
+    check_csv_string_lines_generator,
+)
 from applications.tests.conftest import *  # noqa
 from applications.tests.conftest import split_lines_at_semicolon
 from common.tests.conftest import *  # noqa
@@ -10,7 +14,7 @@ from helsinkibenefit.tests.conftest import *  # noqa
 
 
 def test_talpa_lines(talpa_service):
-    csv_lines = talpa_service.get_csv_lines()
+    csv_lines = list(talpa_service.get_csv_cell_list_lines_generator())
     assert talpa_service.get_applications().count() == 2
     assert len(csv_lines) == 3
     assert csv_lines[0][0] == "Application number"
@@ -18,6 +22,14 @@ def test_talpa_lines(talpa_service):
         csv_lines[1][0] == talpa_service.get_applications().first().application_number
     )
     assert csv_lines[2][0] == talpa_service.get_applications()[1].application_number
+
+
+def test_talpa_csv_cell_list_lines_generator(talpa_service):
+    check_csv_cell_list_lines_generator(talpa_service, expected_row_count_with_header=3)
+
+
+def test_talpa_csv_string_lines_generator(talpa_service):
+    check_csv_string_lines_generator(talpa_service, expected_row_count_with_header=3)
 
 
 def test_talpa_csv_output(talpa_service):

--- a/backend/benefit/applications/tests/test_talpa_integration.py
+++ b/backend/benefit/applications/tests/test_talpa_integration.py
@@ -2,6 +2,7 @@ import datetime
 import decimal
 
 import pytest
+
 from applications.services.talpa_integration import TalpaService
 from applications.tests.common import (
     check_csv_cell_list_lines_generator,

--- a/backend/benefit/calculator/admin.py
+++ b/backend/benefit/calculator/admin.py
@@ -1,3 +1,5 @@
+from django.contrib import admin
+
 from calculator.models import (
     Calculation,
     CalculationRow,
@@ -5,7 +7,6 @@ from calculator.models import (
     PreviousBenefit,
     TrainingCompensation,
 )
-from django.contrib import admin
 
 
 class CalculationRowInline(admin.StackedInline):

--- a/backend/benefit/calculator/api/v1/serializers.py
+++ b/backend/benefit/calculator/api/v1/serializers.py
@@ -1,3 +1,7 @@
+from dateutil.relativedelta import relativedelta
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
 from applications.enums import ApplicationStatus
 from calculator.models import (
     Calculation,
@@ -6,9 +10,6 @@ from calculator.models import (
     PreviousBenefit,
     TrainingCompensation,
 )
-from dateutil.relativedelta import relativedelta
-from django.utils.translation import gettext_lazy as _
-from rest_framework import serializers
 from users.api.v1.serializers import UserSerializer
 from users.models import User
 

--- a/backend/benefit/calculator/api/v1/views.py
+++ b/backend/benefit/calculator/api/v1/views.py
@@ -1,11 +1,11 @@
-from calculator.api.v1.serializers import PreviousBenefitSerializer
-from calculator.models import PreviousBenefit
-from common.permissions import BFIsHandler
 from django_filters import rest_framework as filters
 from drf_spectacular.utils import extend_schema
 from rest_framework import filters as drf_filters
-
 from shared.audit_log.viewsets import AuditLoggingModelViewSet
+
+from calculator.api.v1.serializers import PreviousBenefitSerializer
+from calculator.models import PreviousBenefit
+from common.permissions import BFIsHandler
 
 
 class PreviousBenefitFilter(filters.FilterSet):

--- a/backend/benefit/calculator/models.py
+++ b/backend/benefit/calculator/models.py
@@ -2,8 +2,15 @@ import decimal
 import operator
 from datetime import timedelta
 
-from applications.models import Application, PAY_SUBSIDY_PERCENT_CHOICES
 from babel.dates import format_date
+from django.conf import settings
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+from encrypted_fields.fields import EncryptedCharField, SearchField
+from shared.models.abstract_models import TimeStampedModel, UUIDModel
+from simple_history.models import HistoricalRecords
+
+from applications.models import Application, PAY_SUBSIDY_PERCENT_CHOICES
 from calculator.enums import RowType
 from common.exceptions import BenefitAPIException
 from common.utils import (
@@ -14,13 +21,6 @@ from common.utils import (
     to_decimal,
 )
 from companies.models import Company
-from django.conf import settings
-from django.db import models
-from django.utils.translation import gettext_lazy as _
-from encrypted_fields.fields import EncryptedCharField, SearchField
-from simple_history.models import HistoricalRecords
-
-from shared.models.abstract_models import TimeStampedModel, UUIDModel
 
 STATE_AID_MAX_PERCENTAGE_CHOICES = (
     (50, "50%"),

--- a/backend/benefit/calculator/rules.py
+++ b/backend/benefit/calculator/rules.py
@@ -3,6 +3,8 @@ import datetime
 import decimal
 import logging
 
+from django.db import transaction
+
 from applications.enums import ApplicationStatus, BenefitType
 from calculator.enums import RowType
 from calculator.models import (
@@ -23,7 +25,6 @@ from calculator.models import (
     TrainingCompensationMonthlyRow,
 )
 from common.utils import pairwise
-from django.db import transaction
 
 LOGGER = logging.getLogger(__name__)
 BenefitSubRange = collections.namedtuple(

--- a/backend/benefit/calculator/tests/conftest.py
+++ b/backend/benefit/calculator/tests/conftest.py
@@ -1,5 +1,6 @@
 import factory
 import pytest
+
 from calculator.tests.factories import (
     CalculationFactory,
     PaySubsidyFactory,

--- a/backend/benefit/calculator/tests/factories.py
+++ b/backend/benefit/calculator/tests/factories.py
@@ -3,6 +3,7 @@ import random
 from datetime import date, timedelta
 
 import factory
+
 from applications.tests.factories import ApplicationFactory
 from calculator.enums import RowType
 from calculator.models import (

--- a/backend/benefit/calculator/tests/test_calculator_api.py
+++ b/backend/benefit/calculator/tests/test_calculator_api.py
@@ -3,6 +3,7 @@ import decimal
 from unittest import mock
 
 import pytest
+
 from applications.api.v1.serializers import (
     ApplicantApplicationSerializer,
     HandlerApplicationSerializer,

--- a/backend/benefit/calculator/tests/test_handler_excel_examples.py
+++ b/backend/benefit/calculator/tests/test_handler_excel_examples.py
@@ -1,14 +1,15 @@
 import datetime
 import os
 
+from openpyxl import load_workbook
+from openpyxl.utils import get_column_letter
+
 from applications.enums import ApplicationStatus, BenefitType
 from applications.tests.factories import ApplicationFactory
 from calculator.models import Calculation, STATE_AID_MAX_PERCENTAGE_CHOICES
 from calculator.tests.factories import PaySubsidyFactory, TrainingCompensationFactory
 from common.utils import nested_setattr, to_decimal
 from helsinkibenefit.tests.conftest import *  # noqa
-from openpyxl import load_workbook
-from openpyxl.utils import get_column_letter
 
 
 class CaseNotFound(Exception):

--- a/backend/benefit/calculator/tests/test_manual_override.py
+++ b/backend/benefit/calculator/tests/test_manual_override.py
@@ -2,6 +2,7 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+
 from applications.tests.conftest import *  # noqa
 from calculator.enums import RowType
 from helsinkibenefit.tests.conftest import *  # noqa

--- a/backend/benefit/calculator/tests/test_models.py
+++ b/backend/benefit/calculator/tests/test_models.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 import pytest
+
 from applications.enums import ApplicationStatus, BenefitType
 from applications.tests.conftest import *  # noqa
 from calculator.models import (

--- a/backend/benefit/calculator/tests/test_previous_benefits_api.py
+++ b/backend/benefit/calculator/tests/test_previous_benefits_api.py
@@ -1,10 +1,11 @@
 import decimal
 
+from rest_framework.reverse import reverse
+
 from applications.tests.conftest import *  # noqa
 from calculator.api.v1.serializers import PreviousBenefitSerializer
 from calculator.models import PreviousBenefit
 from calculator.tests.factories import PreviousBenefitFactory
-from rest_framework.reverse import reverse
 
 
 def get_previous_benefits_detail_url(previous_benefit):

--- a/backend/benefit/common/permissions.py
+++ b/backend/benefit/common/permissions.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from rest_framework import permissions
 from rest_framework.exceptions import PermissionDenied
+
 from users.utils import get_company_from_request
 
 

--- a/backend/benefit/common/tests/conftest.py
+++ b/backend/benefit/common/tests/conftest.py
@@ -7,7 +7,6 @@ from django.utils.translation import activate
 from freezegun import freeze_time
 from langdetect import DetectorFactory
 from rest_framework.test import APIClient
-
 from shared.common.tests.conftest import *  # noqa
 from shared.common.tests.conftest import store_tokens_in_session
 

--- a/backend/benefit/common/tests/test_utils.py
+++ b/backend/benefit/common/tests/test_utils.py
@@ -3,13 +3,14 @@ import os
 from datetime import date
 
 import pytest
+from dateutil.relativedelta import relativedelta
+
 from common.utils import (
     date_range_overlap,
     days360,
     duration_in_months,
     get_date_range_end_with_days360,
 )
-from dateutil.relativedelta import relativedelta
 
 
 @pytest.mark.parametrize(

--- a/backend/benefit/companies/admin.py
+++ b/backend/benefit/companies/admin.py
@@ -1,6 +1,7 @@
 # Register your models here.
-from companies.models import Company
 from django.contrib import admin  # noqa
+
+from companies.models import Company
 
 
 @admin.register(Company)

--- a/backend/benefit/companies/api/v1/serializers.py
+++ b/backend/benefit/companies/api/v1/serializers.py
@@ -1,7 +1,8 @@
-from applications.enums import OrganizationType
-from companies.models import Company
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
+
+from applications.enums import OrganizationType
+from companies.models import Company
 
 
 class CompanySerializer(serializers.ModelSerializer):

--- a/backend/benefit/companies/api/v1/views.py
+++ b/backend/benefit/companies/api/v1/views.py
@@ -1,10 +1,5 @@
 import logging
 
-from common.permissions import BFIsAuthenticated, TermsOfServiceAccepted
-from companies.api.v1.serializers import CompanySerializer
-from companies.models import Company
-from companies.services import get_or_create_organisation_with_business_id
-from companies.tests.data.company_data import get_dummy_company_data
 from django.conf import settings
 from django.db import transaction
 from django.http import HttpRequest
@@ -13,8 +8,13 @@ from requests.exceptions import HTTPError
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
 from shared.oidc.utils import get_organization_roles
+
+from common.permissions import BFIsAuthenticated, TermsOfServiceAccepted
+from companies.api.v1.serializers import CompanySerializer
+from companies.models import Company
+from companies.services import get_or_create_organisation_with_business_id
+from companies.tests.data.company_data import get_dummy_company_data
 
 LOGGER = logging.getLogger(__name__)
 

--- a/backend/benefit/companies/models.py
+++ b/backend/benefit/companies/models.py
@@ -1,8 +1,8 @@
-from common.localized_iban_field import LocalizedIBANField
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-
 from shared.models.abstract_models import AbstractCompany
+
+from common.localized_iban_field import LocalizedIBANField
 
 
 class Company(AbstractCompany):

--- a/backend/benefit/companies/services.py
+++ b/backend/benefit/companies/services.py
@@ -1,9 +1,9 @@
-from common.utils import update_object
-from companies.models import Company
 from requests import HTTPError
-
 from shared.service_bus.service_bus_client import ServiceBusClient
 from shared.yrtti.yrtti_client import YRTTIClient
+
+from common.utils import update_object
+from companies.models import Company
 
 
 def get_or_create_company_using_company_data(company_data: dict) -> Company:

--- a/backend/benefit/companies/tests/conftest.py
+++ b/backend/benefit/companies/tests/conftest.py
@@ -1,15 +1,15 @@
 import re
 
 import pytest
+from django.conf import settings
+from shared.service_bus.enums import YtjOrganizationCode
+
 from common.tests.conftest import *  # noqa
 from companies.tests.data.company_data import (
     DUMMY_ASSOCIATION_DATA,
     get_dummy_company_data,
 )
 from companies.tests.factories import CompanyFactory
-from django.conf import settings
-
-from shared.service_bus.enums import YtjOrganizationCode
 
 COMPANY_ROLE_JSON = [
     {

--- a/backend/benefit/companies/tests/factories.py
+++ b/backend/benefit/companies/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
-from companies.models import Company
-
 from shared.service_bus.enums import YtjOrganizationCode
+
+from companies.models import Company
 
 
 class CompanyFactory(factory.django.DjangoModelFactory):

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -2,6 +2,11 @@ import re
 from copy import deepcopy
 
 import pytest
+from django.conf import settings
+from django.test import override_settings
+from requests import HTTPError
+from shared.service_bus.enums import YtjOrganizationCode
+
 from applications.tests.conftest import *  # noqa
 from companies.api.v1.serializers import CompanySerializer
 from companies.models import Company
@@ -10,12 +15,7 @@ from companies.tests.data.company_data import (
     DUMMY_YRTTI_RESPONSE,
     get_dummy_company_data,
 )
-from django.conf import settings
-from django.test import override_settings
-from requests import HTTPError
 from terms.tests.factories import TermsOfServiceApprovalFactory
-
-from shared.service_bus.enums import YtjOrganizationCode
 
 
 def get_company_api_url(business_id=""):

--- a/backend/benefit/companies/tests/test_models.py
+++ b/backend/benefit/companies/tests/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+
 from companies.models import Company
 from companies.tests.factories import CompanyFactory
 

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -4,7 +4,6 @@ import environ
 import sentry_sdk
 from django.utils.translation import gettext_lazy as _
 from sentry_sdk.integrations.django import DjangoIntegration
-
 from shared.service_bus.enums import YtjOrganizationCode
 
 checkout_dir = environ.Path(__file__) - 2

--- a/backend/benefit/helsinkibenefit/urls.py
+++ b/backend/benefit/helsinkibenefit/urls.py
@@ -1,7 +1,3 @@
-from applications.api.v1 import application_batch_views, views as application_views
-from calculator.api.v1 import views as calculator_views
-from common.debug_util import debug_env
-from companies.api.v1.views import GetCompanyView
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
@@ -13,12 +9,17 @@ from drf_spectacular.views import (
     SpectacularRedocView,
     SpectacularSwaggerView,
 )
+from rest_framework_nested import routers
+
+from applications.api.v1 import application_batch_views, views as application_views
+from calculator.api.v1 import views as calculator_views
+from common.debug_util import debug_env
+from companies.api.v1.views import GetCompanyView
 from messages.views import (
     ApplicantMessageViewSet,
     HandlerMessageViewSet,
     HandlerNoteViewSet,
 )
-from rest_framework_nested import routers
 from terms.api.v1.views import ApproveTermsOfServiceView
 from users.api.v1.views import CurrentUserView
 

--- a/backend/benefit/messages/admin.py
+++ b/backend/benefit/messages/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.contrib.admin import display
 from django.utils.translation import gettext_lazy as _
+
 from messages.models import Message
 
 

--- a/backend/benefit/messages/automatic_messages.py
+++ b/backend/benefit/messages/automatic_messages.py
@@ -6,8 +6,9 @@ from django.core.mail import send_mail
 from django.utils import translation
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
-from messages.models import Message, MessageType
 from sentry_sdk import capture_message
+
+from messages.models import Message, MessageType
 
 LOGGER = logging.getLogger(__name__)
 

--- a/backend/benefit/messages/models.py
+++ b/backend/benefit/messages/models.py
@@ -1,6 +1,5 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-
 from shared.models.abstract_models import TimeStampedModel, UUIDModel
 
 

--- a/backend/benefit/messages/permissions.py
+++ b/backend/benefit/messages/permissions.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
-from messages.models import MessageType
 from rest_framework import permissions
+
+from messages.models import MessageType
 from users.utils import get_company_from_request
 
 

--- a/backend/benefit/messages/serializers.py
+++ b/backend/benefit/messages/serializers.py
@@ -1,9 +1,10 @@
-from applications.enums import ApplicationStatus
-from applications.models import Application
 from django.utils.translation import gettext_lazy as _
-from messages.models import Message, MessageType
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound, PermissionDenied
+
+from applications.enums import ApplicationStatus
+from applications.models import Application
+from messages.models import Message, MessageType
 from users.utils import get_company_from_request, get_request_user_from_context
 
 

--- a/backend/benefit/messages/tests/factories.py
+++ b/backend/benefit/messages/tests/factories.py
@@ -1,4 +1,5 @@
 import factory
+
 from messages.models import Message, MessageType
 
 

--- a/backend/benefit/messages/tests/test_api.py
+++ b/backend/benefit/messages/tests/test_api.py
@@ -2,6 +2,14 @@ import uuid
 from copy import deepcopy
 
 import pytest
+from django.conf import settings
+from django.test import override_settings
+from rest_framework.reverse import reverse
+from shared.common.lang_test_utils import (
+    assert_email_body_language,
+    assert_email_subject_language,
+)
+
 from applications.enums import ApplicationStatus
 from applications.tests.factories import HandlingApplicationFactory
 from applications.tests.test_applications_api import (
@@ -10,16 +18,8 @@ from applications.tests.test_applications_api import (
 )
 from common.tests.conftest import get_client_user
 from companies.tests.factories import CompanyFactory
-from django.conf import settings
-from django.test import override_settings
 from messages.models import Message, MessageType
 from messages.tests.factories import MessageFactory
-from rest_framework.reverse import reverse
-
-from shared.common.lang_test_utils import (
-    assert_email_body_language,
-    assert_email_subject_language,
-)
 
 SAMPLE_MESSAGE_PAYLOAD = {
     "content": "Sample message",

--- a/backend/benefit/messages/views.py
+++ b/backend/benefit/messages/views.py
@@ -1,17 +1,17 @@
-from applications.models import Application
-from common.permissions import BFIsApplicant, BFIsHandler, TermsOfServiceAccepted
 from django.conf import settings
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
+from rest_framework import viewsets
+from rest_framework.exceptions import NotFound
+from shared.audit_log.viewsets import AuditLoggingModelViewSet
+
+from applications.models import Application
+from common.permissions import BFIsApplicant, BFIsHandler, TermsOfServiceAccepted
 from messages.automatic_messages import notify_applicant_by_email_about_new_message
 from messages.models import Message
 from messages.permissions import HasMessagePermission
 from messages.serializers import MessageSerializer, NoteSerializer
-from rest_framework import viewsets
-from rest_framework.exceptions import NotFound
 from users.utils import get_company_from_request
-
-from shared.audit_log.viewsets import AuditLoggingModelViewSet
 
 
 class ApplicantMessageViewSet(AuditLoggingModelViewSet):

--- a/backend/benefit/terms/admin.py
+++ b/backend/benefit/terms/admin.py
@@ -1,5 +1,6 @@
 # Register your models here.
 from django.contrib import admin  # noqa
+
 from terms.models import (
     ApplicantConsent,
     ApplicantTermsApproval,

--- a/backend/benefit/terms/api/v1/serializers.py
+++ b/backend/benefit/terms/api/v1/serializers.py
@@ -1,5 +1,6 @@
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
+
 from terms.models import (
     ApplicantConsent,
     ApplicantTermsApproval,

--- a/backend/benefit/terms/api/v1/views.py
+++ b/backend/benefit/terms/api/v1/views.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from common.permissions import BFIsApplicant
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema
@@ -8,6 +7,8 @@ from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from common.permissions import BFIsApplicant
 from terms.api.v1.serializers import (
     ApproveTermsSerializer,
     TermsOfServiceApprovalSerializer,

--- a/backend/benefit/terms/tests/conftest.py
+++ b/backend/benefit/terms/tests/conftest.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 import pytest
+
 from common.tests.conftest import *  # noqa
 from terms.enums import TermsType
 from terms.tests.factories import (

--- a/backend/benefit/terms/tests/factories.py
+++ b/backend/benefit/terms/tests/factories.py
@@ -1,4 +1,5 @@
 import factory
+
 from applications.enums import ApplicationStatus
 from applications.tests.factories import ApplicationFactory
 from companies.tests.factories import CompanyFactory

--- a/backend/benefit/terms/tests/test_api.py
+++ b/backend/benefit/terms/tests/test_api.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 
 import pytest
+
 from applications.api.v1.serializers import ApplicantApplicationSerializer
 from applications.enums import ApplicationStatus
 from applications.tests.conftest import *  # noqa

--- a/backend/benefit/terms/tests/test_models.py
+++ b/backend/benefit/terms/tests/test_models.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 import pytest
 from django.db import transaction
 from django.db.utils import IntegrityError
+
 from helsinkibenefit.tests.conftest import *  # noqa
 from terms.enums import TermsType
 from terms.models import Terms

--- a/backend/benefit/terms/tests/test_terms_of_service_api.py
+++ b/backend/benefit/terms/tests/test_terms_of_service_api.py
@@ -1,11 +1,12 @@
 from datetime import date, timedelta
 
 import pytest
+from django.conf import settings
+from django.urls import reverse
+
 from common.tests.conftest import *  # noqa
 from common.tests.conftest import get_client_user
 from companies.tests.conftest import *  # noqa
-from django.conf import settings
-from django.urls import reverse
 from helsinkibenefit.tests.conftest import *  # noqa
 from terms.enums import TermsType
 from terms.models import Terms

--- a/backend/benefit/users/api/v1/serializers.py
+++ b/backend/benefit/users/api/v1/serializers.py
@@ -1,5 +1,6 @@
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
+
 from terms.api.v1.serializers import TermsOfServiceApprovalSerializer, TermsSerializer
 from terms.enums import TermsType
 from terms.models import Terms, TermsOfServiceApproval

--- a/backend/benefit/users/api/v1/views.py
+++ b/backend/benefit/users/api/v1/views.py
@@ -1,9 +1,10 @@
-from common.permissions import BFIsAuthenticated
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from common.permissions import BFIsAuthenticated
 from users.api.v1.serializers import UserSerializer
 
 

--- a/backend/benefit/users/tests/conftest.py
+++ b/backend/benefit/users/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from common.tests.conftest import *  # noqa
 from helsinkibenefit.tests.conftest import *  # noqa
 

--- a/backend/benefit/users/utils.py
+++ b/backend/benefit/users/utils.py
@@ -1,8 +1,8 @@
+from django.conf import settings
+from shared.oidc.utils import get_organization_roles
+
 from companies.models import Company
 from companies.services import get_or_create_organisation_with_business_id
-from django.conf import settings
-
-from shared.oidc.utils import get_organization_roles
 
 
 def get_request_user_from_context(serializer):


### PR DESCRIPTION
## Description :sparkles:

### BF-Backend: Export CSVs using StreamingHttpResponse

Rationale:
 - Rationale for exporting CSVs using StreamingHttpResponse is to try to
   make CSV exports not return Gateway Timeout i.e. HTTP status code 504
   so easily. The slow CSV export in question is
   HandlerApplicationViewSet.export_csv which seems to be making a lot
   of queries to the database (I tried one export_csv call in a test and
   it made over 200 queries to the database). Because optimizing the
   database query wasn't straightforward other ways to make the CSV
   export pragmatically usable albeit slow were undertaken, and voilà:
   this commit.

Make all CSV exports use StreamingHttpResponse:
 - ApplicationBatchViewSet.talpa_export_batch
 - HandlerApplicationViewSet.export_csv
 - HandlerApplicationViewSet.export_new_accepted_applications
 - HandlerApplicationViewSet.export_new_rejected_applications

To accomplish streaming of CSV data change CSV data generation to use
Python generators by using the yield keyword.

Tests:
 - Fix related tests
 - Add new tests:
   - test_talpa_csv_cell_list_lines_generator
   - test_talpa_csv_string_lines_generator
   - test_applications_csv_cell_list_lines_generator
   - test_applications_csv_string_lines_generator

Add type hints.

Refs YJDH-538

### BF-Backend: Fix bf-py-coding-style.yml & run isort

The GitHub workflow bf-py-coding-style.yml was problematic before
because the isort check for some unknown reason worked differently with
the precommit-setup.cfg than with the benefit backend's own setup.cfg.

Fix the GitHub workflow bf-py-coding-style.yml's "Formatting", "Linting"
and "Import sorting" by separating them into (BF) and (Shared) portions
like in other backends' *-py-coding-style.yml files.

Run "isort ." to fix import sortings.

Refs YJDH-538 (Noticed import sortings were incorrect)

## Issues :bug:

YJDH-538

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
