### PR TITLE
YJDH-645 | KS-Backend: Stream Excel export

### DIFF
--- a/.env.kesaseteli.example
+++ b/.env.kesaseteli.example
@@ -13,6 +13,7 @@ VTJ_PERSONAL_ID_QUERY_URL=https://vtj-integration-test.agw.arodevtest.hel.fi/api
 VTJ_USERNAME=
 VTJ_PASSWORD=
 VTJ_TIMEOUT=30
+EXCEL_DOWNLOAD_BATCH_SIZE=50
 
 # Authentication
 OIDC_OP_BASE_URL=https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect

--- a/backend/kesaseteli/applications/exporters/excel_exporter.py
+++ b/backend/kesaseteli/applications/exporters/excel_exporter.py
@@ -1,11 +1,13 @@
 import io
-from typing import List, NamedTuple
+from typing import Iterable, List, NamedTuple
 
 from django.db.models import QuerySet
+from django.http import HttpRequest
 from django.shortcuts import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from xlsxwriter import Workbook
+from xlsxwriter.worksheet import Worksheet
 
 from applications.enums import ExcelColumns
 from applications.models import EmployerSummerVoucher
@@ -282,7 +284,9 @@ def get_xlsx_filename(columns: ExcelColumns) -> str:
     return filename
 
 
-def set_header_and_formatting(wb, ws, column, field: ExcelField, header_format):
+def set_header_and_formatting(
+    wb: Workbook, ws: Worksheet, column: int, field: ExcelField, header_format
+):
     ws.write(0, column, str(_(field.title)), header_format)
 
     cell_format = wb.add_format()
@@ -292,7 +296,10 @@ def set_header_and_formatting(wb, ws, column, field: ExcelField, header_format):
 
 
 def get_attachment_uri(
-    summer_voucher: EmployerSummerVoucher, field: ExcelField, value, request
+    summer_voucher: EmployerSummerVoucher,
+    field: ExcelField,
+    value,
+    request: HttpRequest,
 ):
     field_name = field.title
     attachment_number = int(field_name.split(" ")[-1])
@@ -320,7 +327,13 @@ def get_attachment_uri(
     return request.build_absolute_uri(path)
 
 
-def handle_special_cases(value, attr_str, summer_voucher, field: ExcelField, request):
+def handle_special_cases(
+    value,
+    attr_str,
+    summer_voucher: EmployerSummerVoucher,
+    field: ExcelField,
+    request: HttpRequest,
+):
     if isinstance(value, bool):
         value = str(_("Kyllä")) if value else str(_("Ei"))
     elif attr_str == "attachments":
@@ -333,9 +346,9 @@ def handle_special_cases(value, attr_str, summer_voucher, field: ExcelField, req
 
 
 def generate_data_row(
-    summer_voucher,
+    summer_voucher: EmployerSummerVoucher,
     fields: List[ExcelField],
-    request,
+    request: HttpRequest,
     is_template: bool = False,
 ) -> list:
     result = []
@@ -367,9 +380,9 @@ def generate_data_row(
 
 
 def generate_data_rows(
-    summer_vouchers,
+    summer_vouchers: Iterable[EmployerSummerVoucher],
     fields: List[ExcelField],
-    request,
+    request: HttpRequest,
     is_template: bool = False,
 ):
     return (
@@ -379,11 +392,11 @@ def generate_data_rows(
 
 
 def write_data_row(
-    ws,
-    row_number,
-    summer_voucher,
+    ws: Worksheet,
+    row_number: int,
+    summer_voucher: EmployerSummerVoucher,
     fields: List[ExcelField],
-    request,
+    request: HttpRequest,
     is_template: bool = False,
 ):
     data_row = generate_data_row(summer_voucher, fields, request, is_template)
@@ -395,7 +408,7 @@ def populate_workbook(
     wb: Workbook,
     summer_vouchers: QuerySet[EmployerSummerVoucher],
     columns: ExcelColumns,
-    request,
+    request: HttpRequest,
     is_template: bool = False,
 ):
     """
@@ -418,9 +431,14 @@ def populate_workbook(
 
 
 def generate_xlsx_template(
-    summer_vouchers: QuerySet[EmployerSummerVoucher], columns: ExcelColumns, request
+    summer_vouchers: QuerySet[EmployerSummerVoucher],
+    columns: ExcelColumns,
+    request: HttpRequest,
 ):
     output = io.BytesIO()
     wb = Workbook(output)
+    # Use the first row in the queryset to generate the .xlsx template for the
+    # xlsx-streaming package which uses the template for determining column names and
+    # types (supports at least boolean, integer and string types) in Excel output
     populate_workbook(wb, summer_vouchers[0:1], columns, request, is_template=True)
     return output

--- a/backend/kesaseteli/applications/tests/test_excel_export.py
+++ b/backend/kesaseteli/applications/tests/test_excel_export.py
@@ -206,10 +206,7 @@ def test_excel_view_download_content(  # noqa: C901
                 expected_attachment_uri = get_attachment_uri(
                     voucher, excel_field, voucher.attachments, response.wsgi_request
                 )
-                if expected_attachment_uri == "":
-                    assert output_column.value is None
-                else:
-                    assert output_column.value == expected_attachment_uri
+                assert output_column.value == expected_attachment_uri
             elif (
                 excel_field.title
                 in (
@@ -219,10 +216,8 @@ def test_excel_view_download_content(  # noqa: C901
                 )
                 and not voucher.application.is_separate_invoicer
             ):
-                assert output_column.value is None, excel_field.title
-            elif excel_field.model_fields == [] and excel_field.value == "":
-                assert output_column.value is None
-            elif excel_field.model_fields == [] and excel_field.value != "":
+                assert output_column.value == "", excel_field.title
+            elif excel_field.model_fields == []:
                 assert output_column.value == excel_field.value
             else:
                 query = EmployerSummerVoucher.objects.filter(pk=voucher.pk)

--- a/backend/kesaseteli/applications/tests/test_excel_export.py
+++ b/backend/kesaseteli/applications/tests/test_excel_export.py
@@ -36,6 +36,10 @@ from applications.exporters.excel_exporter import (
 )
 from applications.models import EmployerSummerVoucher
 from applications.tests.test_models import create_test_employer_summer_vouchers
+from common.tests.factories import (
+    EmployerApplicationFactory,
+    EmployerSummerVoucherFactory,
+)
 from common.urls import handler_403_url
 
 
@@ -101,6 +105,24 @@ def test_excel_view_download_no_unhandled_applications(staff_client):
 
 @pytest.mark.django_db
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+@pytest.mark.parametrize("columns", ExcelColumns.values)
+def test_excel_view_download_no_annual_applications(staff_client, columns):
+    # Create draft applications with/without voucher, these should not be returned
+    EmployerSummerVoucherFactory(
+        application=EmployerApplicationFactory(status=EmployerApplicationStatus.DRAFT)
+    )
+    EmployerApplicationFactory(status=EmployerApplicationStatus.DRAFT)
+
+    response = staff_client.get(
+        f"{excel_download_url()}?download=annual&columns={columns}"
+    )
+
+    assert response.status_code == 200
+    assert "Hakemuksia ei löytynyt." in response.content.decode()
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_excel_view_download_annual(
     staff_client, submitted_summer_voucher, submitted_employment_contract_attachment
 ):
@@ -140,7 +162,15 @@ def test_excel_view_download_content(  # noqa: C901
     download_url,
     expected_output_excel_fields: List[ExcelField],
 ):
-    vouchers = create_test_employer_summer_vouchers(year=2021)
+    def employer_summer_voucher_sorting_key(voucher: EmployerSummerVoucher):
+        # Sorting key should be the same as what is used to order by queryset results
+        # in Excel download, see EmployerApplicationExcelDownloadView
+        return voucher.last_submitted_at, voucher.created_at, voucher.pk
+
+    vouchers: List[EmployerSummerVoucher] = sorted(
+        create_test_employer_summer_vouchers(year=2021),
+        key=employer_summer_voucher_sorting_key,
+    )
 
     with freeze_time(datetime.datetime(2021, 12, 31)):
         response = staff_client.get(download_url)
@@ -169,7 +199,7 @@ def test_excel_view_download_content(  # noqa: C901
     for row_number, (data_row, voucher) in enumerate(zip(data_rows, vouchers), start=1):
         for output_column, excel_field in zip(data_row, expected_output_excel_fields):
             if excel_field.title == ORDER_FIELD_TITLE:
-                assert output_column.value == row_number
+                assert output_column.value == row_number, "Incorrect output sorting"
             elif excel_field.title == RECEIVED_DATE_FIELD_TITLE:
                 assert (
                     output_column.value

--- a/backend/kesaseteli/applications/tests/test_models.py
+++ b/backend/kesaseteli/applications/tests/test_models.py
@@ -49,7 +49,9 @@ def create_test_employer_summer_vouchers(year) -> List[EmployerSummerVoucher]:
             [utc_datetime(year, 3, 11), utc_datetime(year, 9, 1)],
             0,
         ),
+        (utc_datetime(year, 2, 1), [utc_datetime(year, 9, 2)], 1),
         (utc_datetime(year, 2, 5), [utc_datetime(year, 9, 2)], 1),
+        (utc_datetime(year, 2, 2), [utc_datetime(year, 9, 2)], 1),
     ]:
         with freeze_time(created_at):
             voucher = EmployerSummerVoucherFactory(
@@ -76,7 +78,7 @@ def test_employer_summer_voucher_last_submitted_at(year):
     """
     vouchers = create_test_employer_summer_vouchers(year=year)
 
-    assert len(vouchers) == 11
+    assert len(vouchers) == 13
     assert vouchers[0].last_submitted_at == utc_datetime(year, 1, 18)
     assert vouchers[1].last_submitted_at == utc_datetime(year, 2, 1)
     assert vouchers[2].last_submitted_at == utc_datetime(year, 2, 9)
@@ -88,6 +90,8 @@ def test_employer_summer_voucher_last_submitted_at(year):
     assert vouchers[8].last_submitted_at == utc_datetime(year, 3, 12)
     assert vouchers[9].last_submitted_at == utc_datetime(year, 9, 1)
     assert vouchers[10].last_submitted_at == utc_datetime(year, 9, 2)
+    assert vouchers[11].last_submitted_at == utc_datetime(year, 9, 2)
+    assert vouchers[12].last_submitted_at == utc_datetime(year, 9, 2)
 
 
 @pytest.mark.django_db(transaction=True, reset_sequences=True)

--- a/backend/kesaseteli/applications/views.py
+++ b/backend/kesaseteli/applications/views.py
@@ -3,6 +3,7 @@ from functools import partial
 from typing import Union
 
 import xlsx_streaming
+from django.conf import settings
 from django.db.models import OuterRef, QuerySet, Subquery, Window
 from django.db.models.functions import RowNumber
 from django.http import HttpResponseRedirect, StreamingHttpResponse
@@ -80,7 +81,7 @@ class EmployerApplicationExcelDownloadView(TemplateView):
                 qs=queryset,
                 xlsx_template=generate_xlsx_template(queryset, columns, self.request),
                 serializer=serializer,
-                batch_size=50,
+                batch_size=settings.EXCEL_DOWNLOAD_BATCH_SIZE,
             ),
             content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         )

--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -30,7 +30,10 @@ from applications.tests.data.mock_vtj import (
     mock_vtj_person_id_query_not_found_content,
 )
 from companies.models import Company
-from shared.common.tests.factories import HandlerUserFactory, UserFactory
+from shared.common.tests.factories import (
+    DuplicateAllowingUserFactory,
+    HandlerUserFactory,
+)
 
 
 class CompanyFactory(factory.django.DjangoModelFactory):
@@ -99,7 +102,7 @@ class EmployerSummerVoucherFactory(factory.django.DjangoModelFactory):
 
 class EmployerApplicationFactory(factory.django.DjangoModelFactory):
     company = factory.SubFactory(CompanyFactory)
-    user = factory.SubFactory(UserFactory)
+    user = factory.SubFactory(DuplicateAllowingUserFactory)
     status = factory.Faker("random_element", elements=EmployerApplicationStatus.values)
     street_address = factory.Faker("street_address")
     bank_account_number = factory.Faker("iban")

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -137,6 +137,7 @@ env = environ.Env(
     SUOMIFI_ADMINISTRATIVE_FIRST_NAME=(str, None),
     SUOMIFI_ADMINISTRATIVE_LAST_NAME=(str, None),
     SUOMIFI_ADMINISTRATIVE_EMAIL=(str, None),
+    EXCEL_DOWNLOAD_BATCH_SIZE=(int, 50),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -156,6 +157,7 @@ VTJ_USERNAME = env.str("VTJ_USERNAME")
 VTJ_PASSWORD = env.str("VTJ_PASSWORD")
 VTJ_TIMEOUT = env.int("VTJ_TIMEOUT")
 NEXT_PUBLIC_ENABLE_SUOMIFI = env("NEXT_PUBLIC_ENABLE_SUOMIFI")
+EXCEL_DOWNLOAD_BATCH_SIZE = env.int("EXCEL_DOWNLOAD_BATCH_SIZE")
 
 DB_PREFIX = {
     None: env.str("DB_PREFIX"),

--- a/backend/kesaseteli/requirements.in
+++ b/backend/kesaseteli/requirements.in
@@ -21,4 +21,5 @@ python-stdnum
 requests
 sentry-sdk
 xlsxwriter
+xlsx-streaming
 -e file:../shared

--- a/backend/kesaseteli/requirements.txt
+++ b/backend/kesaseteli/requirements.txt
@@ -194,12 +194,16 @@ urllib3==1.26.5
     #   sentry-sdk
 wcwidth==0.2.5
     # via prompt-toolkit
+xlsx-streaming==1.1.0
+    # via -r requirements.in
 xlsxwriter==3.0.1
     # via -r requirements.in
 xmlschema==1.11.2
     # via pysaml2
 zipp==3.8.0
     # via importlib-resources
+zipstream==1.1.4
+    # via xlsx-streaming
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/backend/shared/shared/common/tests/factories.py
+++ b/backend/shared/shared/common/tests/factories.py
@@ -3,6 +3,10 @@ from django.contrib.auth import get_user_model
 
 
 class UserFactory(factory.django.DjangoModelFactory):
+    """
+    Create a Django user with a unique username
+    """
+
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
     username = factory.Faker("user_name")
@@ -10,6 +14,16 @@ class UserFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = get_user_model()
+
+
+class DuplicateAllowingUserFactory(UserFactory):
+    """
+    Create or get a Django user with a possibly duplicated username
+    """
+
+    class Meta:
+        model = get_user_model()
+        django_get_or_create = ("username",)
 
 
 class HandlerUserFactory(UserFactory):


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Add xlsx-streaming Python package 

Refs YJDH-645 (The package to be used for streaming .xlsx files)
 
### KS-Backend: Make Excel export really stream XLSX files 

Refs YJDH-642 (The bug this fix is related to)
Refs YJDH-645 (A fix for YJDH-642)

### KS-Backend: Add type hints, EXCEL_DOWNLOAD_BATCH_SIZE setting

 - Add type hints to some of the functions in excel_exporter.py.
 - Configure Excel download batch size in Excel exporting with setting
   EXCEL_DOWNLOAD_BATCH_SIZE and default value of 50.
 - Add comment to generate_xlsx_template function in excel_exporter.py.

Refs YJDH-645

### KS-Backend: Make Excel download's row order predictable

EmployerApplicationExcelDownloadView:
 - Use triplet (submitted_at, created_at, pk) as the sorting key for the
   Excel download's queryset. Use the same triplet in the queryset's
   order_by clause and the RowNumber window function annotation's
   order_by clause to make the row numbers work correctly. Using
   created_at and primary key as the secondary and tertiary ordering
   parameters to force a predictable although slightly arbitrary
   ordering for queryset rows with identical submitted_at values.

Tests:
 - Add test test_excel_view_download_no_annual_applications to test that
   drafts are not included in the annual Excel downloads and that if
   there are only drafts then nothing is returned.
 - Extend test_excel_view_download_content to test a case where
   submitted_at timestamp is the same and thus the created_at secondary
   sorting key for the Excel download's output should be used.

Factories:
 - Add DuplicateAllowingUserFactory into shared code
   - Creates or gets a Django user with a possibly duplicated username
 - Use DuplicateAllowingUserFactory for EmployerApplicationFactory.user
   - Now creating hundreds of EmployerApplications using
     EmployerApplicationFactory doesn't fail because of duplicate
     usernames (This happened often during testing when creating hundred
     of EmployerApplications)

Refs YJDH-645

## Issues :bug:

YJDH-642 (The bug this fix is related to)
YJDH-645 (A fix for YJDH-642)

## Testing :alembic:

For developers locally:
 - NOTE: These testing instructions are for an empty yjdh_pgdata Docker volume. If you have a working volume already please remove it first or you're on your own.
 - Build the Kesäseteli's backend and the employer frontend:
   - `yarn employer:build`
 - Generate data to test Excel export with:
   - `docker exec -it kesaseteli-backend bash`
   - `python manage.py shell_plus`
   - `from applications.enums import EmployerApplicationStatus`
   - `from applications.models import EmployerApplication, EmployerSummerVoucher`
   - `from common.tests.factories import EmployerApplicationFactory, EmployerSummerVoucherFactory`
   - `for _ in range(51): EmployerSummerVoucherFactory(application=EmployerApplicationFactory(status=EmployerApplicationStatus.DRAFT))`
   - `for _ in range(52): EmployerSummerVoucherFactory(application=EmployerApplicationFactory(status=EmployerApplicationStatus.SUBMITTED))`
   - `for _ in range(53): EmployerApplicationFactory(status=EmployerApplicationStatus.DRAFT)`
   - NOTE: If some of the above Factory calls fails with duplicate keys you can just run those lines again and again until they don't fail. This way you can also generate even more data to test with if you want to.
 - Open https://localhost:8000/excel-download/ in web browser 
   - If this doesn't show the Excel download page then try logging first into https://localhost:8000/admin/ with user admin/admin and then retry opening the Excel download page
 - Click on the `Lataa raportointi-Excel kaikista tämän vuoden hakemuksista`, see that the Excel is downloaded ok and that it contains 52 rows
 - Click on the `Lataa Talpa-Excel kaikista tämän vuoden hakemuksista`, see that the Excel is downloaded ok and that it contains 52 rows
 - Click on `Lataa Talpa-Excel käsittelemättömistä hakemuksista`, see that the Excel is downloaded ok and that it contains 52 rows
 - After this clicking on `Lataa raportointi-Excel käsittelemättömistä hakemuksista` should give a notification "Ei uusia käsittelemättömiä hakemuksia." in the upper area of the window
 - Regenerate data to test Excel export with:
   - `docker exec -it kesaseteli-backend bash`
   - `python manage.py shell_plus`
   - `from applications.enums import EmployerApplicationStatus`
   - `from applications.models import EmployerApplication, EmployerSummerVoucher`
   - `EmployerSummerVoucher.objects.all().delete()`
   - `EmployerApplication.objects.all().delete()`
   - `from applications.models import EmployerApplication, EmployerSummerVoucher`
   - `from common.tests.factories import EmployerApplicationFactory, EmployerSummerVoucherFactory`
   - `for _ in range(51): EmployerSummerVoucherFactory(application=EmployerApplicationFactory(status=EmployerApplicationStatus.DRAFT))`
   - `for _ in range(52): EmployerSummerVoucherFactory(application=EmployerApplicationFactory(status=EmployerApplicationStatus.SUBMITTED))`
   - `for _ in range(53): EmployerApplicationFactory(status=EmployerApplicationStatus.DRAFT)`
   - NOTE: If some of the above Factory calls fails with duplicate keys you can just run those lines again and again until they don't fail. This way you can also generate even more data to test with if you want to.
 - Click on `Lataa raportointi-Excel käsittelemättömistä hakemuksista`, see that the Excel is downloaded ok and that it contains 52 rows

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

Tested locally in Docker that the backend's tests passed (i.e. "pytest . -vv").
Tested locally the Excel export similarly as described in the testing instructions in this PR (Not 100% the same but similarly).

NOTE:
 - **Colors, formatting and default column widths are removed** by this PR from the Excel output—the reason for this is that it did not seem possible to retain them using the xslx-streaming package without major efforts and/or hacks (e.g. monkeypatching the library's functionality). It was confirmed with the Kesäseteli's product owners that this is ok.
