### PR TITLE
HL-611 | Redirect requests for http://localhost to HTTPS on ports 3000+

### DIFF
--- a/localdevelopment/benefit/nginx/nginx.conf
+++ b/localdevelopment/benefit/nginx/nginx.conf
@@ -27,6 +27,8 @@ http {
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
         client_max_body_size 20M;
+        error_page 497 302 =307 https://$host:$server_port$request_uri;
+
         # https://github.com/vercel/next.js/issues/30491#issuecomment-962835174
         location /_next/webpack-hmr {
           proxy_pass http://applicant:3000/_next/webpack-hmr;
@@ -49,6 +51,8 @@ http {
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
         client_max_body_size 20M;
+        error_page 497 302 =307 https://$host:$server_port$request_uri;
+
         # https://github.com/vercel/next.js/issues/30491#issuecomment-962835174
         location /_next/webpack-hmr {
           proxy_pass http://handler:3100/_next/webpack-hmr;

--- a/localdevelopment/employer/nginx/nginx.conf
+++ b/localdevelopment/employer/nginx/nginx.conf
@@ -27,6 +27,7 @@ http {
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
         client_max_body_size 20M;
+        error_page 497 302 =307 https://$host:$server_port$request_uri;
         # https://github.com/vercel/next.js/issues/30491#issuecomment-962835174
         location /_next/webpack-hmr {
           proxy_pass http://kesaseteli-employer:3000/_next/webpack-hmr;

--- a/localdevelopment/handler/nginx/nginx.conf
+++ b/localdevelopment/handler/nginx/nginx.conf
@@ -27,6 +27,7 @@ http {
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
         client_max_body_size 20M;
+        error_page 497 302 =307 https://$host:$server_port$request_uri;
         # https://github.com/vercel/next.js/issues/30491#issuecomment-962835174
         location /_next/webpack-hmr {
           proxy_pass http://kesaseteli-youth:3100/_next/webpack-hmr;
@@ -49,6 +50,7 @@ http {
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
         client_max_body_size 20M;
+        error_page 497 302 =307 https://$host:$server_port$request_uri;
         # https://github.com/vercel/next.js/issues/30491#issuecomment-962835174
         location /_next/webpack-hmr {
             proxy_pass http://kesaseteli-handler:3200/_next/webpack-hmr;

--- a/localdevelopment/tet-admin/nginx/nginx.conf
+++ b/localdevelopment/tet-admin/nginx/nginx.conf
@@ -29,6 +29,7 @@ http {
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
         client_max_body_size 20M;
+        error_page 497 302 =307 https://$host:$server_port$request_uri;
         # https://github.com/vercel/next.js/issues/30491#issuecomment-962835174
         location /_next/webpack-hmr {
             proxy_pass http://te-admn:3000/_next/webpack-hmr;

--- a/localdevelopment/tet-youth/nginx/nginx.conf
+++ b/localdevelopment/tet-youth/nginx/nginx.conf
@@ -28,6 +28,7 @@ http {
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
         client_max_body_size 20M;
+        error_page 497 302 =307 https://$host:$server_port$request_uri;
         # https://github.com/vercel/next.js/issues/30491#issuecomment-962835174
         location /_next/webpack-hmr {
             proxy_pass http://te-yout:3000/_next/webpack-hmr;

--- a/localdevelopment/tet/nginx/nginx.conf
+++ b/localdevelopment/tet/nginx/nginx.conf
@@ -27,6 +27,7 @@ http {
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
         client_max_body_size 20M;
+        error_page 497 302 =307 https://$host:$server_port$request_uri;
         # https://github.com/vercel/next.js/issues/30491#issuecomment-962835174
         location /_next/webpack-hmr {
             proxy_pass http://te-yout:3000/_next/webpack-hmr;
@@ -50,6 +51,7 @@ http {
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
         client_max_body_size 20M;
+        error_page 497 302 =307 https://$host:$server_port$request_uri;
         # https://github.com/vercel/next.js/issues/30491#issuecomment-962835174
         location /_next/webpack-hmr {
             proxy_pass http://te-admn:3000/_next/webpack-hmr;

--- a/localdevelopment/youth/nginx/nginx.conf
+++ b/localdevelopment/youth/nginx/nginx.conf
@@ -27,6 +27,7 @@ http {
         ssl_certificate localhost.crt;
         ssl_certificate_key localhost.key;
         client_max_body_size 20M;
+        error_page 497 302 =307 https://$host:$server_port$request_uri;
         # https://nextjs.org/docs/upgrading
         location /_next/webpack-hmr {
         	proxy_pass http://kesaseteli-youth:3100/_next/webpack-hmr;


### PR DESCRIPTION
Currently, HTTP requests to frontend only show NGINX default error (code 400, Bad Request).

For developer convenience, redirect all requests from HTTP to HTTPS:
  
* http://localhost:3000
* http://localhost:3001
* http://localhost:3002
* http://localhost:3100
* http://localhost:3200

<img width="1048" alt="Screenshot 2022-12-21 at 15 15 51" src="https://user-images.githubusercontent.com/5328394/208914587-1a2ca639-1950-44fa-a050-e77536088a7d.png">
