### PR TITLE
HL-230 | Fix sorting issues with draft listing by using modified_at

### DIFF
--- a/backend/benefit/applications/api/v1/serializers.py
+++ b/backend/benefit/applications/api/v1/serializers.py
@@ -565,7 +565,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
             "end_date",
             "de_minimis_aid",
             "de_minimis_aid_set",
-            "last_modified_at",
+            "modified_at",
             "created_at",
             "additional_information_needed_by",
             "status_last_changed_at",
@@ -590,7 +590,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
             "official_company_city",
             "official_company_postcode",
             "available_benefit_types",
-            "last_modified_at",
+            "modified_at",
             "created_at",
             "additional_information_needed_by",
             "status_last_changed_at",
@@ -708,8 +708,8 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
 
     submitted_at = serializers.SerializerMethodField("get_submitted_at")
 
-    last_modified_at = serializers.SerializerMethodField(
-        "get_last_modified_at",
+    modified_at = serializers.SerializerMethodField(
+        "get_modified_at",
         help_text="Last modified timestamp. Only handlers see the timestamp of non-draft applications.",
     )
 
@@ -872,7 +872,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
     def get_submitted_at(self, obj):
         return getattr(obj, "submitted_at", None)
 
-    def get_last_modified_at(self, obj):
+    def get_modified_at(self, obj):
         if not self.logged_in_user_is_admin() and obj.status != ApplicationStatus.DRAFT:
             return None
         return obj.modified_at

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -1382,14 +1382,14 @@ def add_attachments_to_application(request, application):
     _add_pdf_attachment(request, application, AttachmentType.EMPLOYEE_CONSENT)
 
 
-def test_application_last_modified_at_draft(api_client, application):
+def test_application_modified_at_draft(api_client, application):
     """
     DRAFT application's last_modified_at is visible to applicant
     """
     application.status = ApplicationStatus.DRAFT
     application.save()
     data = ApplicantApplicationSerializer(application).data
-    assert data["last_modified_at"] == datetime(2021, 6, 4, tzinfo=pytz.UTC)
+    assert data["modified_at"] == datetime(2021, 6, 4, tzinfo=pytz.UTC)
 
 
 @pytest.mark.parametrize(
@@ -1402,14 +1402,14 @@ def test_application_last_modified_at_draft(api_client, application):
         ApplicationStatus.REJECTED,
     ],
 )
-def test_application_last_modified_at_non_draft(api_client, application, status):
+def test_application_modified_at_non_draft(api_client, application, status):
     """
     non-DRAFT application's last_modified_at is not visible to applicant
     """
     application.status = status
     application.save()
     data = ApplicantApplicationSerializer(application).data
-    assert data["last_modified_at"] is None
+    assert data["modified_at"] is None
 
 
 @pytest.mark.parametrize(

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -26,6 +26,7 @@
     },
     "pageHeaders": {
       "created": "Created",
+      "saved": "Saved",
       "sent": "Application number: {{applicationNumber}}  |  Submitted {{submittedAt}}",
       "new": "New application",
       "edit": "Application",

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -26,6 +26,7 @@
     },
     "pageHeaders": {
       "created": "Luotu",
+      "saved": "Tallennettu",
       "sent": "Hakemusnumero: {{applicationNumber}}  |  Lähetetty {{submittedAt}}",
       "new": "Uusi hakemus",
       "edit": "Hakemus",

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -26,6 +26,7 @@
     },
     "pageHeaders": {
       "created": "Skapats",
+      "saved": "Sparad",
       "sent": "Ansökningsnummer: {{applicationNumber}}  |  Skickad {{submittedAt}}",
       "new": "Ny ansökan",
       "edit": "Ansökan",

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.tsx
@@ -48,7 +48,7 @@ const ListItem: React.FC<ListItemProps> = (props) => {
     name,
     avatar,
     statusText,
-    createdAt,
+    modifiedAt,
     submittedAt,
     applicationNum,
     allowedAction,
@@ -68,10 +68,10 @@ const ListItem: React.FC<ListItemProps> = (props) => {
             <$DataHeader>{t(`${translationBase}.common.employee`)}</$DataHeader>
             <$DataValue>{name}</$DataValue>
           </$DataColumn>
-          {createdAt && (
+          {modifiedAt && (
             <$DataColumn>
               <$DataHeader>{t(`${translationBase}.common.saved`)}</$DataHeader>
-              <$DataValue>{createdAt}</$DataValue>
+              <$DataValue>{modifiedAt}</$DataValue>
             </$DataColumn>
           )}
           {submittedAt && (

--- a/frontend/benefit/applicant/src/components/applications/applicationList/useApplicationList.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/useApplicationList.ts
@@ -58,7 +58,7 @@ const getEmployeeFullName = (firstName: string, lastName: string): string => {
 };
 
 const getOrderBy = (status: string[]): string =>
-  status.includes('draft') ? '-created_at' : '-submitted_at';
+  status.includes('draft') ? '-modified_at' : '-submitted_at';
 
 const useApplicationList = (status: string[]): ApplicationListProps => {
   const { t } = useTranslation();
@@ -109,8 +109,7 @@ const useApplicationList = (status: string[]): ApplicationListProps => {
       id = '',
       status: appStatus,
       employee,
-      last_modified_at,
-      created_at,
+      modified_at,
       submitted_at,
       application_number: applicationNum,
       additional_information_needed_by,
@@ -128,9 +127,9 @@ const useApplicationList = (status: string[]): ApplicationListProps => {
     const submittedAt = submitted_at
       ? convertToUIDateFormat(submitted_at)
       : '-';
-    const createdAt = created_at && convertToUIDateAndTimeFormat(created_at);
-    const modifiedAt =
-      last_modified_at && convertToUIDateFormat(last_modified_at);
+    const modifiedAtWithTime =
+      modified_at && convertToUIDateAndTimeFormat(modified_at);
+    const modifiedAt = modified_at && convertToUIDateFormat(modified_at);
     const editEndDate =
       additional_information_needed_by &&
       convertToUIDateFormat(additional_information_needed_by);
@@ -143,7 +142,7 @@ const useApplicationList = (status: string[]): ApplicationListProps => {
       status: appStatus,
       unreadMessagesCount: unread_messages_count ?? 0,
     };
-    const draftProps = { createdAt, applicationNum };
+    const draftProps = { modifiedAt: modifiedAtWithTime, applicationNum };
     const submittedProps = {
       submittedAt,
       applicationNum,

--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -142,8 +142,8 @@ const PageContent: React.FC = () => {
         <>
           <$PageSubHeading>
             {`${t(
-              'common:applications.pageHeaders.created'
-            )} ${convertToUIDateAndTimeFormat(application?.createdAt)}`}
+              'common:applications.pageHeaders.saved'
+            )} ${convertToUIDateAndTimeFormat(application?.modifiedAt)}`}
           </$PageSubHeading>
           {(currentStep === 1 || currentStep === 2) && (
             <$PageHeadingHelperText>

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -185,6 +185,7 @@ export type Application = {
   company?: Company;
   archived?: boolean;
   createdAt?: string | null;
+  modifiedAt?: string | null;
   applicationStep?: string | null;
   attachments?: BenefitAttachment[];
   // create_application_for_company ? not present in the UI?
@@ -331,7 +332,7 @@ export type ApplicationData = {
   end_date?: string;
   de_minimis_aid?: boolean;
   de_minimis_aid_set: DeMinimisAidData[]; // required
-  last_modified_at?: string;
+  modified_at?: string;
   attachments?: AttachmentData[];
   create_application_for_company?: string;
   created_at?: string;


### PR DESCRIPTION
## Description

Fix sorting issues with draft listing by using `modified_at` rather than `created_at`.

The actual issue?

1. Applicant makes a new application
2. Applicant presses "Save and close" button
3. Application is now created but listed in by `created_at`
4. Applicant edits to an older draft and presses "Save and close" button
5. Application list for drafts remains unchanged even though the older draft should now be listed before the newly created one

Behaviour is now changed to order the list by `modified_at`.

![drafts](https://user-images.githubusercontent.com/5328394/217782433-75455a5b-71f2-4e4b-9764-2a1af8fddf97.gif)
