### PR TITLE
YJDH-564: fix wizard step styles

### DIFF
--- a/frontend/shared/src/components/stepper/WizardStepper.sc.ts
+++ b/frontend/shared/src/components/stepper/WizardStepper.sc.ts
@@ -1,0 +1,56 @@
+import styled, { DefaultTheme } from 'styled-components';
+
+type Props = { isActive?: boolean };
+
+type $StepContainerProps = Props & {
+  activeStep?: number;
+};
+
+const getActiveColor = (isActive: boolean, theme: DefaultTheme): string =>
+  isActive ? theme.colors.black90 : theme.colors.black20;
+
+export const $StepsContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const $StepContainer = styled.div<$StepContainerProps>`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  position: relative;
+  z-index: 1;
+  cursor: ${({ isActive }) => (isActive ? 'pointer' : 'auto')};
+`;
+
+export const $StepCircle = styled.div<Props>`
+  height: 36px;
+  width: 36px;
+  border-radius: 50%;
+  border: 4px solid
+    ${({ isActive, theme }) => getActiveColor(isActive || false, theme)};
+  text-align: center;
+  color: ${({ isActive, theme }) => getActiveColor(isActive || false, theme)};
+  font-weight: 600;
+  position: relative;
+  line-height: 36px;
+  font-size: ${(props) => props.theme.fontSize.body.m};
+`;
+
+export const $StepTitle = styled.p<Props>`
+  text-align: center;
+  position: absolute;
+  bottom: -40px;
+  color: ${({ isActive, theme }) => getActiveColor(isActive || false, theme)};
+  font-size: ${(props) => props.theme.fontSize.body.m};
+  font-weight: ${(props) => (props.isActive ? 600 : 500)};
+`;
+
+export const $Divider = styled.div<Props>`
+  width: 100%;
+  height: 4px;
+  margin: 4px;
+  background: ${({ isActive, theme }) =>
+    getActiveColor(isActive || false, theme)};
+  flex: 1;
+`;

--- a/frontend/shared/src/components/stepper/WizardStepper.tsx
+++ b/frontend/shared/src/components/stepper/WizardStepper.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import WizardStep from 'shared/components/stepper/WizardStep';
 import useWizard from 'shared/hooks/useWizard';
 
-import { $Divider, $StepsContainer } from './Stepper.sc';
+import { $Divider, $StepsContainer } from './WizardStepper.sc';
 
 const WizardStepper: React.FC = () => {
   const { steps, activeStep } = useWizard();


### PR DESCRIPTION
## Description :sparkles:
At some point wizard step styles have been messed up. Previous it looked like this:

![Screenshot 2022-05-24 at 8 02 51 PM](https://user-images.githubusercontent.com/7648194/170094071-694d831e-ade7-4bb4-b615-2055ec30176f.png)

Now it looks like this:
![Screenshot 2022-05-24 at 8 02 22 PM](https://user-images.githubusercontent.com/7648194/170094068-49a6a197-1628-4ebe-94a6-c1a546398ba7.png)

HL-benefit uses same stepper and it's still looking ok:
![Screenshot 2022-05-25 at 8 12 20 AM](https://user-images.githubusercontent.com/7648194/170184930-68c5a34d-69a5-4370-be25-4f7cacb9127d.png)

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
