### PR TITLE
fix: change youth summer voucher email's year from 2022 to 2023

### DIFF
--- a/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
@@ -700,7 +700,7 @@ msgstr ""
 
 msgid ""
 "Kaupunki korvaa 325 euroa työnantajalle, joka palkkaa Kesäseteliin "
-"oikeutetun nuoren töihin 1.6.–15.8.2022 välisenä aikana."
+"oikeutetun nuoren töihin 1.6.–15.8.2023 välisenä aikana."
 msgstr ""
 "The City of Helsinki will provide a reimbursement of EUR 325 to each "
 "employer who a young person with the summer job voucher between 1 June and "

--- a/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
@@ -670,7 +670,7 @@ msgstr ""
 
 msgid ""
 "Kaupunki korvaa 325 euroa työnantajalle, joka palkkaa Kesäseteliin "
-"oikeutetun nuoren töihin 1.6.–15.8.2022 välisenä aikana."
+"oikeutetun nuoren töihin 1.6.–15.8.2023 välisenä aikana."
 msgstr ""
 
 msgid ""

--- a/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
@@ -697,7 +697,7 @@ msgstr ""
 
 msgid ""
 "Kaupunki korvaa 325 euroa työnantajalle, joka palkkaa Kesäseteliin "
-"oikeutetun nuoren töihin 1.6.–15.8.2022 välisenä aikana."
+"oikeutetun nuoren töihin 1.6.–15.8.2023 välisenä aikana."
 msgstr ""
 "Helsingfors stad betalar 325 euro till en arbetsgivare som anställer en elev "
 "i årskurs 9 med Sommarsedeln för sommaren mellan den 1 juni och den 15 "

--- a/backend/kesaseteli/applications/templates/youth_summer_voucher_email.html
+++ b/backend/kesaseteli/applications/templates/youth_summer_voucher_email.html
@@ -64,7 +64,7 @@
                     <h2>{% trans 'Ohjeita työnantajalle' %}</h2>
                     <p>
                         {% trans 'Kesäseteli on nuorten, yrittäjien ja Helsingin kaupungin yhteinen hanke.' %}
-                        {% trans 'Kaupunki korvaa 325 euroa työnantajalle, joka palkkaa Kesäseteliin oikeutetun nuoren töihin 1.6.–15.8.2022 välisenä aikana.' %}
+                        {% trans 'Kaupunki korvaa 325 euroa työnantajalle, joka palkkaa Kesäseteliin oikeutetun nuoren töihin 1.6.–15.8.2023 välisenä aikana.' %}
                         {% trans 'Kesätyön vähimmäisvaatimuksina ovat 60 tunnin työaika ja 400 euron palkka.' %}
                     </p>
                     <p>

--- a/backend/kesaseteli/applications/templates/youth_summer_voucher_email.txt
+++ b/backend/kesaseteli/applications/templates/youth_summer_voucher_email.txt
@@ -27,7 +27,7 @@
 ------------------------------------------------------------------------
 {% trans 'Ohjeita työnantajalle' %}:
 
-{% trans 'Kesäseteli on nuorten, yrittäjien ja Helsingin kaupungin yhteinen hanke.' %} {% trans 'Kaupunki korvaa 325 euroa työnantajalle, joka palkkaa Kesäseteliin oikeutetun nuoren töihin 1.6.–15.8.2022 välisenä aikana.' %} {% trans 'Kesätyön vähimmäisvaatimuksina ovat 60 tunnin työaika ja 400 euron palkka.' %}
+{% trans 'Kesäseteli on nuorten, yrittäjien ja Helsingin kaupungin yhteinen hanke.' %} {% trans 'Kaupunki korvaa 325 euroa työnantajalle, joka palkkaa Kesäseteliin oikeutetun nuoren töihin 1.6.–15.8.2023 välisenä aikana.' %} {% trans 'Kesätyön vähimmäisvaatimuksina ovat 60 tunnin työaika ja 400 euron palkka.' %}
 
 {% trans 'Muut käyttöehdot voit lukea täältä:' %}
 {% trans 'https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/' %}


### PR DESCRIPTION
## Description :sparkles:

### fix: change youth summer voucher email's year from 2022 to 2023

refs None

## Issues :bug:

`-`

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
