### PR TITLE
HL-661 | Use the correct endpoint for handler

### DIFF
--- a/frontend/benefit/handler/src/hooks/useApplicationsQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useApplicationsQuery.ts
@@ -25,7 +25,7 @@ const useApplicationsQuery = (
     ['applicationsList', ...status],
     async () => {
       const res = axios.get<ApplicationData[]>(
-        `${BackendEndpoint.APPLICATIONS_SIMPLIFIED}`,
+        `${BackendEndpoint.HANDLER_APPLICATIONS_SIMPLIFIED}`,
         {
           params: {
             status: status.join(','),


### PR DESCRIPTION
## Description :sparkles:

I've accidentally used wrong endpoint in frontend when list orderby was implemented. Handler's archive should now be working as intended.

Resolves:

* [HL-651](https://helsinkisolutionoffice.atlassian.net/browse/HL-651)
* [HL-649](https://helsinkisolutionoffice.atlassian.net/browse/HL-649)
* [HL-650](https://helsinkisolutionoffice.atlassian.net/browse/HL-650)



[HL-651]: https://helsinkisolutionoffice.atlassian.net/browse/HL-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-649]: https://helsinkisolutionoffice.atlassian.net/browse/HL-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-650]: https://helsinkisolutionoffice.atlassian.net/browse/HL-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="2532" alt="image" src="https://user-images.githubusercontent.com/5328394/218061277-2ab92db1-facf-44a3-915b-b1fd5f91ab12.png">
