### PR TITLE
YJDH-574 | Suomi.fi authentication logout fixes

### DIFF
--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -506,6 +506,8 @@ SAML_CONFIG = {
             "authn_requests_signed": True,
             "logout_requests_signed": True,
             "logout_responses_signed": True,
+            "signing_algorithm": saml2.xmldsig.SIG_RSA_SHA256,
+            "digest_algorithm": saml2.xmldsig.DIGEST_SHA256,
             "allow_unsolicited": False,
             "ui_info": {
                 "display_name": [

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -339,6 +339,8 @@ else:
 # Authentication
 SESSION_COOKIE_AGE = env.int("SESSION_COOKIE_AGE")
 SESSION_COOKIE_SECURE = True
+# SAML SLO requires allowing sessiond to be passed
+SESSION_COOKIE_SAMESITE = "None"
 
 AUTHENTICATION_BACKENDS = (
     "shared.oidc.auth.HelsinkiOIDCAuthenticationBackend",


### PR DESCRIPTION
## Description :sparkles:
To be able to pass test/use cases required for production the following fixes are needed to get Suomi.fi to work.
- https://palveluhallinta.suomi.fi/fi/sivut/tunnistus/kayttoonotto/kayttoonoton-vaiheet


## Issues :bug:
YJDH-574 Suomi.fi integration
