### PR TITLE
HL-623 Limit upload filetypes

### DIFF
--- a/frontend/shared/src/components/attachments/UploadAttachment.tsx
+++ b/frontend/shared/src/components/attachments/UploadAttachment.tsx
@@ -69,6 +69,7 @@ const UploadAttachment: React.FC<UploadAttachmentProps> = ({
         style={{ display: 'none' }}
         name={name}
         ref={uploadRef}
+        accept={allowedFileTypes.join(', ')}
         onChange={handleUpload}
         data-testid={name}
         id={`upload_attachment_${attachmentType}`}


### PR DESCRIPTION
Adding `accept` attribute to upload `<input>` to limit upload file types to allowed file types. Allowed file types were already defined elsewhere as an array.