### PR TITLE
HL-607 | Use alpine-slim image instead of a default one

### DIFF
--- a/localdevelopment/benefit/nginx/Dockerfile
+++ b/localdevelopment/benefit/nginx/Dockerfile
@@ -1,6 +1,6 @@
-FROM nginx:latest
+FROM nginx:1.23.3-alpine-slim
 
-RUN apt-get update && apt-get install -y openssl
+RUN apk update && apk add bash openssl
 
 COPY entrypoint.sh /usr/local/bin
 


### PR DESCRIPTION
## Description :sparkles:

Achieve a smaller docker fingerprint by switching to alpine-slim instead of the default distro.

## Screenshots :camera_flash:

<img width="1680" alt="Screenshot 2023-01-02 at 13 18 25" src="https://user-images.githubusercontent.com/5328394/210234332-1303273d-946c-447b-af1f-1f303d1f3a08.png">
