### PR TITLE
HL-587 | TET-Backend: Use organization name as a fallback for showing user name

### DIFF
--- a/backend/tet/tet/views.py
+++ b/backend/tet/tet/views.py
@@ -18,13 +18,16 @@ class UserInfoView(View):
                 "given_name": user.first_name,
                 "family_name": user.last_name,
                 "email": user.email,
-                "name": f"{user.first_name} {user.last_name}",
+                "name": f"{user.first_name} {user.last_name}".strip(),
                 "is_ad_login": user.is_staff,
                 "organization_name": get_organization_name(request),
             }
 
             if not (userinfo["given_name"] or userinfo["family_name"]):
                 userinfo["name"] = user.email
+
+            if not userinfo["name"]:
+                userinfo["name"] = userinfo["organization_name"]
 
             return JsonResponse(userinfo)
         else:


### PR DESCRIPTION
## Description :sparkles:

### TET-Backend: Use organization name as a fallback for showing user name

Give a reasonable fallback when GDPR data has been removed

## Issues :bug:

HL-587

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
