### PR TITLE
feat(hl-573): fix redirecting loop when server error

### DIFF
--- a/frontend/kesaseteli/employer/src/hooks/backend/useUserQuery.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useUserQuery.ts
@@ -16,7 +16,7 @@ const useUserQuery = <T = User>({
   const isRouting = useIsRouting();
   return useQuery(BackendEndpoint.USER as QueryKey, {
     enabled: !isRouting,
-    onError: useErrorHandler(false),
+    onError: useErrorHandler(),
     select,
     refetchInterval,
   });

--- a/frontend/kesaseteli/handler/src/hooks/backend/useCompleteYouthApplicationQuery.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/useCompleteYouthApplicationQuery.ts
@@ -37,7 +37,7 @@ const useCompleteYouthApplicationQuery = (
         void onSuccess(data, operation, context);
       }
     },
-    onError: useErrorHandler(false),
+    onError: useErrorHandler(),
     ...restOptions,
   });
 };

--- a/frontend/kesaseteli/handler/src/hooks/backend/useYouthApplicationQuery.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/useYouthApplicationQuery.ts
@@ -8,7 +8,7 @@ const useYouthApplicationQuery = (
   id?: string,
   options?: UseQueryOptions<ActivatedYouthApplication>
 ): UseQueryResult<ActivatedYouthApplication> => {
-  const handleError = useErrorHandler(false);
+  const handleError = useErrorHandler();
   return useQuery({
     queryKey: id ? getYouthApplicationQueryKey(id) : undefined,
     enabled: Boolean(id),

--- a/frontend/kesaseteli/youth/src/hooks/backend/useCreateAdditionalInfoQuery.ts
+++ b/frontend/kesaseteli/youth/src/hooks/backend/useCreateAdditionalInfoQuery.ts
@@ -39,7 +39,7 @@ const useCreateAdditionalInfoQuery = (
         void onSuccess(data, operation, context);
       }
     },
-    onError: useErrorHandler(false),
+    onError: useErrorHandler(),
     ...restOptions,
   });
 };

--- a/frontend/kesaseteli/youth/src/hooks/backend/useSchoolListQuery.ts
+++ b/frontend/kesaseteli/youth/src/hooks/backend/useSchoolListQuery.ts
@@ -5,7 +5,7 @@ import useErrorHandler from 'shared/hooks/useErrorHandler';
 const useSchoolListQuery = (): UseQueryResult<string[]> =>
   useQuery(BackendEndpoint.SCHOOLS, {
     staleTime: Infinity,
-    onError: useErrorHandler(false),
+    onError: useErrorHandler(),
   });
 
 export default useSchoolListQuery;

--- a/frontend/kesaseteli/youth/src/hooks/backend/useYouthApplicationStatusQuery.ts
+++ b/frontend/kesaseteli/youth/src/hooks/backend/useYouthApplicationStatusQuery.ts
@@ -8,7 +8,7 @@ const useYouthApplicationStatusQuery = (
   id?: string,
   options?: UseQueryOptions<YouthApplicationStatus>
 ): UseQueryResult<YouthApplicationStatus> => {
-  const handleError = useErrorHandler(false);
+  const handleError = useErrorHandler();
   return useQuery({
     queryKey: id ? getYouthApplicationStatusQueryKey(id) : undefined,
     enabled: Boolean(id),

--- a/frontend/kesaseteli/youth/src/hooks/useHandleYouthApplicationSubmit.ts
+++ b/frontend/kesaseteli/youth/src/hooks/useHandleYouthApplicationSubmit.ts
@@ -33,7 +33,7 @@ const useHandleYouthApplicationSubmit = (): ReturnType => {
   const router = useRouter();
   const locale = useLocale();
   const goToPage = useGoToPage();
-  const handleDefaultError = useErrorHandler(false);
+  const handleDefaultError = useErrorHandler();
 
   const [submitError, setSubmitError] = React.useState<SubmitError | null>(
     null

--- a/frontend/shared/src/components/forms/buttons/SaveFormButton.tsx
+++ b/frontend/shared/src/components/forms/buttons/SaveFormButton.tsx
@@ -37,7 +37,7 @@ const SaveFormButton = <
 }: Props<FormData, BackendResponseData>): React.ReactElement => {
   const { handleSubmit, formState } = useFormContext<FormData>();
 
-  const onDefaultError = useErrorHandler(false);
+  const onDefaultError = useErrorHandler();
 
   const isSaving = React.useMemo(
     () => saveQuery.isLoading || formState.isSubmitting,

--- a/frontend/shared/src/error-handler/error-handler.ts
+++ b/frontend/shared/src/error-handler/error-handler.ts
@@ -7,17 +7,21 @@ const handleError = (
   error: Error | unknown,
   t: TFunction,
   goToPage: GoToPageFunction,
-  redirectUnauthorized: boolean
+  onLoginPage: boolean
 ): void => {
   if (isError(error)) {
-    // eslint-disable-next-line no-console
-    console.error('Unexpected backend error', error.message);
     if (/40[13]/.test(error.message)) {
-      if (redirectUnauthorized) {
+      if (!onLoginPage) {
         void goToPage('/login?sessionExpired=true');
       }
     } else if (/5\d{2}/.test(error.message)) {
-      void goToPage('/500');
+      // eslint-disable-next-line no-console
+      console.error('Unexpected backend error', error.message);
+      if (onLoginPage) {
+        void goToPage('/login?error=true');
+      } else {
+        void goToPage('/500');
+      }
     } else {
       showErrorToast(
         t('common:error.generic.label'),

--- a/frontend/shared/src/hooks/useErrorHandler.ts
+++ b/frontend/shared/src/hooks/useErrorHandler.ts
@@ -1,14 +1,18 @@
+import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import handleError from 'shared/error-handler/error-handler';
 import useGoToPage from 'shared/hooks/useGoToPage';
 
 type ErrorHandlerFunction = (error: Error | unknown) => void;
 
-const useErrorHandler = (redirectUnauthorized = true): ErrorHandlerFunction => {
+const useErrorHandler = (): ErrorHandlerFunction => {
   const { t } = useTranslation();
   const goToPage = useGoToPage();
+  const { asPath } = useRouter();
+  const onLoginPage = asPath?.startsWith('/login') ?? false;
+
   return (error: Error | unknown) =>
-    handleError(error, t, goToPage, redirectUnauthorized);
+    handleError(error, t, goToPage, onLoginPage);
 };
 
 export default useErrorHandler;

--- a/frontend/tet/admin/src/hooks/backend/useUserQuery.ts
+++ b/frontend/tet/admin/src/hooks/backend/useUserQuery.ts
@@ -8,7 +8,7 @@ const useUserQuery = <T = User>({ refetchInterval, select }: UseQueryOptions<T> 
   const isRouting = useIsRouting();
   return useQuery(BackendEndpoint.USER as QueryKey, {
     enabled: !isRouting,
-    onError: useErrorHandler(false),
+    onError: useErrorHandler(),
     select,
     refetchInterval,
   });

--- a/frontend/tet/admin/src/pages/login.tsx
+++ b/frontend/tet/admin/src/pages/login.tsx
@@ -40,13 +40,6 @@ const Login: NextPage = () => {
     }
   }, [logout, queryClient]);
 
-  if (error || logout) {
-    return null;
-  }
-  if (sessionExpired) {
-    return t(`common:loginPage.logoutInfoContent`);
-  }
-
   return (
     <>
       <LoginHeader />


### PR DESCRIPTION
## Description :sparkles:
Let's detect with next/router when user is on login page. In this case always redirect to login error page instead of 500 page.
This is a change to shared code so it will change the functionality in all frontend services.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
