### PR TITLE
YJDH-516 | KS-Backend: Allow same person to get summer voucher on different years

### DIFF
--- a/backend/kesaseteli/applications/tests/test_models.py
+++ b/backend/kesaseteli/applications/tests/test_models.py
@@ -95,6 +95,33 @@ def test_employer_summer_voucher_last_submitted_at(year):
 
 
 @pytest.mark.django_db(transaction=True, reset_sequences=True)
+def test_youth_summer_voucher_get_last_used_serial_number():
+    assert YouthSummerVoucher.objects.count() == 0
+    assert YouthSummerVoucher.get_last_used_serial_number() is None
+    for ordinal_number in range(1, 10):
+        summer_voucher = (
+            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
+        )
+        assert YouthSummerVoucher.get_last_used_serial_number() is not None
+        assert (
+            YouthSummerVoucher.get_last_used_serial_number()
+            == summer_voucher.summer_voucher_serial_number
+        )
+
+
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
+def test_youth_summer_voucher_first_serial_number():
+    assert YouthSummerVoucher.objects.count() == 0
+    summer_voucher = (
+        AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
+    )
+    assert (
+        summer_voucher.summer_voucher_serial_number
+        == YouthSummerVoucher.SERIAL_NUMBER_SEQUENCE_INITIAL_VALUE
+    )
+
+
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
 def test_youth_summer_voucher_sequentiality():
     assert YouthSummerVoucher.objects.count() == 0
     for ordinal_number in range(1, 10):


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Allow same person to get summer voucher on different years 

Places affected:
 - YouthApplicationViewSet.activate and tests:
   - test_youth_applications_activate_expired_active
   - test_youth_applications_activate_expired_inactive
   - test_youth_applications_activate_unexpired_active
   - test_youth_applications_activate_unexpired_inactive__vtj_disabled
   - test_youth_applications_activate_unexpired_inactive__vtj_enabled
 - YouthApplicationViewSet.create and tests:
   - test_youth_application_post_success
   - test_youth_application_post_rejection

Add support to tests:
 - test_youth_applications_accept_acceptable__vtj_disabled
 - test_youth_applications_accept_acceptable

Also:
 - Simplify test_youth_applications_adfs_login_enforced_action_unused_pk
   parametrizations by removing needless reduce function use
 - Add youth summer voucher serial number sequence related
   variables/function and tests for them
   - test_youth_summer_voucher_get_last_used_serial_number
   - test_youth_summer_voucher_first_serial_number
 - Move class methods from YouthApplication to YouthApplicationQuerySet
   and update their documentation:
   - is_email_used_this_year
   - is_email_or_social_security_number_active_this_year

## Issues :bug:

YJDH-516

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
