### PR TITLE
YJDH-656 | KS-Frontend: Always show titles in employer UI's selection groups

### DIFF
--- a/frontend/kesaseteli/employer/src/components/application/form/SelectionGroup.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/SelectionGroup.tsx
@@ -17,7 +17,6 @@ type Props<V extends readonly string[]> = {
   id: ApplicationFieldPath;
   direction?: SelectionGroupProps['direction'];
   values: V;
-  showTitle?: boolean;
   onChange?: (value?: string) => void;
 } & GridCellProps;
 
@@ -26,7 +25,6 @@ const SelectionGroup = <V extends readonly string[]>({
   validation,
   direction,
   values,
-  showTitle,
   onChange = noop,
   ...$gridCellProps
 }: Props<V>): ReturnType<typeof HdsSelectionGroup> => {
@@ -66,9 +64,7 @@ const SelectionGroup = <V extends readonly string[]>({
           ? `${t('common:application.form.errors.selectionGroups')}`
           : undefined
       }
-      label={
-        showTitle ? t(`common:application.form.inputs.${fieldName}`) : undefined
-      }
+      label={t(`common:application.form.inputs.${fieldName}`)}
       onChange={handleChange}
       getValueText={getValueText}
       {...$gridCellProps}

--- a/frontend/kesaseteli/employer/src/components/application/steps/step2/accordions/EmploymentAccordion.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step2/accordions/EmploymentAccordion.tsx
@@ -84,7 +84,6 @@ const EmploymentAccordion: React.FC<Props> = ({ index }: Props) => {
         />
         <SelectionGroup
           id={getId('target_group')}
-          showTitle={false}
           validation={{
             required: true,
           }}


### PR DESCRIPTION
## Description :sparkles:

Affected selection groups in employer UI:
 - target_group
   - "Vuosiluokka tai syntymävuosi" in Finnish
 - hired_without_voucher_assessment
   - "Olisitko palkannut nuoren ilman kesäseteliä?" in Finnish

Previously the showTitle parameter to these selection groups was either false or not given at all and thus falsy. Thus their titles were not shown. Now the showTitle parameter is removed completely and the selection groups' titles are always shown.

## Issues :bug:

YJDH-656

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
