### PR TITLE
HL-576: Enable sentry stacktrace + fix sample rate to be always 100%

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -71,7 +71,7 @@ const nextConfig = (override) => ({
    // outputStandalone: true
   },
   sentry: {
-    hideSourceMaps: true,
+    hideSourceMaps: disableSourceMaps,
     autoInstrumentServerFunctions: !NEXTJS_DISABLE_SENTRY
   },
   typescript: {

--- a/frontend/shared/src/components/app/BaseApp.tsx
+++ b/frontend/shared/src/components/app/BaseApp.tsx
@@ -27,7 +27,7 @@ type Props = AppProps & {
 
 const getSentryTracesSampleRate = (): number => {
   const sampleRate = process.env.NEXT_PUBLIC_SENTRY_TRACE_SAMPLE_RATE;
-  // default value 1.0 means sentry races 100% of errors.
+  // default value 1.0 means sentry raises 100% of errors.
   return isParsableSafeInteger(sampleRate) ? parseFloat(sampleRate) : 1;
 };
 
@@ -36,7 +36,7 @@ const getSentryTracesSampleRate = (): number => {
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || '',
   environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'development',
-  attachStacktrace: Boolean(process.env.NEXT_PUBLIC_SENTRY_ATTACH_STACKTRACE),
+  attachStacktrace: true,
   maxBreadcrumbs: Number(process.env.NEXT_PUBLIC_SENTRY_MAX_BREADCRUMBS) || 100,
   // Adjust this value in production, or use tracesSampler for greater control
   // @see https://develop.sentry.dev/sdk/performance/

--- a/frontend/shared/src/components/app/BaseApp.tsx
+++ b/frontend/shared/src/components/app/BaseApp.tsx
@@ -15,7 +15,7 @@ import useIsRouting from 'shared/hooks/useIsRouting';
 import GlobalStyling from 'shared/styles/globalStyling';
 import theme from 'shared/styles/theme';
 import maskGDPRData from 'shared/utils/mask-gdpr-data';
-import { isError, isParsableSafeInteger } from 'shared/utils/type-guards';
+import { isError } from 'shared/utils/type-guards';
 import { ThemeProvider } from 'styled-components';
 
 type Props = AppProps & {
@@ -23,12 +23,6 @@ type Props = AppProps & {
   footer?: React.ReactNode;
   layout?: React.FC;
   title?: string;
-};
-
-const getSentryTracesSampleRate = (): number => {
-  const sampleRate = process.env.NEXT_PUBLIC_SENTRY_TRACE_SAMPLE_RATE;
-  // default value 1.0 means sentry raises 100% of errors.
-  return isParsableSafeInteger(sampleRate) ? parseFloat(sampleRate) : 1;
 };
 
 // Centralized logging with Sentry. See more:
@@ -40,7 +34,7 @@ Sentry.init({
   maxBreadcrumbs: Number(process.env.NEXT_PUBLIC_SENTRY_MAX_BREADCRUMBS) || 100,
   // Adjust this value in production, or use tracesSampler for greater control
   // @see https://develop.sentry.dev/sdk/performance/
-  tracesSampleRate: getSentryTracesSampleRate(),
+  tracesSampleRate: 1,
   beforeBreadcrumb(breadcrumb: Sentry.Breadcrumb) {
     return {
       ...breadcrumb,


### PR DESCRIPTION
## Description :sparkles:
I noticed some mistakes in sentry configuration:
- stacktrace was still disabled
- sample rate was not necessary 100% meaning that not all the messages get through
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
