### PR TITLE
HL-604 | Audit-ci should fail if packages are on high or critical level of vulnerability

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Install dependencies
         run: yarn --prefer-offline --frozen-lockfile --check-files
       - name: Run audit
-        run: yarn audit-ci
+        run: yarn audit-ci --config audit-ci.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,7 +92,7 @@
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.9.1",
     "@typescript-eslint/typescript-estree": "^5.13.0",
-    "audit-ci": "^6.1.2",
+    "audit-ci": "^6.6.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.4.1",
     "eslint-config-adjunct": "^4.11.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4094,10 +4094,10 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-audit-ci@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/audit-ci/-/audit-ci-6.1.2.tgz#b3d1beef263f3e090cbf2f7ee828e779c56965d6"
-  integrity sha512-WNhCpShNp5QE1wbfHgaY2QsjFb1SA7n/97tFY69LW7JN0VTQntH1SJQnIODrSAJQdbsf1yA9BOXKBAE2omeOgw==
+audit-ci@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/audit-ci/-/audit-ci-6.6.0.tgz#be31ba8c8097f29de2e3c97de7a316a4f10238ec"
+  integrity sha512-WzYlA3yxnisKcFGGlsbsUX5+6MvYdLxgjzoarWhCeJzKN5KDBNGOaIriVYZJtMTIObkSNGYQw0HEIDMrgXQkBA==
   dependencies:
     JSONStream "^1.3.5"
     cross-spawn "^7.0.3"


### PR DESCRIPTION
This PR fixes audit-ci passing everything with green flag.


If everything works fine, this should error out:
https://github.com/City-of-Helsinki/yjdh/actions/runs/3901962204/jobs/6664440057