### PR TITLE
HL-629 | Add apprenticeship contract for handler

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyView.tsx
@@ -56,11 +56,20 @@ const PaySubsidyView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
           </$ViewField>
         )}
       </$GridCell>
-      <AttachmentsListView
-        title={t('common:attachments.types.paySubsidyDecision.title')}
-        type={ATTACHMENT_TYPES.PAY_SUBSIDY_CONTRACT}
-        attachments={data.attachments || []}
-      />
+      <$GridCell $colSpan={12}>
+        <AttachmentsListView
+          title={t('common:attachments.types.paySubsidyDecision.title')}
+          type={ATTACHMENT_TYPES.PAY_SUBSIDY_CONTRACT}
+          attachments={data.attachments || []}
+        />
+      </$GridCell>
+      <$GridCell $colSpan={12}>
+        <AttachmentsListView
+          title={t('common:attachments.types.educationContract.title')}
+          type={ATTACHMENT_TYPES.EDUCATION_CONTRACT}
+          attachments={data.attachments || []}
+        />
+      </$GridCell>
     </ReviewSection>
   );
 };


### PR DESCRIPTION
## Description :sparkles:

Add apprenticeship attachment doc to handler's application view.

* As per [spec HL-629](https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/HL/boards/204?modal=detail&selectedIssue=HL-629)
* Implementation done according to: "_Voidaan toteuttaa joko otsikon Palkkatukipäätös alle ..._",  because in this section there was already a field `Onko kyseessä oppisopimus? Kyllä / Ei`.

See image, first application does not have "oppisopimus" selected.

![Screenshot 2023-02-03 at 15 11 49](https://user-images.githubusercontent.com/5328394/216611877-c28c4b1e-3a94-436c-9238-43ccef937a6c.png)
