### PR TITLE
HL-600 | TET-Backend: Return empty dictionary as JSON in TetGDPRAPIView.get

### DIFF
--- a/backend/tet/tet/views.py
+++ b/backend/tet/tet/views.py
@@ -113,7 +113,9 @@ class TetGDPRAPIView(APIView):
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
-        return Response(status=status.HTTP_200_OK)
+        return Response(
+            data={}, content_type="application/json", status=status.HTTP_200_OK
+        )
 
     def delete(self, request, *args, **kwargs):
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Description :sparkles:

TET-Backend: Return empty dictionary as JSON in TetGDPRAPIView.get

## Issues :bug:

HL-600

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
