### PR TITLE
chore: use INFO level logger on yjdh backends

### DIFF
--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -266,7 +266,7 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "handlers": {"console": {"class": "logging.StreamHandler"}},
-    "loggers": {"django": {"handlers": ["console"], "level": "ERROR"}},
+    "loggers": {"django": {"handlers": ["console"], "level": "INFO"}},
 }
 
 REST_FRAMEWORK = {

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -314,7 +314,7 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["console"], "level": "WARNING"},
+        "django": {"handlers": ["console"], "level": "INFO"},
     },
 }
 

--- a/backend/tet/tet/settings.py
+++ b/backend/tet/tet/settings.py
@@ -217,7 +217,7 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["console"], "level": "WARNING"},
+        "django": {"handlers": ["console"], "level": "INFO"},
     },
 }
 


### PR DESCRIPTION
## Description :sparkles:
Looks like we use too strict logger level on django settings, now it's downgraded to "INFO" level to see for example
scheduled cron job loggings on kibana. See: https://medium.com/@soroush_safarii/django-log-management-with-elastic-and-kibana-440ab7e2e457
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
