### PR TITLE
HL-616 | Fix keys for footer's copyright text translations

### DIFF
--- a/frontend/benefit/handler/src/components/footer/Footer.tsx
+++ b/frontend/benefit/handler/src/components/footer/Footer.tsx
@@ -17,8 +17,8 @@ const FooterSection: React.FC = () => {
     <$FooterWrapper>
       <Footer title={t('common:appName')} theme="dark">
         <Footer.Base
-          copyrightHolder={t('footer:copyrightText')}
-          copyrightText={t('footer:allRightsReservedText')}
+          copyrightHolder={t('footer.copyrightText')}
+          copyrightText={t('footer.allRightsReservedText')}
         />
       </Footer>
     </$FooterWrapper>


### PR DESCRIPTION
Fix HL handler's footer translation keys.

![image](https://user-images.githubusercontent.com/5328394/210790844-cc0c0e90-3fda-4522-8dca-11560e0b0d73.png)
