### PR TITLE
Configure Sentry for Django, use GPDR-friendly defaults for Sentry

### DIFF
--- a/.env.benefit-backend.example
+++ b/.env.benefit-backend.example
@@ -77,4 +77,16 @@ EMAIL_PORT=25
 EMAIL_TIMEOUT=15
 DEFAULT_FROM_EMAIL='Helsinki-lisä <helsinkilisa@hel.fi>'
 
+# Sentry configuration for scrubbing sensitive data
+# Values set here are for local development, no data is scrubbed.
+ENTRY_ATTACH_STACKTRACE=True
+SENTRY_MAX_BREADCRUMBS=100
+SENTRY_REQUEST_BODIES=always
+SENTRY_SEND_DEFAULT_PII=True
+SENTRY_WITH_LOCALS=True
 
+# For connecting to Sentry, get the correct DSN from Sentry or from a team member
+SENTRY_DSN=
+# The environment that the application is shown under in Sentry
+# local / development / testing
+SENTRY_ENVIRONMENT=local

--- a/backend/benefit/README.md
+++ b/backend/benefit/README.md
@@ -204,3 +204,8 @@ env variables / settings are provided by Azure blob storage:
 - `AZURE_ACCOUNT_NAME`
 - `AZURE_ACCOUNT_KEY`
 - `AZURE_CONTAINER`
+
+## Sentry error monitoring
+The `local`, `development` and `testing` environments are connected to the Sentry instance at [`https://sentry.test.hel.ninja/`](https://sentry.test.hel.ninja/) under the `yjdh-benefit`-team. 
+There are separate Sentry projects for the Django api (`yjdh-benefit-api`), handler UI (`yjdh-benefit-handler`) and applicant UI (`yjdh-benefit-applicant`). 
+To limit the amount of possibly sensitive data sent to Sentry, the same configuration as in kesaseteli is used by default, see [`https://github.com/City-of-Helsinki/yjdh/pull/779`](https://github.com/City-of-Helsinki/yjdh/pull/779).

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -37,6 +37,11 @@ env = environ.Env(
     MAIL_MAILGUN_API=(str, ""),
     SENTRY_DSN=(str, ""),
     SENTRY_ENVIRONMENT=(str, ""),
+    SENTRY_ATTACH_STACKTRACE=(bool, False),
+    SENTRY_MAX_BREADCRUMBS=(int, 0),
+    SENTRY_REQUEST_BODIES=(str, "never"),
+    SENTRY_SEND_DEFAULT_PII=(bool, False),
+    SENTRY_WITH_LOCALS=(bool, False),
     CORS_ALLOWED_ORIGINS=(list, []),
     CORS_ALLOW_ALL_ORIGINS=(bool, False),
     CSRF_COOKIE_DOMAIN=(str, "localhost"),
@@ -151,10 +156,23 @@ DATABASES = {"default": env.db()}
 
 CACHES = {"default": env.cache()}
 
+SENTRY_ATTACH_STACKTRACE = env.bool("SENTRY_ATTACH_STACKTRACE")
+SENTRY_MAX_BREADCRUMBS = env.int("SENTRY_MAX_BREADCRUMBS")
+SENTRY_REQUEST_BODIES = env.str("SENTRY_REQUEST_BODIES")
+SENTRY_SEND_DEFAULT_PII = env.bool("SENTRY_SEND_DEFAULT_PII")
+SENTRY_WITH_LOCALS = env.bool("SENTRY_WITH_LOCALS")
+SENTRY_DSN = env.str("SENTRY_DSN")
+SENTRY_ENVIRONMENT = env.str("SENTRY_ENVIRONMENT")
+
 sentry_sdk.init(
-    dsn=env.str("SENTRY_DSN"),
+    attach_stacktrace=SENTRY_ATTACH_STACKTRACE,
+    max_breadcrumbs=SENTRY_MAX_BREADCRUMBS,
+    request_bodies=SENTRY_REQUEST_BODIES,
+    send_default_pii=SENTRY_SEND_DEFAULT_PII,
+    with_locals=SENTRY_WITH_LOCALS,
+    dsn=SENTRY_DSN,
     release="n/a",
-    environment=env("SENTRY_ENVIRONMENT"),
+    environment=SENTRY_ENVIRONMENT,
     integrations=[DjangoIntegration()],
 )
 

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -156,23 +156,15 @@ DATABASES = {"default": env.db()}
 
 CACHES = {"default": env.cache()}
 
-SENTRY_ATTACH_STACKTRACE = env.bool("SENTRY_ATTACH_STACKTRACE")
-SENTRY_MAX_BREADCRUMBS = env.int("SENTRY_MAX_BREADCRUMBS")
-SENTRY_REQUEST_BODIES = env.str("SENTRY_REQUEST_BODIES")
-SENTRY_SEND_DEFAULT_PII = env.bool("SENTRY_SEND_DEFAULT_PII")
-SENTRY_WITH_LOCALS = env.bool("SENTRY_WITH_LOCALS")
-SENTRY_DSN = env.str("SENTRY_DSN")
-SENTRY_ENVIRONMENT = env.str("SENTRY_ENVIRONMENT")
-
 sentry_sdk.init(
-    attach_stacktrace=SENTRY_ATTACH_STACKTRACE,
-    max_breadcrumbs=SENTRY_MAX_BREADCRUMBS,
-    request_bodies=SENTRY_REQUEST_BODIES,
-    send_default_pii=SENTRY_SEND_DEFAULT_PII,
-    with_locals=SENTRY_WITH_LOCALS,
-    dsn=SENTRY_DSN,
+    attach_stacktrace=env.bool("SENTRY_ATTACH_STACKTRACE"),
+    max_breadcrumbs=env.int("SENTRY_MAX_BREADCRUMBS"),
+    request_bodies=env.str("SENTRY_REQUEST_BODIES"),
+    send_default_pii=env.bool("SENTRY_SEND_DEFAULT_PII"),
+    with_locals=env.bool("SENTRY_WITH_LOCALS"),
+    dsn=env.str("SENTRY_DSN"),
     release="n/a",
-    environment=SENTRY_ENVIRONMENT,
+    environment=env.str("SENTRY_ENVIRONMENT"),
     integrations=[DjangoIntegration()],
 )
 


### PR DESCRIPTION
## Description :sparkles:
The `local`, `development` and `testing` environments are connected to the Sentry instance at [`https://sentry.test.hel.ninja/`](https://sentry.test.hel.ninja/) under the `yjdh-benefit`-team. There are separate Sentry projects for the Django api (`yjdh-benefit-api`), handler UI (`yjdh-benefit-handler`) and applicant UI (`yjdh-benefit-applicant`). To limit the amount of possibly sensitive data sent to Sentry, the same configuration as in kesaseteli is used by default, see [`https://github.com/City-of-Helsinki/yjdh/pull/779`](https://github.com/City-of-Helsinki/yjdh/pull/779).

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
