### PR TITLE
HL-614 | Bump all project's versions to use hds-react 2.10.0

### DIFF
--- a/frontend/benefit/applicant/package.json
+++ b/frontend/benefit/applicant/package.json
@@ -27,7 +27,7 @@
     "dotenv": "^16.0.0",
     "finnish-ssn": "^2.0.4",
     "formik": "^2.2.9",
-    "hds-react": "^1.15.0",
+    "hds-react": "^2.9.0",
     "lodash": "^4.17.21",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/benefit/applicant/package.json
+++ b/frontend/benefit/applicant/package.json
@@ -27,7 +27,7 @@
     "dotenv": "^16.0.0",
     "finnish-ssn": "^2.0.4",
     "formik": "^2.2.9",
-    "hds-react": "^2.9.0",
+    "hds-react": "^2.10.0",
     "lodash": "^4.17.21",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/benefit/handler/package.json
+++ b/frontend/benefit/handler/package.json
@@ -23,7 +23,7 @@
     "camelcase-keys": "^7.0.2",
     "dotenv": "^16.0.0",
     "formik": "^2.2.9",
-    "hds-react": "^1.15.0",
+    "hds-react": "^2.9.0",
     "lodash": "^4.17.21",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/benefit/handler/package.json
+++ b/frontend/benefit/handler/package.json
@@ -23,7 +23,7 @@
     "camelcase-keys": "^7.0.2",
     "dotenv": "^16.0.0",
     "formik": "^2.2.9",
-    "hds-react": "^2.9.0",
+    "hds-react": "^2.10.0",
     "lodash": "^4.17.21",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/benefit/shared/package.json
+++ b/frontend/benefit/shared/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@frontend/shared": "*",
     "camelcase-keys": "^7.0.1",
-    "hds-react": "^1.15.0",
+    "hds-react": "^2.9.0",
     "styled-components": "^5.3.3"
   },
   "devDependencies": {

--- a/frontend/benefit/shared/package.json
+++ b/frontend/benefit/shared/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@frontend/shared": "*",
     "camelcase-keys": "^7.0.1",
-    "hds-react": "^2.9.0",
+    "hds-react": "^2.10.0",
     "styled-components": "^5.3.3"
   },
   "devDependencies": {

--- a/frontend/kesaseteli/employer/package.json
+++ b/frontend/kesaseteli/employer/package.json
@@ -24,7 +24,7 @@
     "axios": "^0.27.2",
     "babel-plugin-import": "^1.13.3",
     "dotenv": "^16.0.0",
-    "hds-react": "^1.15.0",
+    "hds-react": "^2.9.0",
     "ibantools": "^4.1.5",
     "lodash": "^4.17.21",
     "next": "^11.1.4",

--- a/frontend/kesaseteli/employer/package.json
+++ b/frontend/kesaseteli/employer/package.json
@@ -24,7 +24,7 @@
     "axios": "^0.27.2",
     "babel-plugin-import": "^1.13.3",
     "dotenv": "^16.0.0",
-    "hds-react": "^2.9.0",
+    "hds-react": "^2.10.0",
     "ibantools": "^4.1.5",
     "lodash": "^4.17.21",
     "next": "^11.1.4",

--- a/frontend/kesaseteli/handler/package.json
+++ b/frontend/kesaseteli/handler/package.json
@@ -25,7 +25,7 @@
     "babel-plugin-import": "^1.13.3",
     "dotenv": "^16.0.0",
     "finnish-ssn": "^2.0.4",
-    "hds-react": "^2.9.0",
+    "hds-react": "^2.10.0",
     "lodash": "^4.17.21",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/kesaseteli/handler/package.json
+++ b/frontend/kesaseteli/handler/package.json
@@ -25,7 +25,7 @@
     "babel-plugin-import": "^1.13.3",
     "dotenv": "^16.0.0",
     "finnish-ssn": "^2.0.4",
-    "hds-react": "^1.15.0",
+    "hds-react": "^2.9.0",
     "lodash": "^4.17.21",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/kesaseteli/youth/package.json
+++ b/frontend/kesaseteli/youth/package.json
@@ -25,7 +25,7 @@
     "babel-plugin-import": "^1.13.3",
     "dotenv": "^16.0.0",
     "finnish-ssn": "^2.0.4",
-    "hds-react": "^2.9.0",
+    "hds-react": "^2.10.0",
     "lodash": "^4.17.21",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/kesaseteli/youth/package.json
+++ b/frontend/kesaseteli/youth/package.json
@@ -25,7 +25,7 @@
     "babel-plugin-import": "^1.13.3",
     "dotenv": "^16.0.0",
     "finnish-ssn": "^2.0.4",
-    "hds-react": "^1.15.0",
+    "hds-react": "^2.9.0",
     "lodash": "^4.17.21",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/shared/package.json
+++ b/frontend/shared/package.json
@@ -22,7 +22,7 @@
     "express": "^4.17.1",
     "fast-deep-equal": "^3.1.3",
     "finnish-ssn": "^2.0.4",
-    "hds-react": "^2.9.0",
+    "hds-react": "^2.10.0",
     "js-file-download": "^0.4.12",
     "lodash": "^4.17.21",
     "next": "^11.1.4",

--- a/frontend/shared/package.json
+++ b/frontend/shared/package.json
@@ -22,7 +22,7 @@
     "express": "^4.17.1",
     "fast-deep-equal": "^3.1.3",
     "finnish-ssn": "^2.0.4",
-    "hds-react": "^1.15.0",
+    "hds-react": "^2.9.0",
     "js-file-download": "^0.4.12",
     "lodash": "^4.17.21",
     "next": "^11.1.4",

--- a/frontend/tet/admin/package.json
+++ b/frontend/tet/admin/package.json
@@ -25,7 +25,7 @@
     "babel-plugin-import": "^1.13.3",
     "date-fns": "^2.24.0",
     "dotenv": "^16.0.0",
-    "hds-react": "^2.9.0",
+    "hds-react": "^2.10.0",
     "leaflet": "^1.7.1",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/tet/admin/package.json
+++ b/frontend/tet/admin/package.json
@@ -25,7 +25,7 @@
     "babel-plugin-import": "^1.13.3",
     "date-fns": "^2.24.0",
     "dotenv": "^16.0.0",
-    "hds-react": "^1.15.0",
+    "hds-react": "^2.9.0",
     "leaflet": "^1.7.1",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/tet/shared/package.json
+++ b/frontend/tet/shared/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@frontend/shared": "*",
     "axios": "^0.27.2",
-    "hds-react": "^1.15.0",
+    "hds-react": "^2.9.0",
     "next": "^11.1.4",
     "next-i18next": "^10.5.0",
     "react-query": "^3.34.0",

--- a/frontend/tet/shared/package.json
+++ b/frontend/tet/shared/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@frontend/shared": "*",
     "axios": "^0.27.2",
-    "hds-react": "^2.9.0",
+    "hds-react": "^2.10.0",
     "next": "^11.1.4",
     "next-i18next": "^10.5.0",
     "react-query": "^3.34.0",

--- a/frontend/tet/youth/package.json
+++ b/frontend/tet/youth/package.json
@@ -26,7 +26,7 @@
     "leaflet": "^1.7.1",
     "leaflet.markercluster": "^1.5.3",
     "dotenv": "^16.0.0",
-    "hds-react": "^2.9.0",
+    "hds-react": "^2.10.0",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^10.5.0",

--- a/frontend/tet/youth/package.json
+++ b/frontend/tet/youth/package.json
@@ -26,7 +26,7 @@
     "leaflet": "^1.7.1",
     "leaflet.markercluster": "^1.5.3",
     "dotenv": "^16.0.0",
-    "hds-react": "^1.15.0",
+    "hds-react": "^2.9.0",
     "next": "^11.1.4",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^10.5.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7594,15 +7594,15 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hds-core@2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-2.9.0.tgz#0b5a42c27ac2bb97f3e57af1a22c2cc0bc46502f"
-  integrity sha512-Hv9decQIqK5+zwthsODC76TBx0XgCd+83a/uoiZVcYqfJBhFXzEyfdzQjrZ417Zup3pnm9MHcRXH05xIBCqafg==
+hds-core@2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-2.10.0.tgz#bbead215341313cc15591387c0a8d3f013caff4a"
+  integrity sha512-bWVMtSC9PrsiCFDR2myMgXH9vh0iAP+UsuiW/jEo538WCQmAsQPqEAWsRps4GFtRZEAb+OWX+LTNNLwjAHvo1A==
 
-hds-react@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-2.9.0.tgz#7edae4864159b98eee73e71905d50a7cc90dbc0d"
-  integrity sha512-YfjH3KBCaxGuzcl4lbPUGMvNcuuC3iOmixvKhYnV6dAl29x5BI2B1bE7rI3oSwwsWbvvp0LZV41zJxC20yrb1A==
+hds-react@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-2.10.0.tgz#f536b49cc206cf5d10ef6fb877622a0d85dbfbfa"
+  integrity sha512-a3r0Iv67F2qJvORVXatFAFcW4F6ngHYjXNm4eH1Uc0OsZMNaAnlTDaI6CP2y6L2JQBr/70Q/FbjBE/6MHyL1XA==
   dependencies:
     "@babel/runtime" "7.11.2"
     "@emotion/styled-base" "^11.0.0"
@@ -7614,7 +7614,7 @@ hds-react@^2.9.0:
     crc-32 "1.2.0"
     date-fns "2.16.1"
     downshift "6.0.6"
-    hds-core "2.9.0"
+    hds-core "2.10.0"
     kashe "1.0.4"
     lodash.get "^4.4.2"
     lodash.isequal "4.5.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2571,10 +2571,10 @@
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
 
-"@popperjs/core@2.5.3":
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
-  integrity sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg==
+"@popperjs/core@2.11.5":
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
+  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
 "@reach/observe-rect@^1.1.0":
   version "1.2.0"
@@ -3171,6 +3171,11 @@
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
   integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
+
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
 "@types/error-stack-parser@^2.0.0":
   version "2.0.0"
@@ -4735,7 +4740,7 @@ chai@4.3.4:
     pathval "^1.1.1"
     type-detect "^4.0.5"
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.0:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -5337,6 +5342,14 @@ cosmiconfig@^7, cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+crc-32@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
 
 create-ecdh@^4.0.0:
   version "4.0.4"
@@ -6813,6 +6826,11 @@ execa@^5.0.0, execa@^5.1.1:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -7199,6 +7217,13 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-double@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/function-double/-/function-double-1.0.4.tgz#46074f215a171594036d816fa963c2902b482c86"
+  integrity sha512-J+vMIwmWx/uY3Fc4TNeyPyQOjSbaWpHO/xj+tv8RbViLfPipFGohgOWN+kSkuWTwSZPZxMfYopECUA/9Tq8YJA==
+  dependencies:
+    util-arity "^1.1.0"
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
@@ -7569,34 +7594,44 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hds-core@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-1.15.0.tgz#9ffd51e5b75c6ef16dc9afa1366ac474c9d95a18"
-  integrity sha512-+eroRfvXK5hVMLcOshJcLkag11YnlCQlz4VxiTpiCkIcfoP70V10e3NI5c/NsChz/8VNcfqfeIjgZf2q2UxFWw==
+hds-core@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-2.9.0.tgz#0b5a42c27ac2bb97f3e57af1a22c2cc0bc46502f"
+  integrity sha512-Hv9decQIqK5+zwthsODC76TBx0XgCd+83a/uoiZVcYqfJBhFXzEyfdzQjrZ417Zup3pnm9MHcRXH05xIBCqafg==
 
-hds-react@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-1.15.0.tgz#68d1e184052908c97f047ee8d26d452c0af7294f"
-  integrity sha512-Plod/29C4J/quVyCiN7oIZpxPL+jUwwMfOL5eOLQRlo2hbWzSzid0/0b/TYWUmiYP9moV072OcZ9t5FymDAjRw==
+hds-react@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-2.9.0.tgz#7edae4864159b98eee73e71905d50a7cc90dbc0d"
+  integrity sha512-YfjH3KBCaxGuzcl4lbPUGMvNcuuC3iOmixvKhYnV6dAl29x5BI2B1bE7rI3oSwwsWbvvp0LZV41zJxC20yrb1A==
   dependencies:
     "@babel/runtime" "7.11.2"
     "@emotion/styled-base" "^11.0.0"
     "@juggle/resize-observer" "3.2.0"
-    "@popperjs/core" "2.5.3"
+    "@popperjs/core" "2.11.5"
     "@react-aria/visually-hidden" "3.2.0"
+    "@types/cookie" "^0.4.1"
+    cookie "^0.4.1"
+    crc-32 "1.2.0"
     date-fns "2.16.1"
     downshift "6.0.6"
-    hds-core "1.15.0"
+    hds-core "2.9.0"
+    kashe "1.0.4"
+    lodash.get "^4.4.2"
     lodash.isequal "4.5.0"
     lodash.isfunction "3.0.9"
+    lodash.isobject "3.0.2"
+    lodash.isundefined "3.0.1"
+    lodash.pick "^4.4.0"
+    lodash.pickby "^4.6.0"
     lodash.uniqueid "4.0.1"
     lodash.xor "^4.5.0"
+    memoize-one "5.2.1"
+    postcss "7.0.36"
     react-merge-refs "1.1.0"
-    react-popper "2.2.3"
+    react-popper "2.2.5"
     react-spring "9.3.0"
     react-use-measure "2.0.1"
     react-virtual "2.2.7"
-    typescript "4.5.5"
 
 he@1.2.0:
   version "1.2.0"
@@ -9114,6 +9149,14 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
+kashe@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/kashe/-/kashe-1.0.4.tgz#72f538d641f220eb4533a050f1f39b3acac7fafb"
+  integrity sha512-d4N2iljhOrTUszc+fRdfaFRPeu0+hZNbSlXnuTdVcN+IWFMByTNmQzA3SKb1bWctNVXi5RmYQYQjOWqu1mDXpw==
+  dependencies:
+    function-double "^1.0.4"
+    reselect "^4.0.0"
+
 kebab-case@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/kebab-case/-/kebab-case-1.0.1.tgz#bf734fc95400a3701869215d99a902bd3fe72f60"
@@ -9419,6 +9462,11 @@ lodash.isnumber@^3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
   integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
 
+lodash.isobject@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+  integrity sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
@@ -9428,6 +9476,11 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
+lodash.isundefined@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz#23ef3d9535565203a66cefd5b830f848911afb48"
+  integrity sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==
 
 lodash.last@^3.0.0:
   version "3.0.0"
@@ -9448,6 +9501,16 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==
+
+lodash.pickby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
+  integrity sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -9717,6 +9780,11 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
+memoize-one@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
 
 meow@^8.0.0:
   version "8.1.2"
@@ -11122,6 +11190,15 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
+postcss@7.0.36:
+  version "7.0.36"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
+  integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 postcss@8.2.15:
   version "8.2.15"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.15.tgz#9e66ccf07292817d226fc315cbbf9bc148fbca65"
@@ -11197,6 +11274,11 @@ pretty@^2.0.0:
     condense-newlines "^0.2.1"
     extend-shallow "^2.0.1"
     js-beautify "^1.6.12"
+
+printj@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -11574,10 +11656,10 @@ react-pdf@^5.7.2:
     tiny-invariant "^1.0.0"
     tiny-warning "^1.0.0"
 
-react-popper@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
-  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+react-popper@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
+  integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
@@ -12986,6 +13068,13 @@ supports-color@^5.3.0, supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
+  dependencies:
+    has-flag "^3.0.0"
+
 supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
@@ -13760,11 +13849,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
-
 typescript@^3.3.3:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
@@ -13921,6 +14005,11 @@ utf8-byte-length@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
   integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
+
+util-arity@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/util-arity/-/util-arity-1.1.0.tgz#59d01af1fdb3fede0ac4e632b0ab5f6ce97c9330"
+  integrity sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Description

Upgrade all frontends to hds-react ^2.9.0. Should be working out of the box. @nenonja might want to check and refactor Kesäseteli's accordion.

For more details, see the [official migration guide](https://hds.hel.fi/getting-started/hds-2.0/migrating-to-2.0). 

Ticket:
https://helsinkisolutionoffice.atlassian.net/browse/HL-614