### PR TITLE
Seeder improvements

### DIFF
--- a/backend/benefit/applications/management/commands/seed.py
+++ b/backend/benefit/applications/management/commands/seed.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import faker
+import pytz
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
@@ -74,7 +75,7 @@ def run_seed(number):
 
     for factory in factories:
         for _ in range(number):
-            random_datetime = f.past_datetime()
+            random_datetime = f.past_datetime(tzinfo=pytz.UTC)
             application = factory()
             application.created_at = random_datetime
             application.save()

--- a/backend/benefit/applications/management/commands/seed.py
+++ b/backend/benefit/applications/management/commands/seed.py
@@ -1,10 +1,10 @@
-import os
-import shutil
+from datetime import timedelta
 
 import faker
+from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
-import helsinkibenefit.settings as settings
 from applications.enums import ApplicationStatus
 from applications.models import Application, ApplicationBasis
 from applications.tests.factories import (
@@ -16,6 +16,7 @@ from applications.tests.factories import (
     ReceivedApplicationFactory,
     RejectedApplicationFactory,
 )
+from terms.models import Terms
 
 
 class Command(BaseCommand):
@@ -31,23 +32,32 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         total_created = len(ApplicationStatus.values) * options["number"]
-        if os.getenv("DEBUG") != "1":
-            self.stdout.write("Seeding is only allowed in debug mode")
+        if not settings.DEBUG:
+            self.stdout.write(
+                "Seeding is allowed only when the DEBUG variable set to True"
+            )
             return
         run_seed(options["number"])
         self.stdout.write(f"Created {total_created} applications")
 
 
 def clear_applications():
-    """Clear all seeded applications and application basis records,
+    """Clear all seeded applications and application basis records and terms,
     which are not deleted with on_delete=CASCADE and delete the media folder"""
-    Application.objects.all().delete()
+    applications = Application.objects.all()
+    for application in applications:
+        for attachment in application.attachments.all():
+            attachment.attachment_file.delete()
+    applications.delete()
+
     ApplicationBasis.objects.all().delete()
-    shutil.rmtree(settings.MEDIA_ROOT)
+    Terms.objects.all().delete()
 
 
 def run_seed(number):
-    """Delete all existing applications and create applications for all statuses"""
+    """Delete all existing applications and create applications for all statuses,
+    with cancelled applications being modified 31 days ago
+    """
     f = faker.Faker()
 
     clear_applications()
@@ -70,3 +80,8 @@ def run_seed(number):
             application.save()
 
             application.log_entries.all().update(created_at=random_datetime)
+
+    thirtyone_days_ago = timezone.now() - timedelta(days=31)
+
+    applications = Application.objects.filter(status=ApplicationStatus.CANCELLED)
+    applications.update(modified_at=thirtyone_days_ago)

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -153,7 +153,23 @@ def auto_accept_tos(autouse_django_db, accept_tos):
     return accept_tos
 
 
+@pytest.fixture()
+def set_debug_to_true(settings):
+    settings.DEBUG = True
+
+
+@pytest.fixture()
+def set_debug_to_false(settings):
+    settings.DEBUG = False
+
+
 def split_lines_at_semicolon(csv_string):
     # split CSV into lines and columns without using the csv library
     csv_lines = csv_string.splitlines()
     return [line.split(";") for line in csv_lines]
+
+
+def delete_attachments(application):
+    """Delete attachment files from the given applications"""
+    for attachment in application.attachments.all():
+        attachment.attachment_file.delete()

--- a/backend/benefit/applications/tests/test_application_tasks.py
+++ b/backend/benefit/applications/tests/test_application_tasks.py
@@ -11,7 +11,7 @@ from applications.models import Application, Attachment
 from applications.tests.factories import CancelledApplicationFactory
 
 
-def test_seed_applications_with_arguments():
+def test_seed_applications_with_arguments(set_debug_to_true):
     amount = 10
     statuses = ApplicationStatus.values
     total_created = len(ApplicationStatus.values) * amount
@@ -23,6 +23,14 @@ def test_seed_applications_with_arguments():
     )
     assert seeded_applications.count() == total_created
     assert f"Created {total_created} applications" in out.getvalue()
+
+
+def test_seed_is_not_allowed_when_debug_is_false(set_debug_to_false):
+    out = StringIO()
+    call_command("seed", stdout=out)
+    assert (
+        "Seeding is allowed only when the DEBUG variable set to True" in out.getvalue()
+    )
 
 
 def test_delete_cancelled_applications_older_than_30_days():


### PR DESCRIPTION
## Description :sparkles:
Improve the previously added seeder command so that it works better in the development environment where 
attachments are uploaded into Azure blob storage. 
- Delete attachments through the FileModelField class
- Check the DEBUG env-variable with django.conf
- Add a test for the DEBUG variable
- Modify seeder so that cancelled applications have  `modified_at` date older than 30 days.

## Issues :bug:

## Testing :alembic:
Run `pytest applications/tests/test_application_tasks.py`.
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
