### PR TITLE
YJDH-581 YJDH-582 | Send copy of the youth summer voucher to handlers

### DIFF
--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -1577,6 +1577,7 @@ def test_youth_summer_voucher_email_language(api_client, language):
     NEXT_PUBLIC_MOCK_FLAG=True,
     EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
     DEFAULT_FROM_EMAIL="Test sender <testsender@hel.fi>",
+    HANDLER_EMAIL="Test handler <testhandler@hel.fi>",
 )
 @pytest.mark.parametrize("language", get_supported_languages())
 def test_youth_summer_voucher_email_sending(api_client, language):
@@ -1597,6 +1598,7 @@ def test_youth_summer_voucher_email_sending(api_client, language):
     )
     assert youth_summer_voucher_email.from_email == "Test sender <testsender@hel.fi>"
     assert youth_summer_voucher_email.to == [acceptable_youth_application.email]
+    assert youth_summer_voucher_email.bcc == ["Test handler <testhandler@hel.fi>"]
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/common/utils.py
+++ b/backend/kesaseteli/common/utils.py
@@ -61,6 +61,7 @@ def send_mail_with_error_logging(
     from_email,
     recipient_list,
     error_message,
+    bcc=None,
     html_message=None,
     images: Optional[List[MIMEImage]] = None,
 ) -> bool:
@@ -72,6 +73,7 @@ def send_mail_with_error_logging(
     :param from_email: Email address of the email's sender
     :param recipient_list: List of email recipients
     :param error_message: Error message to be logged in case of failure
+    :param bcc: Send a hidden copy of the message to the list of recipients
     :param html_message: Optional html message. If provided the resulting email will be
                          a multipart/alternative email with message as the text/plain
                          content type and html_message as the text/html content type.
@@ -82,7 +84,7 @@ def send_mail_with_error_logging(
     """
     connection = get_connection(fail_silently=True)
     mail = EmailMultiAlternatives(
-        subject, message, from_email, recipient_list, connection=connection
+        subject, message, from_email, to=recipient_list, bcc=bcc, connection=connection
     )
     if html_message:
         mail.attach_alternative(html_message, "text/html")


### PR DESCRIPTION
Send a hidden copy (bcc) of the youth summer voucher to the handler email. This will enable the handlers to deal with possible problems the users are having e.g. handlers are able to re-send a lost voucher to a user.