### PR TITLE
YJDH-655 | Fix YouthApplication factories' need_additional_info

### DIFF
--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -22,16 +22,13 @@ from calculator.models import Calculation
 from calculator.tests.factories import PaySubsidyFactory
 from companies.tests.factories import CompanyFactory
 from helsinkibenefit.tests.conftest import *  # noqa
+from shared.common.tests.utils import normalize_whitespace
 from shared.service_bus.enums import YtjOrganizationCode
 
 DE_MINIMIS_AID_PARTIAL_TEXT = (
     # In English ~= "support is granted as insignificant i.e. de minimis support"
     "tuki myönnetään vähämerkityksisenä eli ns. de minimis -tukena"
 )
-
-
-def normalize_whitespace(text: str) -> str:
-    return " ".join(text.split())
 
 
 def _assert_html_content(html, include_keys=(), excluded_keys=()):

--- a/backend/kesaseteli/applications/tests/test_models.py
+++ b/backend/kesaseteli/applications/tests/test_models.py
@@ -18,7 +18,7 @@ from common.tests.factories import (
     EmployerSummerVoucherFactory,
     YouthSummerVoucherFactory,
 )
-from common.utils import utc_datetime
+from shared.common.tests.utils import utc_datetime
 
 
 def create_test_employer_summer_vouchers(year) -> List[EmployerSummerVoucher]:

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -52,11 +52,8 @@ from common.tests.factories import (
     RejectedYouthApplicationFactory,
     YouthApplicationFactory,
 )
+from common.tests.utils import get_random_social_security_number_for_year
 from common.urls import handler_403_url, handler_youth_application_processing_url
-from common.utils import (
-    get_random_social_security_number_for_year,
-    normalize_whitespace,
-)
 from shared.audit_log.models import AuditLogEntry
 from shared.common.lang_test_utils import (
     assert_email_body_language,
@@ -69,6 +66,7 @@ from shared.common.tests.conftest import (
 )
 from shared.common.tests.factories import UserFactory
 from shared.common.tests.test_validators import get_invalid_postcode_values
+from shared.common.tests.utils import normalize_whitespace
 
 
 def create_same_person_previous_year_accepted_application(

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -19,7 +19,6 @@ from django.test import override_settings
 from django.utils import timezone
 from django.utils.html import strip_tags
 from django.utils.timezone import localdate
-from faker import Faker
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -54,7 +53,10 @@ from common.tests.factories import (
     YouthApplicationFactory,
 )
 from common.urls import handler_403_url, handler_youth_application_processing_url
-from common.utils import normalize_whitespace
+from common.utils import (
+    get_random_social_security_number_for_year,
+    normalize_whitespace,
+)
 from shared.audit_log.models import AuditLogEntry
 from shared.common.lang_test_utils import (
     assert_email_body_language,
@@ -85,14 +87,6 @@ def create_same_person_previous_year_accepted_application(
     assert result.created_at.year == app.created_at.year - 1
     assert result.status == YouthApplicationStatus.ACCEPTED
     return result
-
-
-def get_random_social_security_number_for_year(year):
-    # Freeze time to last day of year to ensure a social security number with given year
-    # is created, see Faker's fi_FI ssn provider:
-    # https://github.com/joke2k/faker/blob/v8.7.0/faker/providers/ssn/fi_FI/__init__.py#L29-L31
-    with freeze_time(date(year=year, month=12, day=31)):
-        return Faker(locale="fi").ssn(min_age=0, max_age=1)
 
 
 def reverse_youth_application_action(action, pk):

--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -7,7 +7,6 @@ import factory.fuzzy
 from django.db.models.signals import post_save
 from django.utils import timezone
 from django.utils.timezone import get_current_timezone
-from faker import Faker
 
 from applications.enums import (
     AdditionalInfoUserReason,
@@ -31,6 +30,7 @@ from applications.tests.data.mock_vtj import (
     mock_vtj_person_id_query_found_content,
     mock_vtj_person_id_query_not_found_content,
 )
+from common.tests.faker import get_faker
 from common.utils import get_random_social_security_number_for_year
 from companies.models import Company
 from shared.common.tests.factories import (
@@ -212,7 +212,7 @@ def get_unlisted_test_schools() -> List[str]:
 
 
 def determine_school(youth_application) -> str:
-    return Faker().random_element(
+    return get_faker().random_element(
         get_unlisted_test_schools()
         if youth_application.is_unlisted_school
         else get_listed_test_schools()
@@ -222,11 +222,11 @@ def determine_school(youth_application) -> str:
 def get_test_phone_number() -> str:
     # PHONE_NUMBER_REGEX didn't accept phone numbers starting with (+358) but did with
     # +358 so removing the parentheses to make the generated phone numbers fit it
-    return Faker(locale="fi").phone_number().replace("(+358)", "+358")
+    return get_faker().phone_number().replace("(+358)", "+358")
 
 
 def determine_modified_at(youth_application) -> Optional[datetime]:
-    return Faker().date_time_between_dates(
+    return get_faker().date_time_between_dates(
         youth_application.created_at + timedelta(days=10),
         youth_application.created_at + timedelta(days=20),
         tzinfo=get_current_timezone(),
@@ -245,7 +245,7 @@ def determine_handler(youth_application):
 
 def determine_handled_at(youth_application):
     if youth_application.status in YouthApplicationStatus.handled_values():
-        return Faker().date_time_between_dates(
+        return get_faker().date_time_between_dates(
             youth_application.created_at + timedelta(days=3),
             youth_application.created_at + timedelta(days=10),
             tzinfo=get_current_timezone(),
@@ -255,7 +255,7 @@ def determine_handled_at(youth_application):
 
 def determine_receipt_confirmed_at(youth_application):
     if youth_application.status in YouthApplicationStatus.active_values():
-        return Faker().date_time_between_dates(
+        return get_faker().date_time_between_dates(
             youth_application.created_at,
             youth_application.created_at + timedelta(days=1),
             tzinfo=get_current_timezone(),
@@ -274,7 +274,7 @@ def determine_is_unlisted_school(youth_application):
         youth_application.status
         in YouthApplicationStatus.can_have_additional_info_values()
     ):
-        return Faker().boolean()
+        return get_faker().boolean()
     else:
         return False
 
@@ -293,13 +293,13 @@ def determine_youth_application_has_additional_info(youth_application):
             in YouthApplicationStatus.must_have_additional_info_values()
         ):
             return True
-        return Faker().boolean()
+        return get_faker().boolean()
     return False
 
 
 def determine_additional_info_provided_at(youth_application):
     if youth_application._has_additional_info:
-        return Faker().date_time_between_dates(
+        return get_faker().date_time_between_dates(
             youth_application.created_at + timedelta(days=1),
             youth_application.created_at + timedelta(days=3),
             tzinfo=get_current_timezone(),
@@ -310,14 +310,14 @@ def determine_additional_info_provided_at(youth_application):
 def determine_additional_info_user_reasons(youth_application):
     if youth_application._has_additional_info:
         return list(
-            Faker().random_elements(AdditionalInfoUserReason.values, unique=True)
+            get_faker().random_elements(AdditionalInfoUserReason.values, unique=True)
         )
     return []
 
 
 def determine_additional_info_description(youth_application):
     if youth_application._has_additional_info:
-        return Faker().sentence()
+        return get_faker().sentence()
     return ""
 
 

--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -31,6 +31,7 @@ from applications.tests.data.mock_vtj import (
     mock_vtj_person_id_query_found_content,
     mock_vtj_person_id_query_not_found_content,
 )
+from common.utils import get_random_social_security_number_for_year
 from companies.models import Company
 from shared.common.tests.factories import (
     DuplicateAllowingUserFactory,
@@ -354,22 +355,7 @@ def determine_need_additional_info_vtj_json(youth_application):
 
 
 def determine_target_group_social_security_number(youth_application):
-    # NOTE: Faker generates a Finnish social security number with a birthdate
-    # today - random days between [min_age * 365, max_age * 365), see
-    # https://github.com/joke2k/faker/blob/v8.7.0/faker/providers/ssn/fi_FI/__init__.py#L29-L31
-    #
-    # Example with ssn(min_age=16, max_age=17):
-    # If today is 2022-12-31 then birthdate is in inclusive range [2006-01-01, 2006-12-31]
-    # If today is 2022-12-30 then birthdate is in inclusive range [2005-12-31, 2006-12-30]
-    # ...
-    # If today is 2022-01-01 then birthdate is in inclusive range [2005-01-02, 2006-01-01]
-    #
-    # So ONLY with the last day of the year will this be returning birthdate with
-    # today.year - ssn.birthdate.year == 16 only, otherwise the value might be 17 also.
-    #
-    # See YouthApplication.is_9th_grader_age and
-    #     YouthApplication.is_upper_secondary_education_1st_year_student_age
-    return Faker(locale="fi").ssn(min_age=16, max_age=17)
+    return get_random_social_security_number_for_year(date.today().year - 16)
 
 
 @factory.django.mute_signals(post_save)

--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -31,7 +31,7 @@ from applications.tests.data.mock_vtj import (
     mock_vtj_person_id_query_not_found_content,
 )
 from common.tests.faker import get_faker
-from common.utils import get_random_social_security_number_for_year
+from common.tests.utils import get_random_social_security_number_for_year
 from companies.models import Company
 from shared.common.tests.factories import (
     DuplicateAllowingUserFactory,

--- a/backend/kesaseteli/common/tests/faker.py
+++ b/backend/kesaseteli/common/tests/faker.py
@@ -1,0 +1,7 @@
+from faker import Faker
+
+_faker = Faker(locale="fi")
+
+
+def get_faker():
+    return _faker

--- a/backend/kesaseteli/common/tests/test_factories.py
+++ b/backend/kesaseteli/common/tests/test_factories.py
@@ -191,6 +191,38 @@ def test_youth_application_factory(  # noqa: C901
 
 
 @pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=True)
+@pytest.mark.parametrize(
+    "youth_application_factory,expected_need_additional_info",
+    [
+        (AdditionalInfoRequestedYouthApplicationFactory, True),
+        (AdditionalInfoProvidedYouthApplicationFactory, True),
+        (InactiveNoNeedAdditionalInfoYouthApplicationFactory, False),
+        (InactiveNeedAdditionalInfoYouthApplicationFactory, True),
+    ],
+)
+@pytest.mark.parametrize("next_public_disable_vtj", [False, True])
+@pytest.mark.parametrize(
+    "freeze_date", ["2021-01-01", "2021-06-15", "2021-12-31", "2023-07-16"]
+)
+def test_need_additional_info(
+    settings,
+    make_youth_application_activation_link_unexpired,
+    youth_application_factory,
+    expected_need_additional_info: bool,
+    next_public_disable_vtj: bool,
+    freeze_date: str,
+):
+    settings.NEXT_PUBLIC_DISABLE_VTJ = next_public_disable_vtj
+    for _ in range(10):  # Run more than once because factories generate random data
+        with freeze_time(freeze_date):
+            youth_application: YouthApplication = youth_application_factory()
+            assert (
+                youth_application.need_additional_info == expected_need_additional_info
+            )
+
+
+@pytest.mark.django_db
 def test_youth_summer_voucher_factory():
     # Run more than once because factories generate random data
     youth_summer_vouchers = YouthSummerVoucherFactory.create_batch(size=20)

--- a/backend/kesaseteli/common/tests/test_utils.py
+++ b/backend/kesaseteli/common/tests/test_utils.py
@@ -1,11 +1,13 @@
 from datetime import datetime, timezone
 
 import pytest
+import stdnum.fi.hetu
 from django.core.exceptions import ValidationError
 
 from common.utils import (
     are_same_text_lists,
     are_same_texts,
+    get_random_social_security_number_for_year,
     has_whitespace,
     is_uppercase,
     normalize_for_string_comparison,
@@ -14,6 +16,7 @@ from common.utils import (
     validate_finnish_social_security_number,
     validate_optional_finnish_social_security_number,
 )
+from shared.common.utils import social_security_number_birthdate
 
 
 def get_empty_values():
@@ -155,3 +158,11 @@ def test_utc_datetime(args):
     result = utc_datetime(*args)
     assert result == datetime(*args, tzinfo=timezone.utc)
     assert result.tzinfo == timezone.utc
+
+
+@pytest.mark.parametrize("year", [1800, 2022, 2023, 2099])
+def test_get_random_social_security_number_for_year(year):
+    for _ in range(1000):
+        result = get_random_social_security_number_for_year(year)
+        assert stdnum.fi.hetu.validate(result, allow_temporary=False)
+        assert social_security_number_birthdate(result).year == year

--- a/backend/kesaseteli/common/tests/test_utils.py
+++ b/backend/kesaseteli/common/tests/test_utils.py
@@ -4,18 +4,17 @@ import pytest
 import stdnum.fi.hetu
 from django.core.exceptions import ValidationError
 
+from common.tests.utils import get_random_social_security_number_for_year
 from common.utils import (
     are_same_text_lists,
     are_same_texts,
-    get_random_social_security_number_for_year,
     has_whitespace,
     is_uppercase,
     normalize_for_string_comparison,
-    normalize_whitespace,
-    utc_datetime,
     validate_finnish_social_security_number,
     validate_optional_finnish_social_security_number,
 )
+from shared.common.tests.utils import normalize_whitespace, utc_datetime
 from shared.common.utils import social_security_number_birthdate
 
 

--- a/backend/kesaseteli/common/tests/utils.py
+++ b/backend/kesaseteli/common/tests/utils.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timezone
+
+from dateutil.relativedelta import relativedelta
+
+from common.tests.faker import get_faker
+from shared.common.tests.utils import create_finnish_social_security_number
+
+
+def get_random_social_security_number_for_year(year: int) -> str:
+    """
+    Create a random non-temporary Finnish social security number for the given year
+    """
+    start_of_year: datetime = datetime(year=year, month=1, day=1, tzinfo=timezone.utc)
+    return create_finnish_social_security_number(
+        birthdate=get_faker()
+        .date_time_between(
+            start_of_year,
+            start_of_year + relativedelta(years=1, seconds=-1),  # Inclusive range
+            tzinfo=timezone.utc,
+        )
+        .date(),
+        individual_number=get_faker().pyint(2, 899),  # Inclusive range
+    )

--- a/backend/kesaseteli/common/utils.py
+++ b/backend/kesaseteli/common/utils.py
@@ -4,11 +4,15 @@ from email.mime.image import MIMEImage
 from functools import partial
 from typing import List, Optional
 
+from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 from stdnum.fi.hetu import is_valid as is_valid_finnish_social_security_number
+
+from common.tests.faker import get_faker
+from shared.common.utils import create_finnish_social_security_number
 
 LOGGER = logging.getLogger(__name__)
 
@@ -116,6 +120,23 @@ def validate_finnish_social_security_number(value):
             ),
             params={"value": value},
         )
+
+
+def get_random_social_security_number_for_year(year: int) -> str:
+    """
+    Create a random non-temporary Finnish social security number for the given year
+    """
+    start_of_year: datetime = datetime(year=year, month=1, day=1, tzinfo=timezone.utc)
+    return create_finnish_social_security_number(
+        birthdate=get_faker()
+        .date_time_between(
+            start_of_year,
+            start_of_year + relativedelta(years=1, seconds=-1),  # Inclusive range
+            tzinfo=timezone.utc,
+        )
+        .date(),
+        individual_number=get_faker().pyint(2, 899),  # Inclusive range
+    )
 
 
 def validate_optional_finnish_social_security_number(value):

--- a/backend/kesaseteli/common/utils.py
+++ b/backend/kesaseteli/common/utils.py
@@ -1,18 +1,13 @@
 import logging
-from datetime import date, datetime, timezone
+from datetime import date
 from email.mime.image import MIMEImage
-from functools import partial
 from typing import List, Optional
 
-from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 from stdnum.fi.hetu import is_valid as is_valid_finnish_social_security_number
-
-from common.tests.faker import get_faker
-from shared.common.utils import create_finnish_social_security_number
 
 LOGGER = logging.getLogger(__name__)
 
@@ -20,10 +15,6 @@ LOGGER = logging.getLogger(__name__)
 def has_whitespace(value):
     value_without_whitespace = "".join(value.split())
     return value != value_without_whitespace
-
-
-def normalize_whitespace(value):
-    return " ".join(value.split())
 
 
 def is_uppercase(value):
@@ -122,23 +113,6 @@ def validate_finnish_social_security_number(value):
         )
 
 
-def get_random_social_security_number_for_year(year: int) -> str:
-    """
-    Create a random non-temporary Finnish social security number for the given year
-    """
-    start_of_year: datetime = datetime(year=year, month=1, day=1, tzinfo=timezone.utc)
-    return create_finnish_social_security_number(
-        birthdate=get_faker()
-        .date_time_between(
-            start_of_year,
-            start_of_year + relativedelta(years=1, seconds=-1),  # Inclusive range
-            tzinfo=timezone.utc,
-        )
-        .date(),
-        individual_number=get_faker().pyint(2, 899),  # Inclusive range
-    )
-
-
 def validate_optional_finnish_social_security_number(value):
     """
     Raise a ValidationError if the given value is not None, an empty string or an
@@ -169,7 +143,3 @@ def getattr_nested(obj, attrs: list):
             with translation.override("fi"):
                 value = getattr(obj, f"get_{attr}_display")()
         return value
-
-
-# Create datetime with UTC timezone
-utc_datetime = partial(datetime, tzinfo=timezone.utc)

--- a/backend/shared/shared/common/tests/test_utils.py
+++ b/backend/shared/shared/common/tests/test_utils.py
@@ -4,11 +4,13 @@ import pytest
 import stdnum.exceptions
 from django.db.models import Q
 
+from shared.common.tests.utils import (
+    create_finnish_social_security_number,
+    set_setting_to_value_or_del_with_none,
+)
 from shared.common.utils import (
     _ALWAYS_FALSE_Q_FILTER,
     any_of_q_filter,
-    create_finnish_social_security_number,
-    set_setting_to_value_or_del_with_none,
     social_security_number_birthdate,
     validate_finnish_social_security_number,
 )

--- a/backend/shared/shared/common/tests/test_utils.py
+++ b/backend/shared/shared/common/tests/test_utils.py
@@ -7,8 +7,10 @@ from django.db.models import Q
 from shared.common.utils import (
     _ALWAYS_FALSE_Q_FILTER,
     any_of_q_filter,
+    create_finnish_social_security_number,
     set_setting_to_value_or_del_with_none,
     social_security_number_birthdate,
+    validate_finnish_social_security_number,
 )
 
 _TEST_SETTING_NAMES = [
@@ -90,6 +92,75 @@ def test_any_of_q_filter(input_kwargs, expected_q_filter):
 )
 def test_valid_social_security_number_birthdate(test_value, expected_result):
     assert social_security_number_birthdate(test_value) == expected_result
+
+
+@pytest.mark.parametrize(
+    "expected_result,birthdate,individual_number",
+    [
+        ("010100+002H", date(year=1800, month=1, day=1), 2),
+        ("010203-1230", date(year=1903, month=2, day=1), 123),
+        ("121212A899H", date(year=2012, month=12, day=12), 899),
+        ("111111-002V", date(year=1911, month=11, day=11), 2),
+        ("111111-111C", date(year=1911, month=11, day=11), 111),
+        ("111111A111C", date(year=2011, month=11, day=11), 111),
+        ("111111-900U", date(year=1911, month=11, day=11), 900),
+        ("111111-9991", date(year=1911, month=11, day=11), 999),
+        ("300522A0024", date(year=2022, month=5, day=30), 2),
+        ("311299A999E", date(year=2099, month=12, day=31), 999),
+    ],
+)
+def test_valid_create_finnish_social_security_number(
+    expected_result: str, birthdate: date, individual_number: int
+):
+    assert validate_finnish_social_security_number(
+        expected_result, allow_temporary=True
+    )
+    assert (
+        create_finnish_social_security_number(birthdate, individual_number)
+        == expected_result
+    )
+
+
+@pytest.mark.parametrize(
+    "birthdate",
+    [
+        date(year=1800, month=1, day=1),
+        date(year=1934, month=10, day=25),
+        date(year=2022, month=5, day=30),
+        date(year=2023, month=8, day=19),
+        date(year=2099, month=12, day=31),
+    ],
+)
+def test_valid_consecutive_create_finnish_social_security_number(birthdate: date):
+    """
+    Testing consecutive social security numbers for validity to ensure all their parts
+    are calculated correctly, including the checksum (i.e. the last character).
+    """
+    for individual_number in range(2, 900):
+        result = create_finnish_social_security_number(birthdate, individual_number)
+        assert len(result) == 11
+        assert validate_finnish_social_security_number(result, allow_temporary=True)
+        individual_number_from_result: int = int(result[-4:-1])
+        assert individual_number_from_result == individual_number
+        assert social_security_number_birthdate(result) == birthdate
+
+
+@pytest.mark.parametrize(
+    "birthdate,individual_number",
+    [
+        (date(year=1799, month=12, day=31), 2),  # Birth year < 1800
+        (date(year=2100, month=1, day=1), 2),  # Birth year > 2099
+        (date(year=2000, month=1, day=1), -1),  # Individual number < 2
+        (date(year=2000, month=1, day=1), 0),  # Individual number < 2
+        (date(year=2000, month=1, day=1), 1),  # Individual number < 2
+        (date(year=2000, month=1, day=1), 1000),  # Individual number > 999
+    ],
+)
+def test_invalid_create_finnish_social_security_number(
+    birthdate: date, individual_number: int
+):
+    with pytest.raises(ValueError):
+        assert create_finnish_social_security_number(birthdate, individual_number)
 
 
 @pytest.mark.django_db

--- a/backend/shared/shared/common/tests/utils.py
+++ b/backend/shared/shared/common/tests/utils.py
@@ -1,0 +1,61 @@
+from datetime import date, datetime, timezone
+from functools import partial
+
+from django.conf import settings
+
+
+def create_finnish_social_security_number(
+    birthdate: date, individual_number: int
+) -> str:
+    """
+    Create a Finnish social security number based on birthdate and individual number
+
+    :param birthdate: Date of birth
+    :param individual_number: Integer value where 2 <= individual_number <= 999
+    :return: Finnish social security number in format <ddmmyyciiis> where
+             dd = day of birth with leading zeroes,
+             mm = month of birth with leading zeroes,
+             yy = year of birth modulo 100 with leading zeroes,
+             c = century of birth ("+" = 1800, "-" = 1900, "A" = 2000),
+             iii = individual number in range 2–999 with leading zeroes,
+             s = checksum value calculated from <ddmmyyiii>.
+    :raises ValueError: if not (1800 <= birthdate.year <= 2099)
+    :raises ValueError: if not (2 <= individual_number <= 999)
+    """
+    if not (1800 <= birthdate.year <= 2099):
+        raise ValueError("Invalid birthdate year, only years 1800–2099 are supported")
+    if not (2 <= individual_number <= 999):
+        raise ValueError("Invalid individual number, must be in range 2–999")
+    ddmmyy: str = f"{birthdate.day:02}{birthdate.month:02}{birthdate.year % 100:02}"
+    iii: str = f"{individual_number:003}"
+    ddmmyyiii: str = f"{ddmmyy}{iii}"
+    century_char: str = {18: "+", 19: "-", 20: "A"}[birthdate.year // 100]
+    checksum_char: str = "0123456789ABCDEFHJKLMNPRSTUVWXY"[int(ddmmyyiii) % 31]
+    return f"{ddmmyy}{century_char}{iii}{checksum_char}"
+
+
+def normalize_whitespace(value: str) -> str:
+    """
+    Normalize whitespace by compacting inner whitespace to single space and removing
+    leading and trailing whitespace.
+
+    For example:
+        normalize_whitespace("  1st   2nd    3rd   ") == "1st 2nd 3rd"
+    """
+    return " ".join(value.split())
+
+
+def set_setting_to_value_or_del_with_none(setting_name: str, setting_value) -> None:
+    """
+    Set setting <setting_name> to value <setting_value> if <setting_value> is not None,
+    otherwise delete the setting <setting_name> if it exists.
+    """
+    if setting_value is None:
+        if hasattr(settings, setting_name):
+            delattr(settings, setting_name)
+    else:
+        setattr(settings, setting_name, setting_value)
+
+
+# Create datetime with UTC timezone
+utc_datetime = partial(datetime, tzinfo=timezone.utc)

--- a/backend/shared/shared/common/utils.py
+++ b/backend/shared/shared/common/utils.py
@@ -137,3 +137,33 @@ def social_security_number_birthdate(social_security_number) -> date:
     century_char = compacted_social_security_number[6]
     century = {"+": 1800, "-": 1900, "A": 2000}[century_char]
     return date(year=century + year_mod_100, month=month, day=day)
+
+
+def create_finnish_social_security_number(
+    birthdate: date, individual_number: int
+) -> str:
+    """
+    Create a Finnish social security number based on birthdate and individual number
+
+    :param birthdate: Date of birth
+    :param individual_number: Integer value where 2 <= individual_number <= 999
+    :return: Finnish social security number in format <ddmmyyciiis> where
+             dd = day of birth with leading zeroes,
+             mm = month of birth with leading zeroes,
+             yy = year of birth modulo 100 with leading zeroes,
+             c = century of birth ("+" = 1800, "-" = 1900, "A" = 2000),
+             iii = individual number in range 2–999 with leading zeroes,
+             s = checksum value calculated from <ddmmyyiii>.
+    :raises ValueError: if not (1800 <= birthdate.year <= 2099)
+    :raises ValueError: if not (2 <= individual_number <= 999)
+    """
+    if not (1800 <= birthdate.year <= 2099):
+        raise ValueError("Invalid birthdate year, only years 1800–2099 are supported")
+    if not (2 <= individual_number <= 999):
+        raise ValueError("Invalid individual number, must be in range 2–999")
+    ddmmyy: str = f"{birthdate.day:02}{birthdate.month:02}{birthdate.year % 100:02}"
+    iii: str = f"{individual_number:003}"
+    ddmmyyiii: str = f"{ddmmyy}{iii}"
+    century_char: str = {18: "+", 19: "-", 20: "A"}[birthdate.year // 100]
+    checksum_char: str = "0123456789ABCDEFHJKLMNPRSTUVWXY"[int(ddmmyyiii) % 31]
+    return f"{ddmmyy}{century_char}{iii}{checksum_char}"

--- a/backend/shared/shared/common/utils.py
+++ b/backend/shared/shared/common/utils.py
@@ -16,18 +16,6 @@ from stdnum.fi.hetu import (
 _ALWAYS_FALSE_Q_FILTER = Q(pk=None)  # A hack but works as primary keys can't be null
 
 
-def set_setting_to_value_or_del_with_none(setting_name: str, setting_value) -> None:
-    """
-    Set setting <setting_name> to value <setting_value> if <setting_value> is not None,
-    otherwise delete the setting <setting_name> if it exists.
-    """
-    if setting_value is None:
-        if hasattr(settings, setting_name):
-            delattr(settings, setting_name)
-    else:
-        setattr(settings, setting_name, setting_value)
-
-
 def any_of_q_filter(**kwargs):
     """
     Return Q filters combined with | i.e. match any of the given keyword arguments.
@@ -137,33 +125,3 @@ def social_security_number_birthdate(social_security_number) -> date:
     century_char = compacted_social_security_number[6]
     century = {"+": 1800, "-": 1900, "A": 2000}[century_char]
     return date(year=century + year_mod_100, month=month, day=day)
-
-
-def create_finnish_social_security_number(
-    birthdate: date, individual_number: int
-) -> str:
-    """
-    Create a Finnish social security number based on birthdate and individual number
-
-    :param birthdate: Date of birth
-    :param individual_number: Integer value where 2 <= individual_number <= 999
-    :return: Finnish social security number in format <ddmmyyciiis> where
-             dd = day of birth with leading zeroes,
-             mm = month of birth with leading zeroes,
-             yy = year of birth modulo 100 with leading zeroes,
-             c = century of birth ("+" = 1800, "-" = 1900, "A" = 2000),
-             iii = individual number in range 2–999 with leading zeroes,
-             s = checksum value calculated from <ddmmyyiii>.
-    :raises ValueError: if not (1800 <= birthdate.year <= 2099)
-    :raises ValueError: if not (2 <= individual_number <= 999)
-    """
-    if not (1800 <= birthdate.year <= 2099):
-        raise ValueError("Invalid birthdate year, only years 1800–2099 are supported")
-    if not (2 <= individual_number <= 999):
-        raise ValueError("Invalid individual number, must be in range 2–999")
-    ddmmyy: str = f"{birthdate.day:02}{birthdate.month:02}{birthdate.year % 100:02}"
-    iii: str = f"{individual_number:003}"
-    ddmmyyiii: str = f"{ddmmyy}{iii}"
-    century_char: str = {18: "+", 19: "-", 20: "A"}[birthdate.year // 100]
-    checksum_char: str = "0123456789ABCDEFHJKLMNPRSTUVWXY"[int(ddmmyyiii) % 31]
-    return f"{ddmmyy}{century_char}{iii}{checksum_char}"

--- a/backend/shared/shared/oidc/tests/test_auth_backend.py
+++ b/backend/shared/shared/oidc/tests/test_auth_backend.py
@@ -12,7 +12,7 @@ from django.test import override_settings, RequestFactory
 from django.utils import timezone
 
 from shared.common.tests.conftest import store_tokens_in_session
-from shared.common.utils import set_setting_to_value_or_del_with_none
+from shared.common.tests.utils import set_setting_to_value_or_del_with_none
 from shared.oidc.auth import HelsinkiOIDCAuthenticationBackend
 from shared.oidc.utils import store_token_info_in_oidc_session
 


### PR DESCRIPTION
## Description :sparkles:

### KS-Backend: Fix need_additional_info generating in factories 

Previously determine_target_group_social_security_number function
sometimes returned social security numbers for two different years.
When NEXT_PUBLIC_DISABLE_VTJ was set to True and
determine_target_group_social_security_number returned a social security
number with year difference of 17 from the current year rather than 16
it made YouthApplication.need_additional_info return True.

Now the determine_target_group_social_security_number only returns
social security numbers with a year difference of 16 from the current
year and AbstractYouthApplicationFactory based factories that expect a
certain need_additional_info value in their created object work with
both NEXT_PUBLIC_DISABLE_VTJ=False and NEXT_PUBLIC_DISABLE_VTJ=True.

Add test_need_additional_info test to test_factories.py to check that
need_additional_info is properly generated in factories.

Add test test_get_random_social_security_number_for_year to test that
get_random_social_security_number_for_year generates valid non-temporary
Finnish social security numbers for a given year.

Shared backend code:
 - Add create_finnish_social_security_number to create a Finnish social
   security number based on birthdate and individual number
 - Add tests for create_finnish_social_security_number
   - test_valid_create_finnish_social_security_number
   - test_valid_consecutive_create_finnish_social_security_number
   - test_invalid_create_finnish_social_security_number

Refs YJDH-655
 
### KS-Backend: Make use of get_faker function to speed up tests 

Not needing to instantiate Faker object but using the same Faker
object sped up locally running all tests using
"pytest . --pyargs shared -vv" from ~320s to ~150s.
Tried once on Windows 10 using Docker Desktop and WSL 2.

Refs YJDH-655 (Thought of the shared Faker object during this ticket)

### HL/KS/Shared-Backends: Move test utils to tests/utils.py 

Move these functions only used in tests to shared.common.tests.utils:
 - create_finnish_social_security_number
 - normalize_whitespace
 - set_setting_to_value_or_del_with_none
 - utc_datetime

KS-Backend:
 - Move get_random_social_security_number_for_year to common.tests.utils

Refs YJDH-655 (Refactoring)

## Issues :bug:

[YJDH-655](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-655)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-655]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ