### PR TITLE
HL-361 | Add browser test for association applicant 

### DIFF
--- a/frontend/benefit/applicant/browser-tests/newApplication/association.testcafe.ts
+++ b/frontend/benefit/applicant/browser-tests/newApplication/association.testcafe.ts
@@ -39,7 +39,7 @@ test('Oppisopimus', async () => {
   const step1 = new Step1();
   await step1.isLoaded(60_000);
 
-  await step1.fillEmployerInfo('3943561142000926');
+  await step1.fillEmployerInfo('3943561142000926', true);
   await step1.fillContactPerson(
     'Waild',
     'Ömoussons',

--- a/frontend/benefit/applicant/browser-tests/newApplication/association.testcafe.ts
+++ b/frontend/benefit/applicant/browser-tests/newApplication/association.testcafe.ts
@@ -1,0 +1,82 @@
+import { HttpRequestHook } from '@frontend/shared/browser-tests/http-utils/http-request-hook';
+import requestLogger, {
+  filterLoggedRequests,
+} from '@frontend/shared/browser-tests/utils/request-logger';
+import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
+
+import MainIngress from '../page-model/MainIngress';
+import Step1 from '../page-model/step1';
+import Step2 from '../page-model/step2';
+import Step3 from '../page-model/step3';
+import TermsOfService from '../page-model/TermsOfService';
+import { getFrontendUrl } from '../utils/url.utils';
+
+const getBackendDomain = (): string =>
+  process.env.NEXT_PUBLIC_BACKEND_URL || 'https://localhost:8000';
+
+const url = getFrontendUrl('/');
+
+fixture('Frontpage')
+  .page(url)
+  .requestHooks(requestLogger, new HttpRequestHook(url, getBackendDomain()))
+  .beforeEach(async (t) => {
+    clearDataToPrintOnFailure(t);
+  })
+  .afterEach(async () =>
+    // eslint-disable-next-line no-console
+    console.log(filterLoggedRequests(requestLogger))
+  );
+
+test('Oppisopimus', async () => {
+  const termsAndConditions = new TermsOfService();
+  await termsAndConditions.isLoaded();
+  await termsAndConditions.clickContinueButton();
+
+  const mainIngress = new MainIngress();
+  await mainIngress.isLoaded();
+  await mainIngress.clickCreateNewApplicationButton();
+
+  const step1 = new Step1();
+  await step1.isLoaded(60_000);
+
+  await step1.fillEmployerInfo('3943561142000926');
+  await step1.fillContactPerson(
+    'Waild',
+    'Ömoussons',
+    '0400123456',
+    'need.email@example.com'
+  );
+
+  await step1.selectNocoOperationNegotiations();
+  await step1.clickSubmit();
+
+  const step2 = new Step2();
+  await step2.isLoaded();
+
+  await step2.fillEmployeeInfo('Truu', 'Koos', '121148-8060', '0501234555');
+  await step2.fillPaidSubsidyGrant();
+  await step2.selectBenefitType('salary');
+  const currentYear: number = new Date().getFullYear();
+  await step2.fillBenefitPeriod(
+    `1.3.${currentYear}`,
+    `28.2.${currentYear + 1}`
+  );
+  await step2.fillEmploymentInfo(
+    'Kirjanpitäjä',
+    '37',
+    'Taloushallintoalan TES',
+    '2050',
+    '400',
+    '600'
+  );
+  await step2.clickSubmit();
+
+  const step3 = new Step3();
+  await step3.isLoaded();
+  await step3.employmentContractNeeded();
+  await step3.paySubsidyDecisionNeeded();
+  await step3.helsinkiBenefitVoucherNeeded();
+
+  await step3.clickDeleteApplication();
+  await step3.confirmDeleteApplication();
+});

--- a/frontend/benefit/applicant/browser-tests/newApplication/company.testcafe.ts
+++ b/frontend/benefit/applicant/browser-tests/newApplication/company.testcafe.ts
@@ -27,7 +27,7 @@ fixture('Frontpage')
     console.log(filterLoggedRequests(requestLogger))
   );
 
-test('Oppisopimus', async () => {
+test('Company', async () => {
   const termsAndConditions = new TermsOfService();
   await termsAndConditions.isLoaded();
   await termsAndConditions.clickContinueButton();

--- a/frontend/benefit/applicant/browser-tests/newApplication/company.testcafe.ts
+++ b/frontend/benefit/applicant/browser-tests/newApplication/company.testcafe.ts
@@ -39,7 +39,7 @@ test('Company', async () => {
   const step1 = new Step1();
   await step1.isLoaded(60_000);
 
-  await step1.fillEmployerInfo('6051437344779954');
+  await step1.fillEmployerInfo('6051437344779954', false);
   await step1.fillContactPerson(
     'Raven',
     'Stamm',

--- a/frontend/benefit/applicant/browser-tests/page-model/step1.ts
+++ b/frontend/benefit/applicant/browser-tests/page-model/step1.ts
@@ -38,6 +38,18 @@ class Step1 extends WizardStep {
     ),
   });
 
+  private businessActivitiesFalse = this.within(
+    this.component.getByRole('group', {
+      name: this.regexp(
+        this.translations.applications.sections.company.fields
+          .associationHasBusinessActivities.label
+      ),
+    })
+  ).findByRole('radio', {
+    name: this.translations.applications.sections.company.fields
+      .associationHasBusinessActivities.no,
+  });
+
   private deMinimisAidFalse = this.within(
     this.component.getByRole('group', {
       name: this.regexp(
@@ -48,6 +60,13 @@ class Step1 extends WizardStep {
   ).findByRole('radio', {
     name: this.translations.applications.sections.company.fields.deMinimisAid
       .no,
+  });
+
+  hasImmediateManagerCheckbox = this.component.findByRole('checkbox', {
+    name: this.regexp(
+      this.translations.applications.sections.company.fields
+        .associationImmediateManagerCheck.placeholder
+    ),
   });
 
   private coOperationNegotiationsFalse = this.within(
@@ -62,8 +81,10 @@ class Step1 extends WizardStep {
       .coOperationNegotiations.no,
   });
 
-  public fillEmployerInfo(iban: string): Promise<void> {
-    return this.fillInput(this.bankAccountNumber, iban);
+  public async fillEmployerInfo(iban: string): Promise<void> {
+    await this.clickSelectRadioButton(this.hasImmediateManagerCheckbox);
+    await this.clickSelectRadioButton(this.businessActivitiesFalse);
+    await this.fillInput(this.bankAccountNumber, iban);
   }
 
   public async fillContactPerson(
@@ -76,6 +97,10 @@ class Step1 extends WizardStep {
     await this.fillInput(this.lastName, lastName);
     await this.fillInput(this.phoneNumber, phoneNumber);
     return this.fillInput(this.email, email);
+  }
+
+  public selectNoBusinessActivities(): Promise<void> {
+    return this.clickSelectRadioButton(this.businessActivitiesFalse);
   }
 
   public selectNoDeMinimis(): Promise<void> {

--- a/frontend/benefit/applicant/browser-tests/page-model/step1.ts
+++ b/frontend/benefit/applicant/browser-tests/page-model/step1.ts
@@ -81,9 +81,14 @@ class Step1 extends WizardStep {
       .coOperationNegotiations.no,
   });
 
-  public async fillEmployerInfo(iban: string): Promise<void> {
-    await this.clickSelectRadioButton(this.hasImmediateManagerCheckbox);
-    await this.clickSelectRadioButton(this.businessActivitiesFalse);
+  public async fillEmployerInfo(
+    iban: string,
+    isAssociation: boolean
+  ): Promise<void> {
+    if (isAssociation) {
+      await this.clickSelectRadioButton(this.hasImmediateManagerCheckbox);
+      await this.clickSelectRadioButton(this.businessActivitiesFalse);
+    }
     await this.fillInput(this.bankAccountNumber, iban);
   }
 

--- a/frontend/benefit/applicant/package.json
+++ b/frontend/benefit/applicant/package.json
@@ -11,8 +11,8 @@
     "test": "jest --passWithNoTests",
     "test:staged": "yarn test --watchAll=false --findRelatedTests",
     "test:coverage": "yarn test --verbose --coverage",
-    "browser-test": "testcafe 'chrome --allow-insecure-localhost --ignore-certificate-errors --ignore-urlfetcher-cert-requests --window-size=\"1249,720\"' browser-tests/",
-    "browser-test:ci": "testcafe 'chrome:headless --disable-gpu --window-size=\"1249,720\"  --ignore-certificate-errors-spki-list=\"8sg/cl7YabrOFqSqH+Bu0e+P27Av33gWgi8Lq28DW1I=,gJt+wt/T3afCRkxtMMSjXcl/99sgzWc2kk1c1PC9tG0=,zrQI2/1q8i2SRPmMZ1sMntIkG+lMW0legPFokDo3nrY=\"' --screenshots path=report --video report --reporter spec,custom,html:report/index.html browser-tests/"
+    "browser-test": "testcafe 'chrome --allow-insecure-localhost --ignore-certificate-errors --ignore-urlfetcher-cert-requests --window-size=\"1249,720\"' browser-tests/newApplication/company.testcafe.ts",
+    "browser-test:ci": "testcafe 'chrome:headless --disable-gpu --window-size=\"1249,720\"  --ignore-certificate-errors-spki-list=\"8sg/cl7YabrOFqSqH+Bu0e+P27Av33gWgi8Lq28DW1I=,gJt+wt/T3afCRkxtMMSjXcl/99sgzWc2kk1c1PC9tG0=,zrQI2/1q8i2SRPmMZ1sMntIkG+lMW0legPFokDo3nrY=\"' --screenshots path=report --video report --reporter spec,custom,html:report/index.html browser-tests/newApplication/company.testcafe.ts"
   },
   "dependencies": {
     "@frontend/shared": "*",


### PR DESCRIPTION
## Description :sparkles:

Basically just duplicate `company.testcafe.ts` and add some functions to click association-specific elements. 

## Issues :bug:

* There will be alot of warnings like:

```
  TestCafe cannot interact with the <input id="benefitTypeSalary"
  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6" type="radio"
  name="benefitType" value="salary_benefit"> element because another element obstructs it.

...
```

I'm guessing they come from HDS components not using browser native checkbox and radio elements and there's little we can do about it.

## Testing :alembic:

### 1. Change env variable

In `.env.benefit-backend` set `DUMMY_COMPANY_FORM_CODE=29`.

### 2. Drop database 

Before proceeding export your previous database so you can continue work later.

Log in to DB container's shell:

```
docker exec -it backend-db /bin/bash
psql -U benefit
```

In psql:

```
DROP SCHEMA public CASCADE;
CREATE SCHEMA public;
```

### 3. Rebuild and seed tables

Just restart `benefit-backend` container.

### 4. Run some tests

```
cd frontend/
yarn
cd frontend/benefit/applicant/
yarn browser-test
```