### PR TITLE
HL-600 | TET-Backend: Production release GDPR API related fixes

### DIFF
--- a/backend/shared/shared/oidc/mixins.py
+++ b/backend/shared/shared/oidc/mixins.py
@@ -1,0 +1,20 @@
+class ForceAmrClaimToListMixin:
+    """
+    Copy of FixTunnistamoMixin from palvelutarjotin:
+    https://github.com/City-of-Helsinki/palvelutarjotin/blob/release-v.1.5.0/palvelutarjotin/oidc.py#L4-L19
+    """
+
+    def __convert_amr_to_list(self, id_token):
+        """
+        OIDC's amr validation fails, since Tunnistamo sends the amr as a string
+        instead of a list:
+        https://github.com/City-of-Helsinki/tunnistamo/commit/a1b434bbbff92466a144f914a98985008d0ea836.
+        To fix the claim validation issue, convert the id_token amr to list
+        when a string is given.
+        """
+        if id_token["amr"] and not isinstance(id_token["amr"], list):
+            id_token["amr"] = [id_token["amr"]]
+
+    def validate_claims(self, id_token):
+        self.__convert_amr_to_list(id_token)
+        super().validate_claims(id_token)

--- a/backend/tet/requirements.in
+++ b/backend/tet/requirements.in
@@ -9,7 +9,7 @@ django-simple-history
 django-storages[azure]
 djangorestframework
 django~=3.2
-drf-oidc-auth==0.10.0  # For GDPR API to work, otherwise got 'Invalid claim: "amr"'
+drf-oidc-auth
 elasticsearch
 factory-boy
 filetype

--- a/backend/tet/requirements.txt
+++ b/backend/tet/requirements.txt
@@ -8,6 +8,8 @@
     # via -r requirements.in
 asgiref==3.3.4
     # via django
+authlib==1.2.0
+    # via drf-oidc-auth
 azure-common==1.1.27
     # via
     #   azure-storage-blob
@@ -29,8 +31,10 @@ chardet==4.0.0
     # via requests
 cryptography==3.4.7
     # via
+    #   authlib
     #   azure-storage-common
     #   django-auth-adfs
+    #   drf-oidc-auth
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
@@ -81,7 +85,7 @@ djangorestframework==3.12.4
     #   drf-oidc-auth
 djangosaml2==1.5.0
     # via yjdh-backend-shared
-drf-oidc-auth==0.10.0
+drf-oidc-auth==3.0.0
     # via -r requirements.in
 ecdsa==0.18.0
     # via python-jose
@@ -95,8 +99,6 @@ faker==8.7.0
     # via factory-boy
 filetype==1.0.7
     # via -r requirements.in
-future==0.18.2
-    # via pyjwkest
 idna==2.10
     # via requests
 importlib-resources==5.8.0
@@ -121,10 +123,6 @@ pycparser==2.20
     # via cffi
 pycryptodome==3.10.1
     # via django-searchable-encrypted-fields
-pycryptodomex==3.16.0
-    # via pyjwkest
-pyjwkest==1.4.2
-    # via drf-oidc-auth
 pyjwt==2.1.0
     # via django-auth-adfs
 pyopenssl==20.0.1
@@ -152,8 +150,8 @@ requests==2.25.1
     #   azure-storage-common
     #   django-auth-adfs
     #   django-helusers
+    #   drf-oidc-auth
     #   mozilla-django-oidc
-    #   pyjwkest
     #   pysaml2
 rsa==4.9
     # via python-jose
@@ -163,7 +161,6 @@ six==1.16.0
     # via
     #   ecdsa
     #   mozilla-django-oidc
-    #   pyjwkest
     #   pyopenssl
     #   pysaml2
     #   python-dateutil

--- a/backend/tet/tet/views.py
+++ b/backend/tet/tet/views.py
@@ -106,12 +106,6 @@ class TetGDPRAPIView(APIView):
     authentication_classes = [ApiTokenAuthentication]
     permission_classes = [GDPRScopesPermission]
 
-    def dispatch(self, request, *args, **kwargs):
-        LOGGER.warning(
-            f'TetGDPRAPIView auth="{request.META.get("HTTP_AUTHORIZATION")}"'
-        )  # DEBUG!
-        return super().dispatch(request, *args, **kwargs)
-
     def get(self, request, *args, **kwargs):
         return Response(
             data={}, content_type="application/json", status=status.HTTP_200_OK

--- a/backend/tet/tet/views.py
+++ b/backend/tet/tet/views.py
@@ -20,6 +20,7 @@ from rest_framework.views import APIView
 
 from events.utils import get_organization_name
 from shared.azure_adfs.auth import is_adfs_login
+from shared.oidc.mixins import ForceAmrClaimToListMixin
 
 LOGGER = logging.getLogger(__name__)
 User = get_user_model()
@@ -97,13 +98,23 @@ class GDPRScopesPermission(IsAuthenticated):
         return False
 
 
+class TetApiTokenAuthentication(ForceAmrClaimToListMixin, ApiTokenAuthentication):
+    """
+    Tunnistamo's "amr" claim is not always a list so using ForceAmrClaimToListMixin
+    to force it to be a list in order to pass "amr" claim validation in authlib:
+    https://github.com/lepture/authlib/blob/v1.2.0/authlib/oidc/core/claims.py#L101-L113
+    """
+
+    pass
+
+
 class TetGDPRAPIView(APIView):
     """
     A dummy GDPR API view which returns success on both get and delete operations
     """
 
     renderer_classes = [JSONRenderer]
-    authentication_classes = [ApiTokenAuthentication]
+    authentication_classes = [TetApiTokenAuthentication]
     permission_classes = [GDPRScopesPermission]
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
## Description :sparkles:

This PR is about production release GDPR API related fixes, see
 - https://github.com/City-of-Helsinki/yjdh/pull/1635#discussion_r1055169944
 - https://github.com/City-of-Helsinki/yjdh/pull/1645#issuecomment-1362609931
 - https://github.com/City-of-Helsinki/yjdh/pull/1647#discussion_r1055451993
 - https://github.com/City-of-Helsinki/yjdh/pull/1647#discussion_r1055457539

The changes are:

### TET-Backend: Remove debug logging, drf-oidc-auth==0.10.0 version binding 

Remove debug logging from TetGDPRAPIView.
Remove drf-oidc-auth version binding to 0.10.0 and update requirements:
  - Removed rows from requirements.in:
    - django-helusers
    - drf-oidc-auth==0.10.0
  - Ran pip-compile on requirements*.in
  - Added rows to requirements.in:
    - django-helusers
    - drf-oidc-auth
  - Ran pip-compile on requirements*.in

Refs HL-600
 
### TET-Backend: Force AMR claim to be a list in ApiTokenAuthentication 

Copied FixTunnistamoMixin from palvelutarjotin
https://github.com/City-of-Helsinki/palvelutarjotin/blob/release-v.1.5.0/palvelutarjotin/oidc.py#L4-L19
add renamed it to ForceAmrClaimToListMixin and added reference to the
source.

Make use of ForceAmrClaimToListMixin to fix ApiTokenAuthentication
use with Tunnistamo, where amr claim's not always a list, and newer
authlib which requires that amr claim if truthy is a list. Practically
the same class as KultusApiTokenAuthentication from
https://github.com/City-of-Helsinki/palvelutarjotin/blob/release-v.1.5.0/palvelutarjotin/oidc.py#L40
but simply with different names and docstring.

Refs HL-600

## Issues :bug:

HL-600

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
