### PR TITLE
YJDH-594 | Fix YouthApplication accept/reject when DISABLE_VTJ is enabled

### DIFF
--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -209,21 +209,24 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
     def accept(self, request, *args, **kwargs) -> HttpResponse:
         youth_application: YouthApplication = self.get_object().lock_for_update()
 
-        try:
-            serializer = YouthApplicationHandlingSerializer(
-                data=request.data, context=self.get_serializer_context()
-            )
-            serializer.is_valid(raise_exception=True)
-        except ValidationError as e:
-            LOGGER.error(
-                f"Youth application was not changed to accepted state because of "
-                f"validation error. Validation error codes: {str(e.get_codes())}"
-            )
-            raise
+        if settings.DISABLE_VTJ:
+            encrypted_handler_vtj_json = None
+        else:
+            try:
+                serializer = YouthApplicationHandlingSerializer(
+                    data=request.data, context=self.get_serializer_context()
+                )
+                serializer.is_valid(raise_exception=True)
+            except ValidationError as e:
+                LOGGER.error(
+                    f"Youth application was not changed to accepted state because of "
+                    f"validation error. Validation error codes: {str(e.get_codes())}"
+                )
+                raise
 
-        encrypted_handler_vtj_json = serializer.validated_data[
-            "encrypted_handler_vtj_json"
-        ]
+            encrypted_handler_vtj_json = serializer.validated_data[
+                "encrypted_handler_vtj_json"
+            ]
 
         if not youth_application.is_accepted and youth_application.accept_manually(
             handler=request.user, encrypted_handler_vtj_json=encrypted_handler_vtj_json
@@ -251,21 +254,24 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
     def reject(self, request, *args, **kwargs) -> HttpResponse:
         youth_application: YouthApplication = self.get_object().lock_for_update()
 
-        try:
-            serializer = YouthApplicationHandlingSerializer(
-                data=request.data, context=self.get_serializer_context()
-            )
-            serializer.is_valid(raise_exception=True)
-        except ValidationError as e:
-            LOGGER.error(
-                f"Youth application was not changed to rejected state because of "
-                f"validation error. Validation error codes: {str(e.get_codes())}"
-            )
-            raise
+        if settings.DISABLE_VTJ:
+            encrypted_handler_vtj_json = None
+        else:
+            try:
+                serializer = YouthApplicationHandlingSerializer(
+                    data=request.data, context=self.get_serializer_context()
+                )
+                serializer.is_valid(raise_exception=True)
+            except ValidationError as e:
+                LOGGER.error(
+                    f"Youth application was not changed to rejected state because of "
+                    f"validation error. Validation error codes: {str(e.get_codes())}"
+                )
+                raise
 
-        encrypted_handler_vtj_json = serializer.validated_data[
-            "encrypted_handler_vtj_json"
-        ]
+            encrypted_handler_vtj_json = serializer.validated_data[
+                "encrypted_handler_vtj_json"
+            ]
 
         if not youth_application.is_rejected and youth_application.reject(
             handler=request.user, encrypted_handler_vtj_json=encrypted_handler_vtj_json

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -551,7 +551,10 @@ class YouthApplication(LockForUpdateMixin, TimeStampedModel, UUIDModel):
         return (
             self.status in YouthApplicationStatus.acceptable_values()
             and HandlerPermission.has_user_permission(handler)
-            and self.is_valid_encrypted_handler_vtj_json(encrypted_handler_vtj_json)
+            and (
+                settings.DISABLE_VTJ
+                or self.is_valid_encrypted_handler_vtj_json(encrypted_handler_vtj_json)
+            )
             and not self.has_youth_summer_voucher
         )
 
@@ -580,9 +583,7 @@ class YouthApplication(LockForUpdateMixin, TimeStampedModel, UUIDModel):
         except ValidationError:
             return False
         vtj_json_dict = json.loads(encrypted_handler_vtj_json)
-        return (
-            "@xmlns" in vtj_json_dict and "vtjkysely" in vtj_json_dict["@xmlns"]
-        ) or (vtj_json_dict == {} and settings.DISABLE_VTJ)
+        return "@xmlns" in vtj_json_dict and "vtjkysely" in vtj_json_dict["@xmlns"]
 
     @transaction.atomic
     def accept_manually(self, handler, encrypted_handler_vtj_json) -> bool:
@@ -612,7 +613,10 @@ class YouthApplication(LockForUpdateMixin, TimeStampedModel, UUIDModel):
         return (
             self.status in YouthApplicationStatus.rejectable_values()
             and HandlerPermission.has_user_permission(handler)
-            and self.is_valid_encrypted_handler_vtj_json(encrypted_handler_vtj_json)
+            and (
+                settings.DISABLE_VTJ
+                or self.is_valid_encrypted_handler_vtj_json(encrypted_handler_vtj_json)
+            )
         )
 
     @transaction.atomic

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -1001,6 +1001,8 @@ def test_youth_applications_reactivate_unexpired_inactive(
     app.refresh_from_db()
     assert response.status_code == status.HTTP_302_FOUND
     assert response.url == app.already_activated_page_url()
+    assert app.encrypted_original_vtj_json is None
+    assert app.encrypted_handler_vtj_json is None
 
 
 @override_settings(


### PR DESCRIPTION
When `DISABLE_VTJ` is enabled, accepting or rejecting a `YouthApplication` will not expect any input for the `encrypted_handler_vtj_json` field and will store `None` to the field.