### PR TITLE
YJDH-542 | KS-Backend: Add more activate unexpired inactive tests

### DIFF
--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -333,6 +333,21 @@ def determine_need_additional_info_vtj_json(youth_application):
 
 
 def determine_target_group_social_security_number(youth_application):
+    # NOTE: Faker generates a Finnish social security number with a birthdate
+    # today - random days between [min_age * 365, max_age * 365), see
+    # https://github.com/joke2k/faker/blob/v8.7.0/faker/providers/ssn/fi_FI/__init__.py#L29-L31
+    #
+    # Example with ssn(min_age=16, max_age=17):
+    # If today is 2022-12-31 then birthdate is in inclusive range [2006-01-01, 2006-12-31]
+    # If today is 2022-12-30 then birthdate is in inclusive range [2005-12-31, 2006-12-30]
+    # ...
+    # If today is 2022-01-01 then birthdate is in inclusive range [2005-01-02, 2006-01-01]
+    #
+    # So ONLY with the last day of the year will this be returning birthdate with
+    # today.year - ssn.birthdate.year == 16 only, otherwise the value might be 17 also.
+    #
+    # See YouthApplication.is_9th_grader_age and
+    #     YouthApplication.is_upper_secondary_education_1st_year_student_age
     return Faker(locale="fi").ssn(min_age=16, max_age=17)
 
 


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Add more activate unexpired inactive tests 

Add more activate unexpired inactive youth application tests:
 - Remove test:
   - test_youth_applications_activate_unexpired_inactive
 - Add tests:
   - test_youth_applications_activate_unexpired_inactive_with_rejection
   - test_youth_applications_activate_unexpired_inactive__vtj_enabled
   - test_youth_applications_activate_unexpired_inactive__vtj_disabled

Now the automatic acceptance of youth applications on their activation
is tested with both VTJ integration disabled and enabled.

Also add helper function get_random_social_security_number_for_year and
a comment to function determine_target_group_social_security_number
about the generated social security numbers' year.

## Issues :bug:

YJDH-542

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
