### PR TITLE
Enable eslint rules to tet projects + fix eslint problems

### DIFF
--- a/frontend/.eslintrc.jsx.js
+++ b/frontend/.eslintrc.jsx.js
@@ -20,7 +20,7 @@ module.exports = {
       },
     },
     {
-      files: ['*.components.ts'],
+      files: ['*.components.ts', '*page.ts', '*.testcafe.ts'],
       rules: {
         'security/detect-non-literal-fs-filename': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/frontend/.eslintrc.jsx.js
+++ b/frontend/.eslintrc.jsx.js
@@ -20,6 +20,12 @@ module.exports = {
       },
     },
     {
+      files: ['*.tsx'],
+      rules: {
+        'react/require-default-props': 'off',
+      },
+    },
+    {
       files: ['*.components.ts', '*page.ts', '*.testcafe.ts'],
       rules: {
         'security/detect-non-literal-fs-filename': 'off',

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step3/attachmentsList/AttachmentsList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step3/attachmentsList/AttachmentsList.tsx
@@ -50,10 +50,4 @@ const AttachmentsList: React.FC<AttachmentsListProps> = ({
   );
 };
 
-AttachmentsList.defaultProps = {
-  showMessage: undefined,
-  attachments: undefined,
-  required: undefined,
-};
-
 export default AttachmentsList;

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/ApplicationFormStep5.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/ApplicationFormStep5.tsx
@@ -4,7 +4,6 @@ import { DynamicFormStepComponentProps } from 'benefit/applicant/types/common';
 import { ATTACHMENT_TYPES, BENEFIT_TYPES } from 'benefit-shared/constants';
 import { Button, IconPen } from 'hds-react';
 import isEmpty from 'lodash/isEmpty';
-import noop from 'lodash/noop';
 import React from 'react';
 import { getFullName } from 'shared/utils/application.utils';
 import { useTheme } from 'styled-components';
@@ -177,13 +176,5 @@ const ApplicationFormStep5: React.FC<
     </>
   );
 };
-
-const defaultProps = {
-  isReadOnly: false,
-  isSubmittedApplication: false,
-  onSubmit: noop,
-};
-
-ApplicationFormStep5.defaultProps = defaultProps;
 
 export default ApplicationFormStep5;

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/attachmentsListView/AttachmentsListView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/attachmentsListView/AttachmentsListView.tsx
@@ -45,8 +45,4 @@ const AttachmentsListView: React.FC<AttachmentsListViewProps> = ({
   ) : null;
 };
 
-AttachmentsListView.defaultProps = {
-  title: undefined,
-};
-
 export default AttachmentsListView;

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
@@ -197,8 +197,4 @@ const CompanyInfoView: React.FC<CompanyInfoViewProps> = ({
   );
 };
 
-CompanyInfoView.defaultProps = {
-  isReadOnly: undefined,
-};
-
 export default CompanyInfoView;

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/employeeView/EmployeeView.tsx
@@ -198,8 +198,4 @@ const EmployeeView: React.FC<EmployeeViewProps> = ({
   );
 };
 
-EmployeeView.defaultProps = {
-  isReadOnly: undefined,
-};
-
 export default EmployeeView;

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step6/ApplicationFormStep6.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step6/ApplicationFormStep6.tsx
@@ -3,7 +3,6 @@ import PdfViewer from 'benefit/applicant/components/pdfViewer/PdfViewer';
 import { DynamicFormStepComponentProps } from 'benefit/applicant/types/common';
 import { TextProp } from 'benefit-shared/types/application';
 import { Button } from 'hds-react';
-import noop from 'lodash/noop';
 import * as React from 'react';
 import { $Checkbox } from 'shared/components/forms/fields/Fields.sc';
 import FormSection from 'shared/components/forms/section/FormSection';
@@ -108,12 +107,5 @@ const ApplicationFormStep6: React.FC<
     </form>
   );
 };
-
-const defaultProps = {
-  isSubmittedApplication: false,
-  onSubmit: noop,
-};
-
-ApplicationFormStep6.defaultProps = defaultProps;
 
 export default ApplicationFormStep6;

--- a/frontend/benefit/applicant/src/components/applications/forms/application/stepperActions/StepperActions.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/stepperActions/StepperActions.tsx
@@ -93,13 +93,4 @@ const StepperActions: React.FC<StepperActionsProps> = ({
   );
 };
 
-const defaultProps = {
-  lastStep: false,
-  handleBack: undefined,
-  handleDelete: undefined,
-  disabledNext: false,
-};
-
-StepperActions.defaultProps = defaultProps;
-
 export default StepperActions;

--- a/frontend/benefit/applicant/src/components/errorPage/ErrorPage.tsx
+++ b/frontend/benefit/applicant/src/components/errorPage/ErrorPage.tsx
@@ -44,8 +44,4 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
   );
 };
 
-ErrorPage.defaultProps = {
-  showActions: undefined,
-};
-
 export default ErrorPage;

--- a/frontend/benefit/applicant/src/components/messenger/Messages.tsx
+++ b/frontend/benefit/applicant/src/components/messenger/Messages.tsx
@@ -52,8 +52,4 @@ const Messages: React.FC<ComponentProps> = ({ data, variant, withScroll }) => {
   );
 };
 
-Messages.defaultProps = {
-  withScroll: false,
-};
-
 export default Messages;

--- a/frontend/benefit/applicant/src/components/messenger/Messenger.tsx
+++ b/frontend/benefit/applicant/src/components/messenger/Messenger.tsx
@@ -1,5 +1,4 @@
 import { Tab, TabPanel, Tabs } from 'hds-react';
-import noop from 'lodash/noop';
 import * as React from 'react';
 import { $TabList } from 'shared/components/benefit/tabs/Tabs.sc';
 import Drawer from 'shared/components/drawer/Drawer';
@@ -50,11 +49,6 @@ const Messenger: React.FC<ComponentProps> = ({
       </Tabs>
     </Drawer>
   );
-};
-
-Messenger.defaultProps = {
-  customItemsMessages: [],
-  onClose: noop,
 };
 
 export default Messenger;

--- a/frontend/benefit/applicant/src/components/pdfViewer/PdfViewer.tsx
+++ b/frontend/benefit/applicant/src/components/pdfViewer/PdfViewer.tsx
@@ -78,11 +78,4 @@ const PdfViewer: React.FC<PdfViewerProps> = ({
   );
 };
 
-const defaultProps = {
-  documentMarginLeft: '0',
-  scale: undefined,
-};
-
-PdfViewer.defaultProps = defaultProps;
-
 export default PdfViewer;

--- a/frontend/benefit/applicant/src/components/summarySection/SummarySection.tsx
+++ b/frontend/benefit/applicant/src/components/summarySection/SummarySection.tsx
@@ -70,12 +70,4 @@ const SummarySection: React.FC<SummarySectionProps> = ({
   );
 };
 
-SummarySection.defaultProps = {
-  children: null,
-  withoutDivider: undefined,
-  paddingBottom: undefined,
-  header: null,
-  action: null,
-};
-
 export default SummarySection;

--- a/frontend/benefit/handler/src/components/applicationReports/ReportsSection.tsx
+++ b/frontend/benefit/handler/src/components/applicationReports/ReportsSection.tsx
@@ -77,9 +77,4 @@ const ReportsSection: React.FC<ReportsSectionProp> = ({
   );
 };
 
-ReportsSection.defaultProps = {
-  children: null,
-  withDivider: false,
-};
-
 export default ReportsSection;

--- a/frontend/benefit/handler/src/components/applicationReview/notificationView/NotificationView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/notificationView/NotificationView.tsx
@@ -69,8 +69,4 @@ const NotificationView: React.FC<Props> = ({ data }) => {
   );
 };
 
-NotificationView.defaultProps = {
-  data: {},
-};
-
 export default NotificationView;

--- a/frontend/benefit/handler/src/components/attachmentsListView/AttachmentsListView.tsx
+++ b/frontend/benefit/handler/src/components/attachmentsListView/AttachmentsListView.tsx
@@ -72,8 +72,4 @@ const AttachmentsListView: React.FC<AttachmentsListViewProps> = ({
   );
 };
 
-AttachmentsListView.defaultProps = {
-  title: undefined,
-};
-
 export default AttachmentsListView;

--- a/frontend/benefit/handler/src/components/messenger/Messages.tsx
+++ b/frontend/benefit/handler/src/components/messenger/Messages.tsx
@@ -52,8 +52,4 @@ const Messages: React.FC<ComponentProps> = ({ data, variant, withScroll }) => {
   );
 };
 
-Messages.defaultProps = {
-  withScroll: false,
-};
-
 export default Messages;

--- a/frontend/benefit/handler/src/components/messenger/Messenger.tsx
+++ b/frontend/benefit/handler/src/components/messenger/Messenger.tsx
@@ -1,5 +1,4 @@
 import { Tab, TabPanel, Tabs } from 'hds-react';
-import noop from 'lodash/noop';
 import * as React from 'react';
 import { $TabList } from 'shared/components/benefit/tabs/Tabs.sc';
 import Drawer from 'shared/components/drawer/Drawer';
@@ -78,13 +77,6 @@ const Messenger: React.FC<ComponentProps> = ({
       </Tabs>
     </Drawer>
   );
-};
-
-Messenger.defaultProps = {
-  customItemsMessages: [],
-  customItemsNotes: [],
-  onClose: () => noop,
-  isReadOnly: false,
 };
 
 export default Messenger;

--- a/frontend/benefit/handler/src/components/reviewSection/ReviewSection.tsx
+++ b/frontend/benefit/handler/src/components/reviewSection/ReviewSection.tsx
@@ -102,12 +102,4 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({
   );
 };
 
-ReviewSection.defaultProps = {
-  children: null,
-  action: null,
-  withMargin: undefined,
-  withoutDivider: undefined,
-  header: undefined,
-};
-
 export default ReviewSection;

--- a/frontend/kesaseteli/employer/src/components/application/ApplicationForm.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/ApplicationForm.tsx
@@ -33,8 +33,5 @@ const ApplicationForm: React.FC<Props> = ({ title, step, children }: Props) => {
   }
   return <PageLoadingSpinner />;
 };
-ApplicationForm.defaultProps = {
-  title: undefined,
-};
 
 export default ApplicationForm;

--- a/frontend/kesaseteli/employer/src/components/application/form/ActionButtons.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/ActionButtons.tsx
@@ -91,8 +91,4 @@ const ActionButtons: React.FC<Props> = ({ onAfterLastStep = noop }) => {
   );
 };
 
-ActionButtons.defaultProps = {
-  onAfterLastStep: noop,
-};
-
 export default ActionButtons;

--- a/frontend/kesaseteli/employer/src/components/application/form/AttachmentInput.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/AttachmentInput.tsx
@@ -172,8 +172,4 @@ const AttachmentInput: React.FC<Props> = ({ index, id, required }) => {
   return <PageLoadingSpinner />;
 };
 
-AttachmentInput.defaultProps = {
-  required: false,
-};
-
 export default AttachmentInput;

--- a/frontend/kesaseteli/employer/src/components/application/form/Checkbox.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/Checkbox.tsx
@@ -52,11 +52,4 @@ const Checkbox: React.FC<Props> = ({
   );
 };
 
-Checkbox.defaultProps = {
-  validation: {},
-  onChange: noop,
-  initialValue: false,
-  label: null,
-};
-
 export default Checkbox;

--- a/frontend/kesaseteli/employer/src/components/application/form/SelectionGroup.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/SelectionGroup.tsx
@@ -76,11 +76,4 @@ const SelectionGroup = <V extends readonly string[]>({
   );
 };
 
-SelectionGroup.defaultProps = {
-  direction: 'horizontal',
-  validation: undefined,
-  showTitle: true,
-  onChange: noop,
-};
-
 export default SelectionGroup;

--- a/frontend/kesaseteli/employer/src/components/application/form/TextInput.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/TextInput.tsx
@@ -59,11 +59,4 @@ const TextInput: React.FC<TextInputProps> = ({
   );
 };
 
-TextInput.defaultProps = {
-  validation: undefined,
-  type: undefined,
-  placeholder: undefined,
-  helperFormat: undefined,
-};
-
 export default TextInput;

--- a/frontend/kesaseteli/employer/src/components/application/steps/step2/accordions/EmploymentAccordionHeader.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step2/accordions/EmploymentAccordionHeader.tsx
@@ -31,8 +31,4 @@ const EmploymentAccordionHeader: React.FC<Props> = ({
   );
 };
 
-EmploymentAccordionHeader.defaultProps = {
-  displayError: false,
-};
-
 export default EmploymentAccordionHeader;

--- a/frontend/kesaseteli/employer/src/components/application/summary/ApplicationSummary.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/summary/ApplicationSummary.tsx
@@ -104,9 +104,4 @@ const ApplicationSummary: React.FC<Props> = ({ header, tooltip }) => {
   return <PageLoadingSpinner />;
 };
 
-ApplicationSummary.defaultProps = {
-  header: '',
-  tooltip: '',
-};
-
 export default ApplicationSummary;

--- a/frontend/kesaseteli/employer/src/components/application/summary/EmploymentFieldSummary.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/summary/EmploymentFieldSummary.tsx
@@ -35,9 +35,4 @@ const EmploymentFieldSummary: React.FC<Props> = ({
   );
 };
 
-EmploymentFieldSummary.defaultProps = {
-  children: null,
-  select: undefined,
-};
-
 export default EmploymentFieldSummary;

--- a/frontend/kesaseteli/handler/src/components/form/Field.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/Field.tsx
@@ -40,11 +40,4 @@ const Field: React.FC<Props> = ({
   );
 };
 
-Field.defaultProps = {
-  id: undefined,
-  type: undefined,
-  value: '-',
-  children: null,
-};
-
 export default Field;

--- a/frontend/kesaseteli/handler/src/components/form/VtjErrorMessage.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/VtjErrorMessage.tsx
@@ -16,8 +16,4 @@ const VtjErrorMessage: React.FC<Props> = ({ reason, params }) => {
   );
 };
 
-VtjErrorMessage.defaultProps = {
-  params: undefined,
-};
-
 export default VtjErrorMessage;

--- a/frontend/kesaseteli/handler/src/components/form/VtjErrorNotification.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/VtjErrorNotification.tsx
@@ -24,9 +24,4 @@ const VtjErrorNotification: React.FC<Props> = ({ reason, type, params }) => {
   );
 };
 
-VtjErrorNotification.defaultProps = {
-  params: undefined,
-  type: 'alert',
-};
-
 export default VtjErrorNotification;

--- a/frontend/shared/src/backend-api/BackendAPIProvider.tsx
+++ b/frontend/shared/src/backend-api/BackendAPIProvider.tsx
@@ -30,8 +30,4 @@ const BackendAPIProvider: React.FC<BackendAPIProviderProps> = ({
   </BackendAPIContext.Provider>
 );
 
-BackendAPIProvider.defaultProps = {
-  headers: undefined,
-};
-
 export default BackendAPIProvider;

--- a/frontend/shared/src/components/app/BaseApp.tsx
+++ b/frontend/shared/src/components/app/BaseApp.tsx
@@ -103,11 +103,4 @@ const BaseApp: React.FC<Props> = ({
   );
 };
 
-BaseApp.defaultProps = {
-  header: null,
-  footer: null,
-  title: undefined,
-  layout: undefined,
-};
-
 export default initLocale(BaseApp);

--- a/frontend/shared/src/components/application-wizard/ApplicationWizard.tsx
+++ b/frontend/shared/src/components/application-wizard/ApplicationWizard.tsx
@@ -38,9 +38,4 @@ const ApplicationWizard: React.FC<WizardProps> = ({
   );
 };
 
-ApplicationWizard.defaultProps = {
-  initialStep: 0,
-  footer: null,
-};
-
 export default ApplicationWizard;

--- a/frontend/shared/src/components/attachments/AttachmentsList.tsx
+++ b/frontend/shared/src/components/attachments/AttachmentsList.tsx
@@ -109,15 +109,4 @@ const AttachmentsList = <T extends Attachment>({
   );
 };
 
-AttachmentsList.defaultProps = {
-  allowedFileTypes: ATTACHMENT_CONTENT_TYPES,
-  maxSize: ATTACHMENT_MAX_SIZE,
-  message: '',
-  errorMessage: '',
-  attachments: [],
-  required: false,
-  buttonRef: null,
-  name: '',
-};
-
 export default AttachmentsList;

--- a/frontend/shared/src/components/attachments/UploadAttachment.tsx
+++ b/frontend/shared/src/components/attachments/UploadAttachment.tsx
@@ -78,12 +78,4 @@ const UploadAttachment: React.FC<UploadAttachmentProps> = ({
   );
 };
 
-UploadAttachment.defaultProps = {
-  ariaUploadText: undefined,
-  icon: undefined,
-  variant: undefined,
-  name: undefined,
-  buttonRef: undefined,
-};
-
 export default UploadAttachment;

--- a/frontend/shared/src/components/drawer/Drawer.tsx
+++ b/frontend/shared/src/components/drawer/Drawer.tsx
@@ -40,11 +40,4 @@ const Drawer: React.FC<DrawerProps> = ({
   );
 };
 
-Drawer.defaultProps = {
-  title: undefined,
-  closeText: undefined,
-  footer: null,
-  onClose: undefined,
-};
-
 export default Drawer;

--- a/frontend/shared/src/components/forms/buttons/SaveFormButton.tsx
+++ b/frontend/shared/src/components/forms/buttons/SaveFormButton.tsx
@@ -1,5 +1,4 @@
 import { Button, CommonButtonProps } from 'hds-react';
-import noop from 'lodash/noop';
 import React from 'react';
 import {
   SubmitErrorHandler,
@@ -70,13 +69,6 @@ const SaveFormButton = <
       {children}
     </ButtonComponent>
   );
-};
-
-SaveFormButton.defaultProps = {
-  onInvalidForm: noop,
-  onSuccess: undefined,
-  onError: undefined,
-  asLink: false,
 };
 
 export default SaveFormButton;

--- a/frontend/shared/src/components/forms/inputs/Checkbox.tsx
+++ b/frontend/shared/src/components/forms/inputs/Checkbox.tsx
@@ -67,8 +67,4 @@ const Checkbox = <T,>({
   );
 };
 
-Checkbox.defaultProps = {
-  onChange: noop,
-};
-
 export default Checkbox;

--- a/frontend/shared/src/components/forms/inputs/DateInput.tsx
+++ b/frontend/shared/src/components/forms/inputs/DateInput.tsx
@@ -58,7 +58,4 @@ const DateInput = <T,>({
   );
 };
 
-DateInput.defaultProps = {
-  errorText: undefined,
-};
 export default DateInput;

--- a/frontend/shared/src/components/forms/inputs/Dropdown.tsx
+++ b/frontend/shared/src/components/forms/inputs/Dropdown.tsx
@@ -75,9 +75,4 @@ const Dropdown = <T, O extends Option>({
   );
 };
 
-Dropdown.defaultProps = {
-  type: 'select',
-  multiselect: false,
-};
-
 export default Dropdown;

--- a/frontend/shared/src/components/forms/inputs/MultiSelectDropdown.tsx
+++ b/frontend/shared/src/components/forms/inputs/MultiSelectDropdown.tsx
@@ -82,9 +82,4 @@ const MultiSelectDropdown = <T, O extends Option>({
   );
 };
 
-MultiSelectDropdown.defaultProps = {
-  type: 'select',
-  multiselect: false,
-};
-
 export default MultiSelectDropdown;

--- a/frontend/shared/src/components/forms/inputs/SelectionGroup.tsx
+++ b/frontend/shared/src/components/forms/inputs/SelectionGroup.tsx
@@ -77,9 +77,4 @@ const SelectionGroup = <T,>({
   );
 };
 
-SelectionGroup.defaultProps = {
-  direction: 'horizontal',
-  label: undefined,
-};
-
 export default SelectionGroup;

--- a/frontend/shared/src/components/forms/inputs/SocialSecurityNumberInput.tsx
+++ b/frontend/shared/src/components/forms/inputs/SocialSecurityNumberInput.tsx
@@ -84,8 +84,4 @@ const SocialSecurityNumberInput = <T,>({
   );
 };
 
-SocialSecurityNumberInput.defaultProps = {
-  placeholder: undefined,
-};
-
 export default SocialSecurityNumberInput;

--- a/frontend/shared/src/components/forms/inputs/TextInput.tsx
+++ b/frontend/shared/src/components/forms/inputs/TextInput.tsx
@@ -97,9 +97,4 @@ const TextInput = <T,>({
   );
 };
 
-TextInput.defaultProps = {
-  type: undefined,
-  placeholder: undefined,
-};
-
 export default TextInput;

--- a/frontend/shared/src/components/header/Header.tsx
+++ b/frontend/shared/src/components/header/Header.tsx
@@ -163,21 +163,4 @@ const Header: React.FC<HeaderProps> = ({
   );
 };
 
-Header.defaultProps = {
-  title: undefined,
-  titleUrl: undefined,
-  skipToContentLabel: undefined,
-  menuToggleAriaLabel: undefined,
-  languages: undefined,
-  isNavigationVisible: undefined,
-  navigationItems: undefined,
-  customItems: null,
-  navigationVariant: undefined,
-  onLanguageChange: undefined,
-  login: undefined,
-  hideLogin: false,
-  theme: undefined,
-  onTitleClick: undefined,
-};
-
 export default Header;

--- a/frontend/shared/src/components/messaging/Actions.tsx
+++ b/frontend/shared/src/components/messaging/Actions.tsx
@@ -70,11 +70,4 @@ const Actions: React.FC<ActionProps> = ({
   );
 };
 
-Actions.defaultProps = {
-  customItems: [],
-  placeholder: '',
-  notification: '',
-  maxLength: 1024,
-};
-
 export default Actions;

--- a/frontend/shared/src/components/messaging/Message.tsx
+++ b/frontend/shared/src/components/messaging/Message.tsx
@@ -37,8 +37,4 @@ const Message: React.FC<MessageProps> = ({
   </$MessageContainer>
 );
 
-Message.defaultProps = {
-  isPrimary: undefined,
-};
-
 export default Message;

--- a/frontend/shared/src/components/modal/Modal.tsx
+++ b/frontend/shared/src/components/modal/Modal.tsx
@@ -86,16 +86,4 @@ const Modal: React.FC<ModalProps> = ({
   );
 };
 
-Modal.defaultProps = {
-  submitButtonIcon: null,
-  headerIcon: null,
-  actionDisabled: undefined,
-  title: undefined,
-  className: undefined,
-  scrollable: undefined,
-  variant: undefined,
-  children: null,
-  customContent: null,
-};
-
 export default Modal;

--- a/frontend/shared/src/components/pages/ErrorPage.tsx
+++ b/frontend/shared/src/components/pages/ErrorPage.tsx
@@ -53,10 +53,4 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
   );
 };
 
-ErrorPage.defaultProps = {
-  errorId: undefined,
-  retry: undefined,
-  logout: undefined,
-};
-
 export default ErrorPage;

--- a/frontend/shared/src/components/pages/ForbiddenPage.tsx
+++ b/frontend/shared/src/components/pages/ForbiddenPage.tsx
@@ -28,8 +28,4 @@ const ForbiddenPage: React.FC = () => {
   );
 };
 
-ForbiddenPage.defaultProps = {
-  helpdeskEmail: undefined,
-};
-
 export default ForbiddenPage;

--- a/frontend/shared/src/components/pages/NotificationPage.tsx
+++ b/frontend/shared/src/components/pages/NotificationPage.tsx
@@ -61,11 +61,4 @@ const NotificationPage: React.FC<Props> = ({
   );
 };
 
-NotificationPage.defaultProps = {
-  size: 'large',
-  goToFrontPageText: undefined,
-  children: null,
-  message: undefined,
-};
-
 export default NotificationPage;

--- a/frontend/shared/src/components/pages/PageLoadingSpinner.tsx
+++ b/frontend/shared/src/components/pages/PageLoadingSpinner.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { $SpinnerContainer } from './PageLoadingSpinner.sc';
 
-const PageLoadingSpinner = (): JSX.Element => (
+const PageLoadingSpinner: React.FC = () => (
   <$SpinnerContainer data-testid="page-loading-spinner">
     <LoadingSpinner />
   </$SpinnerContainer>

--- a/frontend/shared/src/components/pages/ServerErrorPage.tsx
+++ b/frontend/shared/src/components/pages/ServerErrorPage.tsx
@@ -28,8 +28,4 @@ const ServerErrorPage: React.FC<Props> = ({ logout }) => {
   );
 };
 
-ServerErrorPage.defaultProps = {
-  logout: undefined,
-};
-
 export default ServerErrorPage;

--- a/frontend/shared/src/components/stepper/Step.tsx
+++ b/frontend/shared/src/components/stepper/Step.tsx
@@ -25,9 +25,4 @@ const Step = ({
   );
 };
 
-Step.defaultProps = {
-  index: undefined,
-  activeStep: undefined,
-};
-
 export default Step;

--- a/frontend/shared/src/components/stepper/Stepper.tsx
+++ b/frontend/shared/src/components/stepper/Stepper.tsx
@@ -33,8 +33,4 @@ const Stepper: React.FC<StepperProps> = ({ activeStep = 1, steps }) => (
   </$StepsContainer>
 );
 
-Stepper.defaultProps = {
-  activeStep: 1,
-};
-
 export default Stepper;

--- a/frontend/shared/src/components/stepper/WizardStep.tsx
+++ b/frontend/shared/src/components/stepper/WizardStep.tsx
@@ -40,8 +40,4 @@ const WizardStep: React.FC<Props> = ({ title, index = 0 }) => {
   );
 };
 
-WizardStep.defaultProps = {
-  index: 0,
-};
-
 export default WizardStep;

--- a/frontend/shared/src/components/stepper/WizardStepper.tsx
+++ b/frontend/shared/src/components/stepper/WizardStepper.tsx
@@ -26,8 +26,4 @@ const WizardStepper: React.FC = () => {
   );
 };
 
-WizardStepper.defaultProps = {
-  lastVisitedStep: 1,
-};
-
 export default WizardStepper;

--- a/frontend/shared/src/components/table/Table.tsx
+++ b/frontend/shared/src/components/table/Table.tsx
@@ -1,6 +1,5 @@
 import equal from 'fast-deep-equal';
 import { Checkbox, IconAngleDown, RadioButton } from 'hds-react';
-import noop from 'lodash/noop';
 import React, { useCallback, useEffect } from 'react';
 import LoadingSkeleton from 'react-loading-skeleton';
 import {
@@ -374,27 +373,5 @@ TableProps<D>): React.ReactElement => {
     </div>
   );
 };
-
-const defaultProps = {
-  loading: false,
-  canSelectRows: false,
-  canSelectOneRow: false,
-  globalFilter: undefined,
-  getCellProps: () => ({}),
-  renderTableToolsTop: undefined,
-  renderSubComponent: undefined,
-  renderMainHeader: undefined,
-  renderEmptyStateRow: undefined,
-  renderPaginator: undefined,
-  renderTableToolsBottom: undefined,
-  onSelectionChange: noop,
-  onSortedColChange: noop,
-  onSortedColsChange: noop,
-  minimizeAllText: 'Minimize all',
-  noMatchesText: 'No matches',
-  sortBy: undefined,
-};
-
-Table.defaultProps = defaultProps;
 
 export default Table;

--- a/frontend/shared/src/components/toast/Toast.tsx
+++ b/frontend/shared/src/components/toast/Toast.tsx
@@ -90,11 +90,4 @@ const hdsToast = ({
   );
 };
 
-const defaultProps = {
-  autoDismissTime: AUTO_DISMISS_TIME,
-  toastId: '',
-};
-
-NotificationWrapper.defaultProps = defaultProps;
-
 export default hdsToast;

--- a/frontend/tet/admin/package.json
+++ b/frontend/tet/admin/package.json
@@ -14,7 +14,7 @@
 		"test:debug-nock": "cross-env DEBUG=nock.* yarn test",
     "browser-test": "testcafe 'chrome --allow-insecure-localhost --ignore-certificate-errors --ignore-urlfetcher-cert-requests --window-size=\"1249,720\"' browser-tests/",
     "browser-test:ci": "testcafe 'chrome:headless --disable-gpu --window-size=\"1249,720\"  --ignore-certificate-errors-spki-list=\"8sg/cl7YabrOFqSqH+Bu0e+P27Av33gWgi8Lq28DW1I=,gJt+wt/T3afCRkxtMMSjXcl/99sgzWc2kk1c1PC9tG0=,zrQI2/1q8i2SRPmMZ1sMntIkG+lMW0legPFokDo3nrY=\"' --screenshots path=report --video report --reporter spec,custom,html:report/index.html browser-tests/",
-    "lint": "next lint"
+    "lint": "eslint --ext js,ts,tsx src"
   },
   "dependencies": {
     "@frontend/shared": "*",
@@ -23,6 +23,7 @@
     "@sentry/nextjs": "^7.16.0",
     "axios": "^0.27.2",
     "babel-plugin-import": "^1.13.3",
+    "date-fns": "^2.24.0",
     "dotenv": "^16.0.0",
     "hds-react": "^1.15.0",
     "leaflet": "^1.7.1",
@@ -37,6 +38,7 @@
     "react-leaflet": "^3.2.5",
     "react-leaflet-markercluster": "^3.0.0-rc1",
     "react-query": "^3.34.0",
+    "react-toastify": "^9.0.4",
     "styled-components": "^5.3.1"
   },
   "devDependencies": {

--- a/frontend/tet/admin/src/__tests__/copy.test.tsx
+++ b/frontend/tet/admin/src/__tests__/copy.test.tsx
@@ -1,11 +1,11 @@
-import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
-import CopyStaticPage from 'tet/admin/pages/copystatic';
 import { axe } from 'jest-axe';
 import React from 'react';
-import { expectUnauthorizedReply } from 'tet/admin/__tests__/utils/backend/backend-nocks';
-import renderPage from 'tet/admin/__tests__/utils/components/render-page';
 import { waitFor } from 'shared/__tests__/utils/test-utils';
 import { DEFAULT_LANGUAGE } from 'shared/i18n/i18n';
+import { expectUnauthorizedReply } from 'tet/admin/__tests__/utils/backend/backend-nocks';
+import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
+import renderPage from 'tet/admin/__tests__/utils/components/render-page';
+import CopyStaticPage from 'tet/admin/pages/copystatic';
 
 describe('frontend/tet/admin/src/pages/copystatic.tsx', () => {
   it('should have no accessibility violations', async () => {
@@ -19,7 +19,7 @@ describe('frontend/tet/admin/src/pages/copystatic.tsx', () => {
   it('should redirect when unauthorized', async () => {
     expectUnauthorizedReply();
     const spyPush = jest.fn();
-    await renderPage(CopyStaticPage, { push: spyPush });
+    renderPage(CopyStaticPage, { push: spyPush });
     await waitFor(() => expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/login`));
   });
 });

--- a/frontend/tet/admin/src/__tests__/edit.test.tsx
+++ b/frontend/tet/admin/src/__tests__/edit.test.tsx
@@ -1,26 +1,24 @@
-import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
-import EditStaticPage from 'tet/admin/pages/editstatic';
 import { axe } from 'jest-axe';
 import React from 'react';
+import { waitForBackendRequestsToComplete } from 'shared/__tests__/utils/component.utils';
+import { waitFor } from 'shared/__tests__/utils/test-utils';
+import { DEFAULT_LANGUAGE } from 'shared/i18n/i18n';
 import {
-  expectUnauthorizedReply,
-  expectAuthorizedReply,
   expectAttributesFromLinkedEvents,
-  expectWorkingMethodsFromLinkedEvents,
+  expectAuthorizedReply,
   expectToGetSingleEventFromBackend,
+  expectUnauthorizedReply,
+  expectWorkingMethodsFromLinkedEvents,
 } from 'tet/admin/__tests__/utils/backend/backend-nocks';
+import getFormPageApi from 'tet/admin/__tests__/utils/components/get-form-page-api';
+import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
 import renderPage from 'tet/admin/__tests__/utils/components/render-page';
 import getTetAdminTranslationsApi from 'tet/admin/__tests__/utils/i18n/get-tet-admin-translations-api';
-import { DEFAULT_LANGUAGE } from 'shared/i18n/i18n';
-import getFormPageApi from 'tet/admin/__tests__/utils/components/get-form-page-api';
+import EditStaticPage from 'tet/admin/pages/editstatic';
 import { fakeTetEvent } from 'tet-shared/__tests__/utils/fake-objects';
-import { screen, userEvent, within, waitFor } from 'shared/__tests__/utils/test-utils';
-import { TetEvent } from 'tet-shared/types/linkedevents';
-import { waitForBackendRequestsToComplete } from 'shared/__tests__/utils/component.utils';
 
 const {
   translations: { [DEFAULT_LANGUAGE]: translations },
-  regexp,
 } = getTetAdminTranslationsApi();
 
 const event = fakeTetEvent({

--- a/frontend/tet/admin/src/__tests__/index.test.tsx
+++ b/frontend/tet/admin/src/__tests__/index.test.tsx
@@ -1,8 +1,8 @@
-import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
-import IndexPage from 'tet/admin/pages';
+import { screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import React from 'react';
-import { fakeEventListAdmin } from 'tet-shared/__tests__/utils/fake-objects';
+import { waitFor } from 'shared/__tests__/utils/test-utils';
+import { DEFAULT_LANGUAGE } from 'shared/i18n/i18n';
 import {
   expectAttributesFromLinkedEvents,
   expectAuthorizedReply,
@@ -10,10 +10,10 @@ import {
   expectUnauthorizedReply,
   expectWorkingMethodsFromLinkedEvents,
 } from 'tet/admin/__tests__/utils/backend/backend-nocks';
+import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
 import renderPage from 'tet/admin/__tests__/utils/components/render-page';
-import { waitFor } from 'shared/__tests__/utils/test-utils';
-import { DEFAULT_LANGUAGE } from 'shared/i18n/i18n';
-import { screen } from '@testing-library/react';
+import IndexPage from 'tet/admin/pages';
+import { fakeEventListAdmin } from 'tet-shared/__tests__/utils/fake-objects';
 
 describe('frontend/tet/admin/src/pages/index.tsx', () => {
   it('should have no accessibility violations', async () => {

--- a/frontend/tet/admin/src/__tests__/login.test.tsx
+++ b/frontend/tet/admin/src/__tests__/login.test.tsx
@@ -1,7 +1,7 @@
-import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
-import LoginPage from 'tet/admin/pages/login';
 import { axe } from 'jest-axe';
 import React from 'react';
+import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
+import LoginPage from 'tet/admin/pages/login';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({

--- a/frontend/tet/admin/src/__tests__/utils/backend/backend-nocks.ts
+++ b/frontend/tet/admin/src/__tests__/utils/backend/backend-nocks.ts
@@ -1,8 +1,8 @@
-import { BackendEndpoint, getBackendDomain } from 'tet/admin/backend-api/backend-api';
 import nock from 'nock';
-import { TetEvent, TetEvents } from 'tet-shared/types/linkedevents';
 import { waitForBackendRequestsToComplete } from 'shared/__tests__/utils/component.utils';
 import FakeObjectFactory from 'shared/__tests__/utils/FakeObjectFactory';
+import { BackendEndpoint, getBackendDomain } from 'tet/admin/backend-api/backend-api';
+import { TetEvent, TetEvents } from 'tet-shared/types/linkedevents';
 
 const fakeObjectFactory = new FakeObjectFactory();
 

--- a/frontend/tet/admin/src/__tests__/utils/components/get-editor-api.ts
+++ b/frontend/tet/admin/src/__tests__/utils/components/get-editor-api.ts
@@ -1,9 +1,9 @@
-import { screen, userEvent, within, waitFor } from 'shared/__tests__/utils/test-utils';
-import TetPosting from 'tet-shared/types/tetposting';
-import { escapeRegExp } from 'shared/utils/regex.utils';
-import getTetAdminTranslationsApi from 'tet/admin/__tests__/utils/i18n/get-tet-admin-translations-api';
+import { screen, userEvent, within } from 'shared/__tests__/utils/test-utils';
 import { DEFAULT_LANGUAGE, Language } from 'shared/i18n/i18n';
+import getTetAdminTranslationsApi from 'tet/admin/__tests__/utils/i18n/get-tet-admin-translations-api';
+import TetPosting from 'tet-shared/types/tetposting';
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const getEditorApi = (expectedPosting?: TetPosting, lang?: Language) => {
   const {
     translations: { [lang ?? DEFAULT_LANGUAGE]: translations },
@@ -46,7 +46,7 @@ const getEditorApi = (expectedPosting?: TetPosting, lang?: Language) => {
       const parent = field?.parentElement?.parentElement;
       await within(parent).findByText(requiredText);
     },
-    selectionGroupHasError: async (labelText: string): Promise<void> => {
+    selectionGroupHasError: async (): Promise<void> => {
       await screen.findByText(regexp(translations.editor.classification.workMethod));
     },
     errorNotificationIsShown: async (): Promise<void> => {
@@ -57,7 +57,7 @@ const getEditorApi = (expectedPosting?: TetPosting, lang?: Language) => {
   };
   const actions = {
     async clickSendButton() {
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', {
           name: regexp(translations.editor.saveDraft),
         }),

--- a/frontend/tet/admin/src/__tests__/utils/components/get-form-page-api.ts
+++ b/frontend/tet/admin/src/__tests__/utils/components/get-form-page-api.ts
@@ -1,13 +1,9 @@
+import { screen } from 'shared/__tests__/utils/test-utils';
 import getTetAdminTranslationsApi from 'tet/admin/__tests__/utils/i18n/get-tet-admin-translations-api';
-import { screen, userEvent, within, waitFor } from 'shared/__tests__/utils/test-utils';
-import { DEFAULT_LANGUAGE, Language } from 'shared/i18n/i18n';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
 const getFormPageApi = () => {
-  const {
-    translations: { [DEFAULT_LANGUAGE]: translations },
-    regexp,
-  } = getTetAdminTranslationsApi();
+  const { regexp } = getTetAdminTranslationsApi();
 
   return {
     expectations: {

--- a/frontend/tet/admin/src/__tests__/utils/components/get-index-page-api.ts
+++ b/frontend/tet/admin/src/__tests__/utils/components/get-index-page-api.ts
@@ -5,7 +5,7 @@ const getIndexPageApi = () => ({
   expectations: {
     pageIsLoaded() {
       return screen.findByRole('heading', {
-        name: /tet\-paikkailmoitukset/i,
+        name: /tet-paikkailmoitukset/i,
       });
     },
   },

--- a/frontend/tet/admin/src/__tests__/utils/components/render-component.tsx
+++ b/frontend/tet/admin/src/__tests__/utils/components/render-component.tsx
@@ -1,5 +1,5 @@
-import { getBackendDomain } from 'tet/admin/backend-api/backend-api';
 import renderComponentF from 'shared/__tests__/utils/render-component/render-component';
+import { getBackendDomain } from 'tet/admin/backend-api/backend-api';
 
 const render = renderComponentF(getBackendDomain());
 

--- a/frontend/tet/admin/src/__tests__/utils/components/render-page.tsx
+++ b/frontend/tet/admin/src/__tests__/utils/components/render-page.tsx
@@ -1,8 +1,8 @@
-import Footer from 'tet/admin/components/footer/Footer';
-import AuthProvider from 'tet/admin/auth/AuthProvider';
-import Header from 'tet/admin/components/header/Header';
-import { getBackendDomain } from 'tet/admin/backend-api/backend-api';
 import renderPageF from 'shared/__tests__/utils/render-component/render-page';
+import AuthProvider from 'tet/admin/auth/AuthProvider';
+import { getBackendDomain } from 'tet/admin/backend-api/backend-api';
+import Footer from 'tet/admin/components/footer/Footer';
+import Header from 'tet/admin/components/header/Header';
 
 const render = renderPageF({ backendUrl: getBackendDomain(), Header, Footer, AuthProvider, confirmDialog: true });
 

--- a/frontend/tet/admin/src/auth/AuthProvider.tsx
+++ b/frontend/tet/admin/src/auth/AuthProvider.tsx
@@ -1,6 +1,6 @@
-import useUserQuery from 'tet/admin/hooks/backend/useUserQuery';
 import React from 'react';
 import AuthContext from 'shared/auth/AuthContext';
+import useUserQuery from 'tet/admin/hooks/backend/useUserQuery';
 
 const FIVE_MINUTES = 5 * 60 * 1000;
 

--- a/frontend/tet/admin/src/components/BackButton.tsx
+++ b/frontend/tet/admin/src/components/BackButton.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
 import { IconArrowLeft } from 'hds-react';
-import { useTranslation } from 'next-i18next';
-import styled from 'styled-components';
-import { useRouter } from 'next/router';
 import Link from 'next/link';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+import styled from 'styled-components';
 
 const BackButton: React.FC = () => {
-  const router = useRouter();
   const { t } = useTranslation();
 
   const $BackButton = styled.a`
@@ -17,10 +15,6 @@ const BackButton: React.FC = () => {
     font-size: ${(props) => props.theme.fontSize.body.l};
     font-weight: normal;
   `;
-
-  const clickHandler = () => {
-    void router.push('/');
-  };
 
   return (
     <Link href="/" passHref>

--- a/frontend/tet/admin/src/components/InfoDialog.tsx
+++ b/frontend/tet/admin/src/components/InfoDialog.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { Button, Dialog, IconInfoCircle } from 'hds-react';
-import { useTranslation, Trans } from 'next-i18next';
+import { Trans, useTranslation } from 'next-i18next';
+import React from 'react';
 
 type Props = {
   isOpen: boolean;

--- a/frontend/tet/admin/src/components/editor/Combobox.tsx
+++ b/frontend/tet/admin/src/components/editor/Combobox.tsx
@@ -72,12 +72,4 @@ const Combobox = <O extends Option>({
   );
 };
 
-Combobox.defaultProps = {
-  testId: undefined,
-  initialValue: undefined,
-  multiselect: false,
-  validation: {},
-  disabled: false,
-};
-
 export default Combobox;

--- a/frontend/tet/admin/src/components/editor/Combobox.tsx
+++ b/frontend/tet/admin/src/components/editor/Combobox.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
-import { Controller, useFormContext } from 'react-hook-form';
 import { Combobox as HdsCombobox } from 'hds-react';
-import Id from 'shared/types/id';
-import { RegisterOptions, NestedValue } from 'react-hook-form';
 import { useTranslation } from 'next-i18next';
+import React from 'react';
+import { Controller, NestedValue, RegisterOptions, useFormContext } from 'react-hook-form';
+import Id from 'shared/types/id';
 import { Option } from 'tet-shared/types/classification';
 
 type ComboboxFields<O extends Option> = {
@@ -20,7 +18,7 @@ type Props<O extends Option> = {
   placeholder: string;
   multiselect?: boolean;
   validation?: RegisterOptions<ComboboxFields<O>>;
-  filter: any;
+  filter: (options: O[], search: string) => O[];
   optionLabelField: keyof O;
   disabled?: boolean;
   required: boolean;
@@ -29,9 +27,7 @@ type Props<O extends Option> = {
 const Combobox = <O extends Option>({
   id,
   testId,
-  multiselect = false,
   filter,
-  initialValue,
   validation = {},
   label,
   optionLabelField,
@@ -49,7 +45,7 @@ const Combobox = <O extends Option>({
       data-testid={id}
       control={control}
       rules={validation}
-      render={({ field: { ref, value, onChange, ...field }, fieldState: { error, invalid, ...fieldState } }) => (
+      render={({ field: { ref, value, onChange, ...field }, fieldState: { error, invalid } }) => (
         <HdsCombobox<O>
           {...field}
           data-testid={testId}
@@ -74,6 +70,14 @@ const Combobox = <O extends Option>({
       )}
     />
   );
+};
+
+Combobox.defaultProps = {
+  testId: undefined,
+  initialValue: undefined,
+  multiselect: false,
+  validation: {},
+  disabled: false,
 };
 
 export default Combobox;

--- a/frontend/tet/admin/src/components/editor/ComboboxSingleSelect.tsx
+++ b/frontend/tet/admin/src/components/editor/ComboboxSingleSelect.tsx
@@ -67,11 +67,4 @@ const ComboboxSingleSelect = <T, O extends Option>({
   );
 };
 
-ComboboxSingleSelect.defaultProps = {
-  testId: undefined,
-  initialValue: undefined,
-  validation: {},
-  disabled: false,
-};
-
 export default ComboboxSingleSelect;

--- a/frontend/tet/admin/src/components/editor/ComboboxSingleSelect.tsx
+++ b/frontend/tet/admin/src/components/editor/ComboboxSingleSelect.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
 import { Combobox as HdsCombobox } from 'hds-react';
-import Id from 'shared/types/id';
-import { RegisterOptions } from 'react-hook-form';
 import { useTranslation } from 'next-i18next';
+import React from 'react';
+import { Controller, RegisterOptions, useFormContext } from 'react-hook-form';
+import Id from 'shared/types/id';
 
 type Props<T, O extends Option> = {
   id: Id<T>;
@@ -13,7 +12,7 @@ type Props<T, O extends Option> = {
   options: O[];
   placeholder: string;
   validation?: RegisterOptions<T>;
-  filter: any;
+  filter: (options: O[], search: string) => O[];
   optionLabelField: keyof O;
   disabled?: boolean;
   required: boolean;
@@ -44,7 +43,7 @@ const ComboboxSingleSelect = <T, O extends Option>({
       data-testid={id}
       control={control}
       rules={validation}
-      render={({ field: { ref, value, onChange, ...field }, fieldState: { error, invalid, ...fieldState } }) => (
+      render={({ field: { ref, value, onChange, ...field }, fieldState: { error, invalid } }) => (
         <HdsCombobox<O>
           {...field}
           data-testid={testId}
@@ -66,6 +65,13 @@ const ComboboxSingleSelect = <T, O extends Option>({
       )}
     />
   );
+};
+
+ComboboxSingleSelect.defaultProps = {
+  testId: undefined,
+  initialValue: undefined,
+  validation: {},
+  disabled: false,
 };
 
 export default ComboboxSingleSelect;

--- a/frontend/tet/admin/src/components/editor/DateInput.tsx
+++ b/frontend/tet/admin/src/components/editor/DateInput.tsx
@@ -44,11 +44,4 @@ const DateInput: React.FC<Props> = ({ id, label, registerOptions, required = fal
   );
 };
 
-DateInput.defaultProps = {
-  testId: undefined,
-  registerOptions: {},
-  minDate: undefined,
-  helperText: undefined,
-};
-
 export default DateInput;

--- a/frontend/tet/admin/src/components/editor/DateInput.tsx
+++ b/frontend/tet/admin/src/components/editor/DateInput.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
-import { useFormContext, Controller, RegisterOptions } from 'react-hook-form';
 import { DateInput as HdsDateInput } from 'hds-react';
-import Id from 'shared/types/id';
 import { useTranslation } from 'next-i18next';
+import React from 'react';
+import { Controller, RegisterOptions, useFormContext } from 'react-hook-form';
 import { Language } from 'shared/i18n/i18n';
+import Id from 'shared/types/id';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type Props = {
   id: Id<TetPosting>;
@@ -16,7 +16,7 @@ type Props = {
   testId?: string;
 };
 
-const DateInput: React.FC<Props> = ({ id, label, registerOptions, required = false, minDate, helperText , testId}) => {
+const DateInput: React.FC<Props> = ({ id, label, registerOptions, required = false, minDate, helperText, testId }) => {
   const { control } = useFormContext<TetPosting>();
   const { i18n } = useTranslation();
   return (
@@ -40,9 +40,15 @@ const DateInput: React.FC<Props> = ({ id, label, registerOptions, required = fal
       )}
       control={control}
       rules={registerOptions}
-    ></Controller>
+    />
   );
 };
 
-export default DateInput;
+DateInput.defaultProps = {
+  testId: undefined,
+  registerOptions: {},
+  minDate: undefined,
+  helperText: undefined,
+};
 
+export default DateInput;

--- a/frontend/tet/admin/src/components/editor/Dropdown.tsx
+++ b/frontend/tet/admin/src/components/editor/Dropdown.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
-import { useFormContext, Controller, RegisterOptions, NestedValue } from 'react-hook-form';
 import { Select as HdsSelect } from 'hds-react';
+import React from 'react';
+import { Controller, NestedValue, RegisterOptions, useFormContext } from 'react-hook-form';
 import Id from 'shared/types/id';
 import { OptionType } from 'tet-shared/types/classification';
-
-type LanguagesType = Pick<TetPosting, 'languages'>;
+import TetPosting from 'tet-shared/types/tetposting';
 
 type DropdownFields<O extends OptionType> = {
   languages: NestedValue<O[]>;
@@ -15,7 +13,6 @@ type Props<O extends OptionType> = {
   id: Id<DropdownFields<O>>;
   testId?: string;
   options: O[];
-  initialValue: O[];
   label: string;
   registerOptions: RegisterOptions;
 };
@@ -53,8 +50,12 @@ const Dropdown = <O extends OptionType>({
       )}
       rules={registerOptions}
       control={control}
-    ></Controller>
+    />
   );
+};
+
+Dropdown.defaultProps = {
+  testId: undefined,
 };
 
 export default Dropdown;

--- a/frontend/tet/admin/src/components/editor/Dropdown.tsx
+++ b/frontend/tet/admin/src/components/editor/Dropdown.tsx
@@ -54,8 +54,4 @@ const Dropdown = <O extends OptionType>({
   );
 };
 
-Dropdown.defaultProps = {
-  testId: undefined,
-};
-
 export default Dropdown;

--- a/frontend/tet/admin/src/components/editor/EditById.tsx
+++ b/frontend/tet/admin/src/components/editor/EditById.tsx
@@ -1,12 +1,12 @@
-import React, { useContext, useState, useEffect } from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
-import Editor from 'tet/admin/components/editor/Editor';
-import { $Heading, $HeadingContainer } from 'tet/admin/components/jobPostings/JobPostings.sc';
-import PreviewWrapper from 'tet/admin/components/editor/previewWrapper/PreviewWrapper';
-import PostingContainer from 'tet-shared/components/posting/PostingContainer';
-import { PreviewContext } from 'tet/admin/store/PreviewContext';
+import React, { useContext, useEffect, useState } from 'react';
 import Container from 'shared/components/container/Container';
 import BackButton from 'tet/admin/components/BackButton';
+import Editor from 'tet/admin/components/editor/Editor';
+import PreviewWrapper from 'tet/admin/components/editor/previewWrapper/PreviewWrapper';
+import { $Heading, $HeadingContainer } from 'tet/admin/components/jobPostings/JobPostings.sc';
+import { PreviewContext } from 'tet/admin/store/PreviewContext';
+import PostingContainer from 'tet-shared/components/posting/PostingContainer';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type EditByIdProps = {
   title: string;
@@ -20,6 +20,7 @@ const EditById: React.FC<EditByIdProps> = ({ title, data }) => {
   useEffect(() => {
     // If initial, use data from query and not from previewContext
     if (isInitialRender) setIsInitialRender(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (showPreview) {
@@ -30,15 +31,13 @@ const EditById: React.FC<EditByIdProps> = ({ title, data }) => {
     );
   }
   return (
-    <>
-      <Container>
-        <BackButton />
-        <$HeadingContainer>
-          <$Heading>{title}</$Heading>
-        </$HeadingContainer>
-        <Editor initialValue={isInitialRender ? data : tetPosting} />
-      </Container>
-    </>
+    <Container>
+      <BackButton />
+      <$HeadingContainer>
+        <$Heading>{title}</$Heading>
+      </$HeadingContainer>
+      <Editor initialValue={isInitialRender ? data : tetPosting} />
+    </Container>
   );
 };
 

--- a/frontend/tet/admin/src/components/editor/Editor.tsx
+++ b/frontend/tet/admin/src/components/editor/Editor.tsx
@@ -1,19 +1,19 @@
-import React, { useEffect, useContext, useState } from 'react';
-import CompanyInfo from 'tet/admin/components/editor/companyInfo/CompanyInfo';
-import PostingDetails from 'tet/admin/components/editor/postingDetails/PostingDetails';
-import ContactPerson from 'tet/admin/components/editor/contactPerson/ContactPerson';
-import { FormProvider, useForm } from 'react-hook-form';
-import TetPosting from 'tet-shared/types/tetposting';
-import ActionButtons from 'tet/admin/components/editor/form/ActionButtons';
-import { useTranslation } from 'next-i18next';
-import EditorErrorNotification from 'tet/admin/components/editor/EditorErrorNotification';
-import HiddenIdInput from 'tet/admin/components/editor/HiddenIdInput';
-import Classification from 'tet/admin/components/editor/classification/Classification';
 import { DevTool } from '@hookform/devtools';
-import EmployerInfo from 'tet/admin/components/editor/employerInfo/EmployerInfo';
-import ImageUpload from 'tet/admin/components/editor/imageUpload/ImageUpload';
-import { initialPosting } from 'tet/admin/store/PreviewContext';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
 import useLeaveConfirm from 'shared/hooks/useLeaveConfirm';
+import Classification from 'tet/admin/components/editor/classification/Classification';
+import CompanyInfo from 'tet/admin/components/editor/companyInfo/CompanyInfo';
+import ContactPerson from 'tet/admin/components/editor/contactPerson/ContactPerson';
+import EditorErrorNotification from 'tet/admin/components/editor/EditorErrorNotification';
+import EmployerInfo from 'tet/admin/components/editor/employerInfo/EmployerInfo';
+import ActionButtons from 'tet/admin/components/editor/form/ActionButtons';
+import HiddenIdInput from 'tet/admin/components/editor/HiddenIdInput';
+import ImageUpload from 'tet/admin/components/editor/imageUpload/ImageUpload';
+import PostingDetails from 'tet/admin/components/editor/postingDetails/PostingDetails';
+import { initialPosting } from 'tet/admin/store/PreviewContext';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type EditorProps = {
   // eslint-disable-next-line react/require-default-props
@@ -58,6 +58,10 @@ const Editor: React.FC<EditorProps> = ({ initialValue, isNewPosting = false }) =
       <DevTool control={methods.control} />
     </>
   );
+};
+
+Editor.defaultProps = {
+  isNewPosting: false,
 };
 
 export default Editor;

--- a/frontend/tet/admin/src/components/editor/Editor.tsx
+++ b/frontend/tet/admin/src/components/editor/Editor.tsx
@@ -16,7 +16,6 @@ import { initialPosting } from 'tet/admin/store/PreviewContext';
 import TetPosting from 'tet-shared/types/tetposting';
 
 type EditorProps = {
-  // eslint-disable-next-line react/require-default-props
   initialValue?: TetPosting;
   isNewPosting?: boolean;
 };
@@ -58,10 +57,6 @@ const Editor: React.FC<EditorProps> = ({ initialValue, isNewPosting = false }) =
       <DevTool control={methods.control} />
     </>
   );
-};
-
-Editor.defaultProps = {
-  isNewPosting: false,
 };
 
 export default Editor;

--- a/frontend/tet/admin/src/components/editor/EditorErrorNotification.tsx
+++ b/frontend/tet/admin/src/components/editor/EditorErrorNotification.tsx
@@ -13,7 +13,7 @@ const EditorErrorNotification: React.FC = () => {
   const noTetErrors = Object.keys(errors).length === 0;
 
   if (isSubmitted && !noTetErrors) {
-    return <ErrorSummary label={t(`common:editor.notificationTitle`)} autofocus></ErrorSummary>;
+    return <ErrorSummary label={t(`common:editor.notificationTitle`)} autofocus />;
   }
 
   return null;

--- a/frontend/tet/admin/src/components/editor/HiddenIdInput.tsx
+++ b/frontend/tet/admin/src/components/editor/HiddenIdInput.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { useFormContext } from 'react-hook-form';
 import InputProps from 'shared/types/input-props';
 import TetPosting from 'tet-shared/types/tetposting';
-import { useFormContext } from 'react-hook-form';
 
 const HiddenIdInput: React.FC<InputProps<TetPosting>> = ({ id, initialValue }) => {
   const { register } = useFormContext<TetPosting>();

--- a/frontend/tet/admin/src/components/editor/NumberInput.tsx
+++ b/frontend/tet/admin/src/components/editor/NumberInput.tsx
@@ -43,8 +43,4 @@ const NumberInput: React.FC<Props> = ({ id, registerOptions, label, required = f
   );
 };
 
-NumberInput.defaultProps = {
-  testId: undefined,
-};
-
 export default NumberInput;

--- a/frontend/tet/admin/src/components/editor/NumberInput.tsx
+++ b/frontend/tet/admin/src/components/editor/NumberInput.tsx
@@ -1,9 +1,9 @@
 import { NumberInput as HdsNumberInput } from 'hds-react';
+import { useTranslation } from 'next-i18next';
 import React from 'react';
-import { useFormContext, Controller, RegisterOptions } from 'react-hook-form';
+import { Controller, RegisterOptions, useFormContext } from 'react-hook-form';
 import Id from 'shared/types/id';
 import TetPosting from 'tet-shared/types/tetposting';
-import { useTranslation } from 'next-i18next';
 
 type SpotsType = Pick<TetPosting, 'spots'>;
 
@@ -16,15 +16,13 @@ type Props = {
   required: boolean;
 };
 
-const asNumber = (value?: string | number | undefined): number | undefined => Number(value) || undefined;
-
 const NumberInput: React.FC<Props> = ({ id, registerOptions, label, required = false, testId }) => {
   const { control } = useFormContext<SpotsType>();
   const { t } = useTranslation();
   return (
     <Controller
       name={id}
-      render={({ field: { onChange, value }, fieldState: { error, invalid } }) => (
+      render={({ field: { onChange, value }, fieldState: { error } }) => (
         <HdsNumberInput
           id={id}
           data-testid={testId}
@@ -43,6 +41,10 @@ const NumberInput: React.FC<Props> = ({ id, registerOptions, label, required = f
       rules={registerOptions}
     />
   );
+};
+
+NumberInput.defaultProps = {
+  testId: undefined,
 };
 
 export default NumberInput;

--- a/frontend/tet/admin/src/components/editor/PhoneInput.tsx
+++ b/frontend/tet/admin/src/components/editor/PhoneInput.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
-import { useFormContext, Controller, RegisterOptions } from 'react-hook-form';
 import { PhoneInput as HdsPhoneInput } from 'hds-react';
+import React from 'react';
+import { Controller, RegisterOptions, useFormContext } from 'react-hook-form';
 import Id from 'shared/types/id';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type PhoneType = Pick<TetPosting, 'contact_phone'>;
 
@@ -36,6 +36,10 @@ const PhoneInput: React.FC<Props> = ({ id, label, placeholder, registerOptions, 
       rules={registerOptions}
     />
   );
+};
+
+PhoneInput.defaultProps = {
+  testId: undefined,
 };
 
 export default PhoneInput;

--- a/frontend/tet/admin/src/components/editor/PhoneInput.tsx
+++ b/frontend/tet/admin/src/components/editor/PhoneInput.tsx
@@ -38,8 +38,4 @@ const PhoneInput: React.FC<Props> = ({ id, label, placeholder, registerOptions, 
   );
 };
 
-PhoneInput.defaultProps = {
-  testId: undefined,
-};
-
 export default PhoneInput;

--- a/frontend/tet/admin/src/components/editor/SelectionGroup.tsx
+++ b/frontend/tet/admin/src/components/editor/SelectionGroup.tsx
@@ -62,9 +62,4 @@ const SelectionGroup: React.FC<Props> = ({ fieldId, label, options, required, ru
   );
 };
 
-SelectionGroup.defaultProps = {
-  testId: undefined,
-  rules: undefined,
-};
-
 export default SelectionGroup;

--- a/frontend/tet/admin/src/components/editor/SelectionGroup.tsx
+++ b/frontend/tet/admin/src/components/editor/SelectionGroup.tsx
@@ -1,9 +1,9 @@
+import { Checkbox, SelectionGroup as HdsSelectionGroup } from 'hds-react';
 import React from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
 import { Controller, useFormContext } from 'react-hook-form';
-import { SelectionGroup as HdsSelectionGroup, Checkbox } from 'hds-react';
 import Id from 'shared/types/id';
 import { OptionType } from 'tet-shared/types/classification';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type Props = {
   fieldId: Id<Pick<TetPosting, 'keywords_working_methods' | 'keywords_attributes'>>;
@@ -16,13 +16,13 @@ type Props = {
 
 const SelectionGroup: React.FC<Props> = ({ fieldId, label, options, required, rules, testId }) => {
   const { control, setValue, getValues, clearErrors } = useFormContext<TetPosting>();
-  const checkboxChangeHandler = (option: OptionType) => {
+  const checkboxChangeHandler = (option: OptionType): void => {
     const values = getValues(fieldId);
     if (Array.isArray(values)) {
-      let list: OptionType[] = [...values];
+      const list: OptionType[] = [...values];
       const index = list.findIndex((item) => item.value === option.value);
       if (index === -1) {
-        list = list.concat(option);
+        list.push(option);
         if (required) {
           clearErrors(fieldId);
         }
@@ -40,7 +40,7 @@ const SelectionGroup: React.FC<Props> = ({ fieldId, label, options, required, ru
       rules={{
         validate: rules,
       }}
-      render={({ field: { ref, value, ...field }, fieldState: { error, invalid, ...fieldState } }) => (
+      render={({ field: { value }, fieldState: { error } }) => (
         <HdsSelectionGroup
           data-testid={testId}
           label={label}
@@ -60,6 +60,11 @@ const SelectionGroup: React.FC<Props> = ({ fieldId, label, options, required, ru
       )}
     />
   );
+};
+
+SelectionGroup.defaultProps = {
+  testId: undefined,
+  rules: undefined,
 };
 
 export default SelectionGroup;

--- a/frontend/tet/admin/src/components/editor/TextArea.tsx
+++ b/frontend/tet/admin/src/components/editor/TextArea.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
-import { useFormContext, Controller, RegisterOptions } from 'react-hook-form';
 import { TextArea as HdsTextArea } from 'hds-react';
+import React from 'react';
+import { Controller, RegisterOptions, useFormContext } from 'react-hook-form';
 import Id from 'shared/types/id';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type Props = {
   id: Id<TetPosting>;
@@ -31,8 +31,12 @@ const TextArea: React.FC<Props> = ({ id, label, registerOptions, required = fals
       )}
       control={control}
       rules={registerOptions}
-    ></Controller>
+    />
   );
+};
+
+TextArea.defaultProps = {
+  testId: undefined,
 };
 
 export default TextArea;

--- a/frontend/tet/admin/src/components/editor/TextArea.tsx
+++ b/frontend/tet/admin/src/components/editor/TextArea.tsx
@@ -35,8 +35,4 @@ const TextArea: React.FC<Props> = ({ id, label, registerOptions, required = fals
   );
 };
 
-TextArea.defaultProps = {
-  testId: undefined,
-};
-
 export default TextArea;

--- a/frontend/tet/admin/src/components/editor/TextInput.tsx
+++ b/frontend/tet/admin/src/components/editor/TextInput.tsx
@@ -38,8 +38,4 @@ const TextInput: React.FC<Props> = ({ id, label, placeholder, registerOptions, h
   );
 };
 
-TextInput.defaultProps = {
-  testId: undefined,
-  helperText: undefined,
-};
 export default TextInput;

--- a/frontend/tet/admin/src/components/editor/TextInput.tsx
+++ b/frontend/tet/admin/src/components/editor/TextInput.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
-import { useFormContext, Controller, RegisterOptions } from 'react-hook-form';
 import { TextInput as HdsTextInput } from 'hds-react';
+import React from 'react';
+import { Controller, RegisterOptions, useFormContext } from 'react-hook-form';
 import Id from 'shared/types/id';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type Props = {
   id: Id<TetPosting>;
@@ -34,8 +34,12 @@ const TextInput: React.FC<Props> = ({ id, label, placeholder, registerOptions, h
       )}
       control={control}
       rules={registerOptions}
-    ></Controller>
+    />
   );
 };
 
+TextInput.defaultProps = {
+  testId: undefined,
+  helperText: undefined,
+};
 export default TextInput;

--- a/frontend/tet/admin/src/components/editor/__tests__/Editor.test.tsx
+++ b/frontend/tet/admin/src/components/editor/__tests__/Editor.test.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
-import Editor from 'tet/admin/components/editor/Editor';
-import { fakeTetPosting } from 'tet-shared/__tests__/utils/fake-objects';
-import getEditorApi from 'tet/admin/__tests__/utils/components/get-editor-api';
+import { waitForBackendRequestsToComplete } from 'shared/__tests__/utils/component.utils';
+import { waitFor } from 'shared/__tests__/utils/test-utils';
 import {
   expectAttributesFromLinkedEvents,
   expectWorkingMethodsFromLinkedEvents,
 } from 'tet/admin/__tests__/utils/backend/backend-nocks';
-import { screen, waitFor } from 'shared/__tests__/utils/test-utils';
-import { prettyDOM, logRoles } from '@testing-library/react';
-import { waitForBackendRequestsToComplete } from 'shared/__tests__/utils/component.utils';
+import getEditorApi from 'tet/admin/__tests__/utils/components/get-editor-api';
+import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
+import Editor from 'tet/admin/components/editor/Editor';
+import { fakeTetPosting } from 'tet-shared/__tests__/utils/fake-objects';
 
 const posting = fakeTetPosting({
   end_date: '12-12-2022',
@@ -30,14 +29,14 @@ describe('frontend/tet/admin/src/components/editor/Editor', () => {
     await waitForBackendRequestsToComplete();
 
     const editorApi = getEditorApi(posting);
-    //Location details
+    // Location details
     await editorApi.expectations.inputValueIsPresent('title');
-    //Contact details
+    // Contact details
     await editorApi.expectations.inputValueIsPresent('contact_first_name');
     await editorApi.expectations.inputValueIsPresent('contact_last_name');
     await editorApi.expectations.inputValueIsPresent('contact_email');
     await editorApi.expectations.inputValueIsPresent('contact_phone');
-    //Posting details
+    // Posting details
     await editorApi.expectations.inputValueIsPresent('org_name');
     await editorApi.expectations.inputValueIsPresent('start_date');
     await editorApi.expectations.inputValueIsPresent('end_date');
@@ -52,9 +51,7 @@ describe('frontend/tet/admin/src/components/editor/Editor', () => {
       expectWorkingMethodsFromLinkedEvents();
       expectAttributesFromLinkedEvents();
 
-      const {
-        renderResult: { container },
-      } = renderComponent(<Editor />);
+      renderComponent(<Editor />);
       const editorApi = getEditorApi(posting);
 
       // TODO to get the error you need to click publish button instead of send button
@@ -63,17 +60,17 @@ describe('frontend/tet/admin/src/components/editor/Editor', () => {
 
       await waitForBackendRequestsToComplete();
 
-      //Location details
+      // Location details
       await editorApi.expectations.textInputHasError('title');
       await editorApi.expectations.comboboxHasError('Osoite');
 
-      //Contact details
+      // Contact details
       await editorApi.expectations.textInputHasError('contact_first_name');
       await editorApi.expectations.textInputHasError('contact_last_name');
       await editorApi.expectations.textInputHasError('contact_email');
       await editorApi.expectations.textInputHasError('contact_phone');
 
-      //Posting details
+      // Posting details
       await editorApi.expectations.textInputHasError('org_name');
       await editorApi.expectations.textInputHasError('start_date');
       await editorApi.expectations.languageSelectorHasError();

--- a/frontend/tet/admin/src/components/editor/classification/Classification.tsx
+++ b/frontend/tet/admin/src/components/editor/classification/Classification.tsx
@@ -1,18 +1,18 @@
+import { useTranslation } from 'next-i18next';
 import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useQuery } from 'react-query';
 import FormSection from 'shared/components/forms/section/FormSection';
 import { $Grid, $GridCell } from 'shared/components/forms/section/FormSection.sc';
-import { useTranslation } from 'next-i18next';
-import { useTheme } from 'styled-components';
-import { getWorkKeywords, keywordToOptionType } from 'tet-shared/backend-api/linked-events-api';
-import { useQuery } from 'react-query';
-import { OptionType } from 'tet-shared/types/classification';
-import Combobox from 'tet/admin/components/editor/Combobox';
-import SelectionGroup from 'tet/admin/components/editor/SelectionGroup';
-import { useFormContext } from 'react-hook-form';
-import TetPosting from 'tet-shared/types/tetposting';
-import EditorLoadingError from 'tet/admin/components/editor/EditorLoadingError';
 import { Language } from 'shared/i18n/i18n';
+import { useTheme } from 'styled-components';
+import Combobox from 'tet/admin/components/editor/Combobox';
+import EditorLoadingError from 'tet/admin/components/editor/EditorLoadingError';
+import SelectionGroup from 'tet/admin/components/editor/SelectionGroup';
+import { getWorkKeywords, keywordToOptionType } from 'tet-shared/backend-api/linked-events-api';
 import useKeywordType from 'tet-shared/hooks/backend/useKeywordType';
+import { OptionType } from 'tet-shared/types/classification';
+import TetPosting from 'tet-shared/types/tetposting';
 
 export type FilterFunction = (options: OptionType[], search: string) => OptionType[];
 
@@ -25,28 +25,28 @@ const Classification: React.FC = () => {
 
   const keywordsResults = useQuery(['keywords', search], () => getWorkKeywords(search), { enabled: !!search });
 
-  const keywords = React.useMemo(() => {
-    return !keywordsResults.isLoading && keywordsResults.data
-      ? keywordsResults.data.map((k) => keywordToOptionType(k, i18n.language as Language))
-      : [];
-  }, [keywordsResults]);
+  const keywords = React.useMemo(
+    () =>
+      !keywordsResults.isLoading && keywordsResults.data
+        ? keywordsResults.data.map((k) => keywordToOptionType(k, i18n.language as Language))
+        : [],
+    [i18n.language, keywordsResults.data, keywordsResults.isLoading],
+  );
 
   if (methodsAndFeatures.isLoading) {
     return <div>Lataa</div>;
   }
 
-  const filterHandler: FilterFunction = (options, search) => {
-    setSearch(search);
+  const filterHandler: FilterFunction = (options, searchText) => {
+    setSearch(searchText);
     return options;
   };
 
   if (methodsAndFeatures.error) {
     return <EditorLoadingError error={methodsAndFeatures.error} />;
   }
-
-  const isSetRule = () => {
-    return getValues('keywords_working_methods').length > 0 ? true : t('common:editor.posting.validation.isSet');
-  };
+  const isSetRule = (): string | true =>
+    getValues('keywords_working_methods').length > 0 ? true : t<string>('common:editor.posting.validation.isSet');
 
   return (
     <FormSection header={t('common:editor.classification.classifications')}>
@@ -59,13 +59,13 @@ const Classification: React.FC = () => {
       >
         <$GridCell $colSpan={4}>
           <SelectionGroup
-            required={true}
+            required
             testId="posting-form-keywords_working_methods"
             fieldId="keywords_working_methods"
             label={t('common:editor.classification.workMethod')}
             rules={isSetRule}
             options={methodsAndFeatures.workMethodsList}
-          ></SelectionGroup>
+          />
         </$GridCell>
         <$GridCell $colSpan={4}>
           <SelectionGroup
@@ -74,18 +74,18 @@ const Classification: React.FC = () => {
             fieldId="keywords_attributes"
             label={t('common:editor.classification.workFeature')}
             options={methodsAndFeatures.workFeaturesList}
-          ></SelectionGroup>
+          />
         </$GridCell>
         <$GridCell $colSpan={4}>
           <Combobox<OptionType>
-            id={'keywords'}
+            id="keywords"
             testId="posting-form-keywords"
             multiselect
             required={false}
             label={t('common:editor.classification.keywords')}
             placeholder={t('common:editor.classification.search')}
             options={keywords}
-            optionLabelField={'label'}
+            optionLabelField="label"
             filter={filterHandler}
           />
         </$GridCell>

--- a/frontend/tet/admin/src/components/editor/companyInfo/CompanyInfo.tsx
+++ b/frontend/tet/admin/src/components/editor/companyInfo/CompanyInfo.tsx
@@ -1,18 +1,18 @@
+import debounce from 'lodash/debounce';
+import { useTranslation } from 'next-i18next';
 import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useQuery } from 'react-query';
 import FormSection from 'shared/components/forms/section/FormSection';
 import { $Grid, $GridCell } from 'shared/components/forms/section/FormSection.sc';
-import { useTranslation } from 'next-i18next';
 import { useTheme } from 'styled-components';
-import { useQuery } from 'react-query';
-import { getAddressList } from 'tet-shared/backend-api/linked-events-api';
-import debounce from 'lodash/debounce';
+import ComboboxSingleSelect from 'tet/admin/components/editor/ComboboxSingleSelect';
 import TextInput from 'tet/admin/components/editor/TextInput';
 import useValidationRules from 'tet/admin/hooks/translation/useValidationRules';
-import { LocationType, OptionType } from 'tet-shared/types/classification';
-import ComboboxSingleSelect from 'tet/admin/components/editor/ComboboxSingleSelect';
-import TetPosting from 'tet-shared/types/tetposting';
+import { getAddressList } from 'tet-shared/backend-api/linked-events-api';
 import useEventPostingTransformation from 'tet-shared/hooks/backend/useEventPostingTransformation';
-import { useFormContext } from 'react-hook-form';
+import { LocationType, OptionType } from 'tet-shared/types/classification';
+import TetPosting from 'tet-shared/types/tetposting';
 
 const CompanyInfo: React.FC = () => {
   const { t } = useTranslation();
@@ -26,38 +26,36 @@ const CompanyInfo: React.FC = () => {
     enabled: !!addressSearch,
   });
 
-  const keywords: LocationType[] = React.useMemo(() => {
-    return keywordsResults.data
-      ? keywordsResults.data.map(
-          (keyword) =>
-            ({
-              name: getLocalizedString(keyword.name),
-              label: `${getLocalizedString(keyword.name)}, ${getLocalizedString(keyword.street_address)}, ${
-                keyword.postal_code ?? ''
-              }`,
-              value: keyword['@id'],
-              street_address: getLocalizedString(keyword.street_address),
-              postal_code: keyword.postal_code ?? '',
-              position: keyword.position,
-              city: getLocalizedString(keyword.address_locality),
-            } as LocationType),
-        )
-      : [];
-  }, [keywordsResults]);
-
-  const filterSetter = React.useCallback(
-    debounce((search) => setAddressSearch(search), 500),
-    [],
+  const keywords: LocationType[] = React.useMemo(
+    () =>
+      keywordsResults.data
+        ? keywordsResults.data.map(
+            (keyword) =>
+              ({
+                name: getLocalizedString(keyword.name),
+                label: `${getLocalizedString(keyword.name)}, ${getLocalizedString(keyword.street_address)}, ${
+                  keyword.postal_code ?? ''
+                }`,
+                value: keyword['@id'],
+                street_address: getLocalizedString(keyword.street_address),
+                postal_code: keyword.postal_code ?? '',
+                position: keyword.position,
+                city: getLocalizedString(keyword.address_locality),
+              } as LocationType),
+          )
+        : [],
+    [getLocalizedString, keywordsResults.data],
   );
+
+  const filterSetter = debounce((search: string) => setAddressSearch(search), 500);
 
   const addressFilterHandler = (options: OptionType[], search: string): OptionType[] => {
     filterSetter(search);
     return options;
   };
 
-  const locationRequired = () => {
-    return getValues('location')?.value.length > 0 ? true : t('common:editor.posting.validation.required');
-  };
+  const locationRequired = (): true | string =>
+    getValues('location')?.value.length > 0 ? true : t<string>('common:editor.posting.validation.required');
 
   return (
     <FormSection header={t('common:editor.employerInfo.header')}>
@@ -90,17 +88,17 @@ const CompanyInfo: React.FC = () => {
             />
           </$GridCell>
           <$GridCell $colSpan={6}>
-            <ComboboxSingleSelect<TetPosting, LocationType>
+            <ComboboxSingleSelect<TetPosting, OptionType>
               id="location"
-              testId={'posting-form-location'}
-              required={true}
+              testId="posting-form-location"
+              required
               label={t('common:editor.employerInfo.address')}
               placeholder={t('common:editor.employerInfo.streetAddress')}
               options={keywords}
-              optionLabelField={'label'}
+              optionLabelField="label"
               filter={addressFilterHandler}
               validation={{ validate: locationRequired }}
-            ></ComboboxSingleSelect>
+            />
           </$GridCell>
         </$GridCell>
       </$GridCell>

--- a/frontend/tet/admin/src/components/editor/contactPerson/ContactPerson.tsx
+++ b/frontend/tet/admin/src/components/editor/contactPerson/ContactPerson.tsx
@@ -1,17 +1,15 @@
+import { useTranslation } from 'next-i18next';
 import React from 'react';
 import FormSection from 'shared/components/forms/section/FormSection';
 import { $Grid, $GridCell } from 'shared/components/forms/section/FormSection.sc';
-import { useTranslation } from 'next-i18next';
 import { useTheme } from 'styled-components';
-import TetPosting from 'tet-shared/types/tetposting';
-import TextInput from 'tet/admin/components/editor/TextInput';
-import { EditorSectionProps } from 'tet/admin/components/editor/Editor';
 import PhoneInput from 'tet/admin/components/editor/PhoneInput';
+import TextInput from 'tet/admin/components/editor/TextInput';
 import useValidationRules from 'tet/admin/hooks/translation/useValidationRules';
 
 const ContactPerson: React.FC = () => {
   const { t } = useTranslation();
-  const { required, name, email, phone } = useValidationRules();
+  const { name, email, phone } = useValidationRules();
   const theme = useTheme();
 
   return (

--- a/frontend/tet/admin/src/components/editor/employerInfo/EmployerInfo.tsx
+++ b/frontend/tet/admin/src/components/editor/employerInfo/EmployerInfo.tsx
@@ -1,9 +1,9 @@
+import { Notification } from 'hds-react';
+import { useTranslation } from 'next-i18next';
 import React from 'react';
 import FormSection from 'shared/components/forms/section/FormSection';
 import { $Grid, $GridCell } from 'shared/components/forms/section/FormSection.sc';
-import { useTranslation } from 'next-i18next';
 import { useTheme } from 'styled-components';
-import { Notification } from 'hds-react';
 import useUserQuery from 'tet/admin/hooks/backend/useUserQuery';
 
 const EmployerInfo: React.FC = () => {
@@ -12,7 +12,7 @@ const EmployerInfo: React.FC = () => {
   const userQuery = useUserQuery();
 
   return (
-    <FormSection withoutDivider={true} header={t('common:editor.companyInfo')}>
+    <FormSection withoutDivider header={t('common:editor.companyInfo')}>
       <$GridCell
         as={$Grid}
         $colSpan={12}

--- a/frontend/tet/admin/src/components/editor/form/ActionButtons.tsx
+++ b/frontend/tet/admin/src/components/editor/form/ActionButtons.tsx
@@ -1,4 +1,4 @@
-import { Button, IconCross, IconEye, IconUpload, IconSaveDiskette } from 'hds-react';
+import { Button, IconCross, IconEye, IconSaveDiskette, IconUpload } from 'hds-react';
 import cloneDeep from 'lodash/cloneDeep';
 import { useTranslation } from 'next-i18next';
 import React, { useContext } from 'react';
@@ -7,12 +7,12 @@ import FormSection from 'shared/components/forms/section/FormSection';
 import { $Grid, $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import useConfirm from 'shared/hooks/useConfirm';
 import { useTheme } from 'styled-components';
-import useDeleteTetPosting from 'tet/admin/hooks/backend/useDeleteTetPosting';
-import { PreviewContext } from 'tet/admin/store/PreviewContext';
-import TetPosting from 'tet-shared/types/tetposting';
-import { tetPostingToEvent } from 'tet-shared/backend-api/transformations';
-import useUpsertTetPosting from 'tet/admin/hooks/backend/useUpsertTetPosting';
 import InfoDialog from 'tet/admin/components/InfoDialog';
+import useDeleteTetPosting from 'tet/admin/hooks/backend/useDeleteTetPosting';
+import useUpsertTetPosting from 'tet/admin/hooks/backend/useUpsertTetPosting';
+import { PreviewContext } from 'tet/admin/store/PreviewContext';
+import { tetPostingToEvent } from 'tet-shared/backend-api/transformations';
+import TetPosting from 'tet-shared/types/tetposting';
 
 const ActionButtons: React.FC = () => {
   const { setPreviewVisibility, setTetPostingData, setFormValid } = useContext(PreviewContext);
@@ -24,19 +24,17 @@ const ActionButtons: React.FC = () => {
     getValues,
     handleSubmit,
     trigger,
-    formState: { isSubmitting, isDirty },
+    formState: { isSubmitting },
     reset,
   } = useFormContext<TetPosting>();
   const theme = useTheme();
   const posting = getValues();
   const [showInfoDialog, setShowInfoDialog] = React.useState(false);
 
-  console.log('test');
-
   const allowPublish = posting.date_published === null;
   const allowDelete = !!posting.id;
 
-  const showPreview = async () => {
+  const showPreview = async (): Promise<void> => {
     const isValid = await trigger();
     const values = getValues();
     setTetPostingData(cloneDeep(values));
@@ -44,11 +42,7 @@ const ActionButtons: React.FC = () => {
     setPreviewVisibility(true);
   };
 
-  const deletePostingHandler = async () => {
-    await showDeleteConfirm();
-  };
-
-  const showDeleteConfirm = async () => {
+  const showDeleteConfirm = async (): Promise<void> => {
     const isConfirmed = await confirm({
       header: t('common:delete.confirmation', { posting: posting.title }),
       submitButtonLabel: t('common:delete.deletePosting'),
@@ -58,6 +52,8 @@ const ActionButtons: React.FC = () => {
       deleteTetPosting.mutate(posting);
     }
   };
+
+  const deletePostingHandler = async (): Promise<void> => showDeleteConfirm();
 
   const saveHandler = async (validatedPosting: TetPosting): Promise<void> => {
     const event = tetPostingToEvent({

--- a/frontend/tet/admin/src/components/editor/postingDetails/PostingDetails.tsx
+++ b/frontend/tet/admin/src/components/editor/postingDetails/PostingDetails.tsx
@@ -1,43 +1,43 @@
+import isBefore from 'date-fns/isBefore';
+import { Notification } from 'hds-react';
+import { useTranslation } from 'next-i18next';
 import React from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
 import FormSection from 'shared/components/forms/section/FormSection';
 import { $Grid, $GridCell } from 'shared/components/forms/section/FormSection.sc';
-import { useTranslation } from 'next-i18next';
+import { DATE_UI_REGEX } from 'shared/constants';
+import { parseDate } from 'shared/utils/date.utils';
 import { useTheme } from 'styled-components';
 import DateInput from 'tet/admin/components/editor/DateInput';
-import TextInput from 'tet/admin/components/editor/TextInput';
-import TextArea from 'tet/admin/components/editor/TextArea';
-import NumberInput from 'tet/admin/components/editor/NumberInput';
-import useValidationRules from 'tet/admin/hooks/translation/useValidationRules';
-import { Notification } from 'hds-react';
 import Dropdown from 'tet/admin/components/editor/Dropdown';
+import NumberInput from 'tet/admin/components/editor/NumberInput';
+import TextArea from 'tet/admin/components/editor/TextArea';
+import TextInput from 'tet/admin/components/editor/TextInput';
+import useValidationRules from 'tet/admin/hooks/translation/useValidationRules';
 import useLanguageOptions from 'tet-shared/hooks/translation/useLanguageOptions';
-import { useFormContext, useWatch } from 'react-hook-form';
 import TetPosting from 'tet-shared/types/tetposting';
-import { parseDate, isValidDate } from 'shared/utils/date.utils';
-import { DATE_UI_REGEX } from 'shared/constants';
-import isBefore from 'date-fns/isBefore';
 
 const PostingDetails: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { required, name, description, date, website } = useValidationRules();
+  const { required, description, date, website } = useValidationRules();
   const { control, setValue } = useFormContext<TetPosting>();
 
   const languageOptions = useLanguageOptions();
   const startDate = useWatch({
-    control: control,
+    control,
     name: 'start_date',
   });
   const endDate = useWatch({
-    control: control,
+    control,
     name: 'end_date',
   });
 
   React.useEffect(() => {
-    if (isBefore(parseDate(endDate) as Date, parseDate(startDate) as Date)) {
+    if (isBefore(parseDate(endDate), parseDate(startDate))) {
       setValue('end_date', '');
     }
-  }, [startDate, endDate]);
+  }, [startDate, endDate, setValue]);
 
   const minDate = DATE_UI_REGEX.test(startDate) ? parseDate(startDate) : undefined;
 
@@ -55,8 +55,8 @@ const PostingDetails: React.FC = () => {
             id="start_date"
             testId="posting-form-start_date"
             label={t('common:editor.posting.startDateLabel')}
-            required={true}
-            registerOptions={{ required: required, pattern: date.pattern }}
+            required
+            registerOptions={{ required, pattern: date.pattern }}
           />
         </$GridCell>
         <$GridCell $colSpan={3}>
@@ -75,8 +75,8 @@ const PostingDetails: React.FC = () => {
             id="spots"
             testId="posting-form-spots"
             label={t('common:editor.posting.spotsLabel')}
-            registerOptions={{ required: required }}
-            required={true}
+            registerOptions={{ required }}
+            required
           />
         </$GridCell>
         <$GridCell $colSpan={3}>
@@ -84,14 +84,13 @@ const PostingDetails: React.FC = () => {
             id="languages"
             testId="posting-form-languages"
             options={languageOptions}
-            initialValue={[languageOptions[0]]}
             label={t('common:editor.posting.contactLanguage')}
             registerOptions={{
-              required: required,
+              required,
             }}
           />
         </$GridCell>
-        <$GridCell $colSpan={3}></$GridCell>
+        <$GridCell $colSpan={3} />
       </$GridCell>
       <$GridCell as={$Grid} $colSpan={12}>
         <$GridCell $colSpan={6}>
@@ -105,7 +104,7 @@ const PostingDetails: React.FC = () => {
             testId="posting-form-description"
             label={t('common:editor.posting.description')}
             registerOptions={description}
-            required={true}
+            required
           />
         </$GridCell>
       </$GridCell>

--- a/frontend/tet/admin/src/components/editor/previewWrapper/PreviewBar.tsx
+++ b/frontend/tet/admin/src/components/editor/previewWrapper/PreviewBar.tsx
@@ -40,8 +40,4 @@ const PreviewBar: React.FC<BarProps> = ({ hasMargin, allowPublish, onPublish }) 
   );
 };
 
-PreviewBar.defaultProps = {
-  hasMargin: false,
-};
-
 export default PreviewBar;

--- a/frontend/tet/admin/src/components/editor/previewWrapper/PreviewBar.tsx
+++ b/frontend/tet/admin/src/components/editor/previewWrapper/PreviewBar.tsx
@@ -1,0 +1,47 @@
+import { Button, IconArrowLeft, IconUpload } from 'hds-react';
+import { useTranslation } from 'next-i18next';
+import React, { useContext } from 'react';
+import {
+  $BackLink,
+  $Bar,
+  $BarWrapper,
+  $PreviewText,
+} from 'tet/admin/components/editor/previewWrapper/PreviewWrapper.sc';
+import { PreviewContext } from 'tet/admin/store/PreviewContext';
+import Container from 'tet-shared/components/container/Container';
+
+type BarProps = {
+  hasMargin?: boolean;
+  allowPublish: boolean;
+  onPublish: () => void;
+};
+
+const PreviewBar: React.FC<BarProps> = ({ hasMargin, allowPublish, onPublish }) => {
+  const { setPreviewVisibility } = useContext(PreviewContext);
+  const { t } = useTranslation();
+
+  return (
+    <$Bar style={hasMargin ? { marginBottom: '20px' } : {}}>
+      <Container>
+        <$BarWrapper style={{ minHeight: '3.5rem' }}>
+          <$BackLink href="javascipt:void(0)" onClick={() => setPreviewVisibility(false)}>
+            <IconArrowLeft />
+            <span>{t('common:editor.backToEdit')}</span>
+          </$BackLink>
+          <$PreviewText>{t('common:editor.preview')}</$PreviewText>
+          {allowPublish && (
+            <Button onClick={onPublish} variant="success" iconLeft={<IconUpload />}>
+              {t('common:editor.publish')}
+            </Button>
+          )}
+        </$BarWrapper>
+      </Container>
+    </$Bar>
+  );
+};
+
+PreviewBar.defaultProps = {
+  hasMargin: false,
+};
+
+export default PreviewBar;

--- a/frontend/tet/admin/src/components/editor/previewWrapper/PreviewWrapper.tsx
+++ b/frontend/tet/admin/src/components/editor/previewWrapper/PreviewWrapper.tsx
@@ -1,52 +1,11 @@
-import { Button, IconArrowLeft, IconUpload } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React, { useContext } from 'react';
 import useConfirm from 'shared/hooks/useConfirm';
-import {
-  $BackLink,
-  $Bar,
-  $BarWrapper,
-  $PreviewText,
-} from 'tet/admin/components/editor/previewWrapper/PreviewWrapper.sc';
+import PreviewBar from 'tet/admin/components/editor/previewWrapper/PreviewBar';
 import useUpsertTetPosting from 'tet/admin/hooks/backend/useUpsertTetPosting';
 import { PreviewContext } from 'tet/admin/store/PreviewContext';
 import { tetPostingToEvent } from 'tet-shared/backend-api/transformations';
-import Container from 'tet-shared/components/container/Container';
 import TetPosting from 'tet-shared/types/tetposting';
-
-type BarProps = {
-  hasMargin?: boolean;
-  allowPublish: boolean;
-  onPublish: () => void;
-};
-
-const PreviewBar: React.FC<BarProps> = ({ hasMargin, allowPublish, onPublish }) => {
-  const { setPreviewVisibility } = useContext(PreviewContext);
-  const { t } = useTranslation();
-
-  return (
-    <$Bar style={hasMargin ? { marginBottom: '20px' } : {}}>
-      <Container>
-        <$BarWrapper style={{ minHeight: '3.5rem' }}>
-          <$BackLink href="javascipt:void(0)" onClick={() => setPreviewVisibility(false)}>
-            <IconArrowLeft />
-            <span>{t('common:editor.backToEdit')}</span>
-          </$BackLink>
-          <$PreviewText>{t('common:editor.preview')}</$PreviewText>
-          {allowPublish && (
-            <Button onClick={onPublish} variant="success" iconLeft={<IconUpload />}>
-              {t('common:editor.publish')}
-            </Button>
-          )}
-        </$BarWrapper>
-      </Container>
-    </$Bar>
-  );
-};
-
-PreviewBar.defaultProps = {
-  hasMargin: false,
-};
 
 const PreviewWrapper: React.FC<{ posting: TetPosting }> = ({ children, posting }) => {
   const upsertTetPosting = useUpsertTetPosting();

--- a/frontend/tet/admin/src/components/editor/previewWrapper/PreviewWrapper.tsx
+++ b/frontend/tet/admin/src/components/editor/previewWrapper/PreviewWrapper.tsx
@@ -1,19 +1,18 @@
+import { Button, IconArrowLeft, IconUpload } from 'hds-react';
+import { useTranslation } from 'next-i18next';
 import React, { useContext } from 'react';
+import useConfirm from 'shared/hooks/useConfirm';
 import {
+  $BackLink,
   $Bar,
   $BarWrapper,
-  $BackLink,
   $PreviewText,
 } from 'tet/admin/components/editor/previewWrapper/PreviewWrapper.sc';
-import { Button } from 'hds-react';
-import Container from 'tet-shared/components/container/Container';
-import { IconArrowLeft, IconUpload } from 'hds-react';
-import { PreviewContext } from 'tet/admin/store/PreviewContext';
-import { useTranslation } from 'next-i18next';
-import TetPosting from 'tet-shared/types/tetposting';
-import useConfirm from 'shared/hooks/useConfirm';
-import { tetPostingToEvent } from 'tet-shared/backend-api/transformations';
 import useUpsertTetPosting from 'tet/admin/hooks/backend/useUpsertTetPosting';
+import { PreviewContext } from 'tet/admin/store/PreviewContext';
+import { tetPostingToEvent } from 'tet-shared/backend-api/transformations';
+import Container from 'tet-shared/components/container/Container';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type BarProps = {
   hasMargin?: boolean;
@@ -45,6 +44,10 @@ const PreviewBar: React.FC<BarProps> = ({ hasMargin, allowPublish, onPublish }) 
   );
 };
 
+PreviewBar.defaultProps = {
+  hasMargin: false,
+};
+
 const PreviewWrapper: React.FC<{ posting: TetPosting }> = ({ children, posting }) => {
   const upsertTetPosting = useUpsertTetPosting();
   const { confirm } = useConfirm();
@@ -53,7 +56,7 @@ const PreviewWrapper: React.FC<{ posting: TetPosting }> = ({ children, posting }
 
   const allowPublish = posting.date_published === null && formValid;
 
-  const publishPostingHandler = async () => {
+  const publishPostingHandler = async (): Promise<void> => {
     if (posting) {
       const isConfirmed = await confirm({
         header: t('common:publish.confirmation', { posting: posting.title }),
@@ -82,7 +85,7 @@ const PreviewWrapper: React.FC<{ posting: TetPosting }> = ({ children, posting }
     <>
       <PreviewBar allowPublish={allowPublish} onPublish={publishPostingHandler} />
       <div>{children}</div>
-      <PreviewBar hasMargin={true} allowPublish={allowPublish} onPublish={publishPostingHandler} />
+      <PreviewBar hasMargin allowPublish={allowPublish} onPublish={publishPostingHandler} />
     </>
   );
 };

--- a/frontend/tet/admin/src/components/footer/Footer.tsx
+++ b/frontend/tet/admin/src/components/footer/Footer.tsx
@@ -1,12 +1,12 @@
-import { Footer } from 'hds-react';
+import { Footer, IconLinkExternal } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import { IconLinkExternal } from 'hds-react';
 
 // import { $FooterWrapper } from './Footer.sc';
 
 const FooterSection: React.FC = () => {
   const { t } = useTranslation();
+  const newTabText = t('common:footer.newTab');
   return (
     <Footer title={t('common:appName')} theme="dark">
       <Footer.Base
@@ -19,7 +19,7 @@ const FooterSection: React.FC = () => {
           target="_blank"
           href={t('common:footer.accessibilityStatementLink')}
           label={t('common:footer.accessibilityStatement')}
-          aria-label={`${t('common:footer.accessibilityStatement')} - ${t('common:footer.newTab')}`}
+          aria-label={`${t('common:footer.accessibilityStatement')} - ${newTabText}`}
           icon={<IconLinkExternal />}
         />
         <Footer.Item
@@ -28,9 +28,7 @@ const FooterSection: React.FC = () => {
           target="_blank"
           href={t('common:footer.privacyPolicyLink')}
           label={t('common:footer.privacyPolicy')}
-          aria-label={`${t('common:footer.privacyPolicy')} - ${t('common:footer.privacyPolicyPDF')} - ${t(
-            'common:footer.newTab',
-          )}`}
+          aria-label={`${t('common:footer.privacyPolicy')} - ${t('common:footer.privacyPolicyPDF')} - ${newTabText}`}
           icon={<IconLinkExternal />}
         />
         <Footer.Item
@@ -39,7 +37,7 @@ const FooterSection: React.FC = () => {
           target="_blank"
           href={t('common:footer.feedbackLink')}
           label={t('common:footer.feedback')}
-          aria-label={`${t('common:footer.feedback')} - ${t('common:footer.newTab')}`}
+          aria-label={`${t('common:footer.feedback')} - ${newTabText}`}
           icon={<IconLinkExternal />}
         />
       </Footer.Base>

--- a/frontend/tet/admin/src/components/header/Header.tsx
+++ b/frontend/tet/admin/src/components/header/Header.tsx
@@ -2,12 +2,12 @@ import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import BaseHeader from 'shared/components/header/Header';
+import useGoToFrontPage from 'shared/hooks/useGoToFrontPage';
 import { SUPPORTED_LANGUAGES } from 'shared/i18n/i18n';
 import { OptionType } from 'shared/types/common';
 import useLogin from 'tet/admin/hooks/backend/useLogin';
-import useUserQuery from 'tet/admin/hooks/backend/useUserQuery';
 import useLogout from 'tet/admin/hooks/backend/useLogout';
-import useGoToFrontPage from 'shared/hooks/useGoToFrontPage';
+import useUserQuery from 'tet/admin/hooks/backend/useUserQuery';
 
 const Header: React.FC = () => {
   const { t } = useTranslation();
@@ -40,7 +40,6 @@ const Header: React.FC = () => {
 
   const logout: () => void = useLogout();
 
-  const isLoading = userQuery.isLoading;
   const isLoginPage = asPath?.startsWith('/login');
 
   return (
@@ -52,7 +51,7 @@ const Header: React.FC = () => {
       onLanguageChange={handleLanguageChange}
       onTitleClick={goToFrontPage}
       login={
-        !isLoading
+        !userQuery.isLoading
           ? {
               isAuthenticated: !isLoginPage && userQuery.isSuccess,
               loginLabel: t('common:header.loginLabel'),

--- a/frontend/tet/admin/src/components/jobPostings/JobPostings.tsx
+++ b/frontend/tet/admin/src/components/jobPostings/JobPostings.tsx
@@ -1,18 +1,19 @@
 import { Button } from 'hds-react';
-import * as React from 'react';
-import Container from 'shared/components/container/Container';
-import { useTranslation } from 'next-i18next';
-import { $Heading, $HeadingContainer } from './JobPostings.sc';
-import { useQuery } from 'react-query';
-import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
-import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
 import { useRouter } from 'next/router';
-import JobPostingsList from 'tet/admin/components/jobPostings/JobPostingsList';
-import { TetEvents } from 'tet-shared/types/linkedevents';
-import theme from 'shared/styles/theme';
+import { useTranslation } from 'next-i18next';
+import * as React from 'react';
+import { useQuery } from 'react-query';
+import Container from 'shared/components/container/Container';
+import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
 import useConfirm from 'shared/hooks/useConfirm';
-import useEventPostingTransformation from 'tet-shared/hooks/backend/useEventPostingTransformation';
+import theme from 'shared/styles/theme';
+import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
+import JobPostingsList from 'tet/admin/components/jobPostings/JobPostingsList';
 import ErrorText from 'tet-shared/components/ErrorText/ErrorText';
+import useEventPostingTransformation from 'tet-shared/hooks/backend/useEventPostingTransformation';
+import { TetEvents } from 'tet-shared/types/linkedevents';
+
+import { $Heading, $HeadingContainer } from './JobPostings.sc';
 
 const JobPostings: React.FC = () => {
   const { t } = useTranslation();
@@ -31,7 +32,7 @@ const JobPostings: React.FC = () => {
 
   const postings = eventsToTetPostings(data);
 
-  const confirmTerms = async () => {
+  const confirmTerms = async (): Promise<void> => {
     const isConfirmed = await confirm({
       header: t('common:application.createTerms'),
       submitButtonLabel: t('common:application.accept'),
@@ -46,9 +47,7 @@ const JobPostings: React.FC = () => {
     postings.draft.length > 0 || postings.published.length > 0 ? (
       <JobPostingsList draft={postings.draft} published={postings.published} />
     ) : (
-      <>
-        <p>{t('common:application.jobPostings.noPostingsFound')}</p>
-      </>
+      <p>{t('common:application.jobPostings.noPostingsFound')}</p>
     );
 
   return (

--- a/frontend/tet/admin/src/components/jobPostings/JobPostingsList.tsx
+++ b/frontend/tet/admin/src/components/jobPostings/JobPostingsList.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
 import { useTranslation } from 'next-i18next';
+import * as React from 'react';
 import JobPostingsSection from 'tet/admin/components/jobPostings/JobPostingsSection';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type JobPostingsListProps = {
   draft: TetPosting[];
@@ -17,13 +17,13 @@ const JobPostingsList: React.FC<JobPostingsListProps> = ({ draft, published }) =
         postingsTotal={published.length}
         postings={published}
         sectionId="published"
-      ></JobPostingsSection>
+      />
       <JobPostingsSection
         title={t('common:application.jobPostings.draftPostings')}
         postingsTotal={draft.length}
         postings={draft}
         sectionId="draft"
-      ></JobPostingsSection>
+      />
     </>
   );
 };

--- a/frontend/tet/admin/src/components/jobPostings/JobPostingsListItem.tsx
+++ b/frontend/tet/admin/src/components/jobPostings/JobPostingsListItem.tsx
@@ -1,27 +1,27 @@
+import { IconCalendar, IconEye, IconEyeCrossed, IconGroup, IconMenuDots } from 'hds-react';
+import { useTranslation } from 'next-i18next';
 import * as React from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
 import {
-  $PostingCard,
   $ImageContainer,
+  $MenuContainer,
+  $PostingCard,
   $PostingCardBody,
-  $PostingTitle,
+  $PostingDates,
   $PostingDescription,
-  $PostingHeader,
   $PostingFooter,
   $PostingFooterInfo,
-  $MenuContainer,
-  $PostingDates,
+  $PostingHeader,
+  $PostingTitle,
 } from 'tet/admin/components/jobPostings/JobPostingsListItem.sc';
-import { IconMenuDots, IconCalendar, IconGroup, IconEye, IconEyeCrossed } from 'hds-react';
-import { useTranslation } from 'next-i18next';
 import JobPostingsListItemMenu from 'tet/admin/components/jobPostings/JobPostingsListItemMenu';
-import Image from 'next/image';
+import TetPosting from 'tet-shared/types/tetposting';
+
 type JobPostingsListItemProps = {
   posting: TetPosting;
 };
 
 const JobPostingsListItem: React.FC<JobPostingsListItemProps> = ({ posting }) => {
-  //const startingDate = DateTime.fromISO(posting.start_date).toFormat('dd.mm.yyyy');
+  // const startingDate = DateTime.fromISO(posting.start_date).toFormat('dd.mm.yyyy');
   const [showMenu, setShowMenu] = React.useState(false);
   const { t } = useTranslation();
 
@@ -31,7 +31,7 @@ const JobPostingsListItem: React.FC<JobPostingsListItemProps> = ({ posting }) =>
 
   return (
     <$PostingCard>
-      <$ImageContainer imageUrl={imageUrl}></$ImageContainer>
+      <$ImageContainer imageUrl={imageUrl} />
       <$PostingCardBody>
         <$PostingHeader>
           <div>

--- a/frontend/tet/admin/src/components/jobPostings/JobPostingsListItemMenu.tsx
+++ b/frontend/tet/admin/src/components/jobPostings/JobPostingsListItemMenu.tsx
@@ -25,8 +25,8 @@ const JobPostingsListItemMenu: React.FC<JobPostingsListItemMenuProps> = (props) 
 
   React.useEffect(() => {
     const handleClickOutside = (event: MouseEvent): void => {
-      if (ref.current && !ref.current.contains(event.target as HTMLElement)) {
-        onClickOutside && onClickOutside();
+      if (ref.current && !ref.current.contains(event.target as HTMLElement) && typeof onClickOutside === 'function') {
+        onClickOutside();
       }
     };
     document.addEventListener('click', handleClickOutside, true);
@@ -50,10 +50,7 @@ const JobPostingsListItemMenu: React.FC<JobPostingsListItemMenuProps> = (props) 
     });
   };
 
-  const deletePostingHandler = async () => {
-    await showConfirm();
-  };
-  const showConfirm = async () => {
+  const showConfirm = async (): Promise<void> => {
     const isConfirmed = await confirm({
       header: t('common:delete.confirmation', { posting: posting.title }),
       submitButtonLabel: t('common:delete.deletePosting'),
@@ -64,7 +61,9 @@ const JobPostingsListItemMenu: React.FC<JobPostingsListItemMenuProps> = (props) 
     }
   };
 
-  const publishPostingHandler = async () => {
+  const deletePostingHandler = (): Promise<void> => showConfirm();
+
+  const publishPostingHandler = async (): Promise<void> => {
     const isConfirmed = await confirm({
       header: t('common:publish.confirmation', { posting: posting.title }),
       content: t('common:application.publishTerms'),
@@ -98,7 +97,7 @@ const JobPostingsListItemMenu: React.FC<JobPostingsListItemMenuProps> = (props) 
           <span>{t('common:application.jobPostings.menu.copy')}</span>
         </$MenuItem>
         <$MenuItem onClick={deletePostingHandler}>
-          <IconCrossCircle color={'#b01038'} />
+          <IconCrossCircle color="#b01038" />
           <span>{t('common:application.jobPostings.menu.delete')}</span>
         </$MenuItem>
       </ul>

--- a/frontend/tet/admin/src/components/jobPostings/JobPostingsSection.tsx
+++ b/frontend/tet/admin/src/components/jobPostings/JobPostingsSection.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
 import { useTranslation } from 'next-i18next';
+import * as React from 'react';
 import JobPostingsListItem from 'tet/admin/components/jobPostings/JobPostingsListItem';
 import { $HeadingContainer, $Title, $Total } from 'tet/admin/components/jobPostings/JobPostingsSectio.sc';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type JobPostingsSectionProps = {
   title: string;

--- a/frontend/tet/admin/src/components/jobPostings/__tests__/JobPostingsListItem.test.tsx
+++ b/frontend/tet/admin/src/components/jobPostings/__tests__/JobPostingsListItem.test.tsx
@@ -1,10 +1,9 @@
-import { screen } from '@testing-library/react';
-import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
 import React from 'react';
+import { screen, userEvent, within } from 'shared/__tests__/utils/test-utils';
+import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
 import { fakeTetPosting, getPastDate } from 'tet-shared/__tests__/utils/fake-objects';
+
 import JobPostingsListItem from '../JobPostingsListItem';
-import { within } from '@testing-library/dom';
-import userEvent from '@testing-library/user-event';
 
 const notPublished = fakeTetPosting({ title: 'Not published', date_published: null, spots: 3 });
 const published = fakeTetPosting({
@@ -18,7 +17,7 @@ describe('JobPostingsListItem', () => {
   it('should show that posting is published if date_published is not null', async () => {
     renderComponent(<JobPostingsListItem posting={published} />);
 
-    await screen.findByText(/Julkaistu/i);
+    await screen.findByText(/julkaistu/i);
   });
 
   it('should show that posting is not published if date_published is null', async () => {
@@ -36,13 +35,13 @@ describe('JobPostingsListItem', () => {
   it('should show correct menu items for the published posting, when menu is open', async () => {
     renderComponent(<JobPostingsListItem posting={published} />);
 
-    //Expect list to be hidden before click
-    expect(screen.queryByRole('list')).toBeNull();
+    // Expect list to be hidden before click
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
 
     const menuButton = await screen.findByRole('button');
     await userEvent.click(menuButton);
     const list = screen.getByRole('list');
-    expect(within(list).queryByText(/julkaise nyt/i)).toBeNull();
+    expect(within(list).queryByText(/julkaise nyt/i)).not.toBeInTheDocument();
     await within(list).findByText(/muokkaa/i);
     await within(list).findByText(/tee kopio/i);
     await within(list).findByText(/poista/i);
@@ -51,7 +50,7 @@ describe('JobPostingsListItem', () => {
   it('should show correct menu items for the not published posting, when menu is open', async () => {
     renderComponent(<JobPostingsListItem posting={notPublished} />);
 
-    expect(screen.queryByRole('list')).toBeNull();
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
 
     const menuButton = await screen.findByRole('button');
     await userEvent.click(menuButton);

--- a/frontend/tet/admin/src/components/login/LoginHeader.tsx
+++ b/frontend/tet/admin/src/components/login/LoginHeader.tsx
@@ -4,7 +4,7 @@ import Container from 'shared/components/container/Container';
 
 import { $LoginHeader, $LoginHeaderSubtitle, $LoginHeaderTitle } from './LoginHeader.sc';
 
-const LoginHeader = () => {
+const LoginHeader: React.FC = () => {
   const { t } = useTranslation();
 
   return (

--- a/frontend/tet/admin/src/components/login/LoginLinks.tsx
+++ b/frontend/tet/admin/src/components/login/LoginLinks.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import { Card, Button } from 'hds-react';
+import { Button, Card } from 'hds-react';
 import { useTranslation } from 'next-i18next';
-import { $LoginLinks } from './LoginLinks.sc';
+import React from 'react';
 import useLogin from 'tet/admin/hooks/backend/useLogin';
 
-const LoginLinks = () => {
+import { $LoginLinks } from './LoginLinks.sc';
+
+const LoginLinks: React.FC = () => {
   const { t } = useTranslation();
   const loginAdfs = useLogin('adfs');
   const loginOidc = useLogin('oidc');

--- a/frontend/tet/admin/src/components/login/__tests__/LoginLinks.test.tsx
+++ b/frontend/tet/admin/src/components/login/__tests__/LoginLinks.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
-import LoginLinks from 'tet/admin/components/login/LoginLinks';
 import { screen, userEvent, waitFor } from 'shared/__tests__/utils/test-utils';
 import { DEFAULT_LANGUAGE } from 'shared/i18n/i18n';
+import renderComponent from 'tet/admin/__tests__/utils/components/render-component';
 import { getBackendUrl } from 'tet/admin/backend-api/backend-api';
+import LoginLinks from 'tet/admin/components/login/LoginLinks';
 
 describe('frontend/tet/admin/src/components/login/LoginLinks', () => {
   it('should handle ADFS and OIDC login', async () => {
@@ -12,13 +12,13 @@ describe('frontend/tet/admin/src/components/login/LoginLinks', () => {
     const adfsLoginButton = screen.getByTestId('adfsLoginButton');
     const oidcLoginButton = screen.getByTestId('oidcLoginButton');
 
-    userEvent.click(adfsLoginButton);
+    await userEvent.click(adfsLoginButton);
 
     await waitFor(() =>
       expect(spyPush).toHaveBeenCalledWith(`${getBackendUrl('/oauth2/login')}?lang=${DEFAULT_LANGUAGE}`),
     );
 
-    userEvent.click(oidcLoginButton);
+    await userEvent.click(oidcLoginButton);
 
     await waitFor(() =>
       expect(spyPush).toHaveBeenCalledWith(`${getBackendUrl('/oidc/authenticate/')}?lang=${DEFAULT_LANGUAGE}`),

--- a/frontend/tet/admin/src/hooks/backend/useDeleteTetPosting.ts
+++ b/frontend/tet/admin/src/hooks/backend/useDeleteTetPosting.ts
@@ -1,13 +1,13 @@
-import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
-import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
-import useBackendAPI from 'shared/hooks/useBackendAPI';
-import TetPosting from 'tet-shared/types/tetposting';
 import { AxiosError } from 'axios';
 import { useRouter } from 'next/router';
-import showSuccessToast from 'shared/components/toast/show-success-toast';
 import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+import showSuccessToast from 'shared/components/toast/show-success-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
 import useLinkedEventsErrorHandler from 'tet/admin/hooks/backend/useLinkedEventsErrorHandler';
 import { LinkedEventsError } from 'tet-shared/types/linkedevents';
+import TetPosting from 'tet-shared/types/tetposting';
 
 const useDeleteTetPosting = (): UseMutationResult<TetPosting, AxiosError<LinkedEventsError>, TetPosting> => {
   const { t } = useTranslation();

--- a/frontend/tet/admin/src/hooks/backend/useLinkedEventsErrorHandler.ts
+++ b/frontend/tet/admin/src/hooks/backend/useLinkedEventsErrorHandler.ts
@@ -1,8 +1,8 @@
-import { LinkedEventsError } from 'tet-shared/types/linkedevents';
-import showErrorToast from 'shared/components/toast/show-error-toast';
-import { useTranslation } from 'next-i18next';
 import { AxiosError } from 'axios';
 import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import { LinkedEventsError } from 'tet-shared/types/linkedevents';
 
 type ErrorHandlerFn = (error: AxiosError<LinkedEventsError>) => void;
 

--- a/frontend/tet/admin/src/hooks/backend/useLogin.ts
+++ b/frontend/tet/admin/src/hooks/backend/useLogin.ts
@@ -1,7 +1,7 @@
-import { BackendEndpoint, getBackendUrl } from 'tet/admin/backend-api/backend-api';
 import { useRouter } from 'next/router';
 import React from 'react';
 import useLocale from 'shared/hooks/useLocale';
+import { BackendEndpoint, getBackendUrl } from 'tet/admin/backend-api/backend-api';
 
 const loginEndPoints = {
   adfs: BackendEndpoint.LOGIN_ADFS,
@@ -13,7 +13,7 @@ const useLogin = (type: keyof typeof loginEndPoints): (() => Promise<boolean>) =
   const locale = useLocale();
   return React.useCallback(
     () => router.push(`${getBackendUrl(loginEndPoints[type])}?lang=${locale}`),
-    [router, locale],
+    [router, type, locale],
   );
 };
 

--- a/frontend/tet/admin/src/hooks/backend/useLogout.ts
+++ b/frontend/tet/admin/src/hooks/backend/useLogout.ts
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import React from 'react';
-
 import { BackendEndpoint, getBackendUrl } from 'tet/admin/backend-api/backend-api';
 
 const useLogout = (): (() => Promise<boolean>) => {

--- a/frontend/tet/admin/src/hooks/backend/usePublishTetPosting.ts
+++ b/frontend/tet/admin/src/hooks/backend/usePublishTetPosting.ts
@@ -1,13 +1,13 @@
-import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
-import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
-import useBackendAPI from 'shared/hooks/useBackendAPI';
-import TetPosting from 'tet-shared/types/tetposting';
 import { AxiosError } from 'axios';
 import { useRouter } from 'next/router';
-import showSuccessToast from 'shared/components/toast/show-success-toast';
 import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+import showSuccessToast from 'shared/components/toast/show-success-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
 import useLinkedEventsErrorHandler from 'tet/admin/hooks/backend/useLinkedEventsErrorHandler';
 import { LinkedEventsError } from 'tet-shared/types/linkedevents';
+import TetPosting from 'tet-shared/types/tetposting';
 
 const usePublishTetPosting = (): UseMutationResult<TetPosting, AxiosError<LinkedEventsError>, TetPosting> => {
   const { t } = useTranslation();

--- a/frontend/tet/admin/src/hooks/backend/useUploadImage.ts
+++ b/frontend/tet/admin/src/hooks/backend/useUploadImage.ts
@@ -1,14 +1,11 @@
-import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
-import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
-import useBackendAPI from 'shared/hooks/useBackendAPI';
-import TetPosting from 'tet-shared/types/tetposting';
 import { AxiosError } from 'axios';
 import { useRouter } from 'next/router';
-import showSuccessToast from 'shared/components/toast/show-success-toast';
 import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+import showSuccessToast from 'shared/components/toast/show-success-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
 import useLinkedEventsErrorHandler from 'tet/admin/hooks/backend/useLinkedEventsErrorHandler';
 import { LinkedEventsError } from 'tet-shared/types/linkedevents';
-import { ImageObject } from 'tet-shared/types/linkedevents';
 
 const useUploadImage = (): UseMutationResult<File, AxiosError<LinkedEventsError>, File> => {
   const { t } = useTranslation();
@@ -19,17 +16,10 @@ const useUploadImage = (): UseMutationResult<File, AxiosError<LinkedEventsError>
     errorTitle: t('common:api.publishErrorTitle'),
     errorMessage: t('common:api.publishErrorMessage'),
   });
-  const uploadImage = async (image?: File): Promise<ImageObject> => {
-    await new Promise((r) => setTimeout(r, 2000));
-    return {
-      url: 'https://linkedevents-api.dev.hel.ninja/linkedevents-dev/media/images/testimage_9gcuSik.png',
-      '@id': 'https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/image/4234/',
-    };
-  };
 
   return useMutation<File, AxiosError<LinkedEventsError>, File>(
     'postImage',
-    (image: File) => handleResponse<File>(axios.put(`$`)),
+    () => handleResponse<File>(axios.put(`$`)),
     {
       onSuccess: () => {
         void queryClient.removeQueries();

--- a/frontend/tet/admin/src/hooks/backend/useUpsertTetPosting.ts
+++ b/frontend/tet/admin/src/hooks/backend/useUpsertTetPosting.ts
@@ -1,12 +1,12 @@
-import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
-import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
-import useBackendAPI from 'shared/hooks/useBackendAPI';
 import { AxiosError } from 'axios';
 import { useRouter } from 'next/router';
-import { LinkedEventsError, TetUpsert } from 'tet-shared/types/linkedevents';
-import showSuccessToast from 'shared/components/toast/show-success-toast';
 import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+import showSuccessToast from 'shared/components/toast/show-success-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
 import useLinkedEventsErrorHandler from 'tet/admin/hooks/backend/useLinkedEventsErrorHandler';
+import { LinkedEventsError, TetUpsert } from 'tet-shared/types/linkedevents';
 
 const useUpsertTetPosting = (): UseMutationResult<TetUpsert, AxiosError<LinkedEventsError>, TetUpsert> => {
   const { axios, handleResponse } = useBackendAPI();

--- a/frontend/tet/admin/src/hooks/backend/useUserQuery.ts
+++ b/frontend/tet/admin/src/hooks/backend/useUserQuery.ts
@@ -1,8 +1,8 @@
-import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
 import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
 import useErrorHandler from 'shared/hooks/useErrorHandler';
 import useIsRouting from 'shared/hooks/useIsRouting';
 import User from 'shared/types/user';
+import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
 
 const useUserQuery = <T = User>({ refetchInterval, select }: UseQueryOptions<T> = {}): UseQueryResult<T> => {
   const isRouting = useIsRouting();

--- a/frontend/tet/admin/src/hooks/translation/useValidationRules.ts
+++ b/frontend/tet/admin/src/hooks/translation/useValidationRules.ts
@@ -1,11 +1,13 @@
 import { useTranslation } from 'next-i18next';
-import { EMAIL_REGEX, NAMES_REGEX, PHONE_NUMBER_REGEX, DATE_UI_REGEX, WEBSITE_URL } from 'shared/constants';
+import { RegisterOptions } from 'react-hook-form';
+import { DATE_UI_REGEX, EMAIL_REGEX, NAMES_REGEX, PHONE_NUMBER_REGEX, WEBSITE_URL } from 'shared/constants';
 
-const useValidationRules = () => {
+const useValidationRules = (): RegisterOptions & Record<string, RegisterOptions> => {
   const { t } = useTranslation();
   const maxMessage = t('common:editor.posting.validation.max');
   const requiredMessage = t('common:editor.posting.validation.required');
   const correctName = t('common:editor.posting.validation.name');
+  const phoneMessage = t('common:editor.posting.validation.phone');
 
   return {
     required: {
@@ -15,12 +17,10 @@ const useValidationRules = () => {
     date: {
       pattern: {
         value: DATE_UI_REGEX,
-        message: t('common:editor.posting.validation.phone'),
+        message: phoneMessage,
       },
     },
-    maxLength: {
-      message: t('common:editor.posting.validation.max'),
-    },
+    maxlength: t('common:editor.posting.validation.max'),
     name: {
       required: {
         value: true,
@@ -52,7 +52,7 @@ const useValidationRules = () => {
       },
       pattern: {
         value: PHONE_NUMBER_REGEX,
-        message: t('common:editor.posting.validation.phone'),
+        message: phoneMessage,
       },
       required: {
         value: true,
@@ -86,7 +86,7 @@ const useValidationRules = () => {
     website: {
       pattern: {
         value: WEBSITE_URL,
-        message: t('common:editor.posting.validation.phone'),
+        message: phoneMessage,
       },
       maxLength: {
         value: 2048,

--- a/frontend/tet/admin/src/pages/copystatic.tsx
+++ b/frontend/tet/admin/src/pages/copystatic.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
 import { GetStaticProps, NextPage } from 'next';
-import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
-import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
-import EditById from 'tet/admin/components/editor/EditById';
-import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
-import { TetEvent } from 'tet-shared/types/linkedevents';
-import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
 import { useQuery } from 'react-query';
-import PageNotFound from 'shared/components/pages/PageNotFound';
 import withAuth from 'shared/components/hocs/withAuth';
+import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
+import PageNotFound from 'shared/components/pages/PageNotFound';
+import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
+import EditById from 'tet/admin/components/editor/EditById';
 import EditorLoadingError from 'tet/admin/components/editor/EditorLoadingError';
 import useEventPostingTransformation from 'tet-shared/hooks/backend/useEventPostingTransformation';
+import { TetEvent } from 'tet-shared/types/linkedevents';
 
 const CopyStaticPage: NextPage = () => {
   const { t } = useTranslation();
@@ -35,9 +35,8 @@ const CopyStaticPage: NextPage = () => {
     posting.date_published = null;
 
     return <EditById title={t('common:editor.copyTitle')} data={posting} />;
-  } else {
-    return <PageNotFound />;
   }
+  return <PageNotFound />;
 };
 
 export const getStaticProps: GetStaticProps = getServerSideTranslations('common');

--- a/frontend/tet/admin/src/pages/editstatic.tsx
+++ b/frontend/tet/admin/src/pages/editstatic.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
 import { GetStaticProps, NextPage } from 'next';
-import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
-import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
-import EditById from 'tet/admin/components/editor/EditById';
-import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
-import { TetEvent } from 'tet-shared/types/linkedevents';
-import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
 import { useQuery } from 'react-query';
-import PageNotFound from 'shared/components/pages/PageNotFound';
 import withAuth from 'shared/components/hocs/withAuth';
+import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
+import PageNotFound from 'shared/components/pages/PageNotFound';
+import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
+import EditById from 'tet/admin/components/editor/EditById';
 import EditorLoadingError from 'tet/admin/components/editor/EditorLoadingError';
-import useEventPostingTransformation from 'tet-shared/hooks/backend/useEventPostingTransformation';
 import HeaderLinks from 'tet-shared/components/HeaderLinks';
+import useEventPostingTransformation from 'tet-shared/hooks/backend/useEventPostingTransformation';
+import { TetEvent } from 'tet-shared/types/linkedevents';
 
 const EditStaticPage: NextPage = () => {
   const { t } = useTranslation();
@@ -40,9 +40,8 @@ const EditStaticPage: NextPage = () => {
         <EditById title={t('common:editor.editTitle')} data={posting} />
       </>
     );
-  } else {
-    return <PageNotFound />;
   }
+  return <PageNotFound />;
 };
 
 export const getStaticProps: GetStaticProps = getServerSideTranslations('common');

--- a/frontend/tet/admin/src/pages/index.tsx
+++ b/frontend/tet/admin/src/pages/index.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import { GetStaticProps, NextPage } from 'next';
+import React from 'react';
+import withAuth from 'shared/components/hocs/withAuth';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 import JobPostings from 'tet/admin/components/jobPostings/JobPostings';
-import withAuth from 'shared/components/hocs/withAuth';
 
 const Index: NextPage = () => <JobPostings />;
 

--- a/frontend/tet/admin/src/pages/login.tsx
+++ b/frontend/tet/admin/src/pages/login.tsx
@@ -1,19 +1,15 @@
-import { Button, IconSignin } from 'hds-react';
-import useLogin from 'tet/admin/hooks/backend/useLogin';
 import { GetStaticProps, NextPage } from 'next';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { Trans, useTranslation } from 'next-i18next';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useQueryClient } from 'react-query';
 import Container from 'shared/components/container/Container';
 import { $Notification } from 'shared/components/notification/Notification.sc';
 import useClearQueryParams from 'shared/hooks/useClearQueryParams';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
-import { useEffect } from 'react';
-import { useQueryClient } from 'react-query';
 import { $InfoboxContent } from 'tet/admin/components/login/InfoboxContent.sc';
-import LoginLinks from 'tet/admin/components/login/LoginLinks';
 import LoginHeader from 'tet/admin/components/login/LoginHeader';
+import LoginLinks from 'tet/admin/components/login/LoginLinks';
 
 const Login: NextPage = () => {
   const queryClient = useQueryClient();
@@ -36,57 +32,6 @@ const Login: NextPage = () => {
     return `common:loginPage.infoLabel`;
   }, [logout, error, sessionExpired]);
 
-  const notificationContent = React.useMemo((): JSX.Element | null => {
-    if (error || logout) {
-      return null;
-    }
-    if (sessionExpired) {
-      return t(`common:loginPage.logoutInfoContent`);
-    }
-    return (
-      <$InfoboxContent>
-        {t(`common:loginPage.infoContent.listHeading`)}
-        <br />- {t(`common:loginPage.infoContent.bullet1`)}
-        <br />- {t(`common:loginPage.infoContent.bullet2`)}
-        <br />- {t(`common:loginPage.infoContent.bullet3`)}
-        <br />
-        <br />
-        <Trans
-          i18nKey="common:loginPage.infoContent.moreInfo"
-          components={{
-            a: (
-              <a href={t('common:footer.privacyPolicyLink')} rel="noopener noreferrer" target="_blank">
-                {}
-              </a>
-            ),
-          }}
-        >
-          {
-            'Lisätietoja henkilötietojen käsittelystä (mm. oikeusperusteet ja säilytysajat) TET-paikkojen ilmoituspalvelussa löydät <a>opintohallintorekisteristä</a>'
-          }
-        </Trans>
-        <br />
-        <br />
-        {t(`common:loginPage.infoContent.registerRights1`)}
-        <br />
-        <Trans
-          i18nKey="common:loginPage.infoContent.registerRights2"
-          components={{
-            a: (
-              <a href={t('common:footer.privacyPolicyLink')} rel="noopener noreferrer" target="_blank">
-                {}
-              </a>
-            ),
-          }}
-        >
-          {
-            'Rekisteröity voi muun muassa tarkistaa mitä tietoja hänestä on kerätty. Lisätietoja oikeuksista ja niiden toteuttamisesta <a>Helsingin kaupungin tietosuojasivulla</a>.'
-          }
-        </Trans>
-      </$InfoboxContent>
-    );
-  }, [logout, error, sessionExpired, t]);
-
   const notificationType = error || sessionExpired ? 'error' : 'info';
 
   useEffect(() => {
@@ -95,17 +40,62 @@ const Login: NextPage = () => {
     }
   }, [logout, queryClient]);
 
+  if (error || logout) {
+    return null;
+  }
+  if (sessionExpired) {
+    return t(`common:loginPage.logoutInfoContent`);
+  }
+
   return (
     <>
       <LoginHeader />
       <Container>
         <LoginLinks />
         <$Notification label={t(notificationLabelKey)} type={notificationType} size="large">
-          {notificationContent}
+          <$InfoboxContent>
+            {t(`common:loginPage.infoContent.listHeading`)}
+            <br />- {t(`common:loginPage.infoContent.bullet1`)}
+            <br />- {t(`common:loginPage.infoContent.bullet2`)}
+            <br />- {t(`common:loginPage.infoContent.bullet3`)}
+            <br />
+            <br />
+            <Trans
+              i18nKey="common:loginPage.infoContent.moreInfo"
+              components={{
+                a: (
+                  <a href={t('common:footer.privacyPolicyLink')} rel="noopener noreferrer" target="_blank">
+                    {}
+                  </a>
+                ),
+              }}
+            >
+              {
+                'Lisätietoja henkilötietojen käsittelystä (mm. oikeusperusteet ja säilytysajat) TET-paikkojen ilmoituspalvelussa löydät <a>opintohallintorekisteristä</a>'
+              }
+            </Trans>
+            <br />
+            <br />
+            {t(`common:loginPage.infoContent.registerRights1`)}
+            <br />
+            <Trans
+              i18nKey="common:loginPage.infoContent.registerRights2"
+              components={{
+                a: (
+                  <a href={t('common:footer.privacyPolicyLink')} rel="noopener noreferrer" target="_blank">
+                    {}
+                  </a>
+                ),
+              }}
+            >
+              {
+                'Rekisteröity voi muun muassa tarkistaa mitä tietoja hänestä on kerätty. Lisätietoja oikeuksista ja niiden toteuttamisesta <a>Helsingin kaupungin tietosuojasivulla</a>.'
+              }
+            </Trans>
+          </$InfoboxContent>
         </$Notification>
       </Container>
     </>
-
   );
 };
 

--- a/frontend/tet/admin/src/pages/new.tsx
+++ b/frontend/tet/admin/src/pages/new.tsx
@@ -1,17 +1,16 @@
-import React, { useState, useEffect } from 'react';
-import { useContext } from 'react';
 import { GetStaticProps, NextPage } from 'next';
-import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
-import Container from 'shared/components/container/Container';
-import { $Heading, $HeadingContainer } from 'tet/admin/components/jobPostings/JobPostings.sc';
-import Editor from 'tet/admin/components/editor/Editor';
 import { useTranslation } from 'next-i18next';
-import PostingContainer from 'tet-shared/components/posting/PostingContainer';
-import PreviewWrapper from 'tet/admin/components/editor/previewWrapper/PreviewWrapper';
-import { PreviewContext } from 'tet/admin/store/PreviewContext';
-import BackButton from 'tet/admin/components/BackButton';
+import React, { useContext, useEffect, useState } from 'react';
+import Container from 'shared/components/container/Container';
 import withAuth from 'shared/components/hocs/withAuth';
+import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+import BackButton from 'tet/admin/components/BackButton';
+import Editor from 'tet/admin/components/editor/Editor';
+import PreviewWrapper from 'tet/admin/components/editor/previewWrapper/PreviewWrapper';
+import { $Heading, $HeadingContainer } from 'tet/admin/components/jobPostings/JobPostings.sc';
+import { PreviewContext } from 'tet/admin/store/PreviewContext';
 import HeaderLinks from 'tet-shared/components/HeaderLinks';
+import PostingContainer from 'tet-shared/components/posting/PostingContainer';
 
 const NewPostingPage: NextPage = () => {
   const { t } = useTranslation();
@@ -21,6 +20,7 @@ const NewPostingPage: NextPage = () => {
   useEffect(() => {
     // If initial, use data from query and not from previewContext
     if (isInitialRender) setIsInitialRender(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (showPreview) {
@@ -42,7 +42,7 @@ const NewPostingPage: NextPage = () => {
         <$HeadingContainer>
           <$Heading>{t('common:editor.newTitle')}</$Heading>
         </$HeadingContainer>
-        <Editor initialValue={isInitialRender ? undefined : tetPosting} isNewPosting={true} />
+        <Editor initialValue={isInitialRender ? undefined : tetPosting} isNewPosting />
       </Container>
     </>
   );

--- a/frontend/tet/admin/src/query-client/create-query-client.ts
+++ b/frontend/tet/admin/src/query-client/create-query-client.ts
@@ -1,7 +1,7 @@
 import Axios, { AxiosInstance } from 'axios';
 import { QueryClient, QueryFunctionContext, QueryKey } from 'react-query';
 import { isString } from 'shared/utils/type-guards';
-import { getBackendDomain, BackendEndPoints } from 'tet/admin/backend-api/backend-api';
+import { BackendEndPoints, getBackendDomain } from 'tet/admin/backend-api/backend-api';
 
 const createAxios = (): AxiosInstance =>
   Axios.create({

--- a/frontend/tet/admin/src/store/PreviewContext.tsx
+++ b/frontend/tet/admin/src/store/PreviewContext.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import TetPosting from 'tet-shared/types/tetposting';
 import { ensureScheme } from 'tet-shared/backend-api/transformations';
+import TetPosting from 'tet-shared/types/tetposting';
 
 type PreviewContextObj = {
   showPreview: boolean;
@@ -49,17 +49,17 @@ export const PreviewContext = React.createContext<PreviewContextObj>({
   showPreview: false,
   tetPosting: initialPosting,
   formValid: false,
-  setPreviewVisibility: (visibility: boolean) => {},
-  setTetPostingData: (data: TetPosting) => {},
-  setFormValid: (isValid: boolean) => {},
+  setPreviewVisibility: () => {},
+  setTetPostingData: () => {},
+  setFormValid: () => {},
 });
 
-const PreviewContextProvider: React.FC = (props) => {
+const PreviewContextProvider: React.FC = ({ children }) => {
   const [showPreview, setShowPreview] = useState(false);
   const [tetPosting, setTetPosting] = useState<TetPosting>(initialPosting);
   const [formValid, setFormValid] = useState(false);
 
-  const setTetPostingData = (posting: TetPosting) => {
+  const setTetPostingData = (posting: TetPosting): void => {
     const url = ensureScheme(posting?.website_url);
     setTetPosting({
       ...posting,
@@ -76,7 +76,7 @@ const PreviewContextProvider: React.FC = (props) => {
     setFormValid,
   };
 
-  return <PreviewContext.Provider value={contextValue}>{props.children}</PreviewContext.Provider>;
+  return <PreviewContext.Provider value={contextValue}>{children}</PreviewContext.Provider>;
 };
 
 export default PreviewContextProvider;

--- a/frontend/tet/employer/package.json
+++ b/frontend/tet/employer/package.json
@@ -10,7 +10,7 @@
     "test:debug-dom": "cross-env DEBUG_PRINT_LIMIT=1000000 yarn test",
     "test:staged": "yarn test --watchAll=false --findRelatedTests",
     "test:coverage": "yarn test:debug-dom --verbose --coverage",
-    "lint": "next lint"
+    "lint": "eslint --ext js,ts,tsx src"
   },
   "dependencies": {
     "@frontend/shared": "*",

--- a/frontend/tet/shared/.eslintrc.js
+++ b/frontend/tet/shared/.eslintrc.js
@@ -1,7 +1,7 @@
 const { join } = require('path');
 
 module.exports = {
-  extends: ['../../.eslintrc.nextjs.js'],
+  extends: ['../../.eslintrc.jsx.js'],
   rules: {
     'import/no-extraneous-dependencies': [
       'error',

--- a/frontend/tet/shared/src/components/HeaderLinks.tsx
+++ b/frontend/tet/shared/src/components/HeaderLinks.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import React from 'react';
 
-const HeaderLinks = (): JSX.Element => (
+const HeaderLinks: React.FC = () => (
   <Head>
     <link
       rel="stylesheet"

--- a/frontend/tet/shared/src/components/MapScripts.tsx
+++ b/frontend/tet/shared/src/components/MapScripts.tsx
@@ -1,7 +1,7 @@
 import Script from 'next/script';
 import React from 'react';
 
-const MapScripts = (): JSX.Element => (
+const MapScripts: React.FC = () => (
   <Script
     src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"
     // eslint-disable-next-line no-secrets/no-secrets

--- a/frontend/tet/shared/src/components/container/Container.tsx
+++ b/frontend/tet/shared/src/components/container/Container.tsx
@@ -14,10 +14,4 @@ const Container: React.FC<ContainerProps> = ({
   </$Container>
 );
 
-const defaultProps = {
-  backgroundColor: '',
-};
-
-Container.defaultProps = defaultProps;
-
 export default Container;

--- a/frontend/tet/shared/src/components/map/LocationMap.tsx
+++ b/frontend/tet/shared/src/components/map/LocationMap.tsx
@@ -34,9 +34,4 @@ const LocationMap: React.FC<Props> = ({ posting, height, zoom }) => {
   );
 };
 
-LocationMap.defaultProps = {
-  height: '400px',
-  zoom: 11,
-};
-
 export default LocationMap;

--- a/frontend/tet/shared/src/components/map/Map.tsx
+++ b/frontend/tet/shared/src/components/map/Map.tsx
@@ -119,12 +119,4 @@ const Map: React.FC<Props> = ({
   );
 };
 
-Map.defaultProps = {
-  center: [60.1699, 24.9384], // Helsinki location
-  height: '400px',
-  zoom: 11,
-  zoomToPosition: false,
-  showLink: false,
-};
-
 export default Map;

--- a/frontend/tet/shared/src/components/posting/PostingContainer.tsx
+++ b/frontend/tet/shared/src/components/posting/PostingContainer.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import noop from 'lodash/noop';
 import React from 'react';
 import PostingContent from 'tet-shared/components/posting/postingContent/PostingContent';
 import PostingHero from 'tet-shared/components/posting/postingHero/PostingHero';
@@ -25,14 +23,5 @@ const PostingContainer: React.FC<Props> = ({
     <PostingContent posting={posting} />
   </>
 );
-
-PostingContainer.defaultProps = {
-  showBackButton: false,
-};
-
-PostingContainer.defaultProps = {
-  showBackButton: false,
-  onReturnClick: () => noop,
-};
 
 export default PostingContainer;

--- a/frontend/tet/shared/src/components/posting/postingHero/PostingHero.tsx
+++ b/frontend/tet/shared/src/components/posting/postingHero/PostingHero.tsx
@@ -1,5 +1,4 @@
 import { IconArrowLeft, IconLocation } from 'hds-react';
-import noop from 'lodash/noop';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import Container from 'tet-shared/components/container/Container';
@@ -90,11 +89,6 @@ const PostingHero: React.FC<Props> = ({
       </Container>
     </$PostingHero>
   );
-};
-
-PostingHero.defaultProps = {
-  showBackButton: false,
-  onReturnClick: () => noop,
 };
 
 export default PostingHero;

--- a/frontend/tet/shared/src/components/posting/postingInfoItem/PostingInfoItem.tsx
+++ b/frontend/tet/shared/src/components/posting/postingInfoItem/PostingInfoItem.tsx
@@ -37,8 +37,4 @@ const PostingInfoItem: React.FC<Props> = ({ title, body, icon }) => {
   );
 };
 
-PostingInfoItem.defaultProps = {
-  icon: null,
-};
-
 export default PostingInfoItem;

--- a/frontend/tet/youth/browser-tests/pages/frontpage.ts
+++ b/frontend/tet/youth/browser-tests/pages/frontpage.ts
@@ -1,4 +1,4 @@
-import { t, Selector } from 'testcafe';
+import { Selector, t } from 'testcafe';
 
 class Frontpage {
   quickSearchInput = Selector('#searchText');

--- a/frontend/tet/youth/browser-tests/pages/postingpage.ts
+++ b/frontend/tet/youth/browser-tests/pages/postingpage.ts
@@ -6,7 +6,7 @@ class Postingpage {
   // TODO why is this not found?
   backButton = Selector('#backButton');
 
-  goBack = () => t.click(this.backButton);
+  goBack = (): TestControllerPromise => t.click(this.backButton);
 }
 
 export default new Postingpage();

--- a/frontend/tet/youth/browser-tests/pages/searchpage.ts
+++ b/frontend/tet/youth/browser-tests/pages/searchpage.ts
@@ -1,4 +1,4 @@
-import { t, Selector } from 'testcafe';
+import { Selector, t } from 'testcafe';
 
 class Searchpage {
   searchInput = Selector('input').withAttribute('placeholder', /kirjoita hakusana/i);

--- a/frontend/tet/youth/browser-tests/search.testcafe.ts
+++ b/frontend/tet/youth/browser-tests/search.testcafe.ts
@@ -1,13 +1,14 @@
-import { linkedEventsUrl } from '@frontend/te-yout/src/backend-api/backend-api';
 import { HttpRequestHook } from '@frontend/shared/browser-tests/http-utils/http-request-hook';
 import requestLogger, { filterLoggedRequests } from '@frontend/shared/browser-tests/utils/request-logger';
 import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
-import frontpage from './pages/frontpage';
-import searchpage from './pages/searchpage';
-import { Selector } from 'testcafe';
-import postingpage from './pages/postingpage';
 import { getUrl } from '@frontend/shared/browser-tests/utils/url.utils';
 import faker from 'faker';
+import { Selector } from 'testcafe';
+
+import { linkedEventsUrl } from '../src/backend-api/backend-api';
+import frontpage from './pages/frontpage';
+import postingpage from './pages/postingpage';
+import searchpage from './pages/searchpage';
 
 const url = getUrl(process.env.YOUTH_URL ?? 'https://localhost:3001');
 
@@ -25,7 +26,7 @@ fixture('Frontpage')
 const formatDate = (date: Date): string => `${date.getDate()}.${date.getMonth() + 1}.${date.getFullYear()}`;
 
 // This works locally but not on the review environment
-test.skip('simple test', async (t) => {
+test.skip('simple test', async () => {
   const searchTerm = faker.lorem.word();
 
   await frontpage.fillSearch(searchTerm);

--- a/frontend/tet/youth/package.json
+++ b/frontend/tet/youth/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "yarn test:debug-dom --verbose --coverage",
     "browser-test": "testcafe 'chrome --allow-insecure-localhost --ignore-certificate-errors --ignore-urlfetcher-cert-requests --window-size=\"1249,720\"' browser-tests/",
     "browser-test:ci": "testcafe 'chrome:headless --disable-gpu --window-size=\"1249,720\"  --ignore-certificate-errors-spki-list=\"8sg/cl7YabrOFqSqH+Bu0e+P27Av33gWgi8Lq28DW1I=,gJt+wt/T3afCRkxtMMSjXcl/99sgzWc2kk1c1PC9tG0=,zrQI2/1q8i2SRPmMZ1sMntIkG+lMW0legPFokDo3nrY=\"' --screenshots path=report --video report --reporter spec,custom,html:report/index.html browser-tests/",
-    "lint": "next lint"
+    "lint": "eslint --ext js,ts,tsx src browser-tests"
   },
   "dependencies": {
     "@frontend/shared": "*",

--- a/frontend/tet/youth/src/__tests__/index.test.tsx
+++ b/frontend/tet/youth/src/__tests__/index.test.tsx
@@ -1,15 +1,14 @@
-import IndexPage from 'tet/youth/pages';
+import faker from 'faker';
 import { axe } from 'jest-axe';
 import React from 'react';
-
+import { screen, userEvent, waitFor } from 'shared/__tests__/utils/test-utils';
+import { DEFAULT_LANGUAGE } from 'shared/i18n/i18n';
 import renderComponent from 'tet/youth/__tests__/utils/components/render-component';
 import renderPage from 'tet/youth/__tests__/utils/components/render-page';
-import { screen, userEvent, waitFor } from 'shared/__tests__/utils/test-utils';
+import IndexPage from 'tet/youth/pages';
+import { isoDateToHdsFormat } from 'tet-shared/backend-api/transformations';
 
 import getYouthTranslationsApi from './utils/i18n/get-youth-translations';
-import { DEFAULT_LANGUAGE } from 'shared/i18n/i18n';
-import faker from 'faker';
-import { isoDateToHdsFormat } from 'tet-shared/backend-api/transformations';
 
 jest.mock('next/router');
 
@@ -23,7 +22,7 @@ describe('frontend/tet/youth/src/pages/index.tsx', () => {
       writable: true,
       value: jest.fn().mockImplementation((query) => ({
         matches: false,
-        media: query,
+        media: query as unknown,
         onchange: null,
         addListener: jest.fn(), // Deprecated
         removeListener: jest.fn(), // Deprecated

--- a/frontend/tet/youth/src/__tests__/postings.test.tsx
+++ b/frontend/tet/youth/src/__tests__/postings.test.tsx
@@ -1,18 +1,18 @@
-import Postings from 'tet/youth/pages';
+import { within } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import React from 'react';
-import renderPage from 'tet/youth/__tests__/utils/components/render-page';
+import { waitForBackendRequestsToComplete } from 'shared/__tests__/utils/component.utils';
 import { screen, userEvent, waitFor } from 'shared/__tests__/utils/test-utils';
-import { fakeEventListYouth } from 'tet-shared/__tests__/utils/fake-objects';
-import renderComponent from 'tet/youth/__tests__/utils/components/render-component';
 import {
-  expectToGetEventsPageFromBackend,
-  expectToGetAllEventsFromBackend,
   expectAttributesFromLinkedEvents,
+  expectToGetAllEventsFromBackend,
+  expectToGetEventsPageFromBackend,
   expectWorkingMethodsFromLinkedEvents,
 } from 'tet/youth/__tests__/utils/backend/backend-nocks';
-import { within } from '@testing-library/react';
-import { waitForBackendRequestsToComplete } from 'shared/__tests__/utils/component.utils';
+import renderComponent from 'tet/youth/__tests__/utils/components/render-component';
+import renderPage from 'tet/youth/__tests__/utils/components/render-page';
+import Postings from 'tet/youth/pages';
+import { fakeEventListYouth } from 'tet-shared/__tests__/utils/fake-objects';
 
 jest.mock('next/router');
 
@@ -24,7 +24,7 @@ describe('frontend/tet/youth/src/pages/postings.tsx', () => {
       writable: true,
       value: jest.fn().mockImplementation((query) => ({
         matches: false,
-        media: query,
+        media: query as unknown,
         onchange: null,
         addListener: jest.fn(), // Deprecated
         removeListener: jest.fn(), // Deprecated
@@ -43,7 +43,7 @@ describe('frontend/tet/youth/src/pages/postings.tsx', () => {
     expect(results).toHaveNoViolations();
   });
 
-  //List items are not currently found after renderPage(). Nock urls seem to be correct after yarn test:debug-nock
+  // List items are not currently found after renderPage(). Nock urls seem to be correct after yarn test:debug-nock
   it.skip('should show tet postings markers on the map', async () => {
     expectToGetEventsPageFromBackend(postings);
     expectToGetAllEventsFromBackend(postings);
@@ -52,7 +52,8 @@ describe('frontend/tet/youth/src/pages/postings.tsx', () => {
     renderPage(Postings);
     await waitForBackendRequestsToComplete();
 
-    userEvent.click(screen.getByRole('button', { name: /näytä tulokset kartalla/i }));
+    await userEvent.click(screen.getByRole('button', { name: /näytä tulokset kartalla/i }));
+    // eslint-disable-next-line testing-library/no-node-access
     await waitFor(() => expect(document.querySelectorAll('.leaflet-marker-icon')).toHaveLength(2));
   });
 
@@ -60,8 +61,8 @@ describe('frontend/tet/youth/src/pages/postings.tsx', () => {
     expectToGetEventsPageFromBackend(postings);
     expectToGetAllEventsFromBackend(postings);
     renderPage(Postings);
-    //set url params
-    //Check that filters have correct values
+    // set url params
+    // Check that filters have correct values
   });
 
   it.skip('should show all the postings if there are no filters', async () => {
@@ -69,15 +70,15 @@ describe('frontend/tet/youth/src/pages/postings.tsx', () => {
     expectToGetAllEventsFromBackend(postings);
     renderPage(Postings);
     await screen.findByText(/2 hakutulosta/i);
-    await screen.findByText(/Avustaja/i);
-    await screen.findByText(/Kirjasto/i);
+    await screen.findByText(/avustaja/i);
+    await screen.findByText(/kirjasto/i);
   });
 
   it.skip('should show links to the word searches if multiword search had no results', async () => {
     expectToGetEventsPageFromBackend(postings);
     expectToGetAllEventsFromBackend(postings);
     renderPage(Postings);
-    //Set urlparam 'text' to 'kirjasto apulainen'
+    // Set urlparam 'text' to 'kirjasto apulainen'
     const links = screen.getByTestId('search-word-links');
     await within(links).findByRole('link', {
       name: /kirjasto/i,

--- a/frontend/tet/youth/src/__tests__/show.test.tsx
+++ b/frontend/tet/youth/src/__tests__/show.test.tsx
@@ -1,8 +1,7 @@
-import ShowPostingPage from 'tet/youth/pages';
 import { axe } from 'jest-axe';
 import React from 'react';
-
 import renderComponent from 'tet/youth/__tests__/utils/components/render-component';
+import ShowPostingPage from 'tet/youth/pages';
 
 jest.mock('next/router');
 
@@ -12,7 +11,7 @@ describe('frontend/tet/youth/src/pages/postings/show.tsx', () => {
       writable: true,
       value: jest.fn().mockImplementation((query) => ({
         matches: false,
-        media: query,
+        media: query as unknown,
         onchange: null,
         addListener: jest.fn(), // Deprecated
         removeListener: jest.fn(), // Deprecated

--- a/frontend/tet/youth/src/__tests__/utils/backend/backend-nocks.ts
+++ b/frontend/tet/youth/src/__tests__/utils/backend/backend-nocks.ts
@@ -1,7 +1,6 @@
-import { BackendEndpoint, linkedEventsUrl } from 'tet/youth/backend-api/backend-api';
 import nock from 'nock';
+import { linkedEventsUrl } from 'tet/youth/backend-api/backend-api';
 import { LinkedEventsPagedResponse, TetEvent } from 'tet-shared/types/linkedevents';
-import { waitForBackendRequestsToComplete } from 'shared/__tests__/utils/component.utils';
 
 // disable unnecessary axios' expected error messages
 // https://stackoverflow.com/questions/44467657/jest-better-way-to-disable-console-inside-unit-tests
@@ -13,11 +12,11 @@ beforeEach(() => {
 
 afterEach(async () => {
   // avoid situation where some request is still pending but test is completed
-  //await waitForBackendRequestsToComplete();
+  // await waitForBackendRequestsToComplete();
   // Check that all nocks are used: https://michaelheap.com/nock-all-mocks-used/
-  //if (!nock.isDone()) {
-  //throw new Error(`Not all nock interceptors were used: ${JSON.stringify(nock.pendingMocks())}`);
-  //}
+  // if (!nock.isDone()) {
+  // throw new Error(`Not all nock interceptors were used: ${JSON.stringify(nock.pendingMocks())}`);
+  // }
   nock.cleanAll();
 });
 

--- a/frontend/tet/youth/src/__tests__/utils/components/render-page.tsx
+++ b/frontend/tet/youth/src/__tests__/utils/components/render-page.tsx
@@ -1,7 +1,7 @@
+import renderPageF from 'shared/__tests__/utils/render-component/render-page';
+import { linkedEventsUrl } from 'tet/youth/backend-api/backend-api';
 import Footer from 'tet/youth/components/footer/Footer';
 import Header from 'tet/youth/components/header/Header';
-import { linkedEventsUrl } from 'tet/youth/backend-api/backend-api';
-import renderPageF from 'shared/__tests__/utils/render-component/render-page';
 
 const render = renderPageF({
   backendUrl: linkedEventsUrl,

--- a/frontend/tet/youth/src/backend-api/backend-api.ts
+++ b/frontend/tet/youth/src/backend-api/backend-api.ts
@@ -9,9 +9,7 @@ export const BackendEndpoint = {
   KEYWORD: 'keyword/',
 } as const;
 
-export const singleEvent = (id: string) => {
-  return `event/${id}?include=location,keywords`;
-};
+export const singleEvent = (id: string): string => `event/${id}?include=location,keywords`;
 
 export const BackendEndPoints = Object.values(BackendEndpoint);
 

--- a/frontend/tet/youth/src/components/banner/Banner.tsx
+++ b/frontend/tet/youth/src/components/banner/Banner.tsx
@@ -1,12 +1,12 @@
+import { useTranslation } from 'next-i18next';
 import React from 'react';
 import Container from 'shared/components/container/Container';
-import { $Banner, $BannerWrapper, $Title, $ImageWrapper } from './Banner.sc';
 import useMediaQuery from 'shared/hooks/useMediaQuery';
-import Image from 'next/image';
 import { useTheme } from 'styled-components';
-import { useTranslation } from 'next-i18next';
 
-const Banner = () => {
+import { $Banner, $BannerWrapper, $ImageWrapper, $Title } from './Banner.sc';
+
+const Banner: React.FC = () => {
   const theme = useTheme();
   const isSmall = useMediaQuery(`(min-width: ${theme.breakpoints.s})`);
   const { t } = useTranslation();
@@ -18,6 +18,7 @@ const Banner = () => {
           <$Title>{t('common:frontPage.heading')}</$Title>
           {isSmall && (
             <$ImageWrapper>
+              {/* eslint-disable-next-line jsx-a11y/alt-text, @next/next/no-img-element */}
               <img src="/lippakioski.png" />
             </$ImageWrapper>
           )}

--- a/frontend/tet/youth/src/components/footer/Footer.tsx
+++ b/frontend/tet/youth/src/components/footer/Footer.tsx
@@ -1,12 +1,12 @@
-import { Footer } from 'hds-react';
+import { Footer, IconLinkExternal } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import { IconLinkExternal } from 'hds-react';
 
 // import { $FooterWrapper } from './Footer.sc';
 
 const FooterSection: React.FC = () => {
   const { t } = useTranslation();
+  const newTabText = t('common:footer.newTab');
   return (
     <Footer title={t('common:appName')} theme="dark">
       <Footer.Base
@@ -19,7 +19,7 @@ const FooterSection: React.FC = () => {
           target="_blank"
           href={t('common:footer.accessibilityStatementLink')}
           label={t('common:footer.accessibilityStatement')}
-          aria-label={`${t('common:footer.accessibilityStatement')} - ${t('common:footer.newTab')}`}
+          aria-label={`${t('common:footer.accessibilityStatement')} - ${newTabText}`}
           icon={<IconLinkExternal />}
         />
         <Footer.Item
@@ -39,7 +39,7 @@ const FooterSection: React.FC = () => {
           target="_blank"
           href={t('common:footer.feedbackLink')}
           label={t('common:footer.feedback')}
-          aria-label={`${t('common:footer.feedback')} - ${t('common:footer.newTab')}`}
+          aria-label={`${t('common:footer.feedback')} - ${newTabText}`}
           icon={<IconLinkExternal />}
         />
         <Footer.Item
@@ -48,7 +48,7 @@ const FooterSection: React.FC = () => {
           target="_blank"
           href={t('common:footer.moreInfoLink')}
           label={t('common:footer.moreInfo')}
-          aria-label={`${t('common:footer.moreInfo')} - ${t('common:footer.newTab')}`}
+          aria-label={`${t('common:footer.moreInfo')} - ${newTabText}`}
           icon={<IconLinkExternal />}
         />
       </Footer.Base>

--- a/frontend/tet/youth/src/components/header/Header.tsx
+++ b/frontend/tet/youth/src/components/header/Header.tsx
@@ -1,12 +1,11 @@
+import { IconGlobe, LogoLanguage, Navigation } from 'hds-react';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
+import { MAIN_CONTENT_ID } from 'shared/constants';
+import useLocale from 'shared/hooks/useLocale';
 import { SUPPORTED_LANGUAGES } from 'shared/i18n/i18n';
 import { OptionType } from 'shared/types/common';
-
-import { IconGlobe, LogoLanguage, Navigation } from 'hds-react';
-import useLocale from 'shared/hooks/useLocale';
-import { MAIN_CONTENT_ID } from 'shared/constants';
 
 const Header: React.FC = () => {
   const { t } = useTranslation();
@@ -36,7 +35,7 @@ const Header: React.FC = () => {
     [router, asPath],
   );
 
-  const titleClickHandler = () => {
+  const titleClickHandler = (): void => {
     void router.push('/');
   };
 

--- a/frontend/tet/youth/src/components/jobPostingCard/JobPostingCard.tsx
+++ b/frontend/tet/youth/src/components/jobPostingCard/JobPostingCard.tsx
@@ -1,24 +1,24 @@
+import { Button } from 'hds-react';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
 import * as React from 'react';
+import { useTheme } from 'styled-components';
 import {
-  $PostingCard,
   $ImageContainer,
+  $PostingAddress,
+  $PostingCard,
   $PostingCardBody,
   $PostingCardBodyFooter,
-  $PostingTitle,
-  $PostingSubtitle,
-  $PostingDescription,
-  $PostingAddress,
   $PostingDate,
+  $PostingDescription,
   $PostingLanguages,
+  $PostingSubtitle,
+  $PostingTitle,
 } from 'tet/youth/components/jobPostingCard/JobPostingCard.sc';
-import JobPostingCardKeywords from './JobPostingCardKeywords';
-import { useRouter } from 'next/router';
-import { Button } from 'hds-react';
-import { useTheme } from 'styled-components';
 import { OptionType } from 'tet-shared/types/classification';
-import { useTranslation } from 'next-i18next';
 import JobPosting from 'tet-shared/types/tetposting';
-import Image from 'next/image';
+
+import JobPostingCardKeywords from './JobPostingCardKeywords';
 
 type Props = {
   jobPosting: JobPosting;
@@ -38,7 +38,7 @@ const JobPostingCard: React.FC<Props> = ({ jobPosting }) => {
   const languages = jobPosting.languages.map((language: OptionType) => language.label).join(', ');
   const imageUrl = jobPosting?.image_url?.length ? jobPosting.image_url : '/event_placeholder_B.jpg';
 
-  const readMoreHandler = () => {
+  const readMoreHandler = (): void => {
     void router.push(
       {
         pathname: '/postings/show',
@@ -56,7 +56,7 @@ const JobPostingCard: React.FC<Props> = ({ jobPosting }) => {
 
   return (
     <$PostingCard onClick={readMoreHandler}>
-      <$ImageContainer imageUrl={imageUrl}></$ImageContainer>
+      <$ImageContainer imageUrl={imageUrl} />
       <$PostingCardBody>
         <JobPostingCardKeywords jobPosting={jobPosting} />
         <$PostingSubtitle>{jobPosting.organization_name}</$PostingSubtitle>

--- a/frontend/tet/youth/src/components/jobPostingCard/JobPostingCardKeywords.tsx
+++ b/frontend/tet/youth/src/components/jobPostingCard/JobPostingCardKeywords.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import { Tag } from 'hds-react';
-import { OptionType } from 'tet-shared/types/classification';
-import JobPosting from 'tet-shared/types/tetposting';
-import styled from 'styled-components';
-import { useTheme } from 'styled-components';
 import useMediaQuery from 'shared/hooks/useMediaQuery';
+import styled, { useTheme } from 'styled-components';
+import KeyWordList from 'tet/youth/components/keywordList/KeyWordList';
+import JobPosting from 'tet-shared/types/tetposting';
 
 const $KeywordList = styled.ul`
   display: inline-flex;
@@ -26,31 +24,11 @@ type Props = {
 const JobPostingCardKeywords: React.FC<Props> = ({ jobPosting }) => {
   const theme = useTheme();
   const isDesktop = useMediaQuery(`(min-width: ${theme.breakpoints.m})`);
-  const keywordList = (list: OptionType[], color: string) => {
-    return (
-      <>
-        {list.map((keyword: OptionType) => (
-          <li>
-            <Tag
-              theme={{
-                '--tag-background': `var(--color-${color})`,
-                '--tag-color': 'var(--color-black-90)',
-                '--tag-focus-outline-color': 'var(--color-black-90)',
-              }}
-            >
-              {keyword.name}
-            </Tag>
-          </li>
-        ))}
-      </>
-    );
-  };
-
   return (
     <$KeywordList>
-      {keywordList(jobPosting.keywords_working_methods, 'success-light')}
-      {isDesktop && keywordList(jobPosting.keywords_attributes, 'coat-of-arms-medium-light')}
-      {isDesktop && keywordList(jobPosting.keywords, 'engel-medium-light')}
+      <KeyWordList list={jobPosting.keywords_working_methods} color="success-light" />
+      {isDesktop && <KeyWordList list={jobPosting.keywords_attributes} color="coat-of-arms-medium-light" />}
+      {isDesktop && <KeyWordList list={jobPosting.keywords} color="engel-medium-light" />}
     </$KeywordList>
   );
 };

--- a/frontend/tet/youth/src/components/jobPostingSearch/jobPostingSearchTags/JobPostingSearchTags.tsx
+++ b/frontend/tet/youth/src/components/jobPostingSearch/jobPostingSearchTags/JobPostingSearchTags.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
 import { Tag } from 'hds-react';
-import { QueryParams } from 'tet/youth/types/queryparams';
-import { convertToUIDateFormat } from 'shared/utils/date.utils';
-import { $Tags, $RemoveButton } from './JobPostingSearchTags.sc';
 import { useTranslation } from 'next-i18next';
+import React from 'react';
+import { convertToUIDateFormat } from 'shared/utils/date.utils';
+import { QueryParams } from 'tet/youth/types/queryparams';
 import { OptionType } from 'tet-shared/types/classification';
+
+import { $RemoveButton, $Tags } from './JobPostingSearchTags.sc';
 
 type Props = {
   initParams: QueryParams;
@@ -21,9 +22,9 @@ const PostingSearchTags: React.FC<Props> = ({
   onRemoveKeyword,
   languageOptions,
 }) => {
-  const startText = `${initParams.hasOwnProperty('start') ? convertToUIDateFormat(initParams.start as string) : ''}`;
-  const endText = `${initParams.hasOwnProperty('end') ? convertToUIDateFormat(initParams.end as string) : ''}`;
-  const dateText = startText + (startText.length || endText.length ? '-' : '') + endText;
+  const startText = `${initParams.start ? convertToUIDateFormat(initParams.start) : ''}`;
+  const endText = `${initParams.end ? convertToUIDateFormat(initParams.end) : ''}`;
+  const dateText = startText + (startText.length > 0 || endText.length > 0 ? '-' : '') + endText;
   const chosenLanguage = languageOptions.find((language) => language.value === initParams?.language);
 
   const { t } = useTranslation();

--- a/frontend/tet/youth/src/components/jobPostings/JobPostings.tsx
+++ b/frontend/tet/youth/src/components/jobPostings/JobPostings.tsx
@@ -1,39 +1,39 @@
-import React from 'react';
-import JobPostingSearch from 'tet/youth/components/jobPostingSearch/JobPostingSearch';
-import JobPostingList from 'tet/youth/components/jobPostingList/JobPostingList';
-import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
-import { QueryParams } from 'tet/youth/types/queryparams';
 import { useRouter } from 'next/router';
-import useGetPostings from 'tet/youth/hooks/backend/useGetPostings';
-import NoResults from 'tet/youth/components/noResults/NoResults';
-import ScreenReaderHelper from 'tet-shared/components/ScreenReaderHelper';
 import { useTranslation } from 'next-i18next';
+import React from 'react';
+import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
+import JobPostingList from 'tet/youth/components/jobPostingList/JobPostingList';
+import JobPostingSearch from 'tet/youth/components/jobPostingSearch/JobPostingSearch';
+import NoResults from 'tet/youth/components/noResults/NoResults';
+import useGetPostings from 'tet/youth/hooks/backend/useGetPostings';
+import { QueryParams } from 'tet/youth/types/queryparams';
 import ErrorText from 'tet-shared/components/ErrorText/ErrorText';
+import ScreenReaderHelper from 'tet-shared/components/ScreenReaderHelper';
 
 const Postings: React.FC = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const initMap = Object.prototype.hasOwnProperty.call(router.query, 'init_map') && Boolean(router.query.init_map);
   const params = { ...router.query };
-  delete params['init_map'];
+  delete params.init_map;
   const results = useGetPostings({ page_size: 10, ...params });
   const all = useGetPostings({ ...params });
 
   const searchParams = { ...params };
   if (Object.prototype.hasOwnProperty.call(params, 'keyword_AND')) {
-    searchParams['keyword'] = searchParams['keyword_AND'];
-    delete searchParams['keyword_AND'];
+    searchParams.keyword = searchParams.keyword_AND;
+    delete searchParams.keyword_AND;
   }
 
-  const searchHandler = (queryParams: QueryParams) => {
+  const searchHandler = (queryParams: QueryParams): void => {
     const searchQuery = {
       ...(queryParams.text && queryParams.text.length > 0 && { text: queryParams.text }),
       ...(queryParams.start && queryParams.start.length > 0 && { start: queryParams.start }),
       ...(queryParams.end && queryParams.end.length > 0 && { end: queryParams.end }),
-      ...(queryParams.keyword && queryParams.keyword.length > 0 && { ['keyword_AND']: queryParams.keyword }),
+      ...(queryParams.keyword && queryParams.keyword.length > 0 && { keyword_AND: queryParams.keyword }),
       ...(queryParams.language && queryParams.language.length > 0 && { language: queryParams.language }),
     };
-    router.push(
+    void router.push(
       {
         pathname: '/postings',
         query: {
@@ -47,38 +47,26 @@ const Postings: React.FC = () => {
     );
   };
 
-  const postings = () => {
-    const hasNextPage = false;
-    if (results.isLoading) {
-      return <PageLoadingSpinner />;
-    }
+  if (results.isLoading) {
+    return <PageLoadingSpinner />;
+  }
 
-    if (results.error) {
-      return <ErrorText>{t('common:postings.resultsError')}</ErrorText>;
-    }
-
-    if (results.data) {
-      return (
-        <JobPostingList
-          initMap={initMap}
-          firstPostingsPage={results.data}
-          allPostings={all}
-          hasNextPage={hasNextPage}
-        />
-      );
-    } else {
-      return <ErrorText>{t('common:postings.resultsError')}</ErrorText>;
-    }
-  };
+  if (results.error) {
+    return <ErrorText>{t('common:postings.resultsError')}</ErrorText>;
+  }
 
   return (
     <div>
-      <JobPostingSearch initParams={searchParams} onSearchByFilters={searchHandler}></JobPostingSearch>
-      {postings()}
+      <JobPostingSearch initParams={searchParams} onSearchByFilters={searchHandler} />
+      {results.data ? (
+        <JobPostingList initMap={initMap} firstPostingsPage={results.data} allPostings={all} />
+      ) : (
+        <ErrorText>{t('common:postings.resultsError')}</ErrorText>
+      )}
       {results.isSuccess && (
         <NoResults params={searchParams} onSearchByFilters={searchHandler} resultsTotal={results?.data.meta.count} />
       )}
-      <ScreenReaderHelper aria-live="polite" aria-atomic={true}>
+      <ScreenReaderHelper aria-live="polite" aria-atomic>
         {results.isLoading ? t('common:accessibility.eventsLoading') : t('common:accessibility.eventsReady')}
       </ScreenReaderHelper>
     </div>

--- a/frontend/tet/youth/src/components/keywordList/KeyWordList.tsx
+++ b/frontend/tet/youth/src/components/keywordList/KeyWordList.tsx
@@ -1,0 +1,28 @@
+import { Tag } from 'hds-react';
+import * as React from 'react';
+import { OptionType } from 'tet-shared/types/classification';
+
+type Props = {
+  list: OptionType[];
+  color: string;
+};
+
+const KeyWordList: React.FC<Props> = ({ list, color }) => (
+  <>
+    {list.map((keyword: OptionType) => (
+      <li>
+        <Tag
+          theme={{
+            '--tag-background': `var(--color-${color})`,
+            '--tag-color': 'var(--color-black-90)',
+            '--tag-focus-outline-color': 'var(--color-black-90)',
+          }}
+        >
+          {keyword.name}
+        </Tag>
+      </li>
+    ))}
+  </>
+);
+
+export default KeyWordList;

--- a/frontend/tet/youth/src/components/linkSection/LinkSection.tsx
+++ b/frontend/tet/youth/src/components/linkSection/LinkSection.tsx
@@ -1,9 +1,10 @@
+import { useTranslation } from 'next-i18next';
 import React from 'react';
 import Linkbox from 'tet/youth/components/linkbox/Linkbox';
-import { $LinkSection, $Links } from './LinkSection.sc';
-import { useTranslation } from 'next-i18next';
 
-const LinkSection = () => {
+import { $Links, $LinkSection } from './LinkSection.sc';
+
+const LinkSection: React.FC = () => {
   const { t } = useTranslation();
   return (
     <$LinkSection>

--- a/frontend/tet/youth/src/components/linkbox/Linkbox.tsx
+++ b/frontend/tet/youth/src/components/linkbox/Linkbox.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { $Linkbox, $TitleWrapper, $TitleText, $BoxContent } from './Linkbox.sc';
 import { IconArrowRight } from 'hds-react';
+import React from 'react';
+
+import { $BoxContent, $Linkbox, $TitleText, $TitleWrapper } from './Linkbox.sc';
 
 type Props = {
   title: string;
@@ -8,16 +9,14 @@ type Props = {
   content: string;
 };
 
-const Linkbox: React.FC<Props> = ({ title, link, content }) => {
-  return (
-    <$Linkbox>
-      <$TitleWrapper href={link} rel="noopener noreferrer" target="_blank">
-        <$TitleText>{title}</$TitleText>
-        <IconArrowRight size="l" aria-hidden />
-      </$TitleWrapper>
-      <$BoxContent>{content}</$BoxContent>
-    </$Linkbox>
-  );
-};
+const Linkbox: React.FC<Props> = ({ title, link, content }) => (
+  <$Linkbox>
+    <$TitleWrapper href={link} rel="noopener noreferrer" target="_blank">
+      <$TitleText>{title}</$TitleText>
+      <IconArrowRight size="l" aria-hidden />
+    </$TitleWrapper>
+    <$BoxContent>{content}</$BoxContent>
+  </$Linkbox>
+);
 
 export default Linkbox;

--- a/frontend/tet/youth/src/components/noResults/NoResults.tsx
+++ b/frontend/tet/youth/src/components/noResults/NoResults.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import { Link } from 'hds-react';
-import { $Title, $Links } from './NoResults.sc';
-import { QueryParams } from 'tet/youth/types/queryparams';
 import { useTranslation } from 'next-i18next';
+import React from 'react';
+import { QueryParams } from 'tet/youth/types/queryparams';
+
+import { $Links, $Title } from './NoResults.sc';
 
 type Props = {
   params: QueryParams;
@@ -12,14 +13,14 @@ type Props = {
 
 const NoResults: React.FC<Props> = ({ params, onSearchByFilters, resultsTotal }) => {
   const { t } = useTranslation();
-  const searchHandler = (searchText: string) => {
+  const searchHandler = (searchText: string): void => {
     onSearchByFilters({
       ...params,
       text: searchText,
     });
   };
 
-  const ignoredWords = [
+  const ignoredWords = new Set([
     'että',
     'jotta',
     'joten',
@@ -40,22 +41,16 @@ const NoResults: React.FC<Props> = ({ params, onSearchByFilters, resultsTotal })
     'sillä',
     'and',
     'och',
-  ];
-  const searchWords = () => {
-    if (params && params.hasOwnProperty('text')) {
-      const searchWords = params.text.toLowerCase().split(' ');
-      return searchWords.filter((word) => {
-        return !ignoredWords.includes(word);
-      });
-    } else {
-      return [];
-    }
+  ]);
+  const searchWords = (): string[] => {
+    const words = params.text?.toLowerCase().split(' ') ?? [];
+    return words.filter((word) => !ignoredWords.has(word));
   };
 
   if (resultsTotal >= 5) {
     return null;
   }
-  if (params.text && params.text.indexOf(' ') >= 0) {
+  if (params.text?.includes(' ')) {
     return (
       <>
         {resultsTotal === 0 ? (
@@ -65,6 +60,7 @@ const NoResults: React.FC<Props> = ({ params, onSearchByFilters, resultsTotal })
         )}
         <$Links data-testid="search-word-links">
           {searchWords().map((word) => (
+            // eslint-disable-next-line jsx-a11y/anchor-is-valid,no-script-url
             <Link size="L" onClick={() => searchHandler(word)} href="javascript:void(0)">
               {word}
             </Link>
@@ -72,9 +68,8 @@ const NoResults: React.FC<Props> = ({ params, onSearchByFilters, resultsTotal })
         </$Links>
       </>
     );
-  } else {
-    return <$Title>{t('common:postings.fewResultsText')}</$Title>;
   }
+  return <$Title>{t('common:postings.fewResultsText')}</$Title>;
 };
 
 export default NoResults;

--- a/frontend/tet/youth/src/components/pageContent/PageContent.tsx
+++ b/frontend/tet/youth/src/components/pageContent/PageContent.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
-import Image from 'next/image';
-import { $ImageWrapper, $PageContent, $Textbox, $TextboxTitle, $ButtonWrapper } from './PageContent.sc';
-import { useTranslation } from 'next-i18next';
 import { Button, IconMap } from 'hds-react';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
 
-const PageContent = () => {
+import { $ButtonWrapper, $ImageWrapper, $PageContent, $Textbox, $TextboxTitle } from './PageContent.sc';
+
+const PageContent: React.FC = () => {
   const { t } = useTranslation();
   const router = useRouter();
-  const showMapHandler = () => {
-    router.push(
+  const showMapHandler = (): void => {
+    void router.push(
       {
         pathname: '/postings',
         query: {
@@ -19,6 +20,7 @@ const PageContent = () => {
       '/postings',
     );
   };
+  /* eslint-disable no-secrets/no-secrets */
   return (
     <>
       <$ButtonWrapper>
@@ -35,7 +37,7 @@ const PageContent = () => {
             objectFit="contain"
             src="/etela-haaga_kirjasto_230421_kuva_jussi_hellsten_0693.jpg"
             alt="etela haaga kirjasto"
-            priority={true}
+            priority
           />
         </$ImageWrapper>
         <$Textbox>
@@ -45,6 +47,7 @@ const PageContent = () => {
       </$PageContent>
     </>
   );
+  /* eslint-enable no-secrets/no-secrets */
 };
 
 export default PageContent;

--- a/frontend/tet/youth/src/components/quickSearch/QuickSearch.tsx
+++ b/frontend/tet/youth/src/components/quickSearch/QuickSearch.tsx
@@ -1,34 +1,34 @@
-import React from 'react';
-import {
-  $SearchBar,
-  $SearchBarWrapper,
-  $SearchText,
-  $Filters,
-  $SearchField,
-  $DateField,
-  $ButtonContainer,
-  $FiltersLink,
-} from './QuickSearch.sc';
-import { convertToBackendDateFormat } from 'shared/utils/date.utils';
-import { TextInput, Button, DateInput, IconSearch, IconAngleRight } from 'hds-react';
+import { Button, DateInput, IconAngleRight, IconSearch, TextInput } from 'hds-react';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
-import Link from 'next/link';
+import React from 'react';
 import { Language } from 'shared/i18n/i18n';
 
-const QuickSearch = () => {
+import {
+  $ButtonContainer,
+  $DateField,
+  $Filters,
+  $FiltersLink,
+  $SearchBar,
+  $SearchBarWrapper,
+  $SearchField,
+  $SearchText,
+} from './QuickSearch.sc';
+
+const QuickSearch: React.FC = () => {
   const router = useRouter();
   const [searchText, setSearchText] = React.useState<string>('');
   const [startTime, setStartTime] = React.useState('');
   const { t, i18n } = useTranslation();
 
-  const searchHandler = () => {
+  const searchHandler = (): void => {
     const searchQuery = {
       ...(searchText.length > 0 && { text: searchText }),
       ...(startTime.length > 0 && { start: startTime }),
     };
 
-    router.push({
+    void router.push({
       pathname: '/postings',
       query: {
         ...searchQuery,
@@ -48,7 +48,7 @@ const QuickSearch = () => {
               id="searchText"
               data-testid="quickSearchInput"
               placeholder={t('common:filters.searchPlaceholder')}
-            ></TextInput>
+            />
           </$SearchField>
           <$DateField>
             <DateInput
@@ -58,7 +58,7 @@ const QuickSearch = () => {
               value={startTime}
               language={i18n.language as Language}
               placeholder={t('common:filters.startDate')}
-            ></DateInput>
+            />
           </$DateField>
           <$ButtonContainer>
             <Button

--- a/frontend/tet/youth/src/hooks/backend/useGetKeywords.ts
+++ b/frontend/tet/youth/src/hooks/backend/useGetKeywords.ts
@@ -1,10 +1,8 @@
-import { BackendEndpoint } from 'tet/youth/backend-api/backend-api';
 import { useTranslation } from 'next-i18next';
 import { useQuery, UseQueryResult } from 'react-query';
 import showErrorToast from 'shared/components/toast/show-error-toast';
-import { LinkedEventsPagedResponse } from 'tet/youth/linkedevents';
-import { createAxios, handleResponse } from 'tet/youth/backend-api/backend-api'; //TODO to shared
-import { IdObject } from 'tet/youth/linkedevents';
+import { BackendEndpoint, createAxios, handleResponse } from 'tet/youth/backend-api/backend-api'; // TODO to shared
+import { IdObject, LinkedEventsPagedResponse } from 'tet/youth/linkedevents';
 
 type Keyword = IdObject & {
   name: {

--- a/frontend/tet/youth/src/hooks/backend/useGetPostings.ts
+++ b/frontend/tet/youth/src/hooks/backend/useGetPostings.ts
@@ -1,10 +1,9 @@
-import { BackendEndpoint } from 'tet/youth/backend-api/backend-api';
 import { useTranslation } from 'next-i18next';
 import { useQuery, UseQueryResult } from 'react-query';
 import showErrorToast from 'shared/components/toast/show-error-toast';
-import { LinkedEventsPagedResponse, TetEvent } from 'tet-shared/types/linkedevents';
+import { BackendEndpoint, createAxios, handleResponse } from 'tet/youth/backend-api/backend-api'; // TODO to shared
 import { QueryParams } from 'tet/youth/types/queryparams';
-import { createAxios, handleResponse } from 'tet/youth/backend-api/backend-api'; //TODO to shared
+import { LinkedEventsPagedResponse, TetEvent } from 'tet-shared/types/linkedevents';
 
 const useGetPostings = (params: QueryParams): UseQueryResult<LinkedEventsPagedResponse<TetEvent>, Error> => {
   const axios = createAxios();

--- a/frontend/tet/youth/src/hooks/backend/useGetSinglePosting.ts
+++ b/frontend/tet/youth/src/hooks/backend/useGetSinglePosting.ts
@@ -1,10 +1,10 @@
 import { useTranslation } from 'next-i18next';
 import { useQuery, UseQueryResult } from 'react-query';
 import showErrorToast from 'shared/components/toast/show-error-toast';
+import { createAxios, handleResponse } from 'tet/youth/backend-api/backend-api'; // TODO to shared
 import { TetEvent } from 'tet-shared/types/linkedevents';
-import { createAxios, handleResponse } from 'tet/youth/backend-api/backend-api'; //TODO to shared
 
-const useGetSingePosting = (id: string): UseQueryResult<TetEvent, Error> => {
+const useGetSinglePosting = (id: string): UseQueryResult<TetEvent, Error> => {
   const axios = createAxios();
   const { t } = useTranslation();
 
@@ -21,7 +21,7 @@ const useGetSingePosting = (id: string): UseQueryResult<TetEvent, Error> => {
               data_source: 'tet',
             },
           })
-        : axios.get<TetEvent>(pageParam);
+        : axios.get<TetEvent>(pageParam as string);
       return handleResponse(res);
     },
     {
@@ -30,4 +30,4 @@ const useGetSingePosting = (id: string): UseQueryResult<TetEvent, Error> => {
   );
 };
 
-export default useGetSingePosting;
+export default useGetSinglePosting;

--- a/frontend/tet/youth/src/pages/_app.tsx
+++ b/frontend/tet/youth/src/pages/_app.tsx
@@ -1,20 +1,21 @@
 // import 'react-toastify/dist/ReactToastify.css';
 
-import createQueryClient from 'tet/youth/query-client/create-query-client';
 import { AppProps } from 'next/app';
+import Script from 'next/script';
 import { appWithTranslation } from 'next-i18next';
 import React from 'react';
 import { QueryClientProvider } from 'react-query';
 import BaseApp from 'shared/components/app/BaseApp';
-import Header from 'tet/youth/components/header/Header';
 import Footer from 'tet/youth/components/footer/Footer';
-import Script from 'next/script';
+import Header from 'tet/youth/components/header/Header';
+import createQueryClient from 'tet/youth/query-client/create-query-client';
 
 const queryClient = createQueryClient();
 
 const App: React.FC<AppProps> = (appProps) => (
   <>
     <Script
+      id="matomo-script"
       strategy="afterInteractive"
       dangerouslySetInnerHTML={{
         __html: `

--- a/frontend/tet/youth/src/pages/index.tsx
+++ b/frontend/tet/youth/src/pages/index.tsx
@@ -1,22 +1,20 @@
 import type { NextPage } from 'next';
-import React from 'react';
 import { GetStaticProps } from 'next';
+import React from 'react';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 import Banner from 'tet/youth/components/banner/Banner';
-import QuickSearch from 'tet/youth/components/quickSearch/QuickSearch';
-import PageContent from 'tet/youth/components/pageContent/PageContent';
 import LinkSection from 'tet/youth/components/linkSection/LinkSection';
+import PageContent from 'tet/youth/components/pageContent/PageContent';
+import QuickSearch from 'tet/youth/components/quickSearch/QuickSearch';
 
-const Home: NextPage = () => {
-  return (
-    <>
-      <Banner />
-      <QuickSearch />
-      <PageContent />
-      <LinkSection />
-    </>
-  );
-};
+const Home: NextPage = () => (
+  <>
+    <Banner />
+    <QuickSearch />
+    <PageContent />
+    <LinkSection />
+  </>
+);
 
 export const getStaticProps: GetStaticProps = getServerSideTranslations('common');
 

--- a/frontend/tet/youth/src/pages/postings.tsx
+++ b/frontend/tet/youth/src/pages/postings.tsx
@@ -1,25 +1,23 @@
 import type { NextPage } from 'next';
-import React from 'react';
-import JobPostings from 'tet/youth/components/jobPostings/JobPostings';
 import { GetStaticProps } from 'next';
+import Script from 'next/script';
+import React from 'react';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+import JobPostings from 'tet/youth/components/jobPostings/JobPostings';
 import HeaderLinks from 'tet-shared/components/HeaderLinks';
 import MapScripts from 'tet-shared/components/MapScripts';
-import Script from 'next/script';
 
-const Postings: NextPage = () => {
-  return (
-    <>
-      <HeaderLinks />
-      <JobPostings />
-      <MapScripts />
-      <Script
-        src="https://unpkg.com/react-leaflet-markercluster/src/react-leaflet-markercluster.js"
-        strategy="beforeInteractive"
-      />
-    </>
-  );
-};
+const Postings: NextPage = () => (
+  <>
+    <HeaderLinks />
+    <JobPostings />
+    <MapScripts />
+    <Script
+      src="https://unpkg.com/react-leaflet-markercluster/src/react-leaflet-markercluster.js"
+      strategy="beforeInteractive"
+    />
+  </>
+);
 
 export const getStaticProps: GetStaticProps = getServerSideTranslations('common');
 

--- a/frontend/tet/youth/src/pages/postings/show.tsx
+++ b/frontend/tet/youth/src/pages/postings/show.tsx
@@ -1,20 +1,20 @@
 import type { NextPage } from 'next';
-import React from 'react';
 import { GetStaticProps } from 'next';
-import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 import { useRouter } from 'next/router';
-import PostingContainer from 'tet/shared/src/components/posting/PostingContainer';
-import useGetSingePosting from 'tet/youth/hooks/backend/useGetSingePosting';
+import React from 'react';
 import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
 import PageNotFound from 'shared/components/pages/PageNotFound';
-import useEventPostingTransformation from 'tet-shared/hooks/backend/useEventPostingTransformation';
+import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+import PostingContainer from 'tet/shared/src/components/posting/PostingContainer';
+import useGetSinglePosting from 'tet/youth/hooks/backend/useGetSinglePosting';
 import HeaderLinks from 'tet-shared/components/HeaderLinks';
+import useEventPostingTransformation from 'tet-shared/hooks/backend/useEventPostingTransformation';
 
 const ShowPostingPage: NextPage = () => {
   const router = useRouter();
   const { eventToTetPosting, keywordResult } = useEventPostingTransformation();
   const id = router.query.id as string;
-  const { isLoading, data, error } = useGetSingePosting(id);
+  const { isLoading, data, error } = useGetSinglePosting(id);
 
   const returnHandler = (): void => {
     const params = router.query;
@@ -39,12 +39,11 @@ const ShowPostingPage: NextPage = () => {
     return (
       <>
         <HeaderLinks />
-        <PostingContainer posting={eventToTetPosting(data)} showBackButton={true} onReturnClick={returnHandler} />
+        <PostingContainer posting={eventToTetPosting(data)} showBackButton onReturnClick={returnHandler} />
       </>
     );
-  } else {
-    return <PageNotFound />;
   }
+  return <PageNotFound />;
 };
 
 export const getStaticProps: GetStaticProps = getServerSideTranslations('common');


### PR DESCRIPTION
## Description :sparkles:
Looks like the tet projects didnt have the eslint configured correctly. They used `next lint` instead of `eslint` which simply returned zero value instead of actually checking anyhing. Now the script is replaced and all the eslint fixes are done.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
