### PR TITLE
YJDH-574 | Eauth changed for Suomi.fi integration

### DIFF
--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -398,6 +398,10 @@ ADFS_CONTROLLER_GROUP_UUIDS = env.list("ADFS_CONTROLLER_GROUP_UUIDS")
 
 # Suomi.fi (djangosaml2)
 
+SAML_ATTRIBUTE_MAPPING = {
+    "givenName": ("first_name",),
+    "sn": ("last_name",),
+}
 SAML_SESSION_COOKIE_NAME = "kesaseteli_saml_session"
 SAML_CREATE_UNKNOWN_USER = True
 SAML_DJANGO_USER_MAIN_ATTRIBUTE = "username"

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -342,11 +342,17 @@ SESSION_COOKIE_SECURE = True
 # SAML SLO requires allowing sessiond to be passed
 SESSION_COOKIE_SAMESITE = "None"
 
-AUTHENTICATION_BACKENDS = (
-    "shared.oidc.auth.HelsinkiOIDCAuthenticationBackend",
+AUTHENTICATION_BACKENDS = [
     "shared.azure_adfs.auth.HelsinkiAdfsAuthCodeBackend",
-    "shared.suomi_fi.auth.SuomiFiSAML2AuthenticationBackend",
     "django.contrib.auth.backends.ModelBackend",
+]
+
+# If Suomi.fi not enabled we will enable the legacy Kesäseteli auth.
+AUTHENTICATION_BACKENDS.insert(
+    0,
+    "shared.suomi_fi.auth.SuomiFiSAML2AuthenticationBackend"
+    if ENABLE_SUOMIFI
+    else "shared.oidc.auth.HelsinkiOIDCAuthenticationBackend",
 )
 
 OIDC_RP_SIGN_ALGO = "RS256"

--- a/backend/shared/shared/oidc/views/eauth_views.py
+++ b/backend/shared/shared/oidc/views/eauth_views.py
@@ -57,12 +57,21 @@ class EauthAuthenticationRequestView(View):
 
     def get(self, request):
         """Eauth client authentication initialization HTTP endpoint"""
-        if not (request.session.get("oidc_access_token")):
-            return self.login_failure()
 
-        user_info = get_userinfo(request)
+        suomifi_enabled = getattr(settings, "ENABLE_SUOMIFI", False)
 
-        user_ssn = user_info.get("national_id_num")
+        if suomifi_enabled:
+            # Suomi.fi SAML authentication has been enabled
+            user_ssn = request.saml_session.get("national_id_num")
+            if not user_ssn:
+                return self.login_failure()
+        else:
+            if not request.session.get("oidc_access_token"):
+                return self.login_failure()
+
+            user_info = get_userinfo(request)
+            user_ssn = user_info.get("national_id_num")
+
         register_info = self.register_user(user_ssn)
 
         session_id = register_info.get("sessionId")

--- a/backend/shared/shared/oidc/views/hki_views.py
+++ b/backend/shared/shared/oidc/views/hki_views.py
@@ -119,9 +119,18 @@ class HelsinkiOIDCUserInfoView(View):
         return JsonResponse(userinfo)
 
     def get(self, request):
+        suomifi_enabled = getattr(settings, "ENABLE_SUOMIFI", False)
         response = HttpResponse("Unauthorized", status=401)
 
-        if request.user.is_authenticated:
+        if suomifi_enabled and request.user.is_authenticated:
+            # TODO Refactor this SAML related userinfo e.g. to a separate view
+            userinfo = {
+                "given_name": request.user.first_name,
+                "family_name": request.user.last_name,
+                "name": request.user.get_full_name(),
+            }
+            response = JsonResponse(userinfo)
+        elif request.user.is_authenticated:
             try:
                 access_token = request.session.get("oidc_access_token")
 

--- a/backend/shared/shared/suomi_fi/views.py
+++ b/backend/shared/shared/suomi_fi/views.py
@@ -16,9 +16,12 @@ class SuomiFiAssertionConsumerServiceView(AssertionConsumerServiceView):
     def post_login_hook(
         self, request: HttpRequest, user: settings.AUTH_USER_MODEL, session_info: dict
     ) -> None:
-        """
-        Get required information from session_info and push it to the session."""
-        # TODO Get national identification number and store it into the session.
+        """Pick national identification number from ava and put it to the session."""
+        ava = session_info.get("ava", {})
+
+        if user_ssn := ava.get("nationalIdentificationNumber"):
+            request.saml_session["national_id_num"] = user_ssn[0]
+
         super(SuomiFiAssertionConsumerServiceView, self).post_login_hook(
             request, user, session_info
         )


### PR DESCRIPTION
## Description :sparkles:
This PR adds changes that are required to get the Eauthorization working with the Suomi.fi SAML authentication.

## Issues :bug:
YJDH-574 Suomi.fi integration
