### PR TITLE
Fix running Kesäseteli's Platta pipelines on 2022-12-14 production release

### DIFF
--- a/backend/kesaseteli/azure-pipelines-kesaseteli-api-master.yml
+++ b/backend/kesaseteli/azure-pipelines-kesaseteli-api-master.yml
@@ -34,7 +34,7 @@ resources:
   - repository: yjdh-kesaseteli-pipelines
     type: git
     # project/repository
-    name: yjdh/yjdh-kesaseteli-pipelines
+    name: yjdh-kesaseteli/yjdh-kesaseteli-pipelines
 
 extends:
   template: azure-pipelines-kesaseteli-api-master.yml@yjdh-kesaseteli-pipelines

--- a/backend/kesaseteli/azure-pipelines-kesaseteli-api-release.yml
+++ b/backend/kesaseteli/azure-pipelines-kesaseteli-api-release.yml
@@ -34,7 +34,7 @@ resources:
   - repository: yjdh-kesaseteli-pipelines
     type: git
     # project/repository
-    name: yjdh/yjdh-kesaseteli-pipelines
+    name: yjdh-kesaseteli/yjdh-kesaseteli-pipelines
 
 extends:
   template: azure-pipelines-kesaseteli-api-release.yml@yjdh-kesaseteli-pipelines

--- a/frontend/kesaseteli/azure-pipelines-kesaseteli-ui-master.yml
+++ b/frontend/kesaseteli/azure-pipelines-kesaseteli-ui-master.yml
@@ -36,7 +36,7 @@ resources:
   - repository: yjdh-kesaseteli-pipelines
     type: git
     # project/repository
-    name: yjdh/yjdh-kesaseteli-pipelines
+    name: yjdh-kesaseteli/yjdh-kesaseteli-pipelines
 
 extends:
   template: azure-pipelines-kesaseteli-ui-master.yml@yjdh-kesaseteli-pipelines

--- a/frontend/kesaseteli/azure-pipelines-kesaseteli-ui-release.yml
+++ b/frontend/kesaseteli/azure-pipelines-kesaseteli-ui-release.yml
@@ -36,7 +36,7 @@ resources:
   - repository: yjdh-kesaseteli-pipelines
     type: git
     # project/repository
-    name: yjdh/yjdh-kesaseteli-pipelines
+    name: yjdh-kesaseteli/yjdh-kesaseteli-pipelines
 
 extends:
   template: azure-pipelines-kesaseteli-ui-release.yml@yjdh-kesaseteli-pipelines

--- a/frontend/kesaseteli/handler/azure-pipelines-devtest.yml
+++ b/frontend/kesaseteli/handler/azure-pipelines-devtest.yml
@@ -43,7 +43,7 @@ resources:
   - repository: yjdh-kesaseteli-pipelines
     type: git
     # Azure DevOps project/repository
-    name: yjdh/yjdh-kesaseteli-pipelines
+    name: yjdh-kesaseteli/yjdh-kesaseteli-pipelines
 
 extends:
   # Filename in Azure DevOps Repository (note possible -ui or -api)

--- a/frontend/kesaseteli/handler/azure-pipelines-stageprod.yml
+++ b/frontend/kesaseteli/handler/azure-pipelines-stageprod.yml
@@ -43,7 +43,7 @@ resources:
   - repository: yjdh-kesaseteli-pipelines
     type: git
     # Azure DevOps project/repository
-    name: yjdh/yjdh-kesaseteli-pipelines
+    name: yjdh-kesaseteli/yjdh-kesaseteli-pipelines
 
 extends:
   # Filename in Azure DevOps Repository (note possible -ui or -api)

--- a/frontend/kesaseteli/youth/azure-pipelines-devtest.yml
+++ b/frontend/kesaseteli/youth/azure-pipelines-devtest.yml
@@ -43,7 +43,7 @@ resources:
   - repository: yjdh-kesaseteli-pipelines
     type: git
     # Azure DevOps project/repository
-    name: yjdh/yjdh-kesaseteli-pipelines
+    name: yjdh-kesaseteli/yjdh-kesaseteli-pipelines
 
 extends:
   # Filename in Azure DevOps Repository (note possible -ui or -api)

--- a/frontend/kesaseteli/youth/azure-pipelines-stageprod.yml
+++ b/frontend/kesaseteli/youth/azure-pipelines-stageprod.yml
@@ -42,7 +42,7 @@ resources:
   - repository: yjdh-kesaseteli-pipelines
     type: git
     # Azure DevOps project/repository
-    name: yjdh/yjdh-kesaseteli-pipelines
+    name: yjdh-kesaseteli/yjdh-kesaseteli-pipelines
 
 extends:
   # Filename in Azure DevOps Repository (note possible -ui or -api)


### PR DESCRIPTION
## Description :sparkles:

What was done:
 - git checkout -b 2022-12-14-prod-rel-pipeline-fix cdd0ca7656f31ccaa33bdcd4344cd1243c8fce70
 - git cherry-pick ae93c8ad92c6b69e8a11a48371757ee174ff4310
 - git push origin -u 2022-12-14-prod-rel-pipeline-fix

Why was done:
 - To fix running the Platta pipelines of the last production release of Kesäseteli done on Dec 14, 2022 in order to deploy the last production release of Kesäseteli to staging on Platta and test it there