### PR TITLE
HL-553, HL-566 | Update mock flag related permission handling & fix moving application to handling

### DIFF
--- a/backend/benefit/applications/api/v1/views.py
+++ b/backend/benefit/applications/api/v1/views.py
@@ -108,9 +108,9 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
 
     def get_queryset(self) -> QuerySet[Application]:
         user = self.request.user
-        if not settings.NEXT_PUBLIC_MOCK_FLAG and not user.is_authenticated:
-            return Application.objects.none()
-        return Application.objects.all().select_related("company", "employee")
+        if settings.NEXT_PUBLIC_MOCK_FLAG or user.is_authenticated:
+            return Application.objects.all().select_related("company", "employee")
+        return Application.objects.none()
 
     EXCLUDE_FIELDS_FROM_SIMPLE_LIST = [
         "applicant_terms_approval",

--- a/backend/benefit/applications/enums.py
+++ b/backend/benefit/applications/enums.py
@@ -17,7 +17,9 @@ class ApplicationStatus(models.TextChoices):
     @classmethod
     def is_editable_status(cls, user, status):
         if settings.NEXT_PUBLIC_MOCK_FLAG:
-            return True
+            return cls.is_handler_editable_status(
+                status, None
+            ) or cls.is_applicant_editable_status(status)
         elif not user.is_authenticated:
             return False
         elif user.is_handler():

--- a/backend/benefit/applications/tests/test_application_status.py
+++ b/backend/benefit/applications/tests/test_application_status.py
@@ -10,7 +10,13 @@ def test_is_editable_status_with_anonymous_user(
     settings, next_public_mock_flag: bool, status: str
 ):
     settings.NEXT_PUBLIC_MOCK_FLAG = next_public_mock_flag
-    assert (
-        ApplicationStatus(status).is_editable_status(AnonymousUser(), status)
-        == next_public_mock_flag
+    is_editable_status = ApplicationStatus(status).is_editable_status(
+        AnonymousUser(), status
     )
+    if next_public_mock_flag:
+        assert is_editable_status == (
+            ApplicationStatus.is_handler_editable_status(status)
+            or ApplicationStatus.is_applicant_editable_status(status)
+        )
+    else:
+        assert not is_editable_status

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -1136,6 +1136,7 @@ def test_application_status_change_as_applicant(
     "from_status,to_status,expected_code",
     [
         (ApplicationStatus.DRAFT, ApplicationStatus.RECEIVED, 404),
+        (ApplicationStatus.RECEIVED, ApplicationStatus.HANDLING, 200),
         (
             ApplicationStatus.HANDLING,
             ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED,

--- a/backend/benefit/locale/en/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-31 13:26+0300\n"
+"POT-Creation-Date: 2022-11-01 10:42+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,832 +18,628 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applications/api/v1/application_batch_views.py:78
 msgid "Application status cannot be exported because of invalid status"
 msgstr ""
 
-#: applications/api/v1/application_batch_views.py:86
 msgid "Cannot export empty batch"
 msgstr ""
 
-#: applications/api/v1/application_batch_views.py:92
 #, python-brace-format
 msgid "Application batch {date}"
 msgstr ""
 
-#: applications/api/v1/application_batch_views.py:120
 msgid "There is no available application to export, please try again later"
 msgstr ""
 
-#: applications/api/v1/application_batch_views.py:128
 #, python-brace-format
 msgid "TALPA export {date}"
 msgstr ""
 
-#: applications/api/v1/serializers.py:151
 #, python-brace-format
 msgid "Upload file size cannot be greater than {size} bytes"
 msgstr ""
 
-#: applications/api/v1/serializers.py:160
 msgid "Too many attachments"
 msgstr ""
 
-#: applications/api/v1/serializers.py:163
 msgid "Not a valid pdf file"
 msgstr ""
 
-#: applications/api/v1/serializers.py:167
 msgid "Not a valid image file"
 msgstr ""
 
-#: applications/api/v1/serializers.py:209
 msgid "Grant date too much in past"
 msgstr ""
 
-#: applications/api/v1/serializers.py:211
 msgid "Grant date can not be in the future"
 msgstr ""
 
-#: applications/api/v1/serializers.py:312
 msgid "Social security number invalid"
 msgstr ""
 
-#: applications/api/v1/serializers.py:319
 msgid "Social security number checksum invalid"
 msgstr ""
 
-#: applications/api/v1/serializers.py:328
 #, python-brace-format
 msgid "Working hour must be greater than {min_hour} per week"
 msgstr ""
 
-#: applications/api/v1/serializers.py:336
 msgid "Monthly pay must be greater than 0"
 msgstr ""
 
-#: applications/api/v1/serializers.py:342
 msgid "Vacation money must be a positive number"
 msgstr ""
 
-#: applications/api/v1/serializers.py:349
 msgid "Other expenses must be a positive number"
 msgstr ""
 
-#: applications/api/v1/serializers.py:441
 msgid "Applications in a batch can not be changed when batch is in this status"
 msgstr ""
 
-#: applications/api/v1/serializers.py:453
 msgid "This application has invalid status and can not be added to this batch"
 msgstr ""
 
-#: applications/api/v1/serializers.py:929
 msgid "This should be unreachable"
 msgstr ""
 
-#: applications/api/v1/serializers.py:949
 msgid "Invalid value for association_immediate_manager_check"
 msgstr ""
 
-#: applications/api/v1/serializers.py:957
 msgid "for companies, association_immediate_manager_check must always be null"
 msgstr ""
 
-#: applications/api/v1/serializers.py:985
 msgid ""
 "This application has non-null de_minimis_aid but is applied by an association"
 msgstr ""
 
-#: applications/api/v1/serializers.py:994
 msgid "This application has de_minimis_aid set but does not define any"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1003
 msgid "This application can not have de minimis aid"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1011
 msgid "Total amount of de minimis aid too large"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1017
 msgid "start_date must not be in a past year"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1021
 msgid "end_date must not be in a past year"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1032
 msgid "application end_date can not be less than start_date"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1046
 msgid "minimum duration of the benefit is one month"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1053
 msgid "maximum duration of the benefit is 12 months"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1063
 msgid ""
 "This application can not have a description for co-operation negotiations"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1073
 msgid "Pay subsidy percent required"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1081
 #, python-brace-format
 msgid "This application can not have {key}"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1089
 msgid "This application can not have additional_pay_subsidy_percent"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1140
 msgid "This field is required before submitting the application"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1156
 msgid "This field can be set for associations only"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1193
 msgid "This benefit type can not be selected"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1376
 msgid "Application does not have the employee consent attachment"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1380
 msgid "Application cannot have more than one employee consent attachment"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1387 terms/api/v1/views.py:48
 msgid "Terms must be approved"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1442
 msgid "Application does not have required attachments"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1473
 msgid "Application initial state must be draft"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1513
 #, python-brace-format
 msgid "Reading de minimis data failed: {errors}"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1579
-#: applications/api/v1/serializers.py:1677
 msgid "Application can not be changed in this status"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1640
 msgid "create_application_for_company missing from request"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1703
 msgid "The calculation should be created when the application is submitted"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1708
 msgid "The calculation id does not match existing id"
 msgstr ""
 
-#: applications/api/v1/serializers.py:1759
 #, python-brace-format
 msgid "Reading {localized_model_name} data failed: {errors}"
 msgstr ""
 
-#: applications/api/v1/status_transition_validator.py:23
 #, python-brace-format
 msgid "State transition not allowed: {status} to {value}"
 msgstr ""
 
-#: applications/api/v1/status_transition_validator.py:32
 #, python-brace-format
 msgid "Initial status must be {initial_status}"
 msgstr ""
 
-#: applications/api/v1/views.py:125 applications/api/v1/views.py:162
 msgid "Operation not allowed for this application status."
 msgstr ""
 
-#: applications/api/v1/views.py:149
 msgid "File not found."
 msgstr ""
 
-#: applications/api/v1/views.py:326
 #, python-brace-format
 msgid "Helsinki-lisän hakemukset viety {date}"
 msgstr ""
 
-#: applications/benefit_aggregation.py:77
 msgid "Benefit can not be granted before 24-month waiting period expires"
 msgstr ""
 
-#: applications/benefit_aggregation.py:166
-#, python-brace-format
-msgid ""
-"There's already an accepted application or previous benefit with overlapping "
-"date range {start_date} - {end_date}"
+msgid "There's already an accepted application with overlapping date range"
 msgstr ""
 
-#: applications/enums.py:7 applications/enums.py:105
 msgid "Draft"
 msgstr ""
 
-#: applications/enums.py:8
 msgid "Received"
 msgstr ""
 
-#: applications/enums.py:9
 msgid "Handling"
 msgstr ""
 
-#: applications/enums.py:11
 msgid "Additional information requested"
 msgstr ""
 
-#: applications/enums.py:13
 msgid "Cancelled"
 msgstr ""
 
-#: applications/enums.py:14
 msgid "Accepted"
 msgstr ""
 
-#: applications/enums.py:15
 msgid "Rejected"
 msgstr ""
 
-#: applications/enums.py:29 applications/enums.py:52
 msgid "Invalid application status"
 msgstr ""
 
-#: applications/enums.py:31
 msgid "Invalid application status change"
 msgstr ""
 
-#: applications/enums.py:57
 msgid "Employment Benefit"
 msgstr ""
 
-#: applications/enums.py:58
 msgid "Salary Benefit"
 msgstr ""
 
-#: applications/enums.py:59
 msgid "Commission Benefit"
 msgstr ""
 
-#: applications/enums.py:63
 msgid "Step 1 - company details"
 msgstr ""
 
-#: applications/enums.py:64
 msgid "Step 2 - employee details"
 msgstr ""
 
-#: applications/enums.py:65
 msgid "Step 3 - attachments"
 msgstr ""
 
-#: applications/enums.py:66
 msgid "Step 4 - summary"
 msgstr ""
 
-#: applications/enums.py:67
 msgid "Step 5 - power of attorney"
 msgstr ""
 
-#: applications/enums.py:68
 msgid "Step 6 - terms and send"
 msgstr ""
 
-#: applications/enums.py:76
 msgid "Company"
 msgstr ""
 
-#: applications/enums.py:77
 msgid "Association"
 msgstr ""
 
-#: applications/enums.py:89
 msgid "employment contract"
 msgstr ""
 
-#: applications/enums.py:90
 msgid "pay subsidy decision"
 msgstr ""
 
-#: applications/enums.py:91
 msgid "commission contract"
 msgstr ""
 
-#: applications/enums.py:93
 msgid "education contract of the apprenticeship office"
 msgstr ""
 
-#: applications/enums.py:95 applications/enums.py:96
 msgid "helsinki benefit voucher"
 msgstr ""
 
-#: applications/enums.py:100
 msgid "attachment is required"
 msgstr ""
 
-#: applications/enums.py:101
 msgid "attachment is optional"
 msgstr ""
 
-#: applications/enums.py:107
 msgid "Ahjo report created, not yet sent to AHJO"
 msgstr ""
 
-#: applications/enums.py:110
 msgid "Sent to Ahjo, decision pending"
 msgstr ""
 
-#: applications/enums.py:112
 msgid "Accepted in Ahjo"
 msgstr ""
 
-#: applications/enums.py:113
 msgid "Rejected in Ahjo"
 msgstr ""
 
-#: applications/enums.py:115
 msgid "Returned from Ahjo without decision"
 msgstr ""
 
-#: applications/enums.py:117
 msgid "Sent to Talpa"
 msgstr ""
 
-#: applications/enums.py:118
 msgid "Processing is completed"
 msgstr ""
 
-#: applications/models.py:109 calculator/models.py:337 companies/models.py:21
-#: terms/models.py:180
 msgid "company"
 msgstr ""
 
-#: applications/models.py:117
 msgid "status"
 msgstr ""
 
-#: applications/models.py:123
 msgid "application number"
 msgstr ""
 
-#: applications/models.py:126
 msgid "company name"
 msgstr ""
 
-#: applications/models.py:129
 msgid "company form as user-readable text"
 msgstr ""
 
-#: applications/models.py:133 companies/models.py:13
 msgid "YTJ type code for company form"
 msgstr ""
 
-#: applications/models.py:137
 msgid "company department"
 msgstr ""
 
-#: applications/models.py:142 applications/models.py:154
 msgid "company street address"
 msgstr ""
 
-#: applications/models.py:145 applications/models.py:157
 msgid "company city"
 msgstr ""
 
-#: applications/models.py:148 applications/models.py:160
 msgid "company post code"
 msgstr ""
 
-#: applications/models.py:172
 msgid "company bank account number"
 msgstr ""
 
-#: applications/models.py:177 applications/models.py:546
 msgid "first name"
 msgstr ""
 
-#: applications/models.py:180 applications/models.py:549
 msgid "last name"
 msgstr ""
 
-#: applications/models.py:184
 msgid "company contact person's phone number"
 msgstr ""
 
-#: applications/models.py:192
 msgid "company contact person's email"
 msgstr ""
 
-#: applications/models.py:227
 msgid "additional information about the ongoing co-operation negotiations"
 msgstr ""
 
-#: applications/models.py:237 calculator/models.py:233
 msgid "Pay subsidy percent"
 msgstr ""
 
-#: applications/models.py:244
 msgid "Pay subsidy percent for second pay subsidy grant"
 msgstr ""
 
-#: applications/models.py:270 calculator/models.py:91 calculator/models.py:350
 msgid "benefit start from date"
 msgstr ""
 
-#: applications/models.py:273 calculator/models.py:94 calculator/models.py:351
 msgid "benefit end date"
 msgstr ""
 
-#: applications/models.py:301
 msgid "ahjo batch"
 msgstr ""
 
-#: applications/models.py:375 applications/models.py:383
-#: applications/models.py:411 applications/models.py:540
-#: applications/models.py:654 calculator/models.py:220 calculator/models.py:381
-#: messages/models.py:30 terms/models.py:145
 msgid "application"
 msgstr ""
 
-#: applications/models.py:376
 msgid "applications"
 msgstr ""
 
-#: applications/models.py:388
 msgid "granter of the de minimis aid"
 msgstr ""
 
-#: applications/models.py:391
 msgid "amount of the de minimis aid"
 msgstr ""
 
-#: applications/models.py:393
 msgid "benefit granted at"
 msgstr ""
 
-#: applications/models.py:402
 msgid "de minimis aid"
 msgstr ""
 
-#: applications/models.py:403
 msgid "de minimis aids"
 msgstr ""
 
-#: applications/models.py:431
 msgid "application log entry"
 msgstr ""
 
-#: applications/models.py:432
 msgid "application log entries"
 msgstr ""
 
-#: applications/models.py:445
 msgid "status of batch"
 msgstr ""
 
-#: applications/models.py:452
 msgid "proposal for decision"
 msgstr ""
 
-#: applications/models.py:457
 msgid "decision maker's title in Ahjo"
 msgstr ""
 
-#: applications/models.py:460
 msgid "decision maker's name in Ahjo"
 msgstr ""
 
-#: applications/models.py:463
 msgid "section of the law in Ahjo decision"
 msgstr ""
 
-#: applications/models.py:466
 msgid "date of the decision in Ahjo"
 msgstr ""
 
-#: applications/models.py:469
 msgid "Expert inspector's name"
 msgstr ""
 
-#: applications/models.py:472
 msgid "Expert inspector's email address"
 msgstr ""
 
-#: applications/models.py:512
 msgid "application batch"
 msgstr ""
 
-#: applications/models.py:513
 msgid "application batches"
 msgstr ""
 
-#: applications/models.py:533
 msgid "application basis"
 msgstr ""
 
-#: applications/models.py:534
 msgid "application bases"
 msgstr ""
 
-#: applications/models.py:553 calculator/models.py:347
 msgid "social security number"
 msgstr ""
 
-#: applications/models.py:561
 msgid "phone number"
 msgstr ""
 
-#: applications/models.py:568
 msgid "email"
 msgstr ""
 
-#: applications/models.py:578
 msgid "job title"
 msgstr ""
 
-#: applications/models.py:581 calculator/models.py:73
 msgid "monthly pay"
 msgstr ""
 
-#: applications/models.py:588 calculator/models.py:80
 msgid "vacation money"
 msgstr ""
 
-#: applications/models.py:596 calculator/models.py:86
 msgid "other expenses"
 msgstr ""
 
-#: applications/models.py:603
 msgid "working hour"
 msgstr ""
 
-#: applications/models.py:610
 msgid "collective bargaining agreement"
 msgstr ""
 
-#: applications/models.py:613
 msgid "is living in helsinki"
 msgstr ""
 
-#: applications/models.py:617
 msgid "amount of the commission (eur)"
 msgstr ""
 
-#: applications/models.py:626
 msgid "Description of the commission"
 msgstr ""
 
-#: applications/models.py:643
 msgid "employee"
 msgstr ""
 
-#: applications/models.py:644
 msgid "employees"
 msgstr ""
 
-#: applications/models.py:660
 msgid "attachment type in business rules"
 msgstr ""
 
-#: applications/models.py:666
 msgid "technical content type of the attachment"
 msgstr ""
 
-#: applications/models.py:668
 msgid "application attachment content"
 msgstr ""
 
-#: applications/models.py:672
 msgid "attachment"
 msgstr ""
 
-#: applications/models.py:673
 msgid "attachments"
 msgstr ""
 
-#: calculator/api/v1/serializers.py:76
 msgid "Date range too large"
 msgstr ""
 
-#: calculator/api/v1/serializers.py:89
 msgid "This calculation can not have a override_monthly_benefit_amount_comment"
 msgstr ""
 
-#: calculator/api/v1/serializers.py:100
 msgid "This calculation needs override_monthly_benefit_amount_comment"
 msgstr ""
 
-#: calculator/api/v1/serializers.py:122
 msgid "Handler can not be unassigned in this status"
 msgstr ""
 
-#: calculator/api/v1/serializers.py:130
 msgid "Handler can not assigned in this status"
 msgstr ""
 
-#: calculator/enums.py:6
+msgid "Start date cannot be empty"
+msgstr ""
+
+msgid "End date cannot be empty"
+msgstr ""
+
 msgid "Description row, amount ignored"
 msgstr ""
 
-#: calculator/enums.py:7
 msgid "Salary costs"
 msgstr ""
 
-#: calculator/enums.py:8 calculator/models.py:97
 msgid "State aid maximum %"
 msgstr ""
 
-#: calculator/enums.py:9
 msgid "Pay subsidy/month"
 msgstr ""
 
-#: calculator/enums.py:11
 msgid "Helsinki benefit amount monthly"
 msgstr ""
 
-#: calculator/enums.py:14
 msgid "Helsinki benefit amount for a date range"
 msgstr ""
 
-#: calculator/enums.py:17
 msgid "Helsinki benefit total amount"
 msgstr ""
 
-#: calculator/enums.py:20
 msgid "Training compensation amount monthly"
 msgstr ""
 
-#: calculator/enums.py:23
 msgid "Total amount of deductions monthly"
 msgstr ""
 
-#: calculator/models.py:34
 msgid "Calculation already exists"
 msgstr ""
 
-#: calculator/models.py:57
 msgid "handler"
 msgstr ""
 
-#: calculator/models.py:68 calculator/models.py:206 calculator/models.py:426
 msgid "calculation"
 msgstr ""
 
-#: calculator/models.py:107
 msgid "amount of the benefit granted, calculated by the system"
 msgstr ""
 
-#: calculator/models.py:115
 msgid ""
 "monthly amount of the benefit manually entered by the application handler"
 msgstr ""
 
-#: calculator/models.py:126
 msgid "reason for overriding the calculated benefit amount"
 msgstr ""
 
-#: calculator/models.py:174
 msgid "Incomplete application"
 msgstr ""
 
-#: calculator/models.py:207
 msgid "calculations"
 msgstr ""
 
-#: calculator/models.py:227 calculator/models.py:387
 msgid "Pay subsidy start date"
 msgstr ""
 
-#: calculator/models.py:230 calculator/models.py:388
 msgid "Pay subsidy end date"
 msgstr ""
 
-#: calculator/models.py:239
 msgid "Work time percent"
 msgstr ""
 
-#: calculator/models.py:324
 msgid "pay subsidy"
 msgstr ""
 
-#: calculator/models.py:325
 msgid "pay subsidies"
 msgstr ""
 
-#: calculator/models.py:343
 msgid "encrypted social security number"
 msgstr ""
 
-#: calculator/models.py:355
 msgid "monthly amount of the previous benefit"
 msgstr ""
 
-#: calculator/models.py:360
 msgid "total amount of the previous benefit"
 msgstr ""
 
-#: calculator/models.py:370
 msgid "Previously granted benefit"
 msgstr ""
 
-#: calculator/models.py:371
 msgid "Previously granted benefits"
 msgstr ""
 
-#: calculator/models.py:390
 msgid "Monthly amount of compensation"
 msgstr ""
 
-#: calculator/models.py:402
 msgid "training compensation"
 msgstr ""
 
-#: calculator/models.py:403
 msgid "training compensations"
 msgstr ""
 
-#: calculator/models.py:436
 msgid "Description of the row to be shown in handler UI"
 msgstr ""
 
-#: calculator/models.py:439
 msgid "row amount"
 msgstr ""
 
-#: calculator/models.py:441
 msgid "Start date"
 msgstr ""
 
-#: calculator/models.py:442
 msgid "End date"
 msgstr ""
 
-#: calculator/models.py:471
 msgid "calculation row"
 msgstr ""
 
-#: calculator/models.py:472
 msgid "calculation rows"
 msgstr ""
 
-#: common/iban_field.py:14
 msgid "Invalid IBAN"
 msgstr ""
 
-#: common/permissions.py:37
 msgid "You have to accept Terms of Service before doing any action"
 msgstr ""
 
-#: common/permissions.py:56
 msgid "Company information is not available"
 msgstr ""
 
-#: companies/models.py:10
 msgid "bank account number"
 msgstr ""
 
-#: companies/models.py:22
 msgid "companies"
 msgstr ""
 
-#: helsinkibenefit/settings.py:162
 msgid "Finnish"
 msgstr ""
 
-#: helsinkibenefit/settings.py:162
 msgid "English"
 msgstr ""
 
-#: helsinkibenefit/settings.py:162
 msgid "Swedish"
 msgstr ""
 
-#: messages/admin.py:13
 msgid "Application number"
 msgstr ""
 
-#: messages/automatic_messages.py:7
 #, python-brace-format
 msgid ""
 "Your application has been opened for editing. Please make the corrections by "
@@ -851,11 +647,9 @@ msgid ""
 "processed."
 msgstr ""
 
-#: messages/automatic_messages.py:44
 msgid "You have received a new message from Helsinki benefit"
 msgstr ""
 
-#: messages/automatic_messages.py:55
 #, python-format
 msgid ""
 "A new message has been added to the Helsinki-benefit application "
@@ -863,167 +657,123 @@ msgid ""
 "the message."
 msgstr ""
 
-#: messages/models.py:16
 msgid "Note"
 msgstr ""
 
-#: messages/models.py:17
 msgid "Handler's message"
 msgstr ""
 
-#: messages/models.py:18
 msgid "Applicant's message"
 msgstr ""
 
-#: messages/models.py:22
 msgid "content"
 msgstr ""
 
-#: messages/models.py:24
 msgid "sender"
 msgstr ""
 
-#: messages/models.py:33
 msgid "message type"
 msgstr ""
 
-#: messages/models.py:36 messages/models.py:39
 msgid "read by applicant"
 msgstr ""
 
-#: messages/models.py:46
 msgid "message"
 msgstr ""
 
-#: messages/models.py:47
 msgid "messages"
 msgstr ""
 
-#: messages/permissions.py:9
 msgid "You don't have permission to change this message"
 msgstr ""
 
-#: messages/serializers.py:39 messages/views.py:41
 msgid "Application not found"
 msgstr ""
 
-#: messages/serializers.py:44
 msgid "You are not allowed to do this action"
 msgstr ""
 
-#: messages/serializers.py:49
 msgid "Cannot do this action because application is not in the correct status"
 msgstr ""
 
-#: messages/serializers.py:55
 msgid "Applicant is not allowed to do this action"
 msgstr ""
 
-#: messages/serializers.py:62
-msgid "Applicant can send messages only after handler has sent a message first"
-msgstr ""
-
-#: messages/serializers.py:68
 msgid "Handler is not allowed to do this action"
 msgstr ""
 
-#: terms/api/v1/serializers.py:87
 msgid "Only the terms currently in effect can be approved"
 msgstr ""
 
-#: terms/api/v1/serializers.py:96
 msgid ""
 "User must explicitly select all the applicant consents required by the terms"
 msgstr ""
 
-#: terms/api/v1/views.py:42
 msgid "The user has no company, terms of service can not be accepted"
 msgstr ""
 
-#: terms/api/v1/views.py:66
 msgid "The terms of service should only be approved once"
 msgstr ""
 
-#: terms/enums.py:6
 msgid "Terms of service - shown at login"
 msgstr ""
 
-#: terms/enums.py:8
 msgid "Terms of application - show at application submit"
 msgstr ""
 
-#: terms/models.py:31
 msgid "type of terms"
 msgstr ""
 
-#: terms/models.py:40
 msgid "first day these terms are in effect"
 msgstr ""
 
-#: terms/models.py:43
 msgid "finnish terms (pdf file)"
 msgstr ""
 
-#: terms/models.py:44
 msgid "english terms (pdf file)"
 msgstr ""
 
-#: terms/models.py:45
 msgid "swedish terms (pdf file)"
 msgstr ""
 
-#: terms/models.py:58 terms/models.py:59 terms/models.py:71 terms/models.py:126
 msgid "terms"
 msgstr ""
 
-#: terms/models.py:76
 msgid "finnish text for the consent checkbox"
 msgstr ""
 
-#: terms/models.py:79
 msgid "english text for the consent checkbox"
 msgstr ""
 
-#: terms/models.py:82
 msgid "swedish text for the consent checkbox"
 msgstr ""
 
-#: terms/models.py:91
 msgid "application consent"
 msgstr ""
 
-#: terms/models.py:92
 msgid "application consents"
 msgstr ""
 
-#: terms/models.py:118
 msgid "timestamp of approval"
 msgstr ""
 
-#: terms/models.py:122
 msgid "user who approved the terms"
 msgstr ""
 
-#: terms/models.py:134
 msgid "selected applicant consents"
 msgstr ""
 
-#: terms/models.py:167
 msgid "applicant terms approval"
 msgstr ""
 
-#: terms/models.py:168
 msgid "Applicant terms approvals"
 msgstr ""
 
-#: terms/models.py:174
 msgid "user"
 msgstr ""
 
-#: terms/models.py:207
 msgid "terms of service approval"
 msgstr ""
 
-#: terms/models.py:208
 msgid "terms of service approvals"
 msgstr ""

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -5,846 +5,649 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-31 13:26+0300\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"POT-Creation-Date: 2022-11-01 10:42+0200\n"
+"PO-Revision-Date: 2022-11-01 10:45+0200\n"
+"Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
+"Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: applications/api/v1/application_batch_views.py:78
 msgid "Application status cannot be exported because of invalid status"
 msgstr "Hakemuksen tilaa ei voida viedä virheellisen tilan takia"
 
-#: applications/api/v1/application_batch_views.py:86
 msgid "Cannot export empty batch"
 msgstr "Tyhjää erää ei voida viedä"
 
-#: applications/api/v1/application_batch_views.py:92
 #, python-brace-format
 msgid "Application batch {date}"
 msgstr "Hakemuserä {date}"
 
-#: applications/api/v1/application_batch_views.py:120
 msgid "There is no available application to export, please try again later"
 msgstr "Ei vietävää hakemusta, yritä myöhemmin uudelleen"
 
-#: applications/api/v1/application_batch_views.py:128
 #, python-brace-format
 msgid "TALPA export {date}"
 msgstr "TALPA-vienti {date}"
 
-#: applications/api/v1/serializers.py:151
 #, python-brace-format
 msgid "Upload file size cannot be greater than {size} bytes"
 msgstr "Ladattavan tiedoston koko ei voi ylittää {size} tavua"
 
-#: applications/api/v1/serializers.py:160
 msgid "Too many attachments"
 msgstr "Liian monta liitettä"
 
-#: applications/api/v1/serializers.py:163
 msgid "Not a valid pdf file"
 msgstr "Epäkelpo PDF-tiedosto"
 
-#: applications/api/v1/serializers.py:167
 msgid "Not a valid image file"
 msgstr "Epäkelpo kuvatiedosto"
 
-#: applications/api/v1/serializers.py:209
 msgid "Grant date too much in past"
 msgstr "Myöntämispäivä liian kaukana menneisyydessä"
 
-#: applications/api/v1/serializers.py:211
 msgid "Grant date can not be in the future"
 msgstr "Myöntämispäivä ei voi olla tulevaisuudessa"
 
-#: applications/api/v1/serializers.py:312
 msgid "Social security number invalid"
 msgstr "Epäkelpo henkilötunnus"
 
-#: applications/api/v1/serializers.py:319
 msgid "Social security number checksum invalid"
 msgstr "Epäkelpo henkilötunnuksen tarkistussumma"
 
-#: applications/api/v1/serializers.py:328
 #, python-brace-format
 msgid "Working hour must be greater than {min_hour} per week"
 msgstr "Työajan on oltava suurempi kuin {min_hour} viikossa"
 
-#: applications/api/v1/serializers.py:336
 msgid "Monthly pay must be greater than 0"
 msgstr "Kuukausipalkan on oltava suurempi kuin 0"
 
-#: applications/api/v1/serializers.py:342
 msgid "Vacation money must be a positive number"
 msgstr "Lomarahojen täytyy olla positiivinen luku"
 
-#: applications/api/v1/serializers.py:349
 msgid "Other expenses must be a positive number"
 msgstr "Muiden kulujen täytyy olla positiivinen luku"
 
-#: applications/api/v1/serializers.py:441
 msgid "Applications in a batch can not be changed when batch is in this status"
 msgstr "Erän hakemuksia ei voida muuttaa erän ollessa tässä tilassa"
 
-#: applications/api/v1/serializers.py:453
 msgid "This application has invalid status and can not be added to this batch"
 msgstr ""
 "Tämän hakemuksen tila on virheellinen, eikä sitä voi lisätä tähän erään"
 
-#: applications/api/v1/serializers.py:929
 msgid "This should be unreachable"
 msgstr "Tämän pitäisi olla tavoittamattomissa"
 
-#: applications/api/v1/serializers.py:949
 msgid "Invalid value for association_immediate_manager_check"
 msgstr "Epäkelpo arvo kohteessa association_immediate_manager_check"
 
-#: applications/api/v1/serializers.py:957
 msgid "for companies, association_immediate_manager_check must always be null"
 msgstr ""
 "yrityksen ollessa kyseessä kohteen association_immediate_manager_check on "
 "aina oltava tyhjä"
 
-#: applications/api/v1/serializers.py:985
 msgid ""
 "This application has non-null de_minimis_aid but is applied by an association"
 msgstr ""
 "Tässä hakemuksessa on ei-nolla de_minimis_aid, mutta hakija on yhdistys"
 
-#: applications/api/v1/serializers.py:994
 msgid "This application has de_minimis_aid set but does not define any"
 msgstr "Tässä hakemuksessa on valittu de_minimis_aid, mutta sitä ei määritetä"
 
-#: applications/api/v1/serializers.py:1003
 msgid "This application can not have de minimis aid"
 msgstr "Tässä hakemuksessa ei voi olla de minimis -tukea"
 
-#: applications/api/v1/serializers.py:1011
 msgid "Total amount of de minimis aid too large"
 msgstr "De minimis -tuen kokonaismäärä liian suuri"
 
-#: applications/api/v1/serializers.py:1017
 msgid "start_date must not be in a past year"
 msgstr "start_date ei saa olla menneessä vuodessa"
 
-#: applications/api/v1/serializers.py:1021
 msgid "end_date must not be in a past year"
 msgstr "end_date ei saa olla menneessä vuodessa"
 
-#: applications/api/v1/serializers.py:1032
 msgid "application end_date can not be less than start_date"
 msgstr "hakemuksen end_date ei voi olla aiemmin kuin start_date"
 
-#: applications/api/v1/serializers.py:1046
 msgid "minimum duration of the benefit is one month"
 msgstr "avustuksen vähimmäiskesto on yksi kuukausi"
 
-#: applications/api/v1/serializers.py:1053
 msgid "maximum duration of the benefit is 12 months"
 msgstr "avustuksen enimmäiskesto on 12 kuukautta"
 
-#: applications/api/v1/serializers.py:1063
 msgid ""
 "This application can not have a description for co-operation negotiations"
 msgstr "Tässä hakemuksessa ei voi olla kuvausta yhteistoimintaneuvotteluista"
 
-#: applications/api/v1/serializers.py:1073
 msgid "Pay subsidy percent required"
 msgstr "Palkkatukiprosentti on pakollinen"
 
-#: applications/api/v1/serializers.py:1081
 #, python-brace-format
 msgid "This application can not have {key}"
 msgstr "Tässä hakemuksessa ei voi olla kohdetta {key}"
 
-#: applications/api/v1/serializers.py:1089
 msgid "This application can not have additional_pay_subsidy_percent"
 msgstr "Tässä hakemuksessa ei voi olla kohdetta additional_pay_subsidy_percent"
 
-#: applications/api/v1/serializers.py:1140
 msgid "This field is required before submitting the application"
 msgstr "Tämä kenttä on pakollinen ennen hakemuksen lähettämistä"
 
-#: applications/api/v1/serializers.py:1156
 msgid "This field can be set for associations only"
 msgstr "Tämä kenttä voidaan valita vain yhdistyksille"
 
-#: applications/api/v1/serializers.py:1193
 msgid "This benefit type can not be selected"
 msgstr "Tätä avustustyyppiä ei voida valita"
 
-#: applications/api/v1/serializers.py:1376
 msgid "Application does not have the employee consent attachment"
 msgstr "Hakemuksessa ei ole liitteenä työntekijän suostumusta"
 
-#: applications/api/v1/serializers.py:1380
 msgid "Application cannot have more than one employee consent attachment"
 msgstr "Hakemuksessa voi olla enintään yksi työntekijän suostumusliite"
 
-#: applications/api/v1/serializers.py:1387 terms/api/v1/views.py:48
 msgid "Terms must be approved"
 msgstr "Ehdot on hyväksyttävä"
 
-#: applications/api/v1/serializers.py:1442
 msgid "Application does not have required attachments"
 msgstr "Hakemuksessa ei ole pakollisia liitteitä"
 
-#: applications/api/v1/serializers.py:1473
 msgid "Application initial state must be draft"
 msgstr "Hakemuksen alkutilan on oltava luonnos"
 
-#: applications/api/v1/serializers.py:1513
 #, python-brace-format
 msgid "Reading de minimis data failed: {errors}"
 msgstr "De minimis -tietojen lukeminen epäonnistui: {errors}"
 
-#: applications/api/v1/serializers.py:1579
-#: applications/api/v1/serializers.py:1677
 msgid "Application can not be changed in this status"
 msgstr "Hakemusta ei voida muuttaa tässä tilassa"
 
-#: applications/api/v1/serializers.py:1640
 msgid "create_application_for_company missing from request"
 msgstr "create_application_for_company puuttuu pyynnöstä"
 
-#: applications/api/v1/serializers.py:1703
 msgid "The calculation should be created when the application is submitted"
 msgstr "Laskelma on luotava, kun hakemus lähetetään"
 
-#: applications/api/v1/serializers.py:1708
 msgid "The calculation id does not match existing id"
 msgstr "Laskelman tunnus ei vastaa nykyistä tunnusta"
 
-#: applications/api/v1/serializers.py:1759
 #, python-brace-format
 msgid "Reading {localized_model_name} data failed: {errors}"
 msgstr "{localized_model_name} -tietojen lukeminen epäonnistui: {errors}"
 
-#: applications/api/v1/status_transition_validator.py:23
 #, python-brace-format
 msgid "State transition not allowed: {status} to {value}"
 msgstr "Tilan siirto ei ole sallittu: {status} arvoon {value}"
 
-#: applications/api/v1/status_transition_validator.py:32
 #, python-brace-format
 msgid "Initial status must be {initial_status}"
 msgstr "Alkutilan on oltava {initial_status}"
 
-#: applications/api/v1/views.py:125 applications/api/v1/views.py:162
 msgid "Operation not allowed for this application status."
 msgstr "Toiminto ei ole sallittu tässä hakemuksen tilassa."
 
-#: applications/api/v1/views.py:149
 msgid "File not found."
 msgstr "Tiedostoa ei löydy."
 
-#: applications/api/v1/views.py:326
 #, python-brace-format
 msgid "Helsinki-lisän hakemukset viety {date}"
 msgstr ""
 
-#: applications/benefit_aggregation.py:77
 msgid "Benefit can not be granted before 24-month waiting period expires"
 msgstr "Avustusta ei voida myöntää ennen 24 kuukauden odotusajan päättymistä"
 
-#: applications/benefit_aggregation.py:166
-#, python-brace-format
 msgid "There's already an accepted application with overlapping date range"
-msgstr "Tälle työntekijälle on jo hyväksytty hakemus päällekkäisellä aikavälillä"
+msgstr ""
+"Tälle työntekijälle on jo hyväksytty hakemus päällekkäisellä aikavälillä"
 
-#: applications/enums.py:7 applications/enums.py:105
 msgid "Draft"
 msgstr "Luonnos"
 
-#: applications/enums.py:8
 msgid "Received"
 msgstr "Vastaanotettu"
 
-#: applications/enums.py:9
 msgid "Handling"
 msgstr "Käsittely"
 
-#: applications/enums.py:11
 msgid "Additional information requested"
 msgstr "Lisätietoja pyydetty"
 
-#: applications/enums.py:13
 msgid "Cancelled"
 msgstr "Peruutettu"
 
-#: applications/enums.py:14
 msgid "Accepted"
 msgstr "Hyväksytty"
 
-#: applications/enums.py:15
 msgid "Rejected"
 msgstr "Hylätty"
 
-#: applications/enums.py:29 applications/enums.py:52
 msgid "Invalid application status"
 msgstr "Epäkelpo hakemuksen tila"
 
-#: applications/enums.py:31
 msgid "Invalid application status change"
 msgstr "Epäkelpo hakemuksen tila"
 
-#: applications/enums.py:57
 msgid "Employment Benefit"
 msgstr "Työllistämisen Helsinki-lisä"
 
-#: applications/enums.py:58
 msgid "Salary Benefit"
 msgstr "Palkan Helsinki-lisä"
 
-#: applications/enums.py:59
 msgid "Commission Benefit"
 msgstr "Toimeksiannon Helsinki-lisä"
 
-#: applications/enums.py:63
 msgid "Step 1 - company details"
 msgstr "Vaihe 1 – työnantajan tiedot"
 
-#: applications/enums.py:64
 msgid "Step 2 - employee details"
 msgstr "Vaihe 2 – työntekijän tiedot"
 
-#: applications/enums.py:65
 msgid "Step 3 - attachments"
 msgstr "Vaihe 3 – liitteet"
 
-#: applications/enums.py:66
 msgid "Step 4 - summary"
 msgstr "Vaihe 4 – yhteenveto"
 
-#: applications/enums.py:67
 msgid "Step 5 - power of attorney"
 msgstr "Vaihe 5 – valtuutus"
 
-#: applications/enums.py:68
 msgid "Step 6 - terms and send"
 msgstr "Vaihe 6 – ehdot ja lähetys"
 
-#: applications/enums.py:76
 msgid "Company"
 msgstr "Yritys"
 
-#: applications/enums.py:77
 msgid "Association"
 msgstr "Yhdistys"
 
-#: applications/enums.py:89
 msgid "employment contract"
 msgstr "työsopimus"
 
-#: applications/enums.py:90
 msgid "pay subsidy decision"
 msgstr "palkkatukipäätös"
 
-#: applications/enums.py:91
 msgid "commission contract"
 msgstr "toimeksiantosopimus"
 
-#: applications/enums.py:93
 msgid "education contract of the apprenticeship office"
 msgstr "oppisopimustoimiston koulutussopimus"
 
-#: applications/enums.py:95 applications/enums.py:96
 msgid "helsinki benefit voucher"
 msgstr "Helsinki-lisä-seteli"
 
-#: applications/enums.py:100
 msgid "attachment is required"
 msgstr "liite on pakollinen"
 
-#: applications/enums.py:101
 msgid "attachment is optional"
 msgstr "liite on valinnainen"
 
-#: applications/enums.py:107
 msgid "Ahjo report created, not yet sent to AHJO"
 msgstr "Ahjo-raportti luotu, ei vielä lähetetty Ahjoon"
 
-#: applications/enums.py:110
 msgid "Sent to Ahjo, decision pending"
 msgstr "Lähetetty Ahjoon, päätös vireillä"
 
-#: applications/enums.py:112
 msgid "Accepted in Ahjo"
 msgstr "Hyväksytty Ahjossa"
 
-#: applications/enums.py:113
 msgid "Rejected in Ahjo"
 msgstr "Hylätty Ahjossa"
 
-#: applications/enums.py:115
 msgid "Returned from Ahjo without decision"
 msgstr "Palautettu Ahjosta ilman päätöstä"
 
-#: applications/enums.py:117
 msgid "Sent to Talpa"
 msgstr "Lähetetty Talpaan"
 
-#: applications/enums.py:118
 msgid "Processing is completed"
 msgstr "Käsittely on valmis"
 
-#: applications/models.py:109 calculator/models.py:337 companies/models.py:21
-#: terms/models.py:180
 msgid "company"
 msgstr "yritys"
 
-#: applications/models.py:117
 msgid "status"
 msgstr "tila"
 
-#: applications/models.py:123
 msgid "application number"
 msgstr "hakemuksen numero"
 
-#: applications/models.py:126
 msgid "company name"
 msgstr "yrityksen nimi"
 
-#: applications/models.py:129
 msgid "company form as user-readable text"
 msgstr ""
 
-#: applications/models.py:133 companies/models.py:13
 msgid "YTJ type code for company form"
 msgstr ""
 
-#: applications/models.py:137
 msgid "company department"
 msgstr "yrityksen osasto"
 
-#: applications/models.py:142 applications/models.py:154
 msgid "company street address"
 msgstr "yrityksen katuosoite"
 
-#: applications/models.py:145 applications/models.py:157
 msgid "company city"
 msgstr "yrityksen kaupunki"
 
-#: applications/models.py:148 applications/models.py:160
 msgid "company post code"
 msgstr "yrityksen postinumero"
 
-#: applications/models.py:172
 msgid "company bank account number"
 msgstr "yrityksen tilinumero"
 
-#: applications/models.py:177 applications/models.py:546
 msgid "first name"
 msgstr "etunimi"
 
-#: applications/models.py:180 applications/models.py:549
 msgid "last name"
 msgstr "sukunimi"
 
-#: applications/models.py:184
 msgid "company contact person's phone number"
 msgstr "yrityksen yhteyshenkilön puhelinnumero"
 
-#: applications/models.py:192
 msgid "company contact person's email"
 msgstr "yrityksen yhteyshenkilön sähköpostiosoite"
 
-#: applications/models.py:227
 msgid "additional information about the ongoing co-operation negotiations"
 msgstr "lisätietoja käynnissä olevista yhteistoimintaneuvotteluista"
 
-#: applications/models.py:237 calculator/models.py:233
 msgid "Pay subsidy percent"
 msgstr "Palkkatukiprosentti"
 
-#: applications/models.py:244
 msgid "Pay subsidy percent for second pay subsidy grant"
 msgstr "Palkkatukiprosentti toisesta palkkatukiavustuksesta"
 
-#: applications/models.py:270 calculator/models.py:91 calculator/models.py:350
 msgid "benefit start from date"
 msgstr "avustuksen alkamispäivä"
 
-#: applications/models.py:273 calculator/models.py:94 calculator/models.py:351
 msgid "benefit end date"
 msgstr "avustuksen päättymispäivä"
 
-#: applications/models.py:301
 msgid "ahjo batch"
 msgstr "Ahjo-erä"
 
-#: applications/models.py:375 applications/models.py:383
-#: applications/models.py:411 applications/models.py:540
-#: applications/models.py:654 calculator/models.py:220 calculator/models.py:381
-#: messages/models.py:30 terms/models.py:145
 msgid "application"
 msgstr "hakemus"
 
-#: applications/models.py:376
 msgid "applications"
 msgstr "hakemukset"
 
-#: applications/models.py:388
 msgid "granter of the de minimis aid"
 msgstr "de minimis -tuen myöntäjä"
 
-#: applications/models.py:391
 msgid "amount of the de minimis aid"
 msgstr "de minimis -tuen määrä"
 
-#: applications/models.py:393
 msgid "benefit granted at"
 msgstr "avustus myönnetty"
 
-#: applications/models.py:402
 msgid "de minimis aid"
 msgstr "de minimis -tuki"
 
-#: applications/models.py:403
 msgid "de minimis aids"
 msgstr "de minimis -tuet"
 
-#: applications/models.py:431
 msgid "application log entry"
 msgstr "hakemuksen lokimerkintä"
 
-#: applications/models.py:432
 msgid "application log entries"
 msgstr "hakemuksen lokimerkinnät"
 
-#: applications/models.py:445
 msgid "status of batch"
 msgstr "erän tila"
 
-#: applications/models.py:452
 msgid "proposal for decision"
 msgstr "päätösehdotus"
 
-#: applications/models.py:457
 msgid "decision maker's title in Ahjo"
 msgstr "päätöksentekijän tehtävänimike Ahjossa"
 
-#: applications/models.py:460
 msgid "decision maker's name in Ahjo"
 msgstr "päätöksentekijän nimi Ahjossa"
 
-#: applications/models.py:463
 msgid "section of the law in Ahjo decision"
 msgstr "Ahjo-päätöksen lakipykälä"
 
-#: applications/models.py:466
 msgid "date of the decision in Ahjo"
 msgstr "päätöksen päivämäärä Ahjossa"
 
-#: applications/models.py:469
 msgid "Expert inspector's name"
 msgstr "Asiantuntijatarkastajan nimi"
 
-#: applications/models.py:472
 msgid "Expert inspector's email address"
 msgstr "Asiantuntijatarkastajan sähköpostiosoite"
 
-#: applications/models.py:512
 msgid "application batch"
 msgstr "hakemuserä"
 
-#: applications/models.py:513
 msgid "application batches"
 msgstr "hakemuserät"
 
-#: applications/models.py:533
 msgid "application basis"
 msgstr "hakemuksen peruste"
 
-#: applications/models.py:534
 msgid "application bases"
 msgstr "hakemuksen perusteet"
 
-#: applications/models.py:553 calculator/models.py:347
 msgid "social security number"
 msgstr "henkilötunnus"
 
-#: applications/models.py:561
 msgid "phone number"
 msgstr "puhelinnumero"
 
-#: applications/models.py:568
 msgid "email"
 msgstr "sähköpostiosoite"
 
-#: applications/models.py:578
 msgid "job title"
 msgstr "tehtävänimike"
 
-#: applications/models.py:581 calculator/models.py:73
 msgid "monthly pay"
 msgstr "kuukausipalkka"
 
-#: applications/models.py:588 calculator/models.py:80
 msgid "vacation money"
 msgstr "lomaraha"
 
-#: applications/models.py:596 calculator/models.py:86
 msgid "other expenses"
 msgstr "muut kulut"
 
-#: applications/models.py:603
 msgid "working hour"
 msgstr "työaika"
 
-#: applications/models.py:610
 msgid "collective bargaining agreement"
 msgstr "työehtosopimus"
 
-#: applications/models.py:613
 msgid "is living in helsinki"
 msgstr "asuu Helsingissä"
 
-#: applications/models.py:617
 msgid "amount of the commission (eur)"
 msgstr "Toimeksiannon rahamäärä (EUR)"
 
-#: applications/models.py:626
 msgid "Description of the commission"
 msgstr "Toimeksiannon kuvaus"
 
-#: applications/models.py:643
 msgid "employee"
 msgstr "työntekijä"
 
-#: applications/models.py:644
 msgid "employees"
 msgstr "työntekijät"
 
-#: applications/models.py:660
 msgid "attachment type in business rules"
 msgstr "liitetyyppi liiketoimintasäännöissä"
 
-#: applications/models.py:666
 msgid "technical content type of the attachment"
 msgstr "liitteen tekninen sisältötyyppi"
 
-#: applications/models.py:668
 msgid "application attachment content"
 msgstr "hakemuksen liitteen sisältö"
 
-#: applications/models.py:672
 msgid "attachment"
 msgstr "liite"
 
-#: applications/models.py:673
 msgid "attachments"
 msgstr "liitteet"
 
-#: calculator/api/v1/serializers.py:76
 msgid "Date range too large"
 msgstr "Päivämääräalue liian suuri"
 
-#: calculator/api/v1/serializers.py:89
 msgid "This calculation can not have a override_monthly_benefit_amount_comment"
-msgstr "Tässä laskelmassa ei voi olla kohdetta override_monthly_benefit_amount_comment"
+msgstr ""
+"Tässä laskelmassa ei voi olla kohdetta "
+"override_monthly_benefit_amount_comment"
 
-#: calculator/api/v1/serializers.py:100
 msgid "This calculation needs override_monthly_benefit_amount_comment"
-msgstr "Tässä laskelmassa on oltava kohde override_monthly_benefit_amount_comment"
+msgstr ""
+"Tässä laskelmassa on oltava kohde override_monthly_benefit_amount_comment"
 
-#: calculator/api/v1/serializers.py:122
 msgid "Handler can not be unassigned in this status"
 msgstr "Käsittelijää ei voida muuttaa tässä tilassa"
 
-#: calculator/api/v1/serializers.py:130
 msgid "Handler can not assigned in this status"
 msgstr "Käsittelijää ei voida määrittää tässä tilassa"
 
-#: calculator/enums.py:6
+msgid "Start date cannot be empty"
+msgstr "Aloituspäivä ei voi olla tyhjä"
+
+msgid "End date cannot be empty"
+msgstr "Päättymispäivä ei voi olla tyhjä"
+
 msgid "Description row, amount ignored"
 msgstr "Kuvausrivi, rahamäärä ohitettu"
 
-#: calculator/enums.py:7
 msgid "Salary costs"
 msgstr "Palkkakustannukset"
 
-#: calculator/enums.py:8 calculator/models.py:97
 msgid "State aid maximum %"
 msgstr "Valtiontuen enimmäis-%"
 
-#: calculator/enums.py:9
 msgid "Pay subsidy/month"
 msgstr "Palkkatuki/kuukausi"
 
-#: calculator/enums.py:11
 msgid "Helsinki benefit amount monthly"
 msgstr "Helsinki-lisän määrä kuukaudelta"
 
-#: calculator/enums.py:14
 msgid "Helsinki benefit amount for a date range"
 msgstr "Helsinki-lisän määrä ajanjaksolta"
 
-#: calculator/enums.py:17
 msgid "Helsinki benefit total amount"
 msgstr "Helsinki-lisän kokonaismäärä"
 
-#: calculator/enums.py:20
 msgid "Training compensation amount monthly"
 msgstr "Koulutuskorvauksen määrä kuukaudelta"
 
-#: calculator/enums.py:23
 msgid "Total amount of deductions monthly"
 msgstr "Vähennysten kokonaismäärä kuukaudelta"
 
-#: calculator/models.py:34
 msgid "Calculation already exists"
 msgstr "Laskelma on jo olemassa"
 
-#: calculator/models.py:57
 msgid "handler"
 msgstr "käsittelijä"
 
-#: calculator/models.py:68 calculator/models.py:206 calculator/models.py:426
 msgid "calculation"
 msgstr "laskelma"
 
-#: calculator/models.py:107
 msgid "amount of the benefit granted, calculated by the system"
 msgstr "järjestelmän laskema myönnetyn avustuksen määrä"
 
-#: calculator/models.py:115
 msgid ""
 "monthly amount of the benefit manually entered by the application handler"
 msgstr "hakemuksen käsittelijän käsin syöttämä avustuksen määrä"
 
-#: calculator/models.py:126
 msgid "reason for overriding the calculated benefit amount"
 msgstr "lasketun avustuksen määrän ohittamisen syy"
 
-#: calculator/models.py:174
 msgid "Incomplete application"
 msgstr "Puutteellinen hakemus"
 
-#: calculator/models.py:207
 msgid "calculations"
 msgstr "laskelmat"
 
-#: calculator/models.py:227 calculator/models.py:387
 msgid "Pay subsidy start date"
 msgstr "Palkkatuen alkamispäivä"
 
-#: calculator/models.py:230 calculator/models.py:388
 msgid "Pay subsidy end date"
 msgstr "Palkkatuen päättymispäivä"
 
-#: calculator/models.py:239
 msgid "Work time percent"
 msgstr "Työaikaprosentti"
 
-#: calculator/models.py:324
 msgid "pay subsidy"
 msgstr "palkkatuki"
 
-#: calculator/models.py:325
 msgid "pay subsidies"
 msgstr "palkkatuet"
 
-#: calculator/models.py:343
 msgid "encrypted social security number"
 msgstr "salattu henkilötunnus"
 
-#: calculator/models.py:355
 msgid "monthly amount of the previous benefit"
 msgstr "aiemman avustuksen kuukausimäärä"
 
-#: calculator/models.py:360
 msgid "total amount of the previous benefit"
 msgstr "aiemman avustuksen kokonaismäärä"
 
-#: calculator/models.py:370
 msgid "Previously granted benefit"
 msgstr "Aiemmin myönnetty avustus"
 
-#: calculator/models.py:371
 msgid "Previously granted benefits"
 msgstr "Aiemmin myönnetyt avustukset"
 
-#: calculator/models.py:390
 msgid "Monthly amount of compensation"
 msgstr "Korvauksen kuukausimäärä"
 
-#: calculator/models.py:402
 msgid "training compensation"
 msgstr "koulutuskorvaus"
 
-#: calculator/models.py:403
 msgid "training compensations"
 msgstr "koulutuskorvaukset"
 
-#: calculator/models.py:436
 msgid "Description of the row to be shown in handler UI"
 msgstr "Rivin kuvaus näytettävä käsittelijän käyttöliittymässä"
 
-#: calculator/models.py:439
 msgid "row amount"
 msgstr "rivin rahamäärä"
 
-#: calculator/models.py:441
 msgid "Start date"
 msgstr "Alkamispäivä"
 
-#: calculator/models.py:442
 msgid "End date"
 msgstr "Päättymispäivä"
 
-#: calculator/models.py:471
 msgid "calculation row"
 msgstr "laskelmarivi"
 
-#: calculator/models.py:472
 msgid "calculation rows"
 msgstr "laskelmarivit"
 
-#: common/iban_field.py:14
 msgid "Invalid IBAN"
 msgstr "Virheellinen IBAN-tilinumero"
 
-#: common/permissions.py:37
 msgid "You have to accept Terms of Service before doing any action"
 msgstr "Sinun on hyväksyttävä palveluehdot ennen mitään toimenpiteitä"
 
-#: common/permissions.py:56
 msgid "Company information is not available"
 msgstr "Yrityksen tietoja ei ole saatavilla"
 
-#: companies/models.py:10
 msgid "bank account number"
 msgstr "tilinumero"
 
-#: companies/models.py:22
 msgid "companies"
 msgstr "yritykset"
 
-#: helsinkibenefit/settings.py:162
 msgid "Finnish"
 msgstr "Suomi"
 
-#: helsinkibenefit/settings.py:162
 msgid "English"
 msgstr "Englanti"
 
-#: helsinkibenefit/settings.py:162
 msgid "Swedish"
 msgstr "Ruotsi"
 
-#: messages/admin.py:13
 msgid "Application number"
 msgstr "Hakemuksen numero"
 
-#: messages/automatic_messages.py:7
 #, python-brace-format
 msgid ""
 "Your application has been opened for editing. Please make the corrections by "
@@ -855,185 +658,138 @@ msgstr ""
 "{additional_information_needed_by} mennessä, muuten hakemusta ei voida "
 "käsitellä."
 
-#: messages/automatic_messages.py:44
 msgid "You have received a new message from Helsinki benefit"
 msgstr "Olet saanut uuden viestin Helsinki-lisä -hakemukseen"
 
-#: messages/automatic_messages.py:55
 #, python-format
 msgid ""
 "A new message has been added to the Helsinki-benefit application "
 "%(application_number)s (%(submitted_at_fmt)s). Open that application to see "
 "the message."
 msgstr ""
-"Helsinki-lisä hakemukseen %(application_number)s (%(submitted_at_fmt)s) on tullut uusi viesti. "
-"Avaa kyseinen hakemus nähdäksesi viestin."
+"Helsinki-lisä hakemukseen %(application_number)s (%(submitted_at_fmt)s) on "
+"tullut uusi viesti. Avaa kyseinen hakemus nähdäksesi viestin."
 
-#: messages/models.py:16
 msgid "Note"
 msgstr "Huomautus"
 
-#: messages/models.py:17
 msgid "Handler's message"
 msgstr "Käsittelijän viesti"
 
-#: messages/models.py:18
 msgid "Applicant's message"
 msgstr "Hakijan viesti"
 
-#: messages/models.py:22
 msgid "content"
 msgstr "sisältö"
 
-#: messages/models.py:24
 msgid "sender"
 msgstr "lähettäjä"
 
-#: messages/models.py:33
 msgid "message type"
 msgstr "viestityyppi"
 
-#: messages/models.py:36 messages/models.py:39
 msgid "read by applicant"
 msgstr "hakijan lukenut"
 
-#: messages/models.py:46
 msgid "message"
 msgstr "viesti"
 
-#: messages/models.py:47
 msgid "messages"
 msgstr "viestit"
 
-#: messages/permissions.py:9
 msgid "You don't have permission to change this message"
 msgstr "Sinulla ei ole oikeutta muuttaa tätä viestiä"
 
-#: messages/serializers.py:39 messages/views.py:41
 msgid "Application not found"
 msgstr "Hakemusta ei löytynyt"
 
-#: messages/serializers.py:44
 msgid "You are not allowed to do this action"
 msgstr "Sinä et saa tehdä tätä toimenpidettä"
 
-#: messages/serializers.py:49
 msgid "Cannot do this action because application is not in the correct status"
 msgstr ""
 "Tätä toimenpidettä ei voida tehdä, koska hakemus ei ole käsittelytilassa"
 
-#: messages/serializers.py:55
 msgid "Applicant is not allowed to do this action"
 msgstr "Hakija ei saa tehdä tätä toimenpidettä"
 
-#: messages/serializers.py:62
-msgid "Applicant can send messages only after handler has sent a message first"
-msgstr ""
-
-#: messages/serializers.py:68
 msgid "Handler is not allowed to do this action"
 msgstr "Käsittelijä ei saa tehdä tätä toimenpidettä"
 
-#: terms/api/v1/serializers.py:87
 msgid "Only the terms currently in effect can be approved"
 msgstr "Vain voimassa olevat ehdot voidaan hyväksyä"
 
-#: terms/api/v1/serializers.py:96
 msgid ""
 "User must explicitly select all the applicant consents required by the terms"
 msgstr ""
 "Käyttäjän on nimenomaisesti valittava kaikki ehdoissa vaaditut hakijan "
 "suostumukset"
 
-#: terms/api/v1/views.py:42
 msgid "The user has no company, terms of service can not be accepted"
 msgstr "Käyttäjällä ei ole yritystä, palveluehtoja ei voida hyväksyä"
 
-#: terms/api/v1/views.py:66
 msgid "The terms of service should only be approved once"
 msgstr "Palveluehdot tulee hyväksyä vain kerran"
 
-#: terms/enums.py:6
 msgid "Terms of service - shown at login"
 msgstr "Palveluehdot – näytetään sisäänkirjautumisen yhteydessä"
 
-#: terms/enums.py:8
 msgid "Terms of application - show at application submit"
 msgstr "Hakuehdot – näytä hakemuksen lähettämisen yhteydessä"
 
-#: terms/models.py:31
 msgid "type of terms"
 msgstr "ehtojen tyyppi"
 
-#: terms/models.py:40
 msgid "first day these terms are in effect"
 msgstr "näiden ehtojen ensimmäinen voimassaolopäivä"
 
-#: terms/models.py:43
 msgid "finnish terms (pdf file)"
 msgstr "suomenkieliset ehdot (PDF-tiedosto)"
 
-#: terms/models.py:44
 msgid "english terms (pdf file)"
 msgstr "englanninkieliset ehdot (PDF-tiedosto)"
 
-#: terms/models.py:45
 msgid "swedish terms (pdf file)"
 msgstr "ruotsinkieliset ehdot (PDF-tiedosto)"
 
-#: terms/models.py:58 terms/models.py:59 terms/models.py:71 terms/models.py:126
 msgid "terms"
 msgstr "ehdot"
 
-#: terms/models.py:76
 msgid "finnish text for the consent checkbox"
 msgstr "suostumuksen valintaruudun suomenkielinen teksti"
 
-#: terms/models.py:79
 msgid "english text for the consent checkbox"
 msgstr "suostumuksen valintaruudun englanninkielinen teksti"
 
-#: terms/models.py:82
 msgid "swedish text for the consent checkbox"
 msgstr "Suostumuksen valintaruudun ruotsinkielinen teksti"
 
-#: terms/models.py:91
 msgid "application consent"
 msgstr "hakusuostumus"
 
-#: terms/models.py:92
 msgid "application consents"
 msgstr "hakusuostumukset"
 
-#: terms/models.py:118
 msgid "timestamp of approval"
 msgstr "hyväksynnän aikaleima"
 
-#: terms/models.py:122
 msgid "user who approved the terms"
 msgstr "ehdot hyväksynyt käyttäjä"
 
-#: terms/models.py:134
 msgid "selected applicant consents"
 msgstr "valitut hakijan suostumukset"
 
-#: terms/models.py:167
 msgid "applicant terms approval"
 msgstr "hakijan ehtojen hyväksyntä"
 
-#: terms/models.py:168
 msgid "Applicant terms approvals"
 msgstr "hakijan ehtojen hyväksynnät"
 
-#: terms/models.py:174
 msgid "user"
 msgstr "käyttäjä"
 
-#: terms/models.py:207
 msgid "terms of service approval"
 msgstr "palveluehtojen hyväksyntä"
 
-#: terms/models.py:208
 msgid "terms of service approvals"
 msgstr "palveluehtojen hyväksynnät"
-

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -3,850 +3,649 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-31 13:26+0300\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"POT-Creation-Date: 2022-11-01 10:42+0200\n"
+"PO-Revision-Date: 2022-11-01 10:47+0200\n"
+"Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
+"Language-Team: \n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: applications/api/v1/application_batch_views.py:78
 msgid "Application status cannot be exported because of invalid status"
 msgstr "Ansökans status kan inte exporteras på grund av felaktig status"
 
-#: applications/api/v1/application_batch_views.py:86
 msgid "Cannot export empty batch"
 msgstr "Kan inte exportera tom sats"
 
-#: applications/api/v1/application_batch_views.py:92
 #, python-brace-format
 msgid "Application batch {date}"
 msgstr "Ansökningssats {date}"
 
-#: applications/api/v1/application_batch_views.py:120
 msgid "There is no available application to export, please try again later"
 msgstr ""
 "Ingen ansökan finns tillgänglig för export, vänligen försök på nytt senare"
 
-#: applications/api/v1/application_batch_views.py:128
 #, python-brace-format
 msgid "TALPA export {date}"
 msgstr "TALPA-export {date}"
 
-#: applications/api/v1/serializers.py:151
 #, python-brace-format
 msgid "Upload file size cannot be greater than {size} bytes"
 msgstr "Den fil som laddas upp kan inte vara större än {size} byte"
 
-#: applications/api/v1/serializers.py:160
 msgid "Too many attachments"
 msgstr "För många bilagor"
 
-#: applications/api/v1/serializers.py:163
 msgid "Not a valid pdf file"
 msgstr "Ingen giltig PDF-fil"
 
-#: applications/api/v1/serializers.py:167
 msgid "Not a valid image file"
 msgstr "Ingen giltig bildfil"
 
-#: applications/api/v1/serializers.py:209
 msgid "Grant date too much in past"
 msgstr "Beviljandedatum för tidigt"
 
-#: applications/api/v1/serializers.py:211
 msgid "Grant date can not be in the future"
 msgstr "Beviljandedatum kan inte vara i framtiden"
 
-#: applications/api/v1/serializers.py:312
 msgid "Social security number invalid"
 msgstr "Personbeteckning felaktig"
 
-#: applications/api/v1/serializers.py:319
 msgid "Social security number checksum invalid"
 msgstr "Personbeteckning kontrollsumma felaktig"
 
-#: applications/api/v1/serializers.py:328
 #, python-brace-format
 msgid "Working hour must be greater than {min_hour} per week"
 msgstr "Antalet arbetstimmar måste vara högre än {min_hour} per vecka"
 
-#: applications/api/v1/serializers.py:336
 msgid "Monthly pay must be greater than 0"
 msgstr "Månatlig lön måste vara större än 0"
 
-#: applications/api/v1/serializers.py:342
 msgid "Vacation money must be a positive number"
 msgstr "Semesterpenning måste vara ett positivt tal"
 
-#: applications/api/v1/serializers.py:349
 msgid "Other expenses must be a positive number"
 msgstr "Andra kostnader måste vara ett positivt tal"
 
-#: applications/api/v1/serializers.py:441
 msgid "Applications in a batch can not be changed when batch is in this status"
 msgstr "Ansökningar i en sats kan inte ändras när satsen har denna status"
 
-#: applications/api/v1/serializers.py:453
 msgid "This application has invalid status and can not be added to this batch"
 msgstr "Denna ansökan har felaktig status och kan inte läggas till denna sats"
 
-#: applications/api/v1/serializers.py:929
 msgid "This should be unreachable"
 msgstr "Detta bör vara onåbart"
 
-#: applications/api/v1/serializers.py:949
 msgid "Invalid value for association_immediate_manager_check"
 msgstr "Felaktigt värde för association_immediate_manager_check"
 
-#: applications/api/v1/serializers.py:957
 msgid "for companies, association_immediate_manager_check must always be null"
 msgstr ""
 "för företag, association_immediate_manager_check måste alltid vara noll"
 
-#: applications/api/v1/serializers.py:985
 msgid ""
 "This application has non-null de_minimis_aid but is applied by an association"
 msgstr ""
 "Denna ansökan har inte noll de_minimis_aid men ansöks av en sammanslutning"
 
-#: applications/api/v1/serializers.py:994
 msgid "This application has de_minimis_aid set but does not define any"
 msgstr "Denna ansökan har de_minimis_aid men definierar inga"
 
-#: applications/api/v1/serializers.py:1003
 msgid "This application can not have de minimis aid"
 msgstr "Denna ansökan kan inte ha de minimis-stöd"
 
-#: applications/api/v1/serializers.py:1011
 msgid "Total amount of de minimis aid too large"
 msgstr "Totalt belopp av de minimis-stöd är för stort"
 
-#: applications/api/v1/serializers.py:1017
 msgid "start_date must not be in a past year"
 msgstr "Startdatum får inte vara under föregående år"
 
-#: applications/api/v1/serializers.py:1021
 msgid "end_date must not be in a past year"
 msgstr "Slutdatum får inte vara under föregående år"
 
-#: applications/api/v1/serializers.py:1032
 msgid "application end_date can not be less than start_date"
 msgstr "end_date för ansökan kan inte vara tidigare än start_date"
 
-#: applications/api/v1/serializers.py:1046
 msgid "minimum duration of the benefit is one month"
 msgstr "minsta varaktighet för understödet är en månad"
 
-#: applications/api/v1/serializers.py:1053
 msgid "maximum duration of the benefit is 12 months"
 msgstr "längsta varaktighet för understödet är en månad"
 
-#: applications/api/v1/serializers.py:1063
 msgid ""
 "This application can not have a description for co-operation negotiations"
 msgstr "Denna ansökan kan inte ha en beskrivning för samarbetsförhandlingar"
 
-#: applications/api/v1/serializers.py:1073
 msgid "Pay subsidy percent required"
 msgstr "Lönesubventionsprocent krävs"
 
-#: applications/api/v1/serializers.py:1081
 #, python-brace-format
 msgid "This application can not have {key}"
 msgstr "Denna ansökan kan inte ha {key}"
 
-#: applications/api/v1/serializers.py:1089
 msgid "This application can not have additional_pay_subsidy_percent"
 msgstr "Denna ansökan kan inte ha additional_pay_subsidy_percent"
 
-#: applications/api/v1/serializers.py:1140
 msgid "This field is required before submitting the application"
 msgstr "Detta fält måste fyllas i innan ansökan lämnas in"
 
-#: applications/api/v1/serializers.py:1156
 msgid "This field can be set for associations only"
 msgstr "Detta fält är tillgängligt endast för sammanslutningar"
 
-#: applications/api/v1/serializers.py:1193
 msgid "This benefit type can not be selected"
 msgstr "Denna understödstyp kan inte väljas"
 
-#: applications/api/v1/serializers.py:1376
 msgid "Application does not have the employee consent attachment"
 msgstr "Den anställdas samtycke har inte bifogats ansökan"
 
-#: applications/api/v1/serializers.py:1380
 msgid "Application cannot have more than one employee consent attachment"
 msgstr "Fler än ett samtycke av den anställda kan inte bifogas ansökan"
 
-#: applications/api/v1/serializers.py:1387 terms/api/v1/views.py:48
 msgid "Terms must be approved"
 msgstr "Villkor måste godkännas"
 
-#: applications/api/v1/serializers.py:1442
 msgid "Application does not have required attachments"
 msgstr "Ansökan har inte obligatoriska bilagor"
 
-#: applications/api/v1/serializers.py:1473
 msgid "Application initial state must be draft"
 msgstr "Ansökans initialtillstånd måste vara utkast"
 
-#: applications/api/v1/serializers.py:1513
 #, python-brace-format
 msgid "Reading de minimis data failed: {errors}"
 msgstr "De minimis-data kan inte läsas: {errors}"
 
-#: applications/api/v1/serializers.py:1579
-#: applications/api/v1/serializers.py:1677
 msgid "Application can not be changed in this status"
 msgstr "Ansökan kan inte ändras i denna status"
 
-#: applications/api/v1/serializers.py:1640
 msgid "create_application_for_company missing from request"
 msgstr "create_application_for_company saknas från begäran"
 
-#: applications/api/v1/serializers.py:1703
 msgid "The calculation should be created when the application is submitted"
 msgstr "Beräkningen bör skapas när ansökan skickas"
 
-#: applications/api/v1/serializers.py:1708
 msgid "The calculation id does not match existing id"
 msgstr "Beräkningens ID motsvarar inte befintlig ID."
 
-#: applications/api/v1/serializers.py:1759
 #, python-brace-format
 msgid "Reading {localized_model_name} data failed: {errors}"
 msgstr "Data {localized_model_name} kan inte läsas: {errors}"
 
-#: applications/api/v1/status_transition_validator.py:23
 #, python-brace-format
 msgid "State transition not allowed: {status} to {value}"
 msgstr "Tillståndsövergång tillåts inte: {status} till {value}"
 
-#: applications/api/v1/status_transition_validator.py:32
 #, python-brace-format
 msgid "Initial status must be {initial_status}"
 msgstr "Initialstatus måste vara {initial_status}"
 
-#: applications/api/v1/views.py:125 applications/api/v1/views.py:162
 msgid "Operation not allowed for this application status."
 msgstr "Åtgärd tillåts inte för denna ansökningsstatus"
 
-#: applications/api/v1/views.py:149
 msgid "File not found."
 msgstr "Fil hittades inte."
 
-#: applications/api/v1/views.py:326
 #, python-brace-format
 msgid "Helsinki-lisän hakemukset viety {date}"
 msgstr ""
 
-#: applications/benefit_aggregation.py:77
 msgid "Benefit can not be granted before 24-month waiting period expires"
 msgstr "Understöd kan inte beviljas före utgång av väntetid på 24 månader"
 
-#: applications/benefit_aggregation.py:166
 msgid "There's already an accepted application with overlapping date range"
 msgstr ""
 "Det finns redan en godkänd ansökan med överlappande tidsperiod för denna "
 "anställd"
 
-#: applications/enums.py:7 applications/enums.py:105
 msgid "Draft"
 msgstr "Utkast"
 
-#: applications/enums.py:8
 msgid "Received"
 msgstr "Mottaget"
 
-#: applications/enums.py:9
 msgid "Handling"
 msgstr "Handläggs"
 
-#: applications/enums.py:11
 msgid "Additional information requested"
 msgstr "Ytterligare information har begärts"
 
-#: applications/enums.py:13
 msgid "Cancelled"
 msgstr "Återkallad"
 
-#: applications/enums.py:14
 msgid "Accepted"
 msgstr "Godkänd"
 
-#: applications/enums.py:15
 msgid "Rejected"
 msgstr "Avvisad"
 
-#: applications/enums.py:29 applications/enums.py:52
 msgid "Invalid application status"
 msgstr "Felaktig ansökningsstatus"
 
-#: applications/enums.py:31
 msgid "Invalid application status change"
 msgstr "Felaktig ansökningsstatus"
 
-#: applications/enums.py:57
 msgid "Employment Benefit"
 msgstr "Tillägg för sysselsättning"
 
-#: applications/enums.py:58
 msgid "Salary Benefit"
 msgstr "Tillägg för lön"
 
-#: applications/enums.py:59
 msgid "Commission Benefit"
 msgstr "Tillägg för uppdrag"
 
-#: applications/enums.py:63
 msgid "Step 1 - company details"
 msgstr "Steg 1 – arbetsgivaruppgifter"
 
-#: applications/enums.py:64
 msgid "Step 2 - employee details"
 msgstr "Steg 2 – arbetstagaruppgifter"
 
-#: applications/enums.py:65
 msgid "Step 3 - attachments"
 msgstr "Steg 3 – bilagor"
 
-#: applications/enums.py:66
 msgid "Step 4 - summary"
 msgstr "Steg 4 – sammanfattning"
 
-#: applications/enums.py:67
 msgid "Step 5 - power of attorney"
 msgstr "Steg 5 – fullmakt"
 
-#: applications/enums.py:68
 msgid "Step 6 - terms and send"
 msgstr "Steg 6 – villkor och skicka"
 
-#: applications/enums.py:76
 msgid "Company"
 msgstr "Företag"
 
-#: applications/enums.py:77
 msgid "Association"
 msgstr "Sammanslutning"
 
-#: applications/enums.py:89
 msgid "employment contract"
 msgstr "arbetsavtal"
 
-#: applications/enums.py:90
 msgid "pay subsidy decision"
 msgstr "beslut om lönesubvention"
 
-#: applications/enums.py:91
 msgid "commission contract"
 msgstr "uppdragsavtal"
 
-#: applications/enums.py:93
 msgid "education contract of the apprenticeship office"
 msgstr "läroavtal"
 
-#: applications/enums.py:95 applications/enums.py:96
 msgid "helsinki benefit voucher"
 msgstr "sedel för Helsingforstillägg"
 
-#: applications/enums.py:100
 msgid "attachment is required"
 msgstr "bilaga är obligatorisk"
 
-#: applications/enums.py:101
 msgid "attachment is optional"
 msgstr "bilaga är valfri"
 
-#: applications/enums.py:107
 msgid "Ahjo report created, not yet sent to AHJO"
 msgstr "Ahjo-rapport har skapats, ännu inte skickad till Ahjo"
 
-#: applications/enums.py:110
 msgid "Sent to Ahjo, decision pending"
 msgstr "Skickad till Ahjo, väntar på beslut"
 
-#: applications/enums.py:112
 msgid "Accepted in Ahjo"
 msgstr "Godkänd i Ahjo"
 
-#: applications/enums.py:113
 msgid "Rejected in Ahjo"
 msgstr "Avvisad i Ahjo"
 
-#: applications/enums.py:115
 msgid "Returned from Ahjo without decision"
 msgstr "Återsänd från Ahjo utan beslut"
 
-#: applications/enums.py:117
 msgid "Sent to Talpa"
 msgstr "Skickad till Talpa"
 
-#: applications/enums.py:118
 msgid "Processing is completed"
 msgstr "Processen är slutförd"
 
-#: applications/models.py:109 calculator/models.py:337 companies/models.py:21
-#: terms/models.py:180
 msgid "company"
 msgstr "företag"
 
-#: applications/models.py:117
 msgid "status"
 msgstr "status"
 
-#: applications/models.py:123
 msgid "application number"
 msgstr "ansökningsnummer"
 
-#: applications/models.py:126
 msgid "company name"
 msgstr "företagets namn"
 
-#: applications/models.py:129
 msgid "company form as user-readable text"
 msgstr ""
 
-#: applications/models.py:133 companies/models.py:13
 msgid "YTJ type code for company form"
 msgstr ""
 
-#: applications/models.py:137
 msgid "company department"
 msgstr "företagsavdelning"
 
-#: applications/models.py:142 applications/models.py:154
 msgid "company street address"
 msgstr "företagets gatuadress"
 
-#: applications/models.py:145 applications/models.py:157
 msgid "company city"
 msgstr "företagets förläggningsort"
 
-#: applications/models.py:148 applications/models.py:160
 msgid "company post code"
 msgstr "företagets postnummer"
 
-#: applications/models.py:172
 msgid "company bank account number"
 msgstr "företagets kontonummer"
 
-#: applications/models.py:177 applications/models.py:546
 msgid "first name"
 msgstr "förnamn"
 
-#: applications/models.py:180 applications/models.py:549
 msgid "last name"
 msgstr "efternamn"
 
-#: applications/models.py:184
 msgid "company contact person's phone number"
 msgstr "kontaktpersonens telefonnummer"
 
-#: applications/models.py:192
 msgid "company contact person's email"
 msgstr "kontaktpersonens e-postadress"
 
-#: applications/models.py:227
 msgid "additional information about the ongoing co-operation negotiations"
 msgstr "ytterligare information om de pågående samarbetsförhandlingarna"
 
-#: applications/models.py:237 calculator/models.py:233
 msgid "Pay subsidy percent"
 msgstr "Lönesubventionsprocent"
 
-#: applications/models.py:244
 msgid "Pay subsidy percent for second pay subsidy grant"
 msgstr "Lönesubventionsprocent för annan lönesubvention som beviljats"
 
-#: applications/models.py:270 calculator/models.py:91 calculator/models.py:350
 msgid "benefit start from date"
 msgstr "startdatum för understöd"
 
-#: applications/models.py:273 calculator/models.py:94 calculator/models.py:351
 msgid "benefit end date"
 msgstr "slutdatum för understöd"
 
-#: applications/models.py:301
 msgid "ahjo batch"
 msgstr "ahjo-sats"
 
-#: applications/models.py:375 applications/models.py:383
-#: applications/models.py:411 applications/models.py:540
-#: applications/models.py:654 calculator/models.py:220 calculator/models.py:381
-#: messages/models.py:30 terms/models.py:145
 msgid "application"
 msgstr "Ansökan"
 
-#: applications/models.py:376
 msgid "applications"
 msgstr "ansökningar"
 
-#: applications/models.py:388
 msgid "granter of the de minimis aid"
 msgstr "den som beviljat de minimis-stödet"
 
-#: applications/models.py:391
 msgid "amount of the de minimis aid"
 msgstr "belopp för de minimis-stödet"
 
-#: applications/models.py:393
 msgid "benefit granted at"
 msgstr "understöd beviljats av"
 
-#: applications/models.py:402
 msgid "de minimis aid"
 msgstr "de minimis-stöd"
 
-#: applications/models.py:403
 msgid "de minimis aids"
 msgstr "de minimis-stöd"
 
-#: applications/models.py:431
 msgid "application log entry"
 msgstr "registrering i ansökningslogg"
 
-#: applications/models.py:432
 msgid "application log entries"
 msgstr "registreringar i ansökningslogg"
 
-#: applications/models.py:445
 msgid "status of batch"
 msgstr "status av sats"
 
-#: applications/models.py:452
 msgid "proposal for decision"
 msgstr "beslutsförslag"
 
-#: applications/models.py:457
 msgid "decision maker's title in Ahjo"
 msgstr "titel för den som fattar beslut vid Ahjo"
 
-#: applications/models.py:460
 msgid "decision maker's name in Ahjo"
 msgstr "namn på den som fattar beslut vid Ahjo"
 
-#: applications/models.py:463
 msgid "section of the law in Ahjo decision"
 msgstr "lag som tillämpas i Ahjos beslut"
 
-#: applications/models.py:466
 msgid "date of the decision in Ahjo"
 msgstr "datum då beslut fattas vid Ahjo"
 
-#: applications/models.py:469
 msgid "Expert inspector's name"
 msgstr "Namn på sakkunnig inspektör"
 
-#: applications/models.py:472
 msgid "Expert inspector's email address"
 msgstr "E-postadress till sakkunnig inspektör"
 
-#: applications/models.py:512
 msgid "application batch"
 msgstr "ansökningssats"
 
-#: applications/models.py:513
 msgid "application batches"
 msgstr "ansökningssatser"
 
-#: applications/models.py:533
 msgid "application basis"
 msgstr "ansökningsgrund"
 
-#: applications/models.py:534
 msgid "application bases"
 msgstr "ansökningsgrunder"
 
-#: applications/models.py:553 calculator/models.py:347
 msgid "social security number"
 msgstr "personbeteckning"
 
-#: applications/models.py:561
 msgid "phone number"
 msgstr "telefonnummer"
 
-#: applications/models.py:568
 msgid "email"
 msgstr "e-postadress"
 
-#: applications/models.py:578
 msgid "job title"
 msgstr "titel"
 
-#: applications/models.py:581 calculator/models.py:73
 msgid "monthly pay"
 msgstr "månadslön"
 
-#: applications/models.py:588 calculator/models.py:80
 msgid "vacation money"
 msgstr "semesterersättning"
 
-#: applications/models.py:596 calculator/models.py:86
 msgid "other expenses"
 msgstr "övriga kostnader"
 
-#: applications/models.py:603
 msgid "working hour"
 msgstr "arbetstimme"
 
-#: applications/models.py:610
 msgid "collective bargaining agreement"
 msgstr "kollektivavtal"
 
-#: applications/models.py:613
 msgid "is living in helsinki"
 msgstr "bor i Helsingfors"
 
-#: applications/models.py:617
 msgid "amount of the commission (eur)"
 msgstr "uppdragets belopp (euro)"
 
-#: applications/models.py:626
 msgid "Description of the commission"
 msgstr "Beskrivning av uppdraget"
 
-#: applications/models.py:643
 msgid "employee"
 msgstr "anställd"
 
-#: applications/models.py:644
 msgid "employees"
 msgstr "anställda"
 
-#: applications/models.py:660
 msgid "attachment type in business rules"
 msgstr "bilagetyp i företagsregler"
 
-#: applications/models.py:666
 msgid "technical content type of the attachment"
 msgstr "typ av tekniskt innehåll i bilagan"
 
-#: applications/models.py:668
 msgid "application attachment content"
 msgstr "innehåll i bilaga till ansökan"
 
-#: applications/models.py:672
 msgid "attachment"
 msgstr "bilaga"
 
-#: applications/models.py:673
 msgid "attachments"
 msgstr "bilagor"
 
-#: calculator/api/v1/serializers.py:76
 msgid "Date range too large"
 msgstr "Tidsperiod för lång"
 
-#: calculator/api/v1/serializers.py:89
 msgid "This calculation can not have a override_monthly_benefit_amount_comment"
 msgstr "Denna beräkning kan inte ha en override_monthly_benefit_amount_comment"
 
-#: calculator/api/v1/serializers.py:100
 msgid "This calculation needs override_monthly_benefit_amount_comment"
 msgstr "Denna beräkning behöver override_monthly_benefit_amount_comment"
 
-#: calculator/api/v1/serializers.py:122
 msgid "Handler can not be unassigned in this status"
 msgstr "Handläggare kan inte avsättas i denna status"
 
-#: calculator/api/v1/serializers.py:130
 msgid "Handler can not assigned in this status"
 msgstr "Handläggare kan inte utses i denna status"
 
-#: calculator/enums.py:6
+msgid "Start date cannot be empty"
+msgstr "Startdatum kan inte vara tomt"
+
+msgid "End date cannot be empty"
+msgstr "Slutdatum kan inte vara tomt"
+
 msgid "Description row, amount ignored"
 msgstr "Beskrivningsrad, belopp ignorerat"
 
-#: calculator/enums.py:7
 msgid "Salary costs"
 msgstr "Lönekostnader"
 
-#: calculator/enums.py:8 calculator/models.py:97
 msgid "State aid maximum %"
 msgstr "Maximalt statsunderstöd %"
 
-#: calculator/enums.py:9
 msgid "Pay subsidy/month"
 msgstr "Lönesubvention/månad"
 
-#: calculator/enums.py:11
 msgid "Helsinki benefit amount monthly"
 msgstr "Helsingforstilläggets belopp per månad"
 
-#: calculator/enums.py:14
 msgid "Helsinki benefit amount for a date range"
 msgstr "Helsingforstilläggets belopp för en tidsperiod"
 
-#: calculator/enums.py:17
 msgid "Helsinki benefit total amount"
 msgstr "Helsingforstilläggets totala belopp"
 
-#: calculator/enums.py:20
 msgid "Training compensation amount monthly"
 msgstr "Utbildningsersättningens belopp per månad"
 
-#: calculator/enums.py:23
 msgid "Total amount of deductions monthly"
 msgstr "Totalbelopp av avdrag per månad"
 
-#: calculator/models.py:34
 msgid "Calculation already exists"
 msgstr "Beräkning finns redan"
 
-#: calculator/models.py:57
 msgid "handler"
 msgstr "handläggare"
 
-#: calculator/models.py:68 calculator/models.py:206 calculator/models.py:426
 msgid "calculation"
 msgstr "beräkning"
 
-#: calculator/models.py:107
 msgid "amount of the benefit granted, calculated by the system"
 msgstr "understödsbelopp som beviljats, beräknat av systemet"
 
-#: calculator/models.py:115
 msgid ""
 "monthly amount of the benefit manually entered by the application handler"
 msgstr "understödsbeloppet registrerats för hand av den som behandlat ansökan"
 
-#: calculator/models.py:126
 msgid "reason for overriding the calculated benefit amount"
 msgstr "orsak till att förbigå det beräknade understödsbeloppet"
 
-#: calculator/models.py:174
 msgid "Incomplete application"
 msgstr "Ofullständig ansökan"
 
-#: calculator/models.py:207
 msgid "calculations"
 msgstr "beräkningar"
 
-#: calculator/models.py:227 calculator/models.py:387
 msgid "Pay subsidy start date"
 msgstr "Startdatum för lönesubvention "
 
-#: calculator/models.py:230 calculator/models.py:388
 msgid "Pay subsidy end date"
 msgstr "Slutdatum för lönesubvention"
 
-#: calculator/models.py:239
 msgid "Work time percent"
 msgstr "Arbetstidsprocent"
 
-#: calculator/models.py:324
 msgid "pay subsidy"
 msgstr "lönesubvention"
 
-#: calculator/models.py:325
 msgid "pay subsidies"
 msgstr "lönesubventioner"
 
-#: calculator/models.py:343
 msgid "encrypted social security number"
 msgstr "skyddad personbeteckning"
 
-#: calculator/models.py:355
 msgid "monthly amount of the previous benefit"
 msgstr "belopp på det tidigare understödet per månad"
 
-#: calculator/models.py:360
 msgid "total amount of the previous benefit"
 msgstr "belopp på det tidigare understödet"
 
-#: calculator/models.py:370
 msgid "Previously granted benefit"
 msgstr "Tidigare beviljat understöd"
 
-#: calculator/models.py:371
 msgid "Previously granted benefits"
 msgstr "Tidigare beviljade understöd"
 
-#: calculator/models.py:390
 msgid "Monthly amount of compensation"
 msgstr "Ersättningsbelopp per månad"
 
-#: calculator/models.py:402
 msgid "training compensation"
 msgstr "utbildningsersättning"
 
-#: calculator/models.py:403
 msgid "training compensations"
 msgstr "utbildningsersättningar"
 
-#: calculator/models.py:436
 msgid "Description of the row to be shown in handler UI"
 msgstr "Radbeskrivning som visas i handläggarens användargränssnitt"
 
-#: calculator/models.py:439
 msgid "row amount"
 msgstr "antal rader"
 
-#: calculator/models.py:441
 msgid "Start date"
 msgstr "Startdatum"
 
-#: calculator/models.py:442
 msgid "End date"
 msgstr "Slutdatum"
 
-#: calculator/models.py:471
 msgid "calculation row"
 msgstr "beräkningsrad"
 
-#: calculator/models.py:472
 msgid "calculation rows"
 msgstr "beräkningsrader"
 
-#: common/iban_field.py:14
 msgid "Invalid IBAN"
 msgstr "Felaktigt IBAN-kontonummer"
 
-#: common/permissions.py:37
 msgid "You have to accept Terms of Service before doing any action"
 msgstr ""
 "Du måste godkänna användarvillkoren för tjänsten innan du kan göra något"
 
-#: common/permissions.py:56
 msgid "Company information is not available"
 msgstr "Företagets uppgifter är inte tillgängliga"
 
-#: companies/models.py:10
 msgid "bank account number"
 msgstr "bankkontonummer"
 
-#: companies/models.py:22
 msgid "companies"
 msgstr "företag"
 
-#: helsinkibenefit/settings.py:162
 msgid "Finnish"
 msgstr "Finska"
 
-#: helsinkibenefit/settings.py:162
 msgid "English"
 msgstr "Engelska"
 
-#: helsinkibenefit/settings.py:162
 msgid "Swedish"
 msgstr "Svenska"
 
-#: messages/admin.py:13
 msgid "Application number"
 msgstr "Ansökningsnummer"
 
-#: messages/automatic_messages.py:7
 #, python-brace-format
 msgid ""
 "Your application has been opened for editing. Please make the corrections by "
@@ -856,184 +655,139 @@ msgstr ""
 "Din ansökan har öppnats för redigering. Gör ändringarna senast "
 "{additional_information_needed_by}, annars kan ansökan inte behandlas."
 
-#: messages/automatic_messages.py:44
 msgid "You have received a new message from Helsinki benefit"
 msgstr "Du har fått ett nytt meddelande om Helsingforstilläg"
 
-#: messages/automatic_messages.py:55
 #, python-format
 msgid ""
 "A new message has been added to the Helsinki-benefit application "
 "%(application_number)s (%(submitted_at_fmt)s). Open that application to see "
 "the message."
 msgstr ""
-"Ett meddelande om Helsingforstillägg ansökan "
-"%(application_number)s (%(submitted_at_fmt)s) har inkommit. Öppna ansökan i fråga för att se meddelandet."
+"Ett meddelande om Helsingforstillägg ansökan %(application_number)s "
+"(%(submitted_at_fmt)s) har inkommit. Öppna ansökan i fråga för att se "
+"meddelandet."
 
-#: messages/models.py:16
 msgid "Note"
 msgstr "Anteckning"
 
-#: messages/models.py:17
 msgid "Handler's message"
 msgstr "Handläggarens meddelande"
 
-#: messages/models.py:18
 msgid "Applicant's message"
 msgstr "Sökandens meddelande"
 
-#: messages/models.py:22
 msgid "content"
 msgstr "innehåll"
 
-#: messages/models.py:24
 msgid "sender"
 msgstr "Avsändare"
 
-#: messages/models.py:33
 msgid "message type"
 msgstr "meddelandetyp"
 
-#: messages/models.py:36 messages/models.py:39
 msgid "read by applicant"
 msgstr "läst av sökande"
 
-#: messages/models.py:46
 msgid "message"
 msgstr "meddelande"
 
-#: messages/models.py:47
 msgid "messages"
 msgstr "meddelanden"
 
-#: messages/permissions.py:9
 msgid "You don't have permission to change this message"
 msgstr "Du får inte ändra detta meddelande"
 
-#: messages/serializers.py:39 messages/views.py:41
 msgid "Application not found"
 msgstr "Ansökan hittades inte"
 
-#: messages/serializers.py:44
 msgid "You are not allowed to do this action"
 msgstr "Du får inte utföra denna åtgärd"
 
-#: messages/serializers.py:49
 msgid "Cannot do this action because application is not in the correct status"
 msgstr "Kan inte utföra åtgärden eftersom ansökan inte har handläggningsstatus"
 
-#: messages/serializers.py:55
 msgid "Applicant is not allowed to do this action"
 msgstr "Sökande får inte utföra denna åtgärd"
 
-#: messages/serializers.py:62
-msgid "Applicant can send messages only after handler has sent a message first"
-msgstr ""
-
-#: messages/serializers.py:68
 msgid "Handler is not allowed to do this action"
 msgstr "Handläggare får inte utföra denna åtgärd"
 
-#: terms/api/v1/serializers.py:87
 msgid "Only the terms currently in effect can be approved"
 msgstr "Endast de villkor som för tillfället gäller kan godkännas"
 
-#: terms/api/v1/serializers.py:96
 msgid ""
 "User must explicitly select all the applicant consents required by the terms"
 msgstr ""
 "Användare måste uttryckligen välja samtliga samtycken för sökanden som krävs "
 "enligt villkoren"
 
-#: terms/api/v1/views.py:42
 msgid "The user has no company, terms of service can not be accepted"
 msgstr ""
 "Användaren har inget företag, villkoren för tjänsten kan inte godkännas"
 
-#: terms/api/v1/views.py:66
 msgid "The terms of service should only be approved once"
 msgstr "Villkoren för tjänsten bör godkännas endast en gång"
 
-#: terms/enums.py:6
 msgid "Terms of service - shown at login"
 msgstr "Villkor för tjänsten – visas vid inloggning"
 
-#: terms/enums.py:8
 msgid "Terms of application - show at application submit"
 msgstr "Ansökningsvillkor – visas vid inlämning av ansökan"
 
-#: terms/models.py:31
 msgid "type of terms"
 msgstr "typ av villkor"
 
-#: terms/models.py:40
 msgid "first day these terms are in effect"
 msgstr "första datum då dessa villkor gäller"
 
-#: terms/models.py:43
 msgid "finnish terms (pdf file)"
 msgstr "villkoren på finska (PDF-fil)"
 
-#: terms/models.py:44
 msgid "english terms (pdf file)"
 msgstr "villkoren på engelska (PDF-fil)"
 
-#: terms/models.py:45
 msgid "swedish terms (pdf file)"
 msgstr "villkoren på svenska (PDF-fil)"
 
-#: terms/models.py:58 terms/models.py:59 terms/models.py:71 terms/models.py:126
 msgid "terms"
 msgstr "villkor"
 
-#: terms/models.py:76
 msgid "finnish text for the consent checkbox"
 msgstr "finsk text för kryssrutan för samtycke"
 
-#: terms/models.py:79
 msgid "english text for the consent checkbox"
 msgstr "engelsk text för kryssrutan för samtycke"
 
-#: terms/models.py:82
 msgid "swedish text for the consent checkbox"
 msgstr "svensk text för kryssrutan för samtycke"
 
-#: terms/models.py:91
 msgid "application consent"
 msgstr "samtycke till ansökan"
 
-#: terms/models.py:92
 msgid "application consents"
 msgstr "samtycken till ansökan"
 
-#: terms/models.py:118
 msgid "timestamp of approval"
 msgstr "tidpunkt för godkännande"
 
-#: terms/models.py:122
 msgid "user who approved the terms"
 msgstr "den användare som godkände villkoren"
 
-#: terms/models.py:134
 msgid "selected applicant consents"
 msgstr "valda samtycken till ansökan"
 
-#: terms/models.py:167
 msgid "applicant terms approval"
 msgstr "samtycke till ansökningsvillkor"
 
-#: terms/models.py:168
 msgid "Applicant terms approvals"
 msgstr "samtycken till ansökningsvillkor"
 
-#: terms/models.py:174
 msgid "user"
 msgstr "användare"
 
-#: terms/models.py:207
 msgid "terms of service approval"
 msgstr "godkännande av villkoren för tjänsten"
 
-#: terms/models.py:208
 msgid "terms of service approvals"
 msgstr "godkännanden av villkoren för tjänsten"

--- a/backend/benefit/users/api/v1/serializers.py
+++ b/backend/benefit/users/api/v1/serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -67,7 +68,9 @@ class UserSerializer(serializers.ModelSerializer):
     )
 
     def is_terms_of_service_approval_needed(self, obj):
-        if hasattr(obj, "is_handler") and obj.is_handler():
+        if settings.NEXT_PUBLIC_MOCK_FLAG or (
+            hasattr(obj, "is_handler") and obj.is_handler()
+        ):
             return False
         return TermsOfServiceApproval.terms_approval_needed(
             obj, get_company_from_request(self.context.get("request"))

--- a/backend/shared/shared/common/tests/test_mock_enabled_proxy_view.py
+++ b/backend/shared/shared/common/tests/test_mock_enabled_proxy_view.py
@@ -1,0 +1,257 @@
+from collections import namedtuple
+
+import pytest
+from django.test import override_settings
+from django.views import View
+
+from shared.common.views import MockEnabledProxyView
+
+
+class MockRequest:
+    def __init__(self, method):
+        self.method = method
+
+
+ViewCallInfo = namedtuple(
+    "ViewCallInfo", ["class_name", "called_method_name", "request", "args", "kwargs"]
+)
+
+
+class BaseTestView(View):
+    @classmethod
+    def _test_func(
+        cls, called_method_name: str, request, *args, **kwargs
+    ) -> ViewCallInfo:
+        """
+        Return class name, called method name, request, positional arguments and
+        keyword arguments for testing purposes.
+        """
+        return ViewCallInfo(cls.__name__, called_method_name, request, args, kwargs)
+
+    def get(self, request, *args, **kwargs) -> ViewCallInfo:
+        return self.__class__._test_func("get", request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs) -> ViewCallInfo:
+        return self.__class__._test_func("post", request, *args, **kwargs)
+
+    def http_method_not_allowed(self, request, *args, **kwargs) -> ViewCallInfo:
+        return self.__class__._test_func(
+            "http_method_not_allowed", request, *args, **kwargs
+        )
+
+
+class RealTestView(BaseTestView):
+    pass
+
+
+class MockTestView(BaseTestView):
+    pass
+
+
+@pytest.fixture
+def mock_enabled_proxy_view():
+    return MockEnabledProxyView(
+        real_view_class=RealTestView, mock_view_class=MockTestView
+    )
+
+
+def test_view_class_with_inexistent_mock_flag(settings, mock_enabled_proxy_view):
+    if hasattr(settings, "NEXT_PUBLIC_MOCK_FLAG"):
+        delattr(settings, "NEXT_PUBLIC_MOCK_FLAG")
+
+    assert not hasattr(settings, "NEXT_PUBLIC_MOCK_FLAG")
+    assert mock_enabled_proxy_view.view_class == RealTestView
+
+
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=True)
+def test_view_class_with_mock_flag_on(mock_enabled_proxy_view):
+    assert mock_enabled_proxy_view.view_class == MockTestView
+
+
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_view_class_with_mock_flag_off(mock_enabled_proxy_view):
+    assert mock_enabled_proxy_view.view_class == RealTestView
+
+
+def test_view_class_with_changing_mock_flag(settings, mock_enabled_proxy_view):
+    settings.NEXT_PUBLIC_MOCK_FLAG = True
+    assert mock_enabled_proxy_view.view_class == MockTestView
+
+    delattr(settings, "NEXT_PUBLIC_MOCK_FLAG")
+    assert mock_enabled_proxy_view.view_class == RealTestView
+
+    settings.NEXT_PUBLIC_MOCK_FLAG = False
+    assert mock_enabled_proxy_view.view_class == RealTestView
+
+
+@pytest.mark.parametrize("next_public_mock_flag", [False, True])
+@pytest.mark.parametrize("initkwargs", [{}, {"http_method_names": ["get", "post"]}])
+def test_valid_view_initkwargs(settings, next_public_mock_flag: bool, initkwargs: dict):
+    settings.NEXT_PUBLIC_MOCK_FLAG = next_public_mock_flag
+    assert (
+        MockEnabledProxyView(
+            real_view_class=RealTestView, mock_view_class=MockTestView, **initkwargs
+        ).view_initkwargs
+        == initkwargs
+    )
+
+
+@pytest.mark.parametrize("next_public_mock_flag", [False, True])
+@pytest.mark.parametrize(
+    "initkwargs",
+    [
+        {"inexistent_attribute_name": "test"},
+        {"get": "test"},  # Key from View.http_method_names shouldn't be accepted
+        {"options": "test"},  # Key from View.http_method_names shouldn't be accepted
+    ],
+)
+def test_invalid_view_initkwargs(
+    settings, next_public_mock_flag: bool, initkwargs: dict
+):
+    settings.NEXT_PUBLIC_MOCK_FLAG = next_public_mock_flag
+    with pytest.raises(TypeError):
+        MockEnabledProxyView(
+            real_view_class=RealTestView, mock_view_class=MockTestView, **initkwargs
+        )
+
+
+@pytest.mark.parametrize("next_public_mock_flag", [False, True])
+def test_view_callability(
+    settings, mock_enabled_proxy_view, next_public_mock_flag: bool
+):
+    settings.NEXT_PUBLIC_MOCK_FLAG = next_public_mock_flag
+    assert callable(mock_enabled_proxy_view)
+
+
+def test_view_call_with_changing_mock_flag(settings, mock_enabled_proxy_view):
+    # Test classes' called methods should return ViewClassInfo, see BaseTestView
+    settings.NEXT_PUBLIC_MOCK_FLAG = True
+    mock_get_request = MockRequest(method="get")
+    call_info: ViewCallInfo = mock_enabled_proxy_view(mock_get_request, 1, 2, test=3)
+    assert call_info.class_name == "MockTestView"
+    assert call_info.called_method_name == "get"
+    assert call_info.request == mock_get_request
+    assert call_info.args == (1, 2)
+    assert call_info.kwargs == {"test": 3}
+
+    delattr(settings, "NEXT_PUBLIC_MOCK_FLAG")
+    mock_post_request = MockRequest(method="post")
+    call_info: ViewCallInfo = mock_enabled_proxy_view(mock_post_request, 3, 4, a=5, b=6)
+    assert call_info.class_name == "RealTestView"
+    assert call_info.called_method_name == "post"
+    assert call_info.request == mock_post_request
+    assert call_info.args == (3, 4)
+    assert call_info.kwargs == {"a": 5, "b": 6}
+
+    settings.NEXT_PUBLIC_MOCK_FLAG = True
+    call_info: ViewCallInfo = mock_enabled_proxy_view(mock_get_request, "a", 1, c=2)
+    assert call_info.class_name == "MockTestView"
+    assert call_info.called_method_name == "get"
+    assert call_info.request == mock_get_request
+    assert call_info.args == ("a", 1)
+    assert call_info.kwargs == {"c": 2}
+
+    settings.NEXT_PUBLIC_MOCK_FLAG = False
+    call_info: ViewCallInfo = mock_enabled_proxy_view(mock_post_request, test=1, more=2)
+    assert call_info.class_name == "RealTestView"
+    assert call_info.called_method_name == "post"
+    assert call_info.request == mock_post_request
+    assert call_info.args == tuple()
+    assert call_info.kwargs == {"test": 1, "more": 2}
+
+    # Patch method is not implemented in the underlying test views, so it's not allowed
+    mock_patch_request = MockRequest(method="patch")
+    call_info: ViewCallInfo = mock_enabled_proxy_view(mock_patch_request, 1, "a", b=5)
+    assert call_info.class_name == "RealTestView"
+    assert call_info.called_method_name == "http_method_not_allowed"
+    assert call_info.request == mock_patch_request
+    assert call_info.args == (1, "a")
+    assert call_info.kwargs == {"b": 5}
+
+
+@pytest.mark.parametrize(
+    "next_public_mock_flag,expected_view_class_name",
+    [
+        (False, "RealTestView"),
+        (True, "MockTestView"),
+    ],
+)
+@pytest.mark.parametrize(
+    "initkwargs,mock_request,expected_called_method",
+    [
+        ({}, MockRequest(method="get"), "get"),  # View's default methods contain get
+        ({}, MockRequest(method="post"), "post"),  # View's default methods contain post
+        (
+            {},
+            MockRequest(method="patch"),
+            "http_method_not_allowed",  # patch method is not implemented
+        ),
+        (
+            {},
+            MockRequest(method="unknown"),
+            "http_method_not_allowed",  # unknown method is not implemented
+        ),
+        (
+            {"http_method_names": ["post"]},
+            MockRequest(method="get"),
+            "http_method_not_allowed",
+        ),
+        ({"http_method_names": ["post"]}, MockRequest(method="post"), "post"),
+        (
+            {"http_method_names": ["post"]},
+            MockRequest(method="patch"),
+            "http_method_not_allowed",
+        ),
+        ({"http_method_names": ["get", "patch"]}, MockRequest(method="get"), "get"),
+        (
+            {"http_method_names": ["get", "patch"]},
+            MockRequest(method="post"),
+            "http_method_not_allowed",
+        ),
+        (
+            {"http_method_names": ["get", "patch"]},
+            MockRequest(method="patch"),
+            "http_method_not_allowed",  # patch method is not implemented
+        ),
+        ({"http_method_names": ["get", "post"]}, MockRequest(method="get"), "get"),
+        ({"http_method_names": ["get", "post"]}, MockRequest(method="post"), "post"),
+        (
+            {"http_method_names": ["get", "post"]},
+            MockRequest(method="patch"),
+            "http_method_not_allowed",
+        ),
+    ],
+)
+@pytest.mark.parametrize("call_args", [(), ("test", 1, "more_test")])
+@pytest.mark.parametrize(
+    "call_kwargs",
+    [
+        {},
+        {"a": 1, "b": 3.14, "c": "test"},
+        {"outer_key": {"nested_key": "nested_value"}, "outer_key_2": 2},
+    ],
+)
+def test_view_call(
+    settings,
+    next_public_mock_flag: bool,
+    initkwargs: dict,
+    mock_request: MockRequest,
+    expected_view_class_name: str,
+    expected_called_method: str,
+    call_args: tuple,
+    call_kwargs: dict,
+):
+    # This test relys on Django's View class,
+    # see View's as_view, dispatch and http_method_names:
+    # https://github.com/django/django/blob/stable/3.2.x/django/views/generic/base.py
+    settings.NEXT_PUBLIC_MOCK_FLAG = next_public_mock_flag
+    view = MockEnabledProxyView(
+        real_view_class=RealTestView, mock_view_class=MockTestView, **initkwargs
+    )
+    # Test classes' called methods should return ViewClassInfo, see BaseTestView
+    call_info: ViewCallInfo = view(mock_request, *call_args, **call_kwargs)
+    assert call_info.class_name == expected_view_class_name
+    assert call_info.called_method_name == expected_called_method
+    assert call_info.request == mock_request
+    assert call_info.args == call_args
+    assert call_info.kwargs == call_kwargs

--- a/backend/shared/shared/common/views.py
+++ b/backend/shared/shared/common/views.py
@@ -1,0 +1,70 @@
+from typing import Type
+
+from django.conf import settings
+from django.views import View
+
+
+class MockEnabledProxyView:
+    """
+    A view that changes on-the-fly between the real and mocked view based on the current
+    value of NEXT_PUBLIC_MOCK_FLAG.
+
+    An instance of this class tries to act like
+    mock_view_class.as_view(**initkwargs) when NEXT_PUBLIC_MOCK_FLAG setting is set,
+    otherwise as real_view_class.as_view(**initkwargs) where mock_view_class and
+    real_view_class are the classes passed to the __init__ function.
+
+    For reference see django.views.generic.base.View.as_view:
+    https://github.com/django/django/blob/stable/3.2.x/django/views/generic/base.py#L49
+
+    The double underscore prefixes for variables/properties are used to invoke name
+    mangling to avoid name clashes with the enclosed View classes, see PEP8:
+     - https://pep8.org/#method-names-and-instance-variables
+    """
+
+    def __init__(
+        self, real_view_class: Type[View], mock_view_class: Type[View], **initkwargs
+    ):
+        """
+        Initialize the real view to real_view_class.as_view(**initkwargs) and
+        mock view to mock_view_class.as_view(**initkwargs).
+
+        :param real_view_class: Type of View class to use when mocking is turned off
+        :param mock_view_class: Type of View class to use when mocking is turned on
+        :param initkwargs: The keyword arguments passed to real_view_class.as_view and
+                           mock_view_class.as_view functions
+        """
+        self.__real_view = real_view_class.as_view(**initkwargs)
+        self.__mock_view = mock_view_class.as_view(**initkwargs)
+
+    @property
+    def __view(self):
+        """
+        The underlying view initialized using <ViewClass>.as_view(**initkwargs) based
+        on the current value of NEXT_PUBLIC_MOCK_FLAG setting.
+
+        :return: mock_view_class.as_view(**initkwargs) if NEXT_PUBLIC_MOCK_FLAG setting
+                 exists and is truthy, otherwise real_view_class.as_view(**initkwargs)
+        """
+        is_mocked = getattr(settings, "NEXT_PUBLIC_MOCK_FLAG", False)
+        return self.__mock_view if is_mocked else self.__real_view
+
+    def __getattr__(self, name):
+        """
+        Read all attributes not found in this instance from the underlying view.
+
+        This is needed because django.views.generic.base.View.as_view returns a function
+        which has attributes written into it, e.g. view_class and view_initkwargs, and
+        they need to be accessible directly through this instance.
+        """
+        return getattr(self.__view, name)
+
+    def __call__(self, *args, **kwargs):
+        """
+        Redirect all calls made to this instance to the underlying view.
+
+        This is needed because django.views.generic.base.View.as_view returns a function
+        which can be called like function(request, *args, **kwargs) and calling it with
+        the passed parameters needs to be doable directly through this instance.
+        """
+        return self.__view.__call__(*args, **kwargs)

--- a/backend/shared/shared/oidc/tests/test_mock_views.py
+++ b/backend/shared/shared/oidc/tests/test_mock_views.py
@@ -1,5 +1,8 @@
+import itertools
+
 import pytest
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import path, reverse
 
@@ -35,17 +38,53 @@ urlpatterns = [
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "oidc_mock_user_is_staff,oidc_mock_user_is_superuser",
+    itertools.product([None, False, True], repeat=2),  # None means no setting at all
+)
 @override_settings(
     NEXT_PUBLIC_MOCK_FLAG=True,
     LOGIN_REDIRECT_URL="http://example.com/login/",
     ROOT_URLCONF=__name__,
 )
-def test_login_view(client):
+def test_login_view(
+    settings, client, oidc_mock_user_is_staff, oidc_mock_user_is_superuser
+):
+    if oidc_mock_user_is_staff is None:
+        if hasattr(settings, "OIDC_MOCK_USER_IS_STAFF"):
+            delattr(settings, "OIDC_MOCK_USER_IS_STAFF")
+    else:
+        settings.OIDC_MOCK_USER_IS_STAFF = oidc_mock_user_is_staff
+
+    if oidc_mock_user_is_superuser is None:
+        if hasattr(settings, "OIDC_MOCK_USER_IS_SUPERUSER"):
+            delattr(settings, "OIDC_MOCK_USER_IS_SUPERUSER")
+    else:
+        settings.OIDC_MOCK_USER_IS_SUPERUSER = oidc_mock_user_is_superuser
+
+    assert (oidc_mock_user_is_staff is not None) == hasattr(
+        settings, "OIDC_MOCK_USER_IS_STAFF"
+    )
+    assert (oidc_mock_user_is_superuser is not None) == hasattr(
+        settings, "OIDC_MOCK_USER_IS_SUPERUSER"
+    )
+
+    assert bool(oidc_mock_user_is_staff) == getattr(
+        settings, "OIDC_MOCK_USER_IS_STAFF", False
+    )
+    assert bool(oidc_mock_user_is_superuser) == getattr(
+        settings, "OIDC_MOCK_USER_IS_SUPERUSER", False
+    )
+
     login_url = reverse("oidc_authentication_init")
     response = client.get(login_url)
 
     assert response.url == settings.LOGIN_REDIRECT_URL
     assert "_auth_user_id" in client.session  # User authenticated
+    user = get_user_model().objects.get(pk=client.session.get("_auth_user_id"))
+    assert user.is_authenticated
+    assert user.is_staff == bool(oidc_mock_user_is_staff)
+    assert user.is_superuser == bool(oidc_mock_user_is_superuser)
 
 
 @pytest.mark.django_db

--- a/backend/shared/shared/oidc/tests/test_mock_views.py
+++ b/backend/shared/shared/oidc/tests/test_mock_views.py
@@ -4,37 +4,7 @@ import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import override_settings
-from django.urls import path, reverse
-
-from shared.oidc.views.mock_views import (
-    MockAuthenticationRequestView,
-    MockLogoutCallbackView,
-    MockLogoutView,
-    MockUserInfoView,
-)
-
-urlpatterns = [
-    path(
-        "oidc/authenticate/",
-        MockAuthenticationRequestView.as_view(),
-        name="oidc_authentication_init",
-    ),
-    path(
-        "oidc/logout/",
-        MockLogoutView.as_view(),
-        name="oidc_logout",
-    ),
-    path(
-        "oidc/logout_callback/",
-        MockLogoutCallbackView.as_view(),
-        name="oidc_logout_callback",
-    ),
-    path(
-        "oidc/userinfo/",
-        MockUserInfoView.as_view(),
-        name="oidc_userinfo",
-    ),
-]
+from django.urls import reverse
 
 
 @pytest.mark.django_db
@@ -45,7 +15,6 @@ urlpatterns = [
 @override_settings(
     NEXT_PUBLIC_MOCK_FLAG=True,
     LOGIN_REDIRECT_URL="http://example.com/login/",
-    ROOT_URLCONF=__name__,
 )
 def test_login_view(
     settings, client, oidc_mock_user_is_staff, oidc_mock_user_is_superuser
@@ -90,7 +59,6 @@ def test_login_view(
 @pytest.mark.django_db
 @override_settings(
     NEXT_PUBLIC_MOCK_FLAG=True,
-    ROOT_URLCONF=__name__,
     LOGOUT_REDIRECT_URL="http://example.com/logged_out/?status=logout",
 )
 def test_logout_view(user_client, user):
@@ -104,7 +72,6 @@ def test_logout_view(user_client, user):
 @pytest.mark.django_db
 @override_settings(
     NEXT_PUBLIC_MOCK_FLAG=True,
-    ROOT_URLCONF=__name__,
     LOGOUT_REDIRECT_URL="http://example.com/logged_out/?status=logout",
 )
 def test_logout_callback_view(user_client, user):
@@ -115,7 +82,7 @@ def test_logout_callback_view(user_client, user):
 
 
 @pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=True, ROOT_URLCONF=__name__)
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=True)
 def test_userinfo_view(user_client, user):
     logout_url = reverse("oidc_userinfo")
     response = user_client.get(logout_url)

--- a/backend/shared/shared/oidc/urls.py
+++ b/backend/shared/shared/oidc/urls.py
@@ -1,6 +1,6 @@
-from django.conf import settings
 from django.urls import include, path
 
+from shared.common.views import MockEnabledProxyView
 from shared.oidc.views.eauth_views import (
     EauthAuthenticationCallbackView,
     EauthAuthenticationRequestView,
@@ -13,80 +13,65 @@ from shared.oidc.views.hki_views import (
     HelsinkiOIDCLogoutView,
     HelsinkiOIDCUserInfoView,
 )
+from shared.oidc.views.mock_views import (
+    MockAuthenticationRequestView,
+    MockLogoutCallbackView,
+    MockLogoutView,
+    MockUserInfoView,
+)
 
-urlpatterns = []
-
-if settings.NEXT_PUBLIC_MOCK_FLAG:
-    from shared.oidc.views.mock_views import (
-        MockAuthenticationRequestView,
-        MockLogoutCallbackView,
-        MockLogoutView,
-        MockUserInfoView,
-    )
-
-    urlpatterns += [
-        path(
-            "authenticate/",
-            MockAuthenticationRequestView.as_view(),
-            name="oidc_authentication_init",
+urlpatterns = [
+    path(
+        "authenticate/",
+        MockEnabledProxyView(
+            real_view_class=HelsinkiOIDCAuthenticationRequestView,
+            mock_view_class=MockAuthenticationRequestView,
         ),
-        path(
-            "logout/",
-            MockLogoutView.as_view(),
-            name="oidc_logout",
+        name="oidc_authentication_init",
+    ),
+    path(
+        "logout/",
+        MockEnabledProxyView(
+            real_view_class=HelsinkiOIDCLogoutView,
+            mock_view_class=MockLogoutView,
         ),
-        path(
-            "logout_callback/",
-            MockLogoutCallbackView.as_view(),
-            name="oidc_logout_callback",
+        name="oidc_logout",
+    ),
+    path(
+        "logout_callback/",
+        MockEnabledProxyView(
+            real_view_class=HelsinkiOIDCLogoutCallbackView,
+            mock_view_class=MockLogoutCallbackView,
         ),
-        path(
-            "userinfo/",
-            MockUserInfoView.as_view(),
-            name="oidc_userinfo",
+        name="oidc_logout_callback",
+    ),
+    path(
+        "userinfo/",
+        MockEnabledProxyView(
+            real_view_class=HelsinkiOIDCUserInfoView,
+            mock_view_class=MockUserInfoView,
         ),
-    ]
-else:
-    urlpatterns += [
-        path(
-            "authenticate/",
-            HelsinkiOIDCAuthenticationRequestView.as_view(),
-            name="oidc_authentication_init",
-        ),
-        path(
-            "callback/",
-            HelsinkiOIDCAuthenticationCallbackView.as_view(),
-            name="oidc_authentication_callback",
-        ),
-        path(
-            "logout/",
-            HelsinkiOIDCLogoutView.as_view(),
-            name="oidc_logout",
-        ),
-        path(
-            "logout_callback/",
-            HelsinkiOIDCLogoutCallbackView.as_view(),
-            name="oidc_logout_callback",
-        ),
-        path(
-            "userinfo/",
-            HelsinkiOIDCUserInfoView.as_view(),
-            name="oidc_userinfo",
-        ),
-        path(
-            "backchannel/logout/",
-            HelsinkiOIDCBackchannelLogoutView.as_view(),
-            name="oidc_backchannel_logout",
-        ),
-        path("", include("mozilla_django_oidc.urls")),
-        path(
-            "eauthorizations/authenticate/",
-            EauthAuthenticationRequestView.as_view(),
-            name="eauth_authentication_init",
-        ),
-        path(
-            "eauthorizations/callback/",
-            EauthAuthenticationCallbackView.as_view(),
-            name="eauth_authentication_callback",
-        ),
-    ]
+        name="oidc_userinfo",
+    ),
+    path(
+        "callback/",
+        HelsinkiOIDCAuthenticationCallbackView.as_view(),
+        name="oidc_authentication_callback",
+    ),
+    path(
+        "backchannel/logout/",
+        HelsinkiOIDCBackchannelLogoutView.as_view(),
+        name="oidc_backchannel_logout",
+    ),
+    path("", include("mozilla_django_oidc.urls")),
+    path(
+        "eauthorizations/authenticate/",
+        EauthAuthenticationRequestView.as_view(),
+        name="eauth_authentication_init",
+    ),
+    path(
+        "eauthorizations/callback/",
+        EauthAuthenticationCallbackView.as_view(),
+        name="eauth_authentication_callback",
+    ),
+]

--- a/backend/shared/shared/oidc/views/mock_views.py
+++ b/backend/shared/shared/oidc/views/mock_views.py
@@ -61,7 +61,10 @@ class MockAuthenticationRequestView(View):
     @method_decorator(ensure_csrf_cookie)
     def get(self, request, *args, **kwargs):
         if not request.user.is_authenticated:
-            user = UserFactory()
+            user = UserFactory(
+                is_staff=getattr(settings, "OIDC_MOCK_USER_IS_STAFF", False),
+                is_superuser=getattr(settings, "OIDC_MOCK_USER_IS_SUPERUSER", False),
+            )
             auth.login(
                 request, user, backend="django.contrib.auth.backends.ModelBackend"
             )


### PR DESCRIPTION
## Description :sparkles:

### Shared backend: Add is_staff & is_superuser support to OIDC mock user 

Add settings to control OIDC mock user's is_staff & is_superuser values:
 - settings.OIDC_MOCK_USER_IS_STAFF -> OIDC mock user's is_staff
   - If the setting is not set at all then will default to False
 - settings.OIDC_MOCK_USER_IS_SUPERUSER -> OIDC mock user's is_superuser
   - If the setting is not set at all then will default to False

The OIDC mock user is created by MockAuthenticationRequestView which is
mapped to oidc's authenticate endpoint
(See backend/shared/shared/oidc/urls.py) if NEXT_PUBLIC_MOCK_FLAG is set

Refs HL-566
 
### HL-Backend: Update NEXT_PUBLIC_MOCK_FLAG related permission handling 

BaseApplicationViewSet.get_queryset:
 - Refactor logical structure for readability, should not change effect

ApplicationStatus.is_editable_status:
 - Previously NEXT_PUBLIC_MOCK_FLAG allowed to edit all statuses. Now
   NEXT_PUBLIC_MOCK_FLAG allows to edit both handler's and applicant's
   statuses.
 - Update related test_is_editable_status_with_anonymous_user test

UserSerializer.is_terms_of_service_approval_needed:
 - Don't require terms of service to be approved when
   NEXT_PUBLIC_MOCK_FLAG is on

Refs HL-566
 
### Shared backend: Conditionally mock endpoints using MockEnabledProxyView 

Add MockEnabledProxyView and tests:
 - A view that changes on-the-fly between the real and mocked view based
   on the current value of NEXT_PUBLIC_MOCK_FLAG

Refs HL-566
 
### HL-Backend: Don't validate pay subsidies in RECEIVED to HANDLING change 

PaysubsidySerializer:
 - Make start_date and end_date validation errors specific to the fields
 - Skip start_date and end_date validation when application's status is
   changed from RECEIVED to HANDLING

Tests:
 - Add RECEIVED to HANDLING status change case to
   test_application_status_change_as_handler
 - Add test_ignore_pay_subsidy_dates_in_received_to_handling_transition
   test to check that pay subsidies' start and end dates can be empty
   when application's status changes from RECEIVED to HANDLING
 - Move duplicated test code to _set_two_pay_subsidies_with_empty_dates

Translations:
 - Update translations:
   - "python manage.py makemessages --no-location -l fi -l sv -l en"
 - Add Finnish and Swedish translations for
   - "Start date cannot be empty"
   - "End date cannot be empty"

Refs HL-553

## Issues :bug:

HL-553, HL-566

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
