### PR TITLE
YJDH-595 | Additional DISABLE_VTJ fixes

### DIFF
--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -283,7 +283,7 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
 
     @transaction.atomic
     @action(methods=["get"], detail=True)
-    def activate(self, request, *args, **kwargs) -> HttpResponse:
+    def activate(self, request, *args, **kwargs) -> HttpResponse:  # noqa: C901
         youth_application: YouthApplication = self.get_object()
 
         # Lock same person's applications to prevent activation of more than one of them
@@ -309,6 +309,11 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
             return HttpResponseRedirect(youth_application.expired_page_url())
         elif youth_application.activate():
             if settings.DISABLE_VTJ:
+                if youth_application.need_additional_info:
+                    return self._set_application_needs_additional_info(
+                        youth_application=youth_application
+                    )
+
                 LOGGER.info(
                     f"Activated youth application {youth_application.pk}: "
                     "VTJ is disabled, sending application to be processed by a handler"
@@ -344,16 +349,8 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
                         )
                 return HttpResponseRedirect(youth_application.accepted_page_url())
             elif youth_application.need_additional_info:
-                LOGGER.info(
-                    f"Activated youth application {youth_application.pk}: "
-                    "Additional info is needed, redirecting user to page to provide it"
-                )
-                youth_application.status = (
-                    YouthApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED
-                )
-                youth_application.save()
-                return HttpResponseRedirect(
-                    youth_application.additional_info_page_url(pk=youth_application.pk)
+                return self._set_application_needs_additional_info(
+                    youth_application=youth_application
                 )
 
             return HttpResponseRedirect(youth_application.activated_page_url())
@@ -361,6 +358,20 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
         return HttpResponse(
             status=status.HTTP_401_UNAUTHORIZED,
             content="Unable to activate youth application",
+        )
+
+    @staticmethod
+    def _set_application_needs_additional_info(youth_application) -> HttpResponse:
+        LOGGER.info(
+            f"Activated youth application {youth_application.pk}: "
+            "Additional info is needed, redirecting user to page to provide it"
+        )
+        youth_application.status = (
+            YouthApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED
+        )
+        youth_application.save()
+        return HttpResponseRedirect(
+            youth_application.additional_info_page_url(pk=youth_application.pk)
         )
 
     @classmethod

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -296,7 +296,7 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
             if (
                 youth_application.is_active
                 and not youth_application.is_rejected
-                and youth_application.need_additional_info
+                and youth_application.can_set_additional_info
             ):
                 return HttpResponseRedirect(
                     youth_application.additional_info_page_url(pk=youth_application.pk)

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -725,7 +725,7 @@ class YouthApplication(LockForUpdateMixin, TimeStampedModel, UUIDModel):
                  additional info has been provided or not.
         """
         if settings.DISABLE_VTJ:
-            return not self.is_applicant_in_target_group
+            return not (self.is_9th_grader_age and self.attends_helsinkian_school)
 
         return (
             self.is_applicant_dead_according_to_vtj

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -794,7 +794,10 @@ def test_youth_applications_activate_unexpired_active(
 
     assert response.status_code == status.HTTP_302_FOUND
 
-    if active_youth_application.need_additional_info:
+    if (
+        active_youth_application.status
+        == YouthApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED
+    ):
         assert response.url == active_youth_application.additional_info_page_url(
             pk=active_youth_application.pk
         )
@@ -922,7 +925,10 @@ def test_youth_applications_activate_expired_active(
 
     assert response.status_code == status.HTTP_302_FOUND
 
-    if active_youth_application.need_additional_info:
+    if (
+        active_youth_application.status
+        == YouthApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED
+    ):
         assert response.url == active_youth_application.additional_info_page_url(
             pk=active_youth_application.pk
         )

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -985,30 +985,57 @@ def test_youth_applications_dual_activate_unexpired_inactive(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "app_factory,expected_status",
+    [
+        (
+            InactiveNoNeedAdditionalInfoYouthApplicationFactory,
+            YouthApplicationStatus.AWAITING_MANUAL_PROCESSING,
+        ),
+        (
+            InactiveNeedAdditionalInfoYouthApplicationFactory,
+            YouthApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED,
+        ),
+    ],
+)
 @override_settings(DISABLE_VTJ=True)
-def test_youth_applications_reactivate_unexpired_inactive(
+def test_youth_applications_reactivate_unexpired_inactive__vtj_disabled(
+    app_factory,
+    expected_status,
     api_client,
     make_youth_application_activation_link_unexpired,
 ):
     """
-    User tries to reactivate the already active application, he/she should
-    get redirected to the already_activated page.
+    When user tries to activate and reactivate an application, he/she should
+    get redirected to the correct url.
+
+    - Application should get the expected status on the first activation
+    - User should get redirected correctly when trying to reactivate the
+      application.
     """
-    app = InactiveNoNeedAdditionalInfoYouthApplicationFactory(
-        # Activated i.e. waiting for processing
-        status=YouthApplicationStatus.AWAITING_MANUAL_PROCESSING,
+    app = app_factory(
         # Disabled VTJ means there's no VTJ data
         encrypted_original_vtj_json=None,
         encrypted_handler_vtj_json=None,
     )
 
-    response = api_client.get(get_activation_url(app.pk))
+    # Activate and reactivate
+    for i in range(2):
+        response = api_client.get(get_activation_url(app.pk))
+        app.refresh_from_db()
+        assert app.status == expected_status
 
-    app.refresh_from_db()
-    assert response.status_code == status.HTTP_302_FOUND
-    assert response.url == app.already_activated_page_url()
-    assert app.encrypted_original_vtj_json is None
-    assert app.encrypted_handler_vtj_json is None
+        assert response.status_code == status.HTTP_302_FOUND
+
+        if i == 0 and app.status == YouthApplicationStatus.AWAITING_MANUAL_PROCESSING:
+            assert response.url == app.activated_page_url()
+        elif app.status == YouthApplicationStatus.AWAITING_MANUAL_PROCESSING:
+            assert response.url == app.already_activated_page_url()
+        else:
+            assert response.url == app.additional_info_page_url(pk=app.pk)
+
+        assert app.encrypted_original_vtj_json is None
+        assert app.encrypted_handler_vtj_json is None
 
 
 @override_settings(


### PR DESCRIPTION
When `DISABLE_VTJ` is set the logic now also checks if additional information is required for the application. `YouthApplication.need_additional_info` will require additional info when an unlisted school is selected if VTJ is disabled.
