### PR TITLE
HL-604 | Audit-ci should fail if packages are on critical level of vulnerability

### DIFF
--- a/.github/workflows/yarn-audit-scheduled.yml
+++ b/.github/workflows/yarn-audit-scheduled.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: yarn --prefer-offline --frozen-lockfile --check-files
       - name: Run audit
-        run: yarn audit-ci
+        run: yarn audit-ci --config audit-ci.json
       - name: Yarn audit scan failure slack notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/yarn-audit-scheduled.yml
+++ b/.github/workflows/yarn-audit-scheduled.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: yarn --prefer-offline --frozen-lockfile --check-files
       - name: Run audit
-        run: yarn audit-ci --config audit-ci.json
+        run: yarn audit-ci --config audit-ci.jsonc
       - name: Yarn audit scan failure slack notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/frontend/audit-ci.json
+++ b/frontend/audit-ci.json
@@ -1,6 +1,7 @@
 {
   "critical": true,
   "allowlist": [
+    "parse-url",
     "shell-quote",
     "loader-utils"
   ]

--- a/frontend/audit-ci.json
+++ b/frontend/audit-ci.json
@@ -1,8 +1,0 @@
-{
-  "critical": true,
-  "allowlist": [
-    "parse-url",
-    "shell-quote",
-    "loader-utils"
-  ]
-}

--- a/frontend/audit-ci.json
+++ b/frontend/audit-ci.json
@@ -1,4 +1,8 @@
 {
-  "high": true,
-  "allowlist": ["requestretry"]
+  "critical": true,
+  "allowlist": [
+    "parse-url",
+    "shell-quote",
+    "loader-utils"
+  ]
 }

--- a/frontend/audit-ci.json
+++ b/frontend/audit-ci.json
@@ -1,7 +1,6 @@
 {
   "critical": true,
   "allowlist": [
-    "parse-url",
     "shell-quote",
     "loader-utils"
   ]

--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -1,0 +1,13 @@
+{
+  "high": true,
+  "allowlist": [
+    "json5",                // jest, eslint, testcafe, next, babel 
+    "parse-url",            // lerna
+    "parse-path",           // lerna
+    "shell-quote",          // next
+    "loader-utils",         // next
+    "moment",               // testcafe
+    "jsonwebtoken",         // testcafe 
+    "requestretry"          // slack-node
+  ]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,7 +92,7 @@
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.9.1",
     "@typescript-eslint/typescript-estree": "^5.13.0",
-    "audit-ci": "^6.1.2",
+    "audit-ci": "^6.6.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.4.1",
     "eslint-config-adjunct": "^4.11.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4094,10 +4094,10 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-audit-ci@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/audit-ci/-/audit-ci-6.1.2.tgz#b3d1beef263f3e090cbf2f7ee828e779c56965d6"
-  integrity sha512-WNhCpShNp5QE1wbfHgaY2QsjFb1SA7n/97tFY69LW7JN0VTQntH1SJQnIODrSAJQdbsf1yA9BOXKBAE2omeOgw==
+audit-ci@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/audit-ci/-/audit-ci-6.6.0.tgz#be31ba8c8097f29de2e3c97de7a316a4f10238ec"
+  integrity sha512-WzYlA3yxnisKcFGGlsbsUX5+6MvYdLxgjzoarWhCeJzKN5KDBNGOaIriVYZJtMTIObkSNGYQw0HEIDMrgXQkBA==
   dependencies:
     JSONStream "^1.3.5"
     cross-spawn "^7.0.3"


### PR DESCRIPTION
`audit-ci` command didn't use a config file even though it was in place. This resulted in output without an error code and GH Action passed as completed. Now when the config is explicitly put in the workflow, action should report to Slack on any failure (that is, a critical level vulnerability on some package).

I've allowed for some packages that won't invoke a critical level failure. This is because these packages stem from `lerna` and `nextjs` that are on the @nenonja's workboard already and should be merged sooner or later (nextjs v12 and yarn v4 upgrade). Any additional critical vulnerabilities -- we should get the Slack alerts.

~You may have noticed that I've changed the alert level from **high** to **critical**. That's because there's so many of those errors, once again mostly from lerna and nextjs. Those upgrades should be prioritized first anyway.~ 

In hindsight I revert back to **high** vulnerability level and add more to allowlist.