### PR TITLE
YJDH-618 | Export attachments in Talpa Excel export

### DIFF
--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -9,11 +9,7 @@ from PIL import Image, UnidentifiedImageError
 from rest_framework import serializers
 
 from applications.api.v1.validators import validate_additional_info_user_reasons
-from applications.enums import (
-    AttachmentType,
-    EmployerApplicationStatus,
-    SummerVoucherExceptionReason,
-)
+from applications.enums import AttachmentType, EmployerApplicationStatus
 from applications.models import (
     Attachment,
     EmployerApplication,

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -11,6 +11,9 @@ from django.shortcuts import redirect
 from django.utils import translation
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
+
+# FIXME: The issue with CSRF excemptions needs to be solved before the application is put into maintenance mode
+from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -18,9 +21,6 @@ from rest_framework.generics import ListAPIView
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-
-# FIXME: The issue with CSRF excemptions needs to be solved before the application is put into maintenance mode
-from django.views.decorators.csrf import csrf_exempt
 
 from applications.api.v1.permissions import (
     ALLOWED_APPLICATION_UPDATE_STATUSES,

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -28,7 +28,6 @@ from applications.api.v1.permissions import (
     EmployerApplicationPermission,
     EmployerSummerVoucherPermission,
     get_user_company,
-    StaffPermission,
 )
 from applications.api.v1.serializers import (
     AttachmentSerializer,
@@ -52,6 +51,7 @@ from applications.models import (
     YouthApplication,
 )
 from common.decorators import enforce_handler_view_adfs_login
+from common.permissions import HandlerPermission
 from shared.audit_log.viewsets import AuditLoggingModelViewSet
 from shared.vtj.vtj_client import VTJClient
 
@@ -555,7 +555,7 @@ class EmployerSummerVoucherViewSet(AuditLoggingModelViewSet):
     serializer_class = EmployerSummerVoucherSerializer
     permission_classes = [
         IsAuthenticated,
-        StaffPermission | EmployerSummerVoucherPermission,
+        HandlerPermission | EmployerSummerVoucherPermission,
     ]
 
     def get_queryset(self):

--- a/backend/kesaseteli/applications/exporters/excel_exporter.py
+++ b/backend/kesaseteli/applications/exporters/excel_exporter.py
@@ -87,16 +87,6 @@ REMOVABLE_TALPA_FIELD_TITLES = [
     HIRED_WITHOUT_VOUCHER_ASSESSMENT_FIELD_TITLE,
     _("Työnantajan kokemus"),
     _("Muuta"),
-    _("Liite: Työsopimus 1"),
-    _("Liite: Työsopimus 2"),
-    _("Liite: Työsopimus 3"),
-    _("Liite: Työsopimus 4"),
-    _("Liite: Työsopimus 5"),
-    _("Liite: Palkkalaskelma 1"),
-    _("Liite: Palkkalaskelma 2"),
-    _("Liite: Palkkalaskelma 3"),
-    _("Liite: Palkkalaskelma 4"),
-    _("Liite: Palkkalaskelma 5"),
 ]
 
 

--- a/backend/kesaseteli/applications/views.py
+++ b/backend/kesaseteli/applications/views.py
@@ -1,6 +1,5 @@
 from datetime import date
 
-from common.decorators import enforce_handler_view_adfs_login
 from django.db.models import OuterRef, Subquery
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
@@ -13,6 +12,7 @@ from applications.exporters.excel_exporter import (
     get_xlsx_filename,
 )
 from applications.models import EmployerSummerVoucher
+from common.decorators import enforce_handler_view_adfs_login
 
 
 class EmployerApplicationExcelDownloadView(TemplateView):

--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -493,7 +493,7 @@ class YouthSummerVoucherFactory(factory.django.DjangoModelFactory):
     # NOTE: Difference from production use:
     # - This does not generate a gapless sequence
     summer_voucher_serial_number = factory.Faker(
-        "pyint", min_value=1, max_value=(2 ** 63) - 1
+        "pyint", min_value=1, max_value=(2**63) - 1
     )
     target_group = ""
 


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Export attachments in Talpa Excel 

Add following fields to be exported in Talpa Excel export:
 - Liite: Työsopimus 1
 - Liite: Työsopimus 2
 - Liite: Työsopimus 3
 - Liite: Työsopimus 4
 - Liite: Työsopimus 5
 - Liite: Palkkalaskelma 1
 - Liite: Palkkalaskelma 2
 - Liite: Palkkalaskelma 3
 - Liite: Palkkalaskelma 4
 - Liite: Palkkalaskelma 5

"Työsopimus" means an employment contract, first 5 of them are exported.
"Palkkalaskelma" means a payslip, first 5 of them are exported.

Refs YJDH-618
 
### KS-Backend: Fix styles and imports 

Remove unused import and run "black . && isort . && flake8" without
warnings.

Refs YJDH-618 (Noticed these hadn't been run)

### KS-Backend: Fix Excel export tests & test attachments

Fix Excel export tests by not using mock flag, checking for correct
redirection URL and removing ENABLE_ADMIN checks that didn't for an
unknown reason work.

Add attachment export testing to Excel export tests.

Test that Excel download links redirect an unauthenticated user to
handler's 403 page.

Refs YJDH-618

### KS-Backend: Make use of HandlerPermission with attachments

Use HandlerPermission instead of StaffPermission in attachment access
handling.

Refs YJDH-618

## Issues :bug:

YJDH-618

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
