### PR TITLE
TETP-256: Fix login page title

### DIFF
--- a/frontend/tet/admin/src/pages/login.tsx
+++ b/frontend/tet/admin/src/pages/login.tsx
@@ -96,11 +96,6 @@ const Login: NextPage = () => {
 
   return (
     <Container>
-      <Head>
-        <title>
-          {t(notificationLabelKey)} | {t(`common:appName`)}
-        </title>
-      </Head>
       <$Notification label={t(notificationLabelKey)} type={notificationType} size="large">
         {notificationContent}
       </$Notification>


### PR DESCRIPTION
## Description :sparkles:

Do not set the title explicitly for login page.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
