### PR TITLE
HL-600 | TET-Backend: Use drf-oidc-auth 0.10.0 to make GDPR API work

### DIFF
--- a/backend/tet/requirements.in
+++ b/backend/tet/requirements.in
@@ -9,7 +9,7 @@ django-simple-history
 django-storages[azure]
 djangorestframework
 django~=3.2
-drf-oidc-auth
+drf-oidc-auth==0.10.0  # For GDPR API to work, otherwise got 'Invalid claim: "amr"'
 elasticsearch
 factory-boy
 filetype

--- a/backend/tet/requirements.txt
+++ b/backend/tet/requirements.txt
@@ -8,8 +8,6 @@
     # via -r requirements.in
 asgiref==3.3.4
     # via django
-authlib==1.2.0
-    # via drf-oidc-auth
 azure-common==1.1.27
     # via
     #   azure-storage-blob
@@ -31,10 +29,8 @@ chardet==4.0.0
     # via requests
 cryptography==3.4.7
     # via
-    #   authlib
     #   azure-storage-common
     #   django-auth-adfs
-    #   drf-oidc-auth
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
@@ -85,7 +81,7 @@ djangorestframework==3.12.4
     #   drf-oidc-auth
 djangosaml2==1.5.0
     # via yjdh-backend-shared
-drf-oidc-auth==3.0.0
+drf-oidc-auth==0.10.0
     # via -r requirements.in
 ecdsa==0.18.0
     # via python-jose
@@ -99,6 +95,8 @@ faker==8.7.0
     # via factory-boy
 filetype==1.0.7
     # via -r requirements.in
+future==0.18.2
+    # via pyjwkest
 idna==2.10
     # via requests
 importlib-resources==5.8.0
@@ -123,6 +121,10 @@ pycparser==2.20
     # via cffi
 pycryptodome==3.10.1
     # via django-searchable-encrypted-fields
+pycryptodomex==3.16.0
+    # via pyjwkest
+pyjwkest==1.4.2
+    # via drf-oidc-auth
 pyjwt==2.1.0
     # via django-auth-adfs
 pyopenssl==20.0.1
@@ -150,8 +152,8 @@ requests==2.25.1
     #   azure-storage-common
     #   django-auth-adfs
     #   django-helusers
-    #   drf-oidc-auth
     #   mozilla-django-oidc
+    #   pyjwkest
     #   pysaml2
 rsa==4.9
     # via python-jose
@@ -161,6 +163,7 @@ six==1.16.0
     # via
     #   ecdsa
     #   mozilla-django-oidc
+    #   pyjwkest
     #   pyopenssl
     #   pysaml2
     #   python-dateutil


### PR DESCRIPTION
## Description :sparkles:

### TET-Backend: Use drf-oidc-auth 0.10.0 to make GDPR API work

drf-oidc-auth was too new, with the newer version got:

django-helusers/ApiTokenAuthentication.authenticate: self.validate_claims(payload)
->
drf-oidc-auth/JSONWebTokenAuthentication.validate_claims: id_token.validate(
->
authlib/IDToken.validate:
self.validate_amr()
->
authlib/IDToken.validate_amr
->
authlib/InvalidClaimError:
description = 'Invalid claim "{}"'.format(claim)
->
"Invalid claim "amr"

When "amr" was in the decoded JWT token:
 - 'amr': 'heltunnistussuomifi'

The "amr" claim was truthy but wasn't a list which caused the 'Invalid claim "amr"' error message from authlib.

Refs HL-600

## Issues :bug:

HL-600

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
