### PR TITLE
YJDH-569 | KS-Backend: Add and use school_list test fixture

### DIFF
--- a/backend/kesaseteli/applications/tests/test_schools_api.py
+++ b/backend/kesaseteli/applications/tests/test_schools_api.py
@@ -9,48 +9,48 @@ def get_schools_api_url():
 
 
 @pytest.mark.django_db
-def test_schools_list_status_ok(api_client):
+def test_schools_list_status_ok(api_client, school_list):
     response = api_client.get(get_schools_api_url())
     assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.django_db
-def test_schools_list_returns_list(api_client):
+def test_schools_list_returns_list(api_client, school_list):
     response = api_client.get(get_schools_api_url())
     assert type(response.json()) == list
 
 
 @pytest.mark.django_db
-def test_schools_list_returns_non_empty(api_client):
+def test_schools_list_returns_non_empty(api_client, school_list):
     response = api_client.get(get_schools_api_url())
     assert len(response.json()) > 0
 
 
 @pytest.mark.django_db
-def test_schools_list_returns_school_count(api_client):
+def test_schools_list_returns_school_count(api_client, school_list):
     response = api_client.get(get_schools_api_url())
     assert len(response.json()) == School.objects.count()
 
 
 @pytest.mark.django_db
-def test_schools_list_returns_string_collection(api_client):
+def test_schools_list_returns_string_collection(api_client, school_list):
     response = api_client.get(get_schools_api_url())
     assert all(type(element) == str for element in response.json())
 
 
 @pytest.mark.django_db
-def test_schools_list_returns_non_empty_strings_collection(api_client):
+def test_schools_list_returns_non_empty_strings_collection(api_client, school_list):
     response = api_client.get(get_schools_api_url())
     assert all(len(element.strip()) > 0 for element in response.json())
 
 
 @pytest.mark.django_db
-def test_schools_list_returns_unique_elements_collection(api_client):
+def test_schools_list_returns_unique_elements_collection(api_client, school_list):
     response = api_client.get(get_schools_api_url())
     assert len(set(response.json())) == len(response.json())
 
 
 @pytest.mark.django_db
-def test_schools_list_returns_sorted_collection(api_client):
+def test_schools_list_returns_sorted_collection(api_client, school_list):
     response = api_client.get(get_schools_api_url())
     assert sorted(response.json(), key=str.casefold) == response.json()

--- a/backend/kesaseteli/common/tests/conftest.py
+++ b/backend/kesaseteli/common/tests/conftest.py
@@ -5,6 +5,7 @@ from shared.common.tests.conftest import *  # noqa
 from shared.common.tests.conftest import store_tokens_in_session
 
 from applications.enums import AttachmentType, EmployerApplicationStatus
+from applications.models import School
 from common.tests.factories import (
     AcceptableYouthApplicationFactory,
     AcceptedYouthApplicationFactory,
@@ -176,3 +177,90 @@ def api_client2(other_user, company2):
 @pytest.fixture
 def unauthenticated_api_client():
     return APIClient()
+
+
+@pytest.fixture
+def school_list():
+    TEST_SCHOOL_NAMES = [
+        "Aleksis Kiven peruskoulu",
+        "Apollon yhteiskoulu",
+        "Arabian peruskoulu",
+        "Aurinkolahden peruskoulu",
+        "Botby grundskola",
+        "Elias-koulu",
+        "Englantilainen koulu",
+        "Grundskolan Norsen",
+        "Haagan peruskoulu",
+        "Helsingin Juutalainen Yhteiskoulu",
+        "Helsingin Kristillinen koulu",
+        "Helsingin Montessori-koulu",
+        "Helsingin Rudolf Steiner -koulu",
+        "Helsingin Saksalainen koulu",
+        "Helsingin Suomalainen yhteiskoulu",
+        "Helsingin Uusi yhteiskoulu",
+        "Helsingin eurooppalainen koulu",
+        "Helsingin normaalilyseo",
+        "Helsingin ranskalais-suomalainen koulu",
+        "Helsingin yhteislyseo",
+        "Helsingin yliopiston Viikin normaalikoulu",
+        "Herttoniemen yhteiskoulu",
+        "Hiidenkiven peruskoulu",
+        "Hoplaxskolan",
+        "International School of Helsinki",
+        "Itäkeskuksen peruskoulu",
+        "Jätkäsaaren peruskoulu",
+        "Kalasataman peruskoulu",
+        "Kankarepuiston peruskoulu",
+        "Kannelmäen peruskoulu",
+        "Karviaistien koulu",
+        "Kruununhaan yläasteen koulu",
+        "Kruunuvuorenrannan peruskoulu",
+        "Kulosaaren yhteiskoulu",
+        "Käpylän peruskoulu",
+        "Laajasalon peruskoulu",
+        "Latokartanon peruskoulu",
+        "Lauttasaaren yhteiskoulu",
+        "Maatullin peruskoulu",
+        "Malmin peruskoulu",
+        "Marjatta-koulu",
+        "Maunulan yhteiskoulu",
+        "Meilahden yläasteen koulu",
+        "Merilahden peruskoulu",
+        "Minervaskolan",
+        "Munkkiniemen yhteiskoulu",
+        "Myllypuron peruskoulu",
+        "Naulakallion koulu",
+        "Oulunkylän yhteiskoulu",
+        "Outamon koulu",
+        "Pakilan yläasteen koulu",
+        "Pasilan peruskoulu",
+        "Pitäjänmäen peruskoulu",
+        "Pohjois-Haagan yhteiskoulu",
+        "Porolahden peruskoulu",
+        "Puistolan peruskoulu",
+        "Puistopolun peruskoulu",
+        "Pukinmäenkaaren peruskoulu",
+        "Ressu Comprehensive School",
+        "Ressun peruskoulu",
+        "Sakarinmäen peruskoulu",
+        "Solakallion koulu",
+        "Sophie Mannerheimin koulu",
+        "Suomalais-venäläinen koulu",
+        "Suutarinkylän peruskoulu",
+        "Taivallahden peruskoulu",
+        "Toivolan koulu",
+        "Torpparinmäen peruskoulu",
+        "Töölön yhteiskoulu",
+        "Valteri-koulu",
+        "Vartiokylän yläasteen koulu",
+        "Vesalan peruskoulu",
+        "Vuoniityn peruskoulu",
+        "Yhtenäiskoulu",
+        "Zacharias Topeliusskolan",
+        "Åshöjdens grundskola",
+        "Östersundom skola",
+    ]
+    School.objects.bulk_create(
+        objs=[School(name=name) for name in TEST_SCHOOL_NAMES],
+        ignore_conflicts=True,  # Ignore conflicts if a school with name already exists
+    )


### PR DESCRIPTION
## Description :sparkles:

Add school_list fixture which populates the School model and use it in
school list related tests.

This way the school list related tests aren't dependent on the data
migrations having populated the school list.

## Issues :bug:

YJDH-569

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
