### PR TITLE
HL-573 | Shared/TET backend: Determine ADFS login with "ADFS login" group

### DIFF
--- a/backend/shared/shared/azure_adfs/README.md
+++ b/backend/shared/shared/azure_adfs/README.md
@@ -4,6 +4,8 @@ Azure ADFS authentication using the django library `django-auth-adfs`.
 
 Custom logic was written for the callback view `HelsinkiOAuth2CallbackView` and the authentication backend `HelsinkiAdfsAuthCodeBackend`.
 
+### How to set up
+
 To start using this package, follow these steps:
 
 1. Add `django-auth-adfs` to requirements and fill these environment variables:
@@ -58,3 +60,16 @@ To start using this package, follow these steps:
 5. The authentication flow can now be initiated from `/oauth2/login`
 
 More information from [this guide](https://django-auth-adfs.readthedocs.io/en/latest/azure_ad_config_guide.html).
+
+### Optional Django settings
+
+`HANDLERS_GROUP_NAME`:
+ - This group's membership signifies that user qualified as a handler at last ADFS login.
+ - If set and a user group by this name exists then will be added to the logged in user's
+   groups if the [user qualifies as a handler](https://github.com/City-of-Helsinki/yjdh/blob/9f0461309eb0057d28c0fd96c8f5b218cdd5ffea/backend/shared/shared/azure_adfs/auth.py#L190-L202)
+   or removed if the user does not.
+
+`ADFS_LOGIN_GROUP_NAME`:
+ - This group's membership signifies that user has logged in using ADFS at some point.
+ - A group with this name, or "ADFS login" if not set, will be added to the logged in
+   user's groups.

--- a/backend/shared/shared/azure_adfs/tests/test_adfs_login.py
+++ b/backend/shared/shared/azure_adfs/tests/test_adfs_login.py
@@ -8,7 +8,12 @@ from django.contrib.auth.models import Group
 from django.test import override_settings
 from django.urls import reverse
 
-from shared.azure_adfs.auth import HelsinkiAdfsAuthCodeBackend, provider_config
+from shared.azure_adfs.auth import (
+    adfs_login_group_name,
+    HelsinkiAdfsAuthCodeBackend,
+    is_adfs_login,
+    provider_config,
+)
 from shared.common.tests import get_default_test_host
 
 
@@ -153,8 +158,11 @@ def test_authenticate(user):
             auth_user = auth_backend.authenticate(authorization_code="test")
 
     assert auth_user == user
+    assert auth_user.is_authenticated
     assert auth_user.is_staff
-    assert user.groups.filter(name=settings.HANDLERS_GROUP_NAME).exists()
+    assert auth_user.groups.filter(name=settings.HANDLERS_GROUP_NAME).exists()
+    assert auth_user.groups.filter(name=adfs_login_group_name()).exists()
+    assert is_adfs_login(auth_user)
 
 
 @override_settings(


### PR DESCRIPTION
## Description :sparkles:

### Shared/TET backend: Determine ADFS login with "ADFS login" group 

Create "ADFS login" group and add the user to it when logging in using
HelsinkiAdfsAuthCodeBackend. This determines whether user was logged in
using ADFS at some point or not. Use this in TET's UserInfoView to set
return value is_adfs_login.

Return Forbidden 403 HTTP error in TET's UserInfoView if user was logged
in using ADFS at some point but did not qualify as a handler at last
ADFS login.

Add documentation about azure_adfs's optional Django settings:
 - HANDLERS_GROUP_NAME:
   - This group's membership signifies that user qualified as a
     handler at last ADFS login.
   - If set and a user group by this name exists then will be added to
     the logged in user's groups if the user qualifies as a handler or
     removed if the user does not.
 - ADFS_LOGIN_GROUP_NAME:
   - This group's membership signifies that user has logged in using
     ADFS at some point.
   - A group with this name, or "ADFS login" if not set, will be added
     to the logged in user's groups.

## Issues :bug:

HL-573

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
