### PR TITLE
HL-600 | Add TET GDPR API

### DIFF
--- a/backend/benefit/requirements-dev.in
+++ b/backend/benefit/requirements-dev.in
@@ -3,12 +3,12 @@ black
 flake8
 ipython
 isort
+langdetect
+openpyxl # for the Excel testcases from the handlers
 pip-tools
 pytest
 pytest-cov
 pytest-django
 pytest-freezegun
 requests-mock
-Werkzeug
-openpyxl # for the Excel testcases from the handlers
-langdetect
+werkzeug

--- a/backend/benefit/requirements.in
+++ b/backend/benefit/requirements.in
@@ -1,30 +1,30 @@
-Django~=3.2
+-e file:../shared
+babel
 django-cors-headers
 django-environ
 django-extensions
-djangorestframework
+django-filter
+django-localflavor~=3.1
+django-phonenumber-field[phonenumbers]
+django-searchable-encrypted-fields
 django-simple-history
+django-sql-utils
+django-storages[azure]
+django_auth_adfs
+djangorestframework
+django~=3.2
+drf-nested-routers
+drf-spectacular
+elasticsearch
+factory-boy # TODO: added temporarily so that NEXT_PUBLIC_MOCK_FLAG can be set on dev env, remove when authentication done
+filetype
+jinja2
+mozilla_django_oidc
+pdfkit
+pillow
 psycopg2
 python-dateutil
-sentry-sdk
-requests
-django-phonenumber-field[phonenumbers]
-django-localflavor~=3.1
-django-searchable-encrypted-fields
-mozilla_django_oidc
-django_auth_adfs
 pyyaml
+requests
+sentry-sdk
 uritemplate
-drf-spectacular
-django-filter
-django-storages[azure]
-Pillow
-filetype
-elasticsearch
-Jinja2
-pdfkit
-Babel
-factory-boy # TODO: added temporarily so that NEXT_PUBLIC_MOCK_FLAG can be set on dev env, remove when authentication done
-drf-nested-routers
-django-sql-utils
--e file:../shared

--- a/backend/kesaseteli/requirements-dev.in
+++ b/backend/kesaseteli/requirements-dev.in
@@ -11,4 +11,4 @@ pytest-django
 pytest-freezegun
 pytest-xdist[psutil]
 requests-mock
-Werkzeug
+werkzeug

--- a/backend/kesaseteli/requirements.in
+++ b/backend/kesaseteli/requirements.in
@@ -1,25 +1,25 @@
-Django~=3.2
+-e file:../shared
 django-auth-adfs
 django-cors-headers
 django-environ
 django-extensions
 django-localflavor
-djangorestframework
 django-searchable-encrypted-fields
 django-sequences
 django-simple-history
 django-storages[azure]
+djangorestframework
+django~=3.2
 elasticsearch
 factory-boy
 filetype
 ipython
 jsonpath-ng
 mozilla-django-oidc
-Pillow
+pillow
 psycopg2
 python-stdnum
 requests
 sentry-sdk
-xlsxwriter
 xlsx-streaming
--e file:../shared
+xlsxwriter

--- a/backend/tet/events/tests/test_gdpr_api.py
+++ b/backend/tet/events/tests/test_gdpr_api.py
@@ -1,0 +1,35 @@
+import uuid
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from shared.common.tests.factories import UserFactory
+
+
+@pytest.fixture
+def user_with_uuid_username(client):
+    return UserFactory(username=str(uuid.uuid4()))
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("http_method", ["get", "delete"])
+def test_gdpr_api_without_authentication(client, user_with_uuid_username, http_method):
+    client.force_login(user_with_uuid_username)
+    client_method = getattr(client, http_method)
+    assert callable(client_method)
+    url = reverse("gdpr_v1", kwargs={"uuid": user_with_uuid_username.username})
+    response = client_method(url)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("http_method", ["get", "delete"])
+def test_gdpr_api_with_non_uuid_username(client, user_with_uuid_username, http_method):
+    client.force_login(user_with_uuid_username)
+    client_method = getattr(client, http_method)
+    assert callable(client_method)
+    url = reverse("gdpr_v1", kwargs={"uuid": user_with_uuid_username.username})
+    url = url.replace(user_with_uuid_username.username, "not_a_uuid_value")
+    response = client_method(url)
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/tet/requirements-dev.in
+++ b/backend/tet/requirements-dev.in
@@ -10,4 +10,4 @@ pytest-django
 pytest-freezegun
 pytest-xdist[psutil]
 requests-mock
-Werkzeug
+werkzeug

--- a/backend/tet/requirements-dev.txt
+++ b/backend/tet/requirements-dev.txt
@@ -54,8 +54,10 @@ mccabe==0.6.1
     # via flake8
 mypy-extensions==0.4.3
     # via black
-packaging==21.0
-    # via pytest
+packaging==22.0
+    # via
+    #   -c requirements.txt
+    #   pytest
 parso==0.8.2
     # via jedi
 pathspec==0.9.0
@@ -88,8 +90,6 @@ pyflakes==2.4.0
     # via flake8
 pygments==2.9.0
     # via ipython
-pyparsing==2.4.7
-    # via packaging
 pytest==6.2.4
     # via
     #   -r requirements-dev.in

--- a/backend/tet/requirements.in
+++ b/backend/tet/requirements.in
@@ -1,20 +1,20 @@
-Django~=3.2
+-e file:../shared
 django-auth-adfs
 django-cors-headers
 django-environ
 django-extensions
-djangorestframework
 django-searchable-encrypted-fields
 django-simple-history
 django-storages[azure]
+djangorestframework
+django~=3.2
 elasticsearch
 factory-boy
 filetype
 mozilla-django-oidc
-Pillow
+pillow
 psycopg2
 python-stdnum
 requests
 sentry-sdk
 xlsxwriter
--e file:../shared

--- a/backend/tet/requirements.in
+++ b/backend/tet/requirements.in
@@ -3,11 +3,13 @@ django-auth-adfs
 django-cors-headers
 django-environ
 django-extensions
+django-helusers
 django-searchable-encrypted-fields
 django-simple-history
 django-storages[azure]
 djangorestframework
 django~=3.2
+drf-oidc-auth
 elasticsearch
 factory-boy
 filetype

--- a/backend/tet/requirements.txt
+++ b/backend/tet/requirements.txt
@@ -8,6 +8,8 @@
     # via -r requirements.in
 asgiref==3.3.4
     # via django
+authlib==1.2.0
+    # via drf-oidc-auth
 azure-common==1.1.27
     # via
     #   azure-storage-blob
@@ -16,6 +18,8 @@ azure-storage-blob==2.1.0
     # via django-storages
 azure-storage-common==2.1.0
     # via azure-storage-blob
+cachetools==5.2.0
+    # via django-helusers
 certifi==2021.5.30
     # via
     #   elasticsearch
@@ -27,8 +31,10 @@ chardet==4.0.0
     # via requests
 cryptography==3.4.7
     # via
+    #   authlib
     #   azure-storage-common
     #   django-auth-adfs
+    #   drf-oidc-auth
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
@@ -37,16 +43,20 @@ defusedxml==0.7.1
     # via
     #   djangosaml2
     #   pysaml2
+deprecation==2.1.0
+    # via django-helusers
 django==3.2.4
     # via
     #   -r requirements.in
     #   django-auth-adfs
     #   django-cors-headers
     #   django-extensions
+    #   django-helusers
     #   django-searchable-encrypted-fields
     #   django-storages
     #   djangorestframework
     #   djangosaml2
+    #   drf-oidc-auth
     #   mozilla-django-oidc
     #   yjdh-backend-shared
 django-auth-adfs==1.7.0
@@ -61,6 +71,8 @@ django-extensions==3.1.3
     # via
     #   -r requirements.in
     #   yjdh-backend-shared
+django-helusers==0.7.1
+    # via -r requirements.in
 django-searchable-encrypted-fields==0.1.9
     # via -r requirements.in
 django-simple-history==3.0.0
@@ -68,9 +80,15 @@ django-simple-history==3.0.0
 django-storages[azure]==1.11.1
     # via -r requirements.in
 djangorestframework==3.12.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   drf-oidc-auth
 djangosaml2==1.5.0
     # via yjdh-backend-shared
+drf-oidc-auth==3.0.0
+    # via -r requirements.in
+ecdsa==0.18.0
+    # via python-jose
 elasticsearch==7.14.0
     # via -r requirements.in
 elementpath==2.5.3
@@ -91,10 +109,16 @@ mozilla-django-oidc==1.2.4
     # via
     #   -r requirements.in
     #   yjdh-backend-shared
+packaging==22.0
+    # via deprecation
 pillow==8.3.1
     # via -r requirements.in
 psycopg2==2.8.6
     # via -r requirements.in
+pyasn1==0.4.8
+    # via
+    #   python-jose
+    #   rsa
 pycparser==2.20
     # via cffi
 pycryptodome==3.10.1
@@ -112,6 +136,8 @@ python-dateutil==2.8.1
     #   azure-storage-common
     #   faker
     #   pysaml2
+python-jose==3.3.0
+    # via django-helusers
 python-stdnum==1.17
     # via -r requirements.in
 pytz==2021.1
@@ -123,12 +149,17 @@ requests==2.25.1
     #   -r requirements.in
     #   azure-storage-common
     #   django-auth-adfs
+    #   django-helusers
+    #   drf-oidc-auth
     #   mozilla-django-oidc
     #   pysaml2
+rsa==4.9
+    # via python-jose
 sentry-sdk==1.4.1
     # via -r requirements.in
 six==1.16.0
     # via
+    #   ecdsa
     #   mozilla-django-oidc
     #   pyopenssl
     #   pysaml2

--- a/backend/tet/tet/settings.py
+++ b/backend/tet/tet/settings.py
@@ -50,6 +50,12 @@ django_env = environ.Env(
     CSRF_COOKIE_NAME=(str, "yjdhcsrftoken"),
     NEXT_PUBLIC_MOCK_FLAG=(bool, False),
     SESSION_COOKIE_AGE=(int, 3600 * 2),
+    TOKEN_AUTH_ACCEPTED_AUDIENCE=(str, "https://api.hel.fi/auth/tetgdprapitest"),
+    TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX=(str, "https://api.hel.fi/auth/tetgdprapitest"),
+    TOKEN_AUTH_AUTHSERVER_URL=(str, "https://tunnistamo.test.hel.ninja/openid"),
+    TOKEN_AUTH_FIELD_FOR_CONSENTS=(str, "https://api.hel.fi/auth"),
+    TOKEN_AUTH_REQUIRE_SCOPE_PREFIX=(bool, False),
+    OIDC_LEEWAY=(int, 60 * 60 * 2),
     OIDC_RP_CLIENT_ID=(str, ""),
     OIDC_RP_CLIENT_SECRET=(str, ""),
     OIDC_OP_BASE_URL=(str, ""),
@@ -92,6 +98,8 @@ django_env = environ.Env(
     LINKEDEVENTS_URL=(str, ""),
     LINKEDEVENTS_API_KEY=(str, ""),
     LINKEDEVENTS_TIMEOUT=(int, 20),
+    GDPR_API_QUERY_SCOPE=(str, "https://api.hel.fi/auth/tetgdprapitest.gdprquery"),
+    GDPR_API_DELETE_SCOPE=(str, "https://api.hel.fi/auth/tetgdprapitest.gdprdelete"),
 )
 
 if os.path.exists(env_file):
@@ -247,6 +255,19 @@ AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.ModelBackend",
 )
 
+OIDC_API_TOKEN_AUTH = {
+    "AUDIENCE": django_env.str("TOKEN_AUTH_ACCEPTED_AUDIENCE"),
+    "API_SCOPE_PREFIX": django_env.str("TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX"),
+    "ISSUER": django_env.str("TOKEN_AUTH_AUTHSERVER_URL"),
+    "API_AUTHORIZATION_FIELD": django_env.str("TOKEN_AUTH_FIELD_FOR_CONSENTS"),
+    "REQUIRE_API_SCOPE_FOR_AUTHENTICATION": django_env.bool(
+        "TOKEN_AUTH_REQUIRE_SCOPE_PREFIX"
+    ),
+    "USER_RESOLVER": "tet.views.resolve_user",
+}
+
+OIDC_AUTH = {"OIDC_LEEWAY": django_env.int("OIDC_LEEWAY")}
+
 OIDC_RP_SIGN_ALGO = "RS256"
 HELSINKI_PROFILE_SCOPE = "https://api.hel.fi/auth/helsinkiprofile"
 OIDC_RP_SCOPES = f"openid profile {HELSINKI_PROFILE_SCOPE}"
@@ -312,6 +333,9 @@ AZURE_ACCOUNT_KEY = django_env("AZURE_ACCOUNT_KEY")
 AZURE_CONTAINER = django_env("AZURE_CONTAINER")
 
 MAX_UPLOAD_SIZE = 4194304  # 4MB
+
+GDPR_API_QUERY_SCOPE = django_env("GDPR_API_QUERY_SCOPE")
+GDPR_API_DELETE_SCOPE = django_env("GDPR_API_DELETE_SCOPE")
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.

--- a/backend/tet/tet/urls.py
+++ b/backend/tet/tet/urls.py
@@ -6,7 +6,7 @@ from django.views.decorators.http import require_GET
 from rest_framework import routers
 
 from events.api.v1 import views as event_views
-from tet.views import TetLogoutView, UserInfoView
+from tet.views import TetGDPRAPIView, TetLogoutView, UserInfoView
 
 router = routers.DefaultRouter()
 router.register(r"events", event_views.JobPostingsViewSet, basename="jobpostings")
@@ -16,6 +16,7 @@ urlpatterns = [
     path("v1/events/<pk>/publish/", event_views.PublishTetPostingView.as_view()),
     path("v1/events/<pk>/image/", event_views.DeletePostingImageView.as_view()),
     path("v1/images/", event_views.ImageView.as_view()),
+    path("gdpr-api/v1/user/<uuid:uuid>", TetGDPRAPIView.as_view(), name="gdpr_v1"),
     path("userinfo/", UserInfoView.as_view(), name="userinfo"),
     path("logout/", TetLogoutView.as_view(), name="tet_logout"),
     path("oidc/", include("shared.oidc.urls")),

--- a/backend/tet/tet/views.py
+++ b/backend/tet/tet/views.py
@@ -1,10 +1,26 @@
+from typing import Optional
+
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.views import View
 
+# TECHNICAL DEBT:
+# Import using a private module i.e. one starting with a single underscore.
+# "from helusers.oidc import ApiTokenAuthentication" lead to problems as we don't
+# use django-helusers package's user model.
+from helusers._oidc_auth_impl import ApiTokenAuthentication
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from events.utils import get_organization_name
 from shared.azure_adfs.auth import is_adfs_login
+
+User = get_user_model()
 
 
 class UserInfoView(View):
@@ -56,3 +72,60 @@ class TetLogoutView(View):
                 return redirect("/oidc/logout/")
         else:
             return redirect(settings.LOGIN_REDIRECT_URL)
+
+
+class GDPRScopesPermission(IsAuthenticated):
+    """
+    A near copy of GDPRScopesPermission from helsinki-profile-gdpr-api, see
+    https://github.com/City-of-Helsinki/helsinki-profile-gdpr-api/blob/release-0.1.0/helsinki_gdpr/views.py#L30-L43
+
+    TECHNICAL DEBT:
+        Copied because "from helsinki_gdpr.views import GDPRScopesPermission" lead to
+        "from helusers.oidc import ApiTokenAuthentication" which lead to problems as we
+        don't use django-helusers package's user model.
+    """
+
+    def has_permission(self, request, view):
+        authenticated = super().has_permission(request, view)
+        if authenticated:
+            if request.method == "GET":
+                return request.auth.has_api_scopes(settings.GDPR_API_QUERY_SCOPE)
+            elif request.method == "DELETE":
+                return request.auth.has_api_scopes(settings.GDPR_API_DELETE_SCOPE)
+        return False
+
+
+class TetGDPRAPIView(APIView):
+    """
+    A dummy GDPR API view which returns success on both get and delete operations
+    """
+
+    renderer_classes = [JSONRenderer]
+    authentication_classes = [ApiTokenAuthentication]
+    permission_classes = [GDPRScopesPermission]
+
+    def get(self, request, *args, **kwargs):
+        return Response(status=status.HTTP_200_OK)
+
+    def delete(self, request, *args, **kwargs):
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+def resolve_user(_, payload) -> Optional[User]:
+    """
+    User resolver function for django-helusers ApiTokenAuthentication.
+
+    :param _: request
+    :param payload: JWT token payload
+
+    Configured using settings.OIDC_API_TOKEN_AUTH["USER_RESOLVER"], e.g.
+        OIDC_API_TOKEN_AUTH = {
+            ...
+            "USER_RESOLVER": "tet.views.resolve_user"
+            ...
+        }
+    """
+    try:
+        return User.objects.get(username=payload["sub"])
+    except User.objects.DoesNotExist:
+        return None


### PR DESCRIPTION
## Description :sparkles:

### All backends: Normalize case & sort requirements*.in file contents 

Normalize package names to all lowercase letters in requirements*.in
which should be safe because PEP 428 at
https://peps.python.org/pep-0426/#name says:
 - "All comparisons of distribution names MUST be case insensitive"

Sort the package names in requirements*.in to ascending order.

Afterwards ran:
 - pip-compile requirements.in
 - pip-compile requirements-dev.in
 - pip-compile requirements-prod.in
but the requirements*.txt files remained unchanged for all backends.

Refs HL-600 (Looked at requirements*.in when implementing this ticket)
 
### TET-Backend: Add django-helusers and drf-oidc-auth to requirements 

Afterwards ran:
 - pip-compile requirements.in
 - pip-compile requirements-dev.in
 - pip-compile requirements-prod.in

Refs HL-600
 
### TET-Backend: Add dummy TET GDPR API view callable using user UUID 

Examples of endpoints:
  - GET & DELETE: /gdpr-api/v1/user/60404d9b-9e75-43be-bdb4-aae6a1a2f9f6
    - 60404d9b-9e75-43be-bdb4-aae6a1a2f9f6 is user UUID & User.username

Refs HL-600

## Issues :bug:

HL-600

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
