### PR TITLE
YJDH-651 | KS-Backend: Add Excel export for confirmed youth summer applications

### DIFF
--- a/backend/benefit/setup.cfg
+++ b/backend/benefit/setup.cfg
@@ -4,20 +4,23 @@ exclude =
   *migrations*
   .pytest_cache
   var/media
+  .eggs
+  *.egg-info
 ignore = E309
 
 [flake8]
-exclude = migrations,snapshots,.pytest_cache,var/media
+exclude = migrations,snapshots,.pytest_cache,var/media,.eggs,*.egg-info
 max-line-length = 120
 max-complexity = 10
 # E203 and W503 are disabled and W504 enabled for compatibility with Black.
 # For details see "Why are Flake8's E203 and W503 violated?" in Black FAQ at
 # https://black.readthedocs.io/en/stable/faq.html
 ignore = E203, W503
+extend-select = W504
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = helsinkibenefit.settings
-norecursedirs = node_modules .git venv* .pytest_cache var/media
+norecursedirs = node_modules .git venv* .pytest_cache var/media .eggs *.egg-info
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE
 
 [coverage:run]
@@ -33,7 +36,7 @@ indent=4
 length_sort=false
 multi_line_output=3
 order_by_type=false
-skip=migrations,venv,.pytest_cache,var/media
+skip=migrations,venv,.pytest_cache,var/media,.eggs,*.egg-info
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -675,17 +675,17 @@ class YouthApplication(LockForUpdateMixin, TimeStampedModel, UUIDModel):
         )
 
     @property
-    def vtj_last_name(self):
+    def vtj_last_name(self) -> Optional[str]:
         if vtj_last_names := self._vtj_values("$.Henkilo.NykyinenSukunimi.Sukunimi"):
             return vtj_last_names[0]
-        return None
+        return ""
 
     @property
     def attends_helsinkian_school(self) -> bool:
         return not self.is_unlisted_school
 
     @property
-    def vtj_home_municipality(self):
+    def vtj_home_municipality(self) -> Optional[str]:
         if vtj_home_municipality := self._vtj_values("$.Henkilo.Kotikunta.KuntaS"):
             return vtj_home_municipality[0]
         return ""

--- a/backend/kesaseteli/applications/templates/application_excel_download.html
+++ b/backend/kesaseteli/applications/templates/application_excel_download.html
@@ -15,6 +15,11 @@
         </div>
 
         <h1>Lataa Excel tiedostoja</h1>
+
+        <br/>
+        <h2>Työnantajien kesäsetelihakemukset:</h2>
+        <br/>
+
         <p>
             {% trans 'Luo uusi excel tiedosto kaikista järjestelmän käsittelemättömistä hakemuksista. Kun hakemus lisätään käsittelemättömien hakemusten excel tiedostoon, se merkataan järjestelmässä "käsitellyiksi" eikä sitä tuoda enää seuraavaan käsittelemättömien hakemusten exceliin.' %}
         </p>
@@ -36,4 +41,13 @@
         <div class="col-xs-6">
             <a href="{% url 'excel-download' %}?download=annual&columns=talpa" class="btn btn-secondary btn-lg active" role="button" aria-pressed="true">{% trans 'Lataa Talpa-Excel kaikista tämän vuoden hakemuksista' %}</a>
         </div>
+
+        <br/>
+        <h2>Nuorten kesäsetelihakemukset:</h2>
+        <br/>
+
+        <div class="col-xs-6">
+            <a href="{% url 'youth-excel-download' %}" class="btn btn-secondary btn-lg active" role="button" aria-pressed="true">{% trans 'Lataa Excel kaikista nuorten vahvistetuista kesäsetelihakemuksista' %}</a>
+        </div>
+
 </div>

--- a/backend/kesaseteli/applications/tests/conftest.py
+++ b/backend/kesaseteli/applications/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import random
 from datetime import timedelta
 
 import factory.random
@@ -13,6 +14,7 @@ from common.tests.conftest import *  # noqa
 def setup_test_environment(settings):
     DetectorFactory.seed = 0
     factory.random.reseed_random("888")
+    random.seed(888)
 
 
 @pytest.fixture

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -414,6 +414,7 @@ def test_youth_applications_process_valid_pk(
         )
 
 
+@override_settings(NEXT_PUBLIC_DISABLE_VTJ=True)
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "mock_flag,client_fixture_func,expected_status_code,expected_redirect_to",

--- a/backend/kesaseteli/kesaseteli/urls.py
+++ b/backend/kesaseteli/kesaseteli/urls.py
@@ -6,7 +6,10 @@ from django.urls import include, path
 from rest_framework import routers
 
 from applications.api.v1 import views as application_views
-from applications.views import EmployerApplicationExcelDownloadView
+from applications.views import (
+    EmployerApplicationExcelDownloadView,
+    YouthApplicationExcelExportViewSet,
+)
 from companies.api.v1.views import GetCompanyView
 from shared.suomi_fi.views import (
     SuomiFiAssertionConsumerServiceView,
@@ -30,6 +33,11 @@ urlpatterns = [
         "excel-download/",
         EmployerApplicationExcelDownloadView.as_view(),
         name="excel-download",
+    ),
+    path(
+        "excel-download/confirmed-youth-applications/",
+        YouthApplicationExcelExportViewSet.as_view({"get": "list"}),
+        name="youth-excel-download",
     ),
     path("logout/", LogoutView.as_view(), name="logout"),
 ]

--- a/backend/kesaseteli/pyproject.toml
+++ b/backend/kesaseteli/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+extend-exclude = '''
+(
+  .pytest_cache
+  | var/media
+)
+'''

--- a/backend/kesaseteli/setup.cfg
+++ b/backend/kesaseteli/setup.cfg
@@ -1,16 +1,26 @@
 [pep8]
 max-line-length = 120
-exclude = *migrations*
+exclude =
+  *migrations*
+  .pytest_cache
+  var/media
+  .eggs
+  *.egg-info
 ignore = E309
 
 [flake8]
-exclude = migrations
+exclude = migrations,snapshots,.pytest_cache,var/media,.eggs,*.egg-info
 max-line-length = 120
 max-complexity = 10
+# E203 and W503 are disabled and W504 enabled for compatibility with Black.
+# For details see "Why are Flake8's E203 and W503 violated?" in Black FAQ at
+# https://black.readthedocs.io/en/stable/faq.html
+ignore = E203, W503
+extend-select = W504
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = kesaseteli.settings
-norecursedirs = node_modules .git venv*
+norecursedirs = node_modules .git venv* .pytest_cache var/media .eggs *.egg-info
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE
 
 [coverage:run]
@@ -26,7 +36,7 @@ indent=4
 length_sort=false
 multi_line_output=3
 order_by_type=false
-skip=migrations,venv
+skip=migrations,venv,.pytest_cache,var/media,.eggs,*.egg-info
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True

--- a/backend/shared/precommit-setup.cfg
+++ b/backend/shared/precommit-setup.cfg
@@ -1,16 +1,26 @@
 [pep8]
 max-line-length = 120
-exclude = *migrations*
+exclude =
+  *migrations*
+  .pytest_cache
+  var/media
+  .eggs
+  *.egg-info
 ignore = E309
 
 [flake8]
-exclude = migrations,snapshots
+exclude = migrations,snapshots,.pytest_cache,var/media,.eggs,*.egg-info
 max-line-length = 120
 max-complexity = 10
 # E203 and W503 are disabled and W504 enabled for compatibility with Black.
 # For details see "Why are Flake8's E203 and W503 violated?" in Black FAQ at
 # https://black.readthedocs.io/en/stable/faq.html
 ignore = E203, W503
+extend-select = W504
+
+[tool:pytest]
+norecursedirs = node_modules .git venv* .pytest_cache var/media .eggs *.egg-info
+doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE
 
 [coverage:run]
 branch = True
@@ -25,7 +35,7 @@ indent=4
 length_sort=false
 multi_line_output=3
 order_by_type=false
-skip=migrations,venv
+skip=migrations,venv,.pytest_cache,var/media,.eggs,*.egg-info
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True

--- a/backend/shared/setup.cfg
+++ b/backend/shared/setup.cfg
@@ -1,20 +1,25 @@
 [pep8]
 max-line-length = 120
-exclude = *migrations*
+exclude =
+  *migrations*
+  .pytest_cache
+  var/media
+  .eggs
+  *.egg-info
 ignore = E309
 
 [flake8]
-exclude = migrations,snapshots,*.egg-info/
+exclude = migrations,snapshots,.pytest_cache,var/media,.eggs,*.egg-info
+max-line-length = 120
+max-complexity = 10
 # E203 and W503 are disabled and W504 enabled for compatibility with Black.
 # For details see "Why are Flake8's E203 and W503 violated?" in Black FAQ at
 # https://black.readthedocs.io/en/stable/faq.html
 ignore = E203, W503
 extend-select = W504
-max-line-length = 120
-max-complexity = 10
 
 [tool:pytest]
-norecursedirs = node_modules .git venv*
+norecursedirs = node_modules .git venv* .pytest_cache var/media .eggs *.egg-info
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE
 
 [coverage:run]
@@ -30,8 +35,9 @@ indent=4
 length_sort=false
 multi_line_output=3
 order_by_type=false
-skip=migrations,venv,.eggs
+skip=migrations,venv,.pytest_cache,var/media,.eggs,*.egg-info
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
+known_first_party = shared

--- a/backend/shared/shared/audit_log/viewsets.py
+++ b/backend/shared/shared/audit_log/viewsets.py
@@ -59,6 +59,10 @@ class AuditLoggingModelViewSet(ModelViewSet):
         with self.record_action():
             return super().retrieve(request, *args, **kwargs)
 
+    def list(self, request, *args, **kwargs):
+        with self.record_action():
+            return super().list(request, *args, **kwargs)
+
     @transaction.atomic
     def perform_create(self, serializer):
         with self.record_action():

--- a/backend/tet/pyproject.toml
+++ b/backend/tet/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+extend-exclude = '''
+(
+  .pytest_cache
+  | var/media
+)
+'''

--- a/backend/tet/setup.cfg
+++ b/backend/tet/setup.cfg
@@ -1,16 +1,26 @@
 [pep8]
 max-line-length = 120
-exclude = *migrations*
+exclude =
+  *migrations*
+  .pytest_cache
+  var/media
+  .eggs
+  *.egg-info
 ignore = E309
 
 [flake8]
-exclude = migrations
+exclude = migrations,snapshots,.pytest_cache,var/media,.eggs,*.egg-info
 max-line-length = 120
 max-complexity = 10
+# E203 and W503 are disabled and W504 enabled for compatibility with Black.
+# For details see "Why are Flake8's E203 and W503 violated?" in Black FAQ at
+# https://black.readthedocs.io/en/stable/faq.html
+ignore = E203, W503
+extend-select = W504
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = tet.settings
-norecursedirs = node_modules .git venv*
+norecursedirs = node_modules .git venv* .pytest_cache var/media .eggs *.egg-info
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE
 
 [coverage:run]
@@ -26,7 +36,7 @@ indent=4
 length_sort=false
 multi_line_output=3
 order_by_type=false
-skip=migrations,venv
+skip=migrations,venv,.pytest_cache,var/media,.eggs,*.egg-info
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Add confirmed youth applications Excel export & tests 

Add new tests:
 - test_youth_excel_download_no_youth_applications
 - test_youth_excel_download_writes_audit_log
 - test_youth_excel_download_content

Add parametrization to extisting test:
 - test_excel_view_download_with_unauthenticated_user

Also:
 - Disable VTJ in test_youth_applications_detail_valid_pk test to fix
   the test case
 - Add audit log support for list function in AuditLoggingModelViewSet
   - AuditLoggingModelViewSet inherits ModelViewSet which inherits
     ListModelMixin which has a list function so it makes sense to add
     an audit log entry also for list calls

Refs YJDH-651
 
### All backends: Extend and synchronize black/flake/pep8/pytest settings 

Similar to change in b1084fb. Should
speed up running "black . && isort . && flake8" because of excluding
e.g. var/media also in the kesaseteli backend.

Now:
 - Identical pyproject.toml files for configuring black present in:
   - benefit
   - kesaseteli
   - tet
 - setup.cfg files identical between benefit/kesaseteli/tet/shared
   except for DJANGO_SETTINGS_MODULE
 - precommit-setup.cfg identical to shared/setup.cfg

Refs YJDH-651

## Issues :bug:

YJDH-651

## Testing :alembic:

Steps:
 - Set `NEXT_PUBLIC_MOCK_FLAG=True` to `.env.kesaseteli`
 - `yarn youth:up --build`
 - Generate some youth applications test data using Django shell, see "Generating test data" below
 - Open https://localhost:8000/excel-download/
 - Click on "Lataa Excel kaikista nuorten vahvistetuista kesäsetelihakemuksista" button
 - Open the downloaded file "Nuorten kesäsetelihakemukset-YYYY-MM-DD.xlsx" where YYYY-MM-DD is today

### Generating test data:
`docker exec -it kesaseteli-backend python manage.py shell_plus`:
```python
from common.tests.factories import *
InactiveYouthApplicationFactory()  # This should not be exported
apps = (
	ActiveYouthApplicationFactory.create_batch(size=12)
	+ [
		YouthApplicationFactory(status=status)
		for status in YouthApplicationStatus.active_values()
	]
	+ [
		ActiveVtjTestCaseYouthApplicationFactory(last_name=vtj_test_case)
		for vtj_test_case in VtjTestCase.values
	]
)
# Update created_at specially as its initial save uses auto_now_add
for app in apps:
	app.created_at -= timedelta(seconds=random.randint(0, 60 * 60 * 24 * 10))
	app.save(update_fields=["created_at"])
	app.refresh_from_db()
```

## Screenshots :camera_flash:

![1](https://user-images.githubusercontent.com/77663720/206372504-1a1ff348-d87f-42b4-9718-d869d29cf63d.png)

![2](https://user-images.githubusercontent.com/77663720/206372507-50db4876-52ff-4865-a241-0321af158e42.png)

## Additional notes :spiral_notepad:
