### PR TITLE
DRAFT: YJDH-578 | Make Suomi.fi / Helsinki profile login configurable

### DIFF
--- a/backend/shared/shared/common/enums.py
+++ b/backend/shared/shared/common/enums.py
@@ -1,0 +1,41 @@
+import re
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class LoginProvider(models.TextChoices):
+    HELSINKI_PROFILE = "Helsinki-profiili", _("Helsinki-profiili")
+    SUOMI_FI = "Suomi.fi", _("Suomi.fi")
+
+    @staticmethod
+    def suomi_fi_matcher() -> re.Pattern:
+        """
+        Regular expression pattern matching LoginProvider.SUOMI_FI enum value
+        with leeway related to whitespace, character case and word delimiters.
+        """
+        return re.compile(r"^\s*Suomi[._]?fi\s*$", re.IGNORECASE)
+
+    @staticmethod
+    def helsinki_profile_matcher() -> re.Pattern:
+        """
+        Regular expression pattern matching LoginProvider.HELSINKI_PROFILE enum value
+        with leeway related to whitespace, character case, word delimiters and language.
+        """
+        return re.compile(r"^\s*Helsinki[ _-]?(profile|profiili)\s*$", re.IGNORECASE)
+
+    @classmethod
+    def is_suomi_fi(cls, value) -> bool:
+        """
+        Does the given value as a string match LoginProvider.SUOMI_FI with
+        LoginProvider.suomi_fi_matcher()?
+        """
+        return cls.suomi_fi_matcher().fullmatch(str(value)) is not None
+
+    @classmethod
+    def is_helsinki_profile(cls, value) -> bool:
+        """
+        Does the given value as a string match LoginProvider.HELSINKI_PROFILE with
+        LoginProvider.helsinki_profile_matcher()?
+        """
+        return cls.helsinki_profile_matcher().fullmatch(str(value)) is not None

--- a/backend/shared/shared/common/tests/test_enums.py
+++ b/backend/shared/shared/common/tests/test_enums.py
@@ -1,0 +1,99 @@
+import pytest
+
+from shared.common.enums import LoginProvider
+
+
+def make_test_string_variations(test_values):
+    return sorted(
+        set(
+            [
+                format_string.format(value=getattr(value, func_name)())
+                for func_name in ["upper", "lower", "title"]
+                for format_string in [" {value}", "{value} ", "   {value}    "]
+                for value in test_values
+            ]
+        )
+    )
+
+
+def get_matching_suomi_fi_test_values():
+    return make_test_string_variations(
+        [
+            LoginProvider.SUOMI_FI.value,
+            "Suomi.fi",
+            "Suomifi",
+            "Suomi_fi",
+        ]
+    )
+
+
+def get_matching_helsinki_profile_test_values():
+    return make_test_string_variations(
+        [
+            LoginProvider.HELSINKI_PROFILE.value,
+            "Helsinki-profiili",
+            "Helsinki_profiili",
+            "Helsinki profiili",
+            "Helsinkiprofiili",
+            "Helsinki-profile",
+            "Helsinki_profile",
+            "Helsinki profile",
+            "Helsinkiprofile",
+        ]
+    )
+
+
+def get_non_matching_suomi_fi_test_values():
+    return get_matching_helsinki_profile_test_values() + [
+        "",
+        "suomi.finland",
+        "test",
+    ]
+
+
+def get_non_matching_helsinki_profile_test_values():
+    return get_matching_suomi_fi_test_values() + [
+        "",
+        "helsingin profiili",
+        "test",
+    ]
+
+
+@pytest.mark.parametrize("test_value", get_matching_suomi_fi_test_values())
+def test_login_provider_suomi_fi_matcher_match(test_value):
+    assert LoginProvider.suomi_fi_matcher().fullmatch(test_value) is not None
+
+
+@pytest.mark.parametrize("test_value", get_non_matching_suomi_fi_test_values())
+def test_login_provider_suomi_fi_matcher_no_match(test_value):
+    assert LoginProvider.suomi_fi_matcher().fullmatch(test_value) is None
+
+
+@pytest.mark.parametrize("test_value", get_matching_helsinki_profile_test_values())
+def test_login_provider_helsinki_profile_matcher_match(test_value):
+    assert LoginProvider.helsinki_profile_matcher().fullmatch(test_value) is not None
+
+
+@pytest.mark.parametrize("test_value", get_non_matching_helsinki_profile_test_values())
+def test_login_provider_helsinki_profile_matcher_no_match(test_value):
+    assert LoginProvider.helsinki_profile_matcher().fullmatch(test_value) is None
+
+
+@pytest.mark.parametrize("test_value", get_matching_helsinki_profile_test_values())
+def test_login_provider_is_helsinki_profile_valid(test_value):
+    assert LoginProvider.is_helsinki_profile(test_value)
+
+
+@pytest.mark.parametrize("test_value", get_non_matching_helsinki_profile_test_values())
+def test_login_provider_is_helsinki_profile_invalid(test_value):
+    assert not LoginProvider.is_helsinki_profile(test_value)
+
+
+@pytest.mark.parametrize("test_value", get_matching_suomi_fi_test_values())
+def test_login_provider_is_suomi_fi_valid(test_value):
+    assert LoginProvider.is_suomi_fi(test_value)
+
+
+@pytest.mark.parametrize("test_value", get_non_matching_suomi_fi_test_values())
+def test_login_provider_is_suomi_fi_invalid(test_value):
+    assert not LoginProvider.is_suomi_fi(test_value)


### PR DESCRIPTION
## Description :sparkles:

This code was separated from #1160 i.e. making it configurable whether to use Helsinki profile (Helsinki-profiili in Finnish) or Suomi.fi to login will be done separately.

## Issues :bug:
YJDH-578 (Making Suomi.fi / Helsinki profile login configurable)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
