### PR TITLE
yjdh-657: fix endless loop on kesaseteli login page

### DIFF
--- a/frontend/kesaseteli/employer/src/__tests__/application.test.tsx
+++ b/frontend/kesaseteli/employer/src/__tests__/application.test.tsx
@@ -36,7 +36,11 @@ describe('frontend/kesaseteli/employer/src/pages/application.tsx', () => {
       const spyPush = jest.fn();
       renderPage(ApplicationPage, { push: spyPush });
       await waitFor(() =>
-        expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/login`)
+        expect(spyPush).toHaveBeenCalledWith(
+          `${DEFAULT_LANGUAGE}/login?sessionExpired=true`,
+          undefined,
+          { shallow: false }
+        )
       );
     });
 
@@ -51,8 +55,8 @@ describe('frontend/kesaseteli/employer/src/pages/application.tsx', () => {
         await waitFor(() =>
           expect(spyReplace).toHaveBeenCalledWith(
             `${DEFAULT_LANGUAGE}/`,
-            `${DEFAULT_LANGUAGE}/`,
-            {}
+            undefined,
+            { shallow: false }
           )
         );
       });
@@ -67,11 +71,9 @@ describe('frontend/kesaseteli/employer/src/pages/application.tsx', () => {
           locale,
         });
         await waitFor(() =>
-          expect(spyReplace).toHaveBeenCalledWith(
-            `${locale}/`,
-            `${locale}/`,
-            {}
-          )
+          expect(spyReplace).toHaveBeenCalledWith(`${locale}/`, undefined, {
+            shallow: false,
+          })
         );
       });
 
@@ -82,7 +84,11 @@ describe('frontend/kesaseteli/employer/src/pages/application.tsx', () => {
           const spyPush = jest.fn();
           renderPage(ApplicationPage, { query: { id }, push: spyPush });
           await waitFor(() => {
-            expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/500`);
+            expect(spyPush).toHaveBeenCalledWith(
+              `${DEFAULT_LANGUAGE}/500`,
+              undefined,
+              { shallow: false }
+            );
           });
         });
       });

--- a/frontend/kesaseteli/employer/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/employer/src/__tests__/index.test.tsx
@@ -33,7 +33,11 @@ describe('frontend/kesaseteli/employer/src/pages/index.tsx', () => {
     const spyPush = jest.fn();
     renderPage(IndexPage, { push: spyPush });
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/login`)
+      expect(spyPush).toHaveBeenCalledWith(
+        `${DEFAULT_LANGUAGE}/login?sessionExpired=true`,
+        undefined,
+        { shallow: false }
+      )
     );
   });
 
@@ -45,7 +49,11 @@ describe('frontend/kesaseteli/employer/src/pages/index.tsx', () => {
         const spyPush = jest.fn();
         renderPage(IndexPage, { push: spyPush });
         await waitFor(() =>
-          expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/500`)
+          expect(spyPush).toHaveBeenCalledWith(
+            `${DEFAULT_LANGUAGE}/500`,
+            undefined,
+            { shallow: false }
+          )
         );
       });
       it('Should show errorPage when applications creation error', async () => {
@@ -55,7 +63,11 @@ describe('frontend/kesaseteli/employer/src/pages/index.tsx', () => {
         const spyPush = jest.fn();
         renderPage(IndexPage, { push: spyPush });
         await waitFor(() =>
-          expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/500`)
+          expect(spyPush).toHaveBeenCalledWith(
+            `${DEFAULT_LANGUAGE}/500`,
+            undefined,
+            { shallow: false }
+          )
         );
       });
     });

--- a/frontend/kesaseteli/employer/src/pages/application.tsx
+++ b/frontend/kesaseteli/employer/src/pages/application.tsx
@@ -22,13 +22,13 @@ const ApplicationPage: NextPage = () => {
   const goToPage = useGoToPage();
 
   if (!isRouterLoading && !applicationId) {
-    void goToPage('/', { operation: 'replace' });
+    void goToPage('/', 'replace');
     return null;
   }
 
   if (applicationQuery.isSuccess) {
     if (applicationQuery.data.status !== 'draft' && applicationId) {
-      void goToPage(`/thankyou?id=${applicationId}`, { operation: 'replace' });
+      void goToPage(`/thankyou?id=${applicationId}`, 'replace');
     }
 
     return (

--- a/frontend/kesaseteli/employer/src/pages/thankyou.tsx
+++ b/frontend/kesaseteli/employer/src/pages/thankyou.tsx
@@ -36,9 +36,7 @@ const ThankYouPage: NextPage = () => {
   if (applicationQuery.isSuccess) {
     const application = applicationQuery.data;
     if (applicationId && application.status === 'draft') {
-      void goToPage(`/application?id=${applicationId}`, {
-        operation: 'replace',
-      });
+      void goToPage(`/application?id=${applicationId}`, 'replace');
     }
     return (
       <Container>

--- a/frontend/kesaseteli/handler/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/handler/src/__tests__/index.test.tsx
@@ -49,7 +49,11 @@ describe('frontend/kesaseteli/handler/src/pages/index.tsx', () => {
     const spyPush = jest.fn();
     renderPage(HandlerIndex, { push: spyPush, query: { id: '123-abc' } });
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/500`)
+      expect(spyPush).toHaveBeenCalledWith(
+        `${DEFAULT_LANGUAGE}/500`,
+        undefined,
+        { shallow: false }
+      )
     );
   });
 
@@ -520,7 +524,11 @@ describe('frontend/kesaseteli/handler/src/pages/index.tsx', () => {
         await indexPageApi.expectations.showsConfirmDialog(operationType);
         await indexPageApi.actions.clickConfirmButton(operationType, 500);
         await waitFor(() =>
-          expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/500`)
+          expect(spyPush).toHaveBeenCalledWith(
+            `${DEFAULT_LANGUAGE}/500`,
+            undefined,
+            { shallow: false }
+          )
         );
       });
     });

--- a/frontend/kesaseteli/youth/src/__tests__/additional_info.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/additional_info.test.tsx
@@ -39,7 +39,11 @@ describe('frontend/kesaseteli/youth/src/pages/additional_info.tsx', () => {
       query: { id: APPLICATION_ID },
     });
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/500`)
+      expect(spyPush).toHaveBeenCalledWith(
+        `${DEFAULT_LANGUAGE}/500`,
+        undefined,
+        { shallow: false }
+      )
     );
   });
 

--- a/frontend/kesaseteli/youth/src/__tests__/email_in_use.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/email_in_use.test.tsx
@@ -23,7 +23,9 @@ describe('frontend/kesaseteli/youth/src/pages/email_in_use.tsx', () => {
     await emailInUseApi.expectations.pageIsLoaded();
     await emailInUseApi.actions.clickGoToFrontPageButton();
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`)
+      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`, undefined, {
+        shallow: false,
+      })
     );
   });
 

--- a/frontend/kesaseteli/youth/src/__tests__/expired.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/expired.test.tsx
@@ -23,7 +23,9 @@ describe('frontend/kesaseteli/youth/src/pages/expired.tsx', () => {
     await expiredPageApi.expectations.pageIsLoaded();
     await expiredPageApi.actions.clickGoToFrontPageButton();
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`)
+      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`, undefined, {
+        shallow: false,
+      })
     );
   });
 

--- a/frontend/kesaseteli/youth/src/__tests__/inadmissible_data.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/inadmissible_data.test.tsx
@@ -23,7 +23,9 @@ describe('frontend/kesaseteli/youth/src/pages/inadmissible_data.tsx', () => {
     await emailInUseApi.expectations.pageIsLoaded();
     await emailInUseApi.actions.clickGoToFrontPageButton();
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`)
+      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`, undefined, {
+        shallow: false,
+      })
     );
   });
 });

--- a/frontend/kesaseteli/youth/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/index.test.tsx
@@ -213,7 +213,11 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
         backendExpectation: expectToCreateYouthApplication,
       });
       await waitFor(() =>
-        expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/thankyou`)
+        expect(spyPush).toHaveBeenCalledWith(
+          `${DEFAULT_LANGUAGE}/thankyou`,
+          undefined,
+          { shallow: false }
+        )
       );
     });
 
@@ -227,7 +231,11 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
         backendExpectation: expectToCreateYouthApplication,
       });
       await waitFor(() =>
-        expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/thankyou`)
+        expect(spyPush).toHaveBeenCalledWith(
+          `${DEFAULT_LANGUAGE}/thankyou`,
+          undefined,
+          { shallow: false }
+        )
       );
     });
 
@@ -244,7 +252,11 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
         backendExpectation: expectToCreateYouthApplication,
       });
       await waitFor(() =>
-        expect(spyPush).toHaveBeenCalledWith(`${language}/thankyou`)
+        expect(spyPush).toHaveBeenCalledWith(
+          `${language}/thankyou`,
+          undefined,
+          { shallow: false }
+        )
       );
     });
 
@@ -271,7 +283,11 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
         backendExpectation: expectToReplyErrorWhenCreatingYouthApplication(500),
       });
       await waitFor(() =>
-        expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/500`)
+        expect(spyPush).toHaveBeenCalledWith(
+          `${DEFAULT_LANGUAGE}/500`,
+          undefined,
+          { shallow: false }
+        )
       );
     });
 
@@ -290,9 +306,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
           ),
         });
         await waitFor(() =>
-          expect(spyPush).toHaveBeenCalledWith(
-            `${DEFAULT_LANGUAGE}/${errorType}`
-          )
+          expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/${errorType}`)
         );
       });
     }
@@ -354,7 +368,11 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
           backendExpectation: expectToCreateYouthApplication,
         });
         await waitFor(() =>
-          expect(spyPush).toHaveBeenCalledWith(`${language}/thankyou`)
+          expect(spyPush).toHaveBeenCalledWith(
+            `${language}/thankyou`,
+            undefined,
+            { shallow: false }
+          )
         );
       });
 
@@ -395,7 +413,11 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
             expectToReplyErrorWhenCreatingYouthApplication(500),
         });
         await waitFor(() =>
-          expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/500`)
+          expect(spyPush).toHaveBeenCalledWith(
+            `${DEFAULT_LANGUAGE}/500`,
+            undefined,
+            { shallow: false }
+          )
         );
       });
 
@@ -420,9 +442,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
             ),
           });
           await waitFor(() =>
-            expect(spyPush).toHaveBeenCalledWith(
-              `${DEFAULT_LANGUAGE}/${errorType}`
-            )
+            expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/${errorType}`)
           );
         });
       }

--- a/frontend/kesaseteli/youth/src/__tests__/thankyou.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/thankyou.test.tsx
@@ -25,7 +25,9 @@ describe('frontend/kesaseteli/youth/src/pages/thankyou.tsx', () => {
     await thankYouPageApi.expectations.pageIsLoaded();
     await thankYouPageApi.actions.clickGoToFrontPageButton();
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`)
+      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`, undefined, {
+        shallow: false,
+      })
     );
   });
 

--- a/frontend/shared/src/error-handler/error-handler.ts
+++ b/frontend/shared/src/error-handler/error-handler.ts
@@ -6,6 +6,7 @@ import { isError } from 'shared/utils/type-guards';
 type Params = {
   error: Error | unknown;
   t: TFunction;
+  pathname: string;
   goToPage: GoToPageFunction;
   onAuthError?: () => void;
   onServerError?: () => void;
@@ -13,9 +14,13 @@ type Params = {
 };
 
 const handleError = (args: Params): void => {
-  const { error, t, goToPage } = args;
+  const { error, t, pathname, goToPage } = args;
   const {
-    onAuthError = () => goToPage('/login?sessionExpired=true'),
+    onAuthError = () => {
+      if (pathname !== '/login') {
+        goToPage('/login?sessionExpired=true');
+      }
+    },
     onServerError = () => goToPage('/500'),
     onCommonError = () =>
       showErrorToast(

--- a/frontend/shared/src/hooks/useErrorHandler.ts
+++ b/frontend/shared/src/hooks/useErrorHandler.ts
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import handleError from 'shared/error-handler/error-handler';
 import useGoToPage from 'shared/hooks/useGoToPage';
@@ -12,10 +13,11 @@ type Props = {
 
 const useErrorHandler = (props: Props = {}): ErrorHandlerFunction => {
   const { t } = useTranslation();
+  const { pathname } = useRouter();
   const goToPage = useGoToPage();
 
   return (error: Error | unknown) =>
-    handleError({ error, t, goToPage, ...props });
+    handleError({ error, t, pathname, goToPage, ...props });
 };
 
 export default useErrorHandler;

--- a/frontend/shared/src/hooks/useGoToPage.ts
+++ b/frontend/shared/src/hooks/useGoToPage.ts
@@ -7,24 +7,19 @@ import GoToPageFunction from 'shared/types/go-to-page-function';
 const useGoToPage = (): GoToPageFunction => {
   const router = useRouter();
   const locale = useLocale();
-  const isRouting = useIsRouting();
-
+  const isAlreadyRouting = useIsRouting();
   return React.useCallback(
-    (pagePath, options): void => {
-      if (isRouting) {
-        // if already routing dont re-route;
+    (pagePath, operation = 'push'): void => {
+      // if already routing, or we're trying to route to same path (including query params), do nothing
+      if (isAlreadyRouting || pagePath === router.asPath) {
         return;
       }
       const path = `${locale}${pagePath || '/'}`;
-      if (options) {
-        const { operation, asPath, ...routerOptions } = options;
-        const op = operation ?? 'push';
-        void router[op](path, asPath ?? path, routerOptions);
-      } else {
-        void router.push(path);
-      }
+      // use shallow route when we are already on the same path (ignoring query params)
+      const shallow = pagePath === router.pathname;
+      void router[operation](path, undefined, { shallow });
     },
-    [locale, router, isRouting]
+    [locale, router, isAlreadyRouting]
   );
 };
 

--- a/frontend/shared/src/types/go-to-page-function.d.ts
+++ b/frontend/shared/src/types/go-to-page-function.d.ts
@@ -1,11 +1,6 @@
-type Options = {
-  operation?: 'push' | 'replace';
-  asPath?: string;
-  shallow?: boolean;
-  locale?: string | false;
-  scroll?: boolean;
-};
-
-type GoToPageFunction = (pagePath?: string, options?: Options) => void;
+type GoToPageFunction = (
+  pagePath?: string,
+  operation?: 'push' | 'replace'
+) => void;
 
 export default GoToPageFunction;

--- a/frontend/tet/admin/src/__tests__/copy.test.tsx
+++ b/frontend/tet/admin/src/__tests__/copy.test.tsx
@@ -20,6 +20,8 @@ describe('frontend/tet/admin/src/pages/copystatic.tsx', () => {
     expectUnauthorizedReply();
     const spyPush = jest.fn();
     renderPage(CopyStaticPage, { push: spyPush });
-    await waitFor(() => expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/login`));
+    await waitFor(() =>
+      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/login`, undefined, { shallow: false }),
+    );
   });
 });

--- a/frontend/tet/admin/src/__tests__/edit.test.tsx
+++ b/frontend/tet/admin/src/__tests__/edit.test.tsx
@@ -38,7 +38,9 @@ describe('frontend/tet/admin/src/pages/editstatic.tsx', () => {
     expectUnauthorizedReply();
     const spyPush = jest.fn();
     renderPage(EditStaticPage, { push: spyPush });
-    await waitFor(() => expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/login`));
+    await waitFor(() =>
+      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/login`, undefined, { shallow: false }),
+    );
   });
 
   // this test occasionally fails

--- a/frontend/tet/admin/src/__tests__/index.test.tsx
+++ b/frontend/tet/admin/src/__tests__/index.test.tsx
@@ -29,7 +29,13 @@ describe('frontend/tet/admin/src/pages/index.tsx', () => {
     expectUnauthorizedReply();
     const spyPush = jest.fn();
     renderPage(IndexPage, { push: spyPush });
-    await waitFor(() => expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/login`));
+    await waitFor(() =>
+      expect(spyPush).toHaveBeenCalledWith(
+        `${DEFAULT_LANGUAGE}/login?sessionExpired=true`,
+        undefined,
+        { shallow: false }
+      )
+    );
   });
 
   describe('when authorized', () => {


### PR DESCRIPTION
To make sure error handler doesn't cause infinite loop, let's do the following:
- if we are already on login page and get auth error, do nothing (because on login page we are not authorized yet)
- if we are routing to the same path where we already are, use shallow route (to avoid unnecessary refresh)
- if we are routing to exact same path where we already are, do nothing (to avoid loop)

## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
