### PR TITLE
HL-566 | Force pytest settings

### DIFF
--- a/backend/benefit/applications/tests/test_application_batch_api.py
+++ b/backend/benefit/applications/tests/test_application_batch_api.py
@@ -8,7 +8,6 @@ import pytest
 import pytz
 from django.conf import settings
 from django.http import StreamingHttpResponse
-from django.test import override_settings
 from rest_framework.reverse import reverse
 
 from applications.api.v1.serializers import ApplicationBatchSerializer
@@ -23,13 +22,11 @@ def get_batch_detail_url(application_batch):
     return reverse("v1:applicationbatch-detail", kwargs={"pk": application_batch.id})
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_get_application_batch_unauthenticated(anonymous_client, application_batch):
     response = anonymous_client.get(get_batch_detail_url(application_batch))
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_get_application_batch_as_applicant(api_client, application_batch):
     response = api_client.get(get_batch_detail_url(application_batch))
     assert response.status_code == 403

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -64,7 +64,6 @@ def get_handler_detail_url(application):
     return reverse("v1:handler-application-detail", kwargs={"pk": application.id})
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "view_name",
     [
@@ -86,7 +85,6 @@ def test_applications_unauthenticated(anonymous_client, application, view_name):
     assert audit_event["target"]["type"] == "Application"
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "view_name",
     [
@@ -221,7 +219,6 @@ def test_applications_simple_list_filter(
     assert response.status_code == 200
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize("url_func", [get_detail_url, get_handler_detail_url])
 def test_application_single_read_unauthenticated(
     anonymous_client, application, url_func
@@ -230,7 +227,6 @@ def test_application_single_read_unauthenticated(
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_application_single_read_unauthorized(
     api_client, anonymous_application, mock_get_organisation_roles_and_create_company
 ):
@@ -314,7 +310,6 @@ def test_application_template(api_client):
     )  # as of 2021-06-16, just a dummy implementation exists
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_application_post_success_unauthenticated(anonymous_client, application):
     data = ApplicantApplicationSerializer(application).data
     application.delete()
@@ -525,7 +520,6 @@ def test_application_post_invalid_employee_data(api_client, application):
     )  # Check if the error still there
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_application_put_edit_fields_unauthenticated(anonymous_client, application):
     data = ApplicantApplicationSerializer(application).data
     data["company_contact_person_phone_number"] = "+358505658789"
@@ -536,7 +530,6 @@ def test_application_put_edit_fields_unauthenticated(anonymous_client, applicati
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_application_put_edit_fields_unauthorized(
     api_client, anonymous_application, mock_get_organisation_roles_and_create_company
 ):
@@ -869,14 +862,12 @@ def test_association_immediate_manager_check_valid(api_client, association_appli
     assert response.status_code == 200
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.django_db
 def test_application_delete_unauthenticated(anonymous_client, application):
     response = anonymous_client.delete(get_detail_url(application))
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.django_db
 def test_application_delete_unauthorized(
     api_client, anonymous_application, mock_get_organisation_roles_and_create_company
@@ -1400,7 +1391,6 @@ def test_application_last_modified_at_draft(api_client, application):
     assert data["last_modified_at"] == datetime(2021, 6, 4, tzinfo=pytz.UTC)
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "status",
     [
@@ -1572,7 +1562,6 @@ def _add_pdf_attachment(
         return attachment
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.django_db
 def test_attachment_delete_unauthenticated(request, anonymous_client, application):
     attachment = _add_pdf_attachment(request, application)
@@ -1586,7 +1575,6 @@ def test_attachment_delete_unauthenticated(request, anonymous_client, applicatio
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.django_db
 def test_attachment_delete_unauthorized(
     request,
@@ -1605,7 +1593,6 @@ def test_attachment_delete_unauthorized(
     assert response.status_code == 404
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "status,expected_code",
     [
@@ -1637,7 +1624,6 @@ def test_attachment_delete(request, api_client, application, status, expected_co
         assert application.attachments.count() == 1
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "status,upload_result",
     [
@@ -1673,7 +1659,6 @@ def test_pdf_attachment_upload_and_download_as_applicant(
     assert bytes[:4].decode("utf-8") == "%PDF"
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "status,upload_result",
     [
@@ -1707,7 +1692,6 @@ def test_pdf_attachment_upload_and_download_as_handler(
     assert file_dl.status_code == 200
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.django_db
 def test_attachment_download_unauthenticated(request, anonymous_client, application):
     attachment = _add_pdf_attachment(request, application)
@@ -1721,7 +1705,6 @@ def test_attachment_download_unauthenticated(request, anonymous_client, applicat
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.django_db
 def test_attachment_download_unauthorized(
     request,
@@ -1740,7 +1723,6 @@ def test_attachment_download_unauthorized(
     assert response.status_code == 404
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "status",
     [
@@ -1986,7 +1968,6 @@ def test_application_number(api_client, application):
     assert next_application.application_number == application.application_number + 2
 
 
-@override_settings(DISABLE_TOS_APPROVAL_CHECK=False, NEXT_PUBLIC_MOCK_FLAG=False)
 def test_application_api_before_accept_tos(api_client, application):
     # Clear user TOS approval
     TermsOfServiceApproval.objects.all().delete()

--- a/backend/benefit/calculator/tests/test_previous_benefits_api.py
+++ b/backend/benefit/calculator/tests/test_previous_benefits_api.py
@@ -1,6 +1,5 @@
 import decimal
 
-from django.test import override_settings
 from rest_framework.reverse import reverse
 
 from applications.tests.conftest import *  # noqa
@@ -13,13 +12,11 @@ def get_previous_benefits_detail_url(previous_benefit):
     return reverse("v1:previousbenefit-detail", kwargs={"pk": previous_benefit.id})
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_get_previous_benefit_unauthenticated(anonymous_client, previous_benefit):
     response = anonymous_client.get(get_previous_benefits_detail_url(previous_benefit))
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_get_previous_benefit_applicant(api_client, previous_benefit):
     response = api_client.get(get_previous_benefits_detail_url(previous_benefit))
     assert response.status_code == 403
@@ -44,13 +41,11 @@ def test_previous_benefits_list(handler_api_client, previous_benefit):
     assert response.status_code == 200
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_previous_benefits_list_as_applicant(api_client, previous_benefit):
     response = api_client.get(reverse("v1:previousbenefit-list"))
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_previous_benefits_list_unauthenticated(anonymous_client, previous_benefit):
     response = anonymous_client.get(reverse("v1:previousbenefit-list"))
     assert response.status_code == 403
@@ -81,7 +76,6 @@ def test_create_previous_benefit(handler_api_client, previous_benefit):
     assert response.status_code == 201
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_create_previous_benefit_unauthenticated(anonymous_client, previous_benefit):
     data = PreviousBenefitSerializer(previous_benefit).data
     previous_benefit.delete()
@@ -94,7 +88,6 @@ def test_create_previous_benefit_unauthenticated(anonymous_client, previous_bene
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_create_previous_benefit_as_applicant(api_client, previous_benefit):
     data = PreviousBenefitSerializer(previous_benefit).data
     previous_benefit.delete()
@@ -107,7 +100,6 @@ def test_create_previous_benefit_as_applicant(api_client, previous_benefit):
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_previous_benefit_put_as_applicant(api_client, previous_benefit):
     data = PreviousBenefitSerializer(previous_benefit).data
     data["monthly_amount"] = "1234.56"
@@ -118,7 +110,6 @@ def test_previous_benefit_put_as_applicant(api_client, previous_benefit):
     assert response.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_previous_benefit_put_unauthenticated(anonymous_client, previous_benefit):
     data = PreviousBenefitSerializer(previous_benefit).data
     data["monthly_amount"] = "1234.56"
@@ -157,7 +148,6 @@ def test_previous_benefit_delete(handler_api_client, previous_benefit):
     assert PreviousBenefit.objects.all().count() == 0
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_previous_benefit_delete_unauthenticated(anonymous_client, previous_benefit):
     """
     modify existing previous_benefit
@@ -169,7 +159,6 @@ def test_previous_benefit_delete_unauthenticated(anonymous_client, previous_bene
     assert PreviousBenefit.objects.all().count() == 1
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_previous_benefit_delete_as_applicant(api_client, previous_benefit):
     """
     modify existing previous_benefit

--- a/backend/benefit/common/tests/conftest.py
+++ b/backend/benefit/common/tests/conftest.py
@@ -18,6 +18,11 @@ def _api_client():
 
 @pytest.fixture(autouse=True)
 def setup_test_environment(settings):
+    settings.MAILER_EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+    settings.DEFAULT_FROM_EMAIL = "noreply@foo.bar"
+    settings.LANGUAGE_CODE = "fi"
+    settings.DISABLE_TOS_APPROVAL_CHECK = False
+    settings.NEXT_PUBLIC_MOCK_FLAG = False
     factory.random.reseed_random("777")
     DetectorFactory.seed = 0
     random.seed(777)

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -34,7 +34,6 @@ def set_up_ytj_mock_requests(
     requests_mock.get(business_details_url, json=business_details_response)
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.django_db
 def test_get_company_unauthenticated(anonymous_client):
     response = anonymous_client.get(get_company_api_url())
@@ -67,7 +66,6 @@ def test_get_mock_company_results_in_error(
 
 
 @pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_get_company_from_service_bus_invalid_response(
     api_client, requests_mock, mock_get_organisation_roles_and_create_company
 ):
@@ -85,7 +83,6 @@ def test_get_company_from_service_bus_invalid_response(
 
 
 @pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_get_organisation_from_service_bus(
     api_client,
     bf_user,
@@ -112,7 +109,6 @@ def test_get_organisation_from_service_bus(
 
 
 @pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_get_organisation_from_service_bus_missing_business_line(
     api_client,
     bf_user,
@@ -141,7 +137,6 @@ def test_get_organisation_from_service_bus_missing_business_line(
 
 
 @pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_get_company_from_yrtti(
     api_client,
     bf_user,
@@ -177,7 +172,6 @@ def test_get_company_from_yrtti(
 
 
 @pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False, DISABLE_TOS_APPROVAL_CHECK=False)
 def test_get_company_from_service_bus_and_yrtti_results_in_error(
     api_client, requests_mock, mock_get_organisation_roles_and_create_company
 ):
@@ -192,7 +186,6 @@ def test_get_company_from_service_bus_and_yrtti_results_in_error(
 
 
 @pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_get_company_from_service_bus_and_yrtti_with_fallback_data(
     api_client, requests_mock, mock_get_organisation_roles_and_create_company
 ):

--- a/backend/benefit/helsinkibenefit/tests/conftest.py
+++ b/backend/benefit/helsinkibenefit/tests/conftest.py
@@ -16,10 +16,3 @@ def django_db_setup(django_db_setup, django_db_blocker):
 @pytest.fixture(scope="session")
 def django_db_modify_db_settings():
     pass
-
-
-@pytest.fixture(autouse=True)
-def force_settings(settings):
-    settings.MAILER_EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
-    settings.DEFAULT_FROM_EMAIL = "noreply@foo.bar"
-    settings.LANGUAGE_CODE = "fi"

--- a/backend/benefit/messages/tests/test_api.py
+++ b/backend/benefit/messages/tests/test_api.py
@@ -27,7 +27,6 @@ SAMPLE_MESSAGE_PAYLOAD = {
 }
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "view_name",
     [
@@ -45,7 +44,6 @@ def test_list_message_unauthenticated(
     assert result.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "view_name",
     [
@@ -137,7 +135,6 @@ def test_list_notes(handler_api_client, handling_application):
     assert len(result.data) == 2
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "view_name",
     [
@@ -156,7 +153,6 @@ def test_create_message_unauthenticated(
     assert result.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "view_name",
     [
@@ -181,7 +177,6 @@ def test_create_message_unauthorized(api_client, handling_application, view_name
     assert result.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_create_applicant_message_invalid(
     api_client, application, mock_get_organisation_roles_and_create_company
 ):
@@ -224,7 +219,6 @@ def test_create_applicant_message_invalid(
     )
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_create_handler_message_invalid(handler_api_client, handling_application):
     msg = deepcopy(SAMPLE_MESSAGE_PAYLOAD)
     msg["message_type"] = MessageType.APPLICANT_MESSAGE
@@ -241,7 +235,6 @@ def test_create_handler_message_invalid(handler_api_client, handling_application
     )
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "status,expected_result",
     [
@@ -339,7 +332,6 @@ def test_create_message(
     assert message_qs.first().sender.id == user.id
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "view_name",
     [
@@ -365,7 +357,6 @@ def test_update_message_unauthenticated(
     assert result.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "view_name,msg_type",
     [
@@ -406,7 +397,6 @@ def test_update_message_unauthorized(
         assert result.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_update_message_not_allowed(
     api_client,
     handler_api_client,
@@ -431,7 +421,6 @@ def test_update_message_not_allowed(
     assert result.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "view_name",
     [
@@ -453,7 +442,6 @@ def test_delete_message_unauthenticated(
     assert result.status_code == 403
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.parametrize(
     "view_name",
     [
@@ -520,7 +508,6 @@ def test_delete_message(
     assert Message.objects.count() == 0
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_applications_list_with_message_count(
     api_client, handling_application, handler_api_client
 ):
@@ -602,7 +589,6 @@ def test_list_messages_read_receipt(
         assert Message.objects.filter(seen_by_handler=True).count() == 2
 
 
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_applications_list_with_message_count_multiple_messages(
     api_client, handling_application, handler_api_client
 ):

--- a/backend/benefit/pyproject.toml
+++ b/backend/benefit/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+extend-exclude = '''
+(
+  .pytest_cache
+  | var/media
+)
+'''

--- a/backend/benefit/setup.cfg
+++ b/backend/benefit/setup.cfg
@@ -1,10 +1,13 @@
 [pep8]
 max-line-length = 120
-exclude = *migrations*
+exclude =
+  *migrations*
+  .pytest_cache
+  var/media
 ignore = E309
 
 [flake8]
-exclude = migrations,snapshots
+exclude = migrations,snapshots,.pytest_cache,var/media
 max-line-length = 120
 max-complexity = 10
 # E203 and W503 are disabled and W504 enabled for compatibility with Black.
@@ -14,7 +17,7 @@ ignore = E203, W503
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = helsinkibenefit.settings
-norecursedirs = node_modules .git venv*
+norecursedirs = node_modules .git venv* .pytest_cache var/media
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE
 
 [coverage:run]
@@ -30,7 +33,7 @@ indent=4
 length_sort=false
 multi_line_output=3
 order_by_type=false
-skip=migrations,venv
+skip=migrations,venv,.pytest_cache,var/media
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True

--- a/backend/benefit/terms/tests/test_terms_of_service_api.py
+++ b/backend/benefit/terms/tests/test_terms_of_service_api.py
@@ -2,7 +2,6 @@ from datetime import date, timedelta
 
 import pytest
 from django.conf import settings
-from django.test import override_settings
 from django.urls import reverse
 
 from common.tests.conftest import *  # noqa
@@ -184,7 +183,6 @@ def test_approve_terms_too_many_consents(
     )
 
 
-@override_settings(DISABLE_TOS_APPROVAL_CHECK=False, NEXT_PUBLIC_MOCK_FLAG=False)
 def test_validate_tos_approval_by_session(
     api_client,
     terms_of_service,


### PR DESCRIPTION
## Description :sparkles:

### HL-Backend: Force settings for pytest runs 

Combine force_settings and setup_test_environment autouse fixtures into
the latter and add following settings to it:
 - settings.DISABLE_TOS_APPROVAL_CHECK = False
 - settings.NEXT_PUBLIC_MOCK_FLAG = False

Remove all now unnecessary uses of:
 - @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 - @override_settings(DISABLE_TOS_APPROVAL_CHECK=False)

Refs HL-566
 
### HL-Backend: Add black/coverage/flake8/pep8/pytest excludes 

Add pyproject.toml to configure black because black AFAIK can not be
configured using setup.cfg at the moment.

Exclude the following directories in black/coverage/flake8/pep8/pytest:
 - .pytest_cache
 - var/media

This speeds up
 - "black . && isort . && flake8" from minutes to ~10 seconds
 - "pytest . --collect-only" from minutes to ~6 seconds
in Docker on Windows 10 using Docker Desktop and WSL 2. I saw around
100k files in /app/var/media (i.e. the MEDIA_ROOT directory) at one
point locally when testing so excluding a directory with that many files
helps.

Refs HL-566

## Issues :bug:

HL-566

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
