### PR TITLE
HL-608 | Fix broken TestCafé run, issue with loading CDN content from test proxy

### DIFF
--- a/frontend/benefit/applicant/src/components/pdfViewer/PdfViewer.tsx
+++ b/frontend/benefit/applicant/src/components/pdfViewer/PdfViewer.tsx
@@ -9,8 +9,12 @@ import { useTheme } from 'styled-components';
 
 import { $ActionsWrapper, $ViewerWrapper } from './PdfViewer.sc';
 import { usePdfViewer } from './usePdfViewer';
-// test if it works in production
-pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
+
+// TODO: Test if it works in production
+// Update as of 2023-01-03: Not sure if this is necessary AT ALL
+if (process.env.NODE_ENV === 'production') {
+  pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
+}
 
 type PdfViewerProps = {
   file: string;


### PR DESCRIPTION
## Description :sparkles:

Whole test case would hang in it's first action.

https://helsinkisolutionoffice.atlassian.net/browse/HL-608

## Issues :bug:

CDN causing trouble, TestCafé won't be able to download the file. Just load the file while in production.

```
   1) A JavaScript error occurred on "https://localhost:3000/".
      Repeat test actions in the browser and check the console for errors.
      To ignore client-side JavaScript errors, enable the "--skip-js-errors" CLI option, or set the "skipJsErrors" configuration file property to "true".
      If the website only throws this error when you test it with TestCafe, please create a new issue at:
      "https://github.com/DevExpress/testcafe/issues/new?template=bug-report.md".

      JavaScript error details:
      Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'http://localhost:60483/!s/https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.12.313/pdf.worker.js' failed to load.
```

[HL-608]: https://helsinkisolutionoffice.atlassian.net/browse/HL-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ