### PR TITLE
YJDH-642 | KS-Backend: Fix annual Talpa Excel export

### DIFF
--- a/backend/kesaseteli/applications/tests/test_excel_export.py
+++ b/backend/kesaseteli/applications/tests/test_excel_export.py
@@ -5,6 +5,7 @@ from typing import List
 
 import openpyxl
 import pytest
+from django.http import StreamingHttpResponse
 from django.shortcuts import reverse
 from django.test import override_settings
 from django.urls.exceptions import NoReverseMatch
@@ -86,7 +87,7 @@ def test_excel_view_download_unhandled(
     assert submitted_summer_voucher.is_exported is True
     # Cannot decode an xlsx file
     with pytest.raises(UnicodeDecodeError):
-        response.content.decode()
+        response.getvalue().decode()
 
 
 @pytest.mark.django_db
@@ -113,7 +114,7 @@ def test_excel_view_download_annual(
     assert submitted_summer_voucher.is_exported is False
     # Cannot decode an xlsx file
     with pytest.raises(UnicodeDecodeError):
-        response.content.decode()
+        response.getvalue().decode()
 
 
 @pytest.mark.django_db
@@ -144,9 +145,9 @@ def test_excel_view_download_content(  # noqa: C901
     with freeze_time(datetime.datetime(2021, 12, 31)):
         response = staff_client.get(download_url)
 
-    assert type(response.content) == bytes
+    assert isinstance(response, StreamingHttpResponse)
 
-    workbook = openpyxl.load_workbook(filename=BytesIO(response.content))
+    workbook = openpyxl.load_workbook(filename=BytesIO(response.getvalue()))
     active_worksheet = workbook.active
 
     rows_generator = active_worksheet.rows

--- a/backend/kesaseteli/applications/views.py
+++ b/backend/kesaseteli/applications/views.py
@@ -31,8 +31,9 @@ class EmployerApplicationExcelDownloadView(TemplateView):
         ).order_by("-modified_at")
         return (
             EmployerSummerVoucher.objects.select_related(
-                "application", "application__company"
+                "application", "application__company", "application__user"
             )
+            .prefetch_related("attachments")
             .annotate(submitted_at=Subquery(newest_submitted.values("modified_at")[:1]))
             .order_by("submitted_at")
         )

--- a/backend/kesaseteli/applications/views.py
+++ b/backend/kesaseteli/applications/views.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from django.db.models import OuterRef, Subquery
+from django.db.models import OuterRef, QuerySet, Subquery
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.translation import gettext_lazy as _
@@ -23,6 +23,19 @@ class EmployerApplicationExcelDownloadView(TemplateView):
     """
 
     template_name = "application_excel_download.html"
+
+    @staticmethod
+    def base_queryset() -> QuerySet[EmployerSummerVoucher]:
+        newest_submitted = EmployerSummerVoucher.history.filter(
+            id=OuterRef("id"), application__status=EmployerApplicationStatus.SUBMITTED
+        ).order_by("-modified_at")
+        return (
+            EmployerSummerVoucher.objects.select_related(
+                "application", "application__company"
+            )
+            .annotate(submitted_at=Subquery(newest_submitted.values("modified_at")[:1]))
+            .order_by("submitted_at")
+        )
 
     @enforce_handler_view_adfs_login
     def get(self, request, *args, **kwargs):
@@ -73,19 +86,9 @@ class EmployerApplicationExcelDownloadView(TemplateView):
         Export unhandled applications and redirect back to the excel download page.
         The user will see a new xlsx file generated in the generated files list.
         """
-        newest_submitted = EmployerSummerVoucher.history.filter(
-            id=OuterRef("id"), application__status=EmployerApplicationStatus.SUBMITTED
-        ).order_by("-modified_at")
-        queryset = (
-            EmployerSummerVoucher.objects.select_related(
-                "application", "application__company"
-            )
-            .filter(
-                is_exported=False,
-                application__status=EmployerApplicationStatus.SUBMITTED,
-            )
-            .annotate(submitted_at=Subquery(newest_submitted.values("modified_at")[:1]))
-            .order_by("submitted_at")
+        queryset = self.base_queryset().filter(
+            is_exported=False,
+            application__status=EmployerApplicationStatus.SUBMITTED,
         )
         if not queryset.exists():
             return self.render_error(_("Ei uusia käsittelemättömiä hakemuksia."))
@@ -104,19 +107,12 @@ class EmployerApplicationExcelDownloadView(TemplateView):
         file will not be saved on disk and will not be shown on the xlsx files list.
         """
         start_of_year = date(date.today().year, 1, 1)
-        newest_submitted = EmployerSummerVoucher.history.filter(
-            id=OuterRef("id"), application__status=EmployerApplicationStatus.SUBMITTED
-        ).order_by("-modified_at")
         queryset = (
-            EmployerSummerVoucher.objects.select_related(
-                "application", "application__company"
-            )
+            self.base_queryset()
             .filter(
                 application__created_at__gte=start_of_year,
             )
             .exclude(application__status=EmployerApplicationStatus.DRAFT)
-            .annotate(submitted_at=Subquery(newest_submitted.values("modified_at")[:1]))
-            .order_by("submitted_at")
         )
         if not queryset.exists():
             return self.render_error(_("Hakemuksia ei löytynyt."))


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Use streaming FileResponse in Excel export

Use a FileResponse in EmployerApplicationExcelDownloadView in order to
avoid getting a Gateway Timeout 504 error if the Excel export takes too
long.

### KS-Backend: Use select/prefetch_related in Excel export

EmployerApplicationExcelDownloadView:
 - Select and prefetch related objects in Excel export to hopefully
   speed up the query.

### KS-Backend: Refactor Excel exporting functions

EmployerApplicationExcelDownloadView:
 - Move shared query part from export_and_download_annual_applications
   and export_and_download_unhandled_applications to base_queryset

## Issues :bug:

[YJDH-642](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-642) ("BE: Kesäsetelin tämän vuoden hakemusten Talpa-Excelin lataaminen epäonnistuu yhdyskäytävän aikakatkaisuun")

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

Similar to the fix in https://github.com/City-of-Helsinki/yjdh/pull/1118