### PR TITLE
YJDH-532 | KS-Backend: Ignore rejected youth applications in activation

### DIFF
--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -241,12 +241,16 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
         )
         list(same_persons_apps)  # Force evaluation of queryset to lock its rows
 
-        if same_persons_apps.active().exists():
-            if youth_application.is_active and youth_application.need_additional_info:
+        if same_persons_apps.active().non_rejected().exists():
+            if (
+                youth_application.is_active
+                and not youth_application.is_rejected
+                and youth_application.need_additional_info
+            ):
                 return HttpResponseRedirect(
                     youth_application.additional_info_page_url(pk=youth_application.pk)
                 )
-            else:  # not the active one or does not need additional info
+            else:  # not the active non-rejected one or does not need additional info
                 return HttpResponseRedirect(
                     youth_application.already_activated_page_url()
                 )

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -526,14 +526,16 @@ def test_youth_applications_detail_encrypted_vtj_json(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "language,disable_vtj,expected_status_code",
+    "language,disable_vtj,rejected_application_exists,expected_status_code",
     [
         (
             language,
             disable_vtj,
+            rejected_application_exists,
             status.HTTP_302_FOUND if disable_vtj else status.HTTP_501_NOT_IMPLEMENTED,
         )
         for language in get_supported_languages()
+        for rejected_application_exists in [False, True]
         for disable_vtj in [True]
     ],
 )
@@ -543,6 +545,7 @@ def test_youth_applications_activate_unexpired_inactive(
     settings,
     language,
     disable_vtj,
+    rejected_application_exists,
     expected_status_code,
 ):
     settings.DISABLE_VTJ = disable_vtj
@@ -555,6 +558,12 @@ def test_youth_applications_activate_unexpired_inactive(
     assert not inactive_youth_application.is_active
     assert not inactive_youth_application.has_activation_link_expired
     assert inactive_youth_application.language == language
+
+    if rejected_application_exists:
+        RejectedYouthApplicationFactory.create(
+            email=inactive_youth_application.email,
+            social_security_number=inactive_youth_application.social_security_number,
+        )
 
     response = api_client.get(get_activation_url(inactive_youth_application.pk))
 
@@ -580,14 +589,16 @@ def test_youth_applications_activate_unexpired_inactive(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "language,disable_vtj,youth_application_factory",
+    "language,disable_vtj,rejected_application_exists,youth_application_factory",
     [
         (
             language,
             disable_vtj,
+            rejected_application_exists,
             youth_application_factory,
         )
         for language in get_supported_languages()
+        for rejected_application_exists in [False, True]
         for disable_vtj in [True]
         for youth_application_factory in [
             AwaitingManualProcessingYouthApplicationFactory,
@@ -601,6 +612,7 @@ def test_youth_applications_activate_unexpired_active(
     settings,
     language,
     disable_vtj,
+    rejected_application_exists,
     youth_application_factory,
 ):
     settings.DISABLE_VTJ = disable_vtj
@@ -615,6 +627,12 @@ def test_youth_applications_activate_unexpired_active(
     assert active_youth_application.language == language
     assert not active_youth_application.has_additional_info
     assert not active_youth_application.has_youth_summer_voucher
+
+    if rejected_application_exists:
+        RejectedYouthApplicationFactory.create(
+            email=active_youth_application.email,
+            social_security_number=active_youth_application.social_security_number,
+        )
 
     response = api_client.get(get_activation_url(active_youth_application.pk))
 
@@ -637,16 +655,18 @@ def test_youth_applications_activate_unexpired_active(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "language,disable_vtj,youth_application_factory,need_additional_info",
+    "language,disable_vtj,rejected_application_exists,youth_application_factory,need_additional_info",
     [
         (
             language,
             disable_vtj,
+            rejected_application_exists,
             youth_application_factory,
             need_additional_info,
         )
         for language in get_supported_languages()
         for disable_vtj in [True]
+        for rejected_application_exists in [False, True]
         for youth_application_factory, need_additional_info in [
             (InactiveNoNeedAdditionalInfoYouthApplicationFactory, False),
             (InactiveNeedAdditionalInfoYouthApplicationFactory, True),
@@ -659,6 +679,7 @@ def test_youth_applications_activate_expired_inactive(
     settings,
     language,
     disable_vtj,
+    rejected_application_exists,
     youth_application_factory,
     need_additional_info,
 ):
@@ -675,6 +696,12 @@ def test_youth_applications_activate_expired_inactive(
     assert not inactive_youth_application.has_additional_info
     assert not inactive_youth_application.has_youth_summer_voucher
 
+    if rejected_application_exists:
+        RejectedYouthApplicationFactory.create(
+            email=inactive_youth_application.email,
+            social_security_number=inactive_youth_application.social_security_number,
+        )
+
     response = api_client.get(get_activation_url(inactive_youth_application.pk))
 
     assert response.status_code == status.HTTP_302_FOUND
@@ -690,15 +717,17 @@ def test_youth_applications_activate_expired_inactive(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "language,disable_vtj,youth_application_factory",
+    "language,disable_vtj,rejected_application_exists,youth_application_factory",
     [
         (
             language,
             disable_vtj,
+            rejected_application_exists,
             youth_application_factory,
         )
         for language in get_supported_languages()
         for disable_vtj in [True]
+        for rejected_application_exists in [False, True]
         for youth_application_factory in [
             AwaitingManualProcessingYouthApplicationFactory,
             AdditionalInfoRequestedYouthApplicationFactory,
@@ -711,6 +740,7 @@ def test_youth_applications_activate_expired_active(
     settings,
     language,
     disable_vtj,
+    rejected_application_exists,
     youth_application_factory,
 ):
     settings.DISABLE_VTJ = disable_vtj
@@ -725,6 +755,12 @@ def test_youth_applications_activate_expired_active(
     assert active_youth_application.language == language
     assert not active_youth_application.has_additional_info
     assert not active_youth_application.has_youth_summer_voucher
+
+    if rejected_application_exists:
+        RejectedYouthApplicationFactory.create(
+            email=active_youth_application.email,
+            social_security_number=active_youth_application.social_security_number,
+        )
 
     response = api_client.get(get_activation_url(active_youth_application.pk))
 


### PR DESCRIPTION
## Description :sparkles:

PR #1094 was incomplete, it only disregarded rejected youth applications
in youth application creation. This commit adds disregarding of
rejected youth applications in activation. This should now allow a
person to submit a new youth application and have it accepted even if
they have a previously rejected youth application.

Add test cases for activation where a rejected youth application for the
same person using the same email already exists. All rejected youth
applications should be ignored in activation.

Refs YJDH-532 (Disregarding rejected youth applications)
Refs PR #1094 (Disregarding rejected youth applications on creation)

## Issues :bug:

YJDH-532
PR #1094

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
