### PR TITLE
HL-553 | Restrict pay subsidies' date validation to salary benefits

### DIFF
--- a/backend/benefit/applications/tests/factories.py
+++ b/backend/benefit/applications/tests/factories.py
@@ -138,7 +138,7 @@ class ReceivedApplicationFactory(ApplicationFactory):
 
     @factory.post_generation
     def calculation(self, created, extracted, **kwargs):
-        self.calculation = Calculation.objects.create_for_application(self)
+        self.calculation = Calculation.objects.create_for_application(self, **kwargs)
         self.calculation.init_calculator()
         self.calculation.calculate()
 

--- a/backend/benefit/calculator/api/v1/serializers.py
+++ b/backend/benefit/calculator/api/v1/serializers.py
@@ -2,7 +2,7 @@ from dateutil.relativedelta import relativedelta
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
-from applications.enums import ApplicationStatus
+from applications.enums import ApplicationStatus, BenefitType
 from applications.models import Application
 from calculator.models import (
     Calculation,
@@ -224,6 +224,11 @@ class PaySubsidySerializer(serializers.ModelSerializer):
             is not None
         )
 
+    def _is_salary_benefit_type(self):
+        return (
+            self.context["request"].data["benefit_type"] == BenefitType.SALARY_BENEFIT
+        )
+
     HANDLING_STARTED_STATUSES: set = {
         ApplicationStatus.HANDLING,
         ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED,
@@ -245,7 +250,11 @@ class PaySubsidySerializer(serializers.ModelSerializer):
         )
 
     def _are_dates_required(self):
-        return self._has_handling_started() and not self._is_manual_mode()
+        return (
+            self._has_handling_started()
+            and self._is_salary_benefit_type()
+            and not self._is_manual_mode()
+        )
 
     def validate(self, data):
         request = self.context.get("request")

--- a/backend/benefit/calculator/models.py
+++ b/backend/benefit/calculator/models.py
@@ -29,11 +29,19 @@ STATE_AID_MAX_PERCENTAGE_CHOICES = (
 
 
 class CalculationManager(models.Manager):
-    def create_for_application(self, application):
+    def create_for_application(
+        self, application: Application, **kwargs
+    ) -> "Calculation":
+        """
+        Create Calculation object for application with Calculation attributes optionally
+        overridden by the kwargs values.
+        """
         if hasattr(application, "calculation"):
             raise BenefitAPIException(_("Calculation already exists"))
         calculation = Calculation(application=application)
         calculation.reset_values()
+        for attribute_name, attribute_value in kwargs.items():
+            setattr(calculation, attribute_name, attribute_value)
         calculation.save()
         return calculation
 


### PR DESCRIPTION
## Description :sparkles:

### HL-Backend: Restrict pay subsidies' date validation to salary benefits 

Tests:
 - Add new tests
   - test_pay_subsidies_validation_in_handling
     - Test that pay subsidies' validation works as expected for
       applications in handling
 - Fix existing tests
   - test_application_edit_pay_subsidy_invalid_values
   - test_validate_pay_subsidy_dates_when_application_is_handled

## Issues :bug:

HL-553

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
