### PR TITLE
YJDH-626 | KS-Backend: Add contact info to reporting Excel export

### DIFF
--- a/backend/kesaseteli/applications/exporters/excel_exporter.py
+++ b/backend/kesaseteli/applications/exporters/excel_exporter.py
@@ -35,12 +35,8 @@ WORK_HOURS_FIELD_TITLE = _("Työtunnit")
 REMOVABLE_REPORTING_FIELD_TITLES = [
     _("Y-tunnus"),
     _("Yhdyshenkilö"),
-    _("Yhdyshenkilön sähköposti"),
-    _("Yhdyshenkilön Puhelin"),
     _("Erillinen laskuttaja"),
     _("Laskuttajan nimi"),
-    _("Laskuttajan sähköposti"),
-    _("Laskuttajan Puhelin"),
     _("Raporttiin luokittelu"),
     _("Liite: Työsopimus 1"),
     _("Liite: Työsopimus 2"),

--- a/backend/kesaseteli/applications/exporters/excel_exporter.py
+++ b/backend/kesaseteli/applications/exporters/excel_exporter.py
@@ -31,12 +31,15 @@ SALARY_PAID_FIELD_TITLE = _("Maksettu palkka")
 SPECIAL_CASE_FIELD_TITLE = _("Erikoistapaus (esim yhdeksäsluokkalainen)")
 SUM_FIELD_TITLE = _("Summa")
 WORK_HOURS_FIELD_TITLE = _("Työtunnit")
+INVOICER_EMAIL_FIELD_TITLE = _("Laskuttajan sähköposti")
+INVOICER_NAME_FIELD_TITLE = _("Laskuttajan nimi")
+INVOICER_PHONE_NUMBER_FIELD_TITLE = _("Laskuttajan Puhelin")
 
 REMOVABLE_REPORTING_FIELD_TITLES = [
     _("Y-tunnus"),
     _("Yhdyshenkilö"),
     _("Erillinen laskuttaja"),
-    _("Laskuttajan nimi"),
+    INVOICER_NAME_FIELD_TITLE,
     _("Raporttiin luokittelu"),
     _("Liite: Työsopimus 1"),
     _("Liite: Työsopimus 2"),
@@ -68,9 +71,9 @@ REMOVABLE_TALPA_FIELD_TITLES = [
     _("Yhdyshenkilön sähköposti"),
     _("Yhdyshenkilön Puhelin"),
     _("Erillinen laskuttaja"),
-    _("Laskuttajan nimi"),
-    _("Laskuttajan sähköposti"),
-    _("Laskuttajan Puhelin"),
+    INVOICER_NAME_FIELD_TITLE,
+    INVOICER_EMAIL_FIELD_TITLE,
+    INVOICER_PHONE_NUMBER_FIELD_TITLE,
     _("Yrityksen toimiala"),
     _("Työn suorituspaikan postinumero"),
     EMPLOYMENT_START_DATE_FIELD_TITLE,
@@ -166,17 +169,17 @@ FIELDS = [
         "#E7E3F9",
     ),
     ExcelField(
-        _("Laskuttajan nimi"), "%s", ["application__invoicer_name"], 30, "#E7E3F9"
+        INVOICER_NAME_FIELD_TITLE, "%s", ["application__invoicer_name"], 30, "#E7E3F9"
     ),
     ExcelField(
-        _("Laskuttajan sähköposti"),
+        INVOICER_EMAIL_FIELD_TITLE,
         "%s",
         ["application__invoicer_email"],
         30,
         "#E7E3F9",
     ),
     ExcelField(
-        _("Laskuttajan Puhelin"),
+        INVOICER_PHONE_NUMBER_FIELD_TITLE,
         "%s",
         ["application__invoicer_phone_number"],
         30,


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Add contact info to reporting Excel export

Add the following contact info fields to reporting Excel export:
 - "Yhdyshenkilön sähköposti" i.e. contact person's email
 - "Yhdyshenkilön Puhelin" i.e. contact person's phone number
 - "Laskuttajan sähköposti" i.e. invoicer's email
 - "Laskuttajan Puhelin" i.e. invoicer's phone number
 
### KS-Backend: Fix Excel export tests & add to them

Fix test_excel_view_download_content test:
 - Handle special case of invoicer related fields when separate invoicer
   is not used

Add new Excel export related tests:
 - test_removable_reporting_field_titles
   - Test that values in REMOVABLE_REPORTING_FIELD_TITLES are unique
   - Test that REMOVABLE_REPORTING_FIELD_TITLES is a subset of FIELDS
 - test_removable_talpa_field_titles
   - Test that values in REMOVABLE_TALPA_FIELD_TITLES are unique
   - Test that REMOVABLE_TALPA_FIELD_TITLES is a subset of FIELDS

## Issues :bug:

YJDH-626

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
