### PR TITLE
feat(hl-573): route to login error page on userquery error

### DIFF
--- a/frontend/kesaseteli/employer/src/hooks/backend/useUserQuery.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useUserQuery.ts
@@ -6,6 +6,7 @@ import {
   UseQueryResult,
 } from 'react-query';
 import useErrorHandler from 'shared/hooks/useErrorHandler';
+import useGoToPage from 'shared/hooks/useGoToPage';
 import useIsRouting from 'shared/hooks/useIsRouting';
 import User from 'shared/types/user';
 
@@ -14,9 +15,12 @@ const useUserQuery = <T = User>({
   select,
 }: UseQueryOptions<T> = {}): UseQueryResult<T> => {
   const isRouting = useIsRouting();
+  const goToPage = useGoToPage();
   return useQuery(BackendEndpoint.USER as QueryKey, {
     enabled: !isRouting,
-    onError: useErrorHandler(),
+    onError: useErrorHandler({
+      onServerError: () => goToPage('/login?error=true'),
+    }),
     select,
     refetchInterval,
   });

--- a/frontend/shared/src/error-handler/error-handler.ts
+++ b/frontend/shared/src/error-handler/error-handler.ts
@@ -3,30 +3,34 @@ import showErrorToast from 'shared/components/toast/show-error-toast';
 import GoToPageFunction from 'shared/types/go-to-page-function';
 import { isError } from 'shared/utils/type-guards';
 
-const handleError = (
-  error: Error | unknown,
-  t: TFunction,
-  goToPage: GoToPageFunction,
-  onLoginPage: boolean
-): void => {
-  if (isError(error)) {
-    if (/40[13]/.test(error.message)) {
-      if (!onLoginPage) {
-        void goToPage('/login?sessionExpired=true');
-      }
-    } else if (/5\d{2}/.test(error.message)) {
-      // eslint-disable-next-line no-console
-      console.error('Unexpected backend error', error.message);
-      if (onLoginPage) {
-        void goToPage('/login?error=true');
-      } else {
-        void goToPage('/500');
-      }
-    } else {
+type Params = {
+  error: Error | unknown;
+  t: TFunction;
+  goToPage: GoToPageFunction;
+  onAuthError?: () => void;
+  onServerError?: () => void;
+  onCommonError?: () => void;
+};
+
+const handleError = (args: Params): void => {
+  const { error, t, goToPage } = args;
+  const {
+    onAuthError = () => goToPage('/login?sessionExpired=true'),
+    onServerError = () => goToPage('/500'),
+    onCommonError = () =>
       showErrorToast(
         t('common:error.generic.label'),
         t('common:error.generic.text')
-      );
+      ),
+  } = args;
+
+  if (isError(error)) {
+    if (/40[13]/.test(error.message)) {
+      onAuthError();
+    } else if (/5\d{2}/.test(error.message)) {
+      onServerError();
+    } else {
+      onCommonError();
     }
   }
 };

--- a/frontend/shared/src/hooks/useErrorHandler.ts
+++ b/frontend/shared/src/hooks/useErrorHandler.ts
@@ -1,18 +1,21 @@
-import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import handleError from 'shared/error-handler/error-handler';
 import useGoToPage from 'shared/hooks/useGoToPage';
 
 type ErrorHandlerFunction = (error: Error | unknown) => void;
 
-const useErrorHandler = (): ErrorHandlerFunction => {
+type Props = {
+  onAuthError?: () => void;
+  onServerError?: () => void;
+  onCommonError?: () => void;
+};
+
+const useErrorHandler = (props: Props = {}): ErrorHandlerFunction => {
   const { t } = useTranslation();
   const goToPage = useGoToPage();
-  const { asPath } = useRouter();
-  const onLoginPage = asPath?.startsWith('/login') ?? false;
 
   return (error: Error | unknown) =>
-    handleError(error, t, goToPage, onLoginPage);
+    handleError({ error, t, goToPage, ...props });
 };
 
 export default useErrorHandler;

--- a/frontend/tet/admin/src/hooks/backend/useUserQuery.ts
+++ b/frontend/tet/admin/src/hooks/backend/useUserQuery.ts
@@ -1,14 +1,18 @@
 import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
 import useErrorHandler from 'shared/hooks/useErrorHandler';
+import useGoToPage from 'shared/hooks/useGoToPage';
 import useIsRouting from 'shared/hooks/useIsRouting';
 import User from 'shared/types/user';
 import { BackendEndpoint } from 'tet/admin/backend-api/backend-api';
 
 const useUserQuery = <T = User>({ refetchInterval, select }: UseQueryOptions<T> = {}): UseQueryResult<T> => {
   const isRouting = useIsRouting();
+  const goToPage = useGoToPage();
   return useQuery(BackendEndpoint.USER as QueryKey, {
     enabled: !isRouting,
-    onError: useErrorHandler(),
+    onError: useErrorHandler({
+      onServerError: () => goToPage('/login?error=true'),
+    }),
     select,
     refetchInterval,
   });


### PR DESCRIPTION
## Description :sparkles:
Second try to fix the endless error page loop when unauthenticated. 
Now resolution is not to move 500 page when user query throws server error but go to login error page instead
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
