### PR TITLE
(WIP): HL-553: Error in manual calculator

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -95,7 +95,8 @@ class AttachmentField(FileField):
 
         url_pattern_name = "v1:applicant-application-download-attachment"
         request = self.context.get("request")
-        if request and get_request_user_from_context(self).is_handler():
+        requested_user = get_request_user_from_context(self)
+        if request and not isinstance(requested_user, AnonymousUser) and requested_user.is_handler():
             url_pattern_name = "v1:handler-application-download-attachment"
 
         path = reverse(

--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -96,7 +96,11 @@ class AttachmentField(FileField):
         url_pattern_name = "v1:applicant-application-download-attachment"
         request = self.context.get("request")
         requested_user = get_request_user_from_context(self)
-        if request and not isinstance(requested_user, AnonymousUser) and requested_user.is_handler():
+        if (
+            request
+            and not isinstance(requested_user, AnonymousUser)
+            and requested_user.is_handler()
+        ):
             url_pattern_name = "v1:handler-application-download-attachment"
 
         path = reverse(
@@ -858,7 +862,6 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
             last_possible_end_date = get_date_range_end_with_days360(
                 obj.start_date, aggregated_info.months_remaining
             )
-
         return {
             "months_used": to_decimal(
                 aggregated_info.months_used, decimal_places=2, allow_null=True

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -476,7 +476,7 @@
     "termsOfServiceHeader": "Tietoa työnantajan edustajien henkilötietojen käsittelystä"
   },
   "errorPage": {
-    "title": "Palvelussa on valitettavsti tapahtunut virhe",
+    "title": "Palvelussa on valitettavasti tapahtunut virhe",
     "message": "Yritämme todennäköisesti jo korjata ongelmaa. Yritä myöhemmin uudelleen.",
     "home": "Palaa etusivulle",
     "logout": "Kirjaudu ulos"

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -79,7 +79,7 @@
   },
   "menuToggleAriaLabel": "Menu",
   "errorPage": {
-    "title": "Palvelussa on valitettavsti tapahtunut virhe",
+    "title": "Palvelussa on valitettavasti tapahtunut virhe",
     "message": "Yritämme todennäköisesti jo parhaillaan korjata ongelmaa. Yritä myöhemmin uudelleen.",
     "home": "Palaa etusivulle",
     "logout": "Kirjaudu ulos"

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -431,5 +431,6 @@
     "infoLabel": "Using the service requires strong authentication",
     "logoutInfoContent": "You have been logged out. If you want to continue to use the service, you have to log in again click the button here below.",
     "infoContent": "You should identify yourself to be able to advance to the service. You can choose yourself which identification method you want to use. Click on the bottom below to identify yourself."
-  }
+  },
+  "select": "Valitse"
 }

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -79,7 +79,7 @@
   },
   "menuToggleAriaLabel": "Menu",
   "errorPage": {
-    "title": "Palvelussa on valitettavsti tapahtunut virhe",
+    "title": "Palvelussa on valitettavasti tapahtunut virhe",
     "message": "Yritämme todennäköisesti jo parhaillaan korjata ongelmaa. Yritä myöhemmin uudelleen.",
     "home": "Palaa etusivulle",
     "logout": "Kirjaudu ulos"

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -432,5 +432,6 @@
     "infoLabel": "Palvelun käyttäminen edellyttää vahvaa tunnistautumista",
     "logoutInfoContent": "Sinut on kirjattu ulos. Jos haluat jatkaa asiointia palvelussa, kirjaudu uudelleen sisään klikkaamalla alla olevasta painikkeesta.",
     "infoContent": "Jotta voit edetä palvelussa, sinun täytyy tunnistautua. Voit valita itse, mitä tunnistustapaa haluat käyttää. Tunnistustietosi kulkevat suojatussa yhteydessä. Klikkaa alla olevasta painikkeesta tunnistautuaksesi."
-  }
+  },
+  "select": "Valitse"
 }

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -79,7 +79,7 @@
   },
   "menuToggleAriaLabel": "Menu",
   "errorPage": {
-    "title": "Palvelussa on valitettavsti tapahtunut virhe",
+    "title": "Palvelussa on valitettavasti tapahtunut virhe",
     "message": "Yritämme todennäköisesti jo parhaillaan korjata ongelmaa. Yritä myöhemmin uudelleen.",
     "home": "Palaa etusivulle",
     "logout": "Kirjaudu ulos"

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -431,5 +431,6 @@
       "logoutInfoContent": "Du har nu loggats ut. Om du vill fortsätta använda tjänsten, logga in på nytt genom att klicka på knappen nedan.",
       "infoContent": "Du bör identifiera dig för att kunna avancera till tjänsten. Du kan själv välja det identifieringssätt du vill använda. Identifieringsuppgifterna rör sig i en säker anslutning. Klicka på nedanstående knapp för att identifiera dig. "
     }
-  }
+  },
+  "select": "Valitse"
 }

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
@@ -58,7 +58,7 @@ const useSalaryBenefitCalculatorData = (
   );
 
   const { calculateSalaryBenefit, calculationsErrors } =
-    useHandlerReviewActions(application);
+    useHandlerReviewActions(application, isManualCalculator);
 
   const [newTrainingCompensation, setNewTrainingCompensation] =
     useState<TrainingCompensation>({

--- a/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
+++ b/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
@@ -27,7 +27,8 @@ interface HandlerReviewActions {
 }
 
 const useHandlerReviewActions = (
-  application: Application
+  application: Application,
+  isManualCalculator?: boolean
 ): HandlerReviewActions => {
   const updateApplicationQuery = useUpdateApplicationQuery();
   const [calculationsErrors, setCalculationErrors] = useState<
@@ -112,12 +113,14 @@ const useHandlerReviewActions = (
       ? values.overrideMonthlyBenefitAmountComment
       : '';
 
-    const paySubsidies = values.paySubsidies?.map((item) => ({
-      ...item,
-      workTimePercent: stringToFloatValue(item.workTimePercent),
-      startDate: convertToBackendDateFormat(item.startDate),
-      endDate: convertToBackendDateFormat(item.endDate),
-    }));
+    const paySubsidies = isManualCalculator
+      ? []
+      : values.paySubsidies?.map((item) => ({
+          ...item,
+          workTimePercent: stringToFloatValue(item.workTimePercent),
+          startDate: convertToBackendDateFormat(item.startDate),
+          endDate: convertToBackendDateFormat(item.endDate),
+        }));
 
     const trainingCompensations = values.trainingCompensations?.map((item) => ({
       ...item,
@@ -134,24 +137,40 @@ const useHandlerReviewActions = (
       overrideMonthlyBenefitAmount,
     } = values;
 
+    const emptyCalculation = {
+      ...application.calculation,
+      start_date: null,
+      end_date: null,
+      state_aid_max_percentage: null,
+      granted_as_de_minimis_aid: false,
+      target_group_check: false,
+      calculated_benefit_amount: null,
+      override_monthly_benefit_amount: null,
+      override_monthly_benefit_amount_comment: '',
+      rows: [],
+      handler_details: null,
+      duration_in_months_rounded: null,
+    };
+
     return snakecaseKeys(
       {
         ...application,
-        calculation: application.calculation
-          ? {
-              ...application.calculation,
-              startDate,
-              endDate,
-              monthlyPay: stringToFloatValue(monthlyPay),
-              otherExpenses: stringToFloatValue(otherExpenses),
-              vacationMoney: stringToFloatValue(vacationMoney),
-              overrideMonthlyBenefitAmount: stringToFloatValue(
-                overrideMonthlyBenefitAmount
-              ),
-              stateAidMaxPercentage,
-              overrideMonthlyBenefitAmountComment,
-            }
-          : undefined,
+        calculation:
+          application.calculation && isManualCalculator
+            ? {
+                ...application.calculation,
+                startDate,
+                endDate,
+                monthlyPay: stringToFloatValue(monthlyPay),
+                otherExpenses: stringToFloatValue(otherExpenses),
+                vacationMoney: stringToFloatValue(vacationMoney),
+                overrideMonthlyBenefitAmount: stringToFloatValue(
+                  overrideMonthlyBenefitAmount
+                ),
+                stateAidMaxPercentage,
+                overrideMonthlyBenefitAmountComment,
+              }
+            : emptyCalculation,
         paySubsidies,
         trainingCompensations,
       },


### PR DESCRIPTION
## Description :sparkles:
HL-553: Error in manual calculator. Backend validation fails when both calculation abject and paysubsidies objecs are sent to backend. Let's strip the either object out before sending application.  Which one is stripped depends on manual calculation checkbox value.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
