### PR TITLE
HL-581 | HL-Backend: Fix URLs for YRTTI and YTJ Palveluväylä test integrations

### DIFF
--- a/.env.benefit-backend.example
+++ b/.env.benefit-backend.example
@@ -55,8 +55,8 @@ MEDIA_ROOT=/app/var/media
 CSRF_TRUSTED_ORIGINS=localhost:3000
 
 YRTTI_TIMEOUT=30
-YRTTI_BASIC_INFO_PATH=https://yrtti-integration-dev.agw.arodevtest.hel.fi/api/BasicInfo
-SERVICE_BUS_INFO_PATH=https://ytj-integration-dev.agw.arodevtest.hel.fi/api/GetCompany
+YRTTI_BASIC_INFO_PATH=https://yrtti-integration-test.agw.arodevtest.hel.fi/api/BasicInfo
+SERVICE_BUS_INFO_PATH=https://ytj-integration-test.agw.arodevtest.hel.fi/api/GetCompany
 YRTTI_AUTH_PASSWORD=
 YRTTI_AUTH_USERNAME=helsinkilisatest
 

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -116,14 +116,14 @@ env = environ.Env(
     DISABLE_TOS_APPROVAL_CHECK=(bool, False),
     YRTTI_BASIC_INFO_PATH=(
         str,
-        "https://yrtti-integration-dev.agw.arodevtest.hel.fi/api/BasicInfo",
+        "https://yrtti-integration-test.agw.arodevtest.hel.fi/api/BasicInfo",
     ),
     YRTTI_AUTH_USERNAME=(str, "sample_username"),
     YRTTI_AUTH_PASSWORD=(str, "sample_password"),
     YRTTI_TIMEOUT=(int, 30),
     SERVICE_BUS_INFO_PATH=(
         str,
-        "https://ytj-integration-dev.agw.arodevtest.hel.fi/api/GetCompany",
+        "https://ytj-integration-test.agw.arodevtest.hel.fi/api/GetCompany",
     ),
     SERVICE_BUS_AUTH_USERNAME=(str, "sample_username"),
     SERVICE_BUS_AUTH_PASSWORD=(str, "sample_password"),


### PR DESCRIPTION
## Description :sparkles:

Change the URLs for YRTTI and YTJ Palveluväylä test integrations:
 - https://yrtti-integration-dev.agw.arodevtest.hel.fi/api/BasicInfo → https://yrtti-integration-test.agw.arodevtest.hel.fi/api/BasicInfo
 - https://ytj-integration-dev.agw.arodevtest.hel.fi/api/GetCompany → https://ytj-integration-test.agw.arodevtest.hel.fi/api/GetCompany

## Issues :bug:

HL-581

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
