### PR TITLE
HL-613 | For handler, register EN and SV languages to nextjs but remove the language selector

### DIFF
--- a/frontend/benefit/handler/next-i18next.config.js
+++ b/frontend/benefit/handler/next-i18next.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   i18n: {
     defaultLocale: 'fi',
-    locales: ['fi'],
+    locales: ['fi', 'en', 'sv'],
     localeDetection: false,
   },
 };

--- a/frontend/benefit/handler/src/components/header/Header.tsx
+++ b/frontend/benefit/handler/src/components/header/Header.tsx
@@ -5,20 +5,14 @@ import BaseHeader from 'shared/components/header/Header';
 import { useHeader } from './useHeader';
 
 const Header: React.FC = () => {
-  const {
-    t,
-    languageOptions,
-    navigationItems,
-    isNavigationVisible,
-    handleLanguageChange,
-  } = useHeader();
+  const { t, navigationItems, isNavigationVisible, handleLanguageChange } =
+    useHeader();
 
   return (
     <BaseHeader
       title={t('common:appName')}
       titleUrl={ROUTES.HOME}
       menuToggleAriaLabel={t('common:menuToggleAriaLabel')}
-      languages={languageOptions}
       isNavigationVisible={isNavigationVisible}
       navigationItems={navigationItems}
       onLanguageChange={handleLanguageChange}


### PR DESCRIPTION
* Remove language selector from handler frontend (only FI will be used for now)
* Future proof language switch behaviour: register SV and EN to handler / nextjs so that switching won't crash the whole app