### PR TITLE
HL-437 | Handler is able to log out

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -12,7 +12,9 @@
     "drawer": {
       "title": "Hakemuksen viestit"
     },
-    "languageMenuButtonAriaLabel": "Select language"
+    "languageMenuButtonAriaLabel": "Select language",
+    "logoutLabel": "Log out",
+    "loginLabel": "Log in"
   },
   "notifications": {
     "accepted": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -12,7 +12,9 @@
     "drawer": {
       "title": "Hakemuksen viestit"
     },
-    "languageMenuButtonAriaLabel": "Valitse kieli"
+    "languageMenuButtonAriaLabel": "Valitse kieli",
+    "logoutLabel": "Kirjaudu ulos",
+    "loginLabel": "Kirjaudu sisään"
   },
   "notifications": {
     "accepted": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -12,7 +12,9 @@
     "drawer": {
       "title": "Hakemuksen viestit"
     },
-    "languageMenuButtonAriaLabel": "Ändra språk"
+    "languageMenuButtonAriaLabel": "Ändra språk",
+    "logoutLabel": "Logga ut",
+    "loginLabel": "Logga in"
   },
   "notifications": {
     "accepted": {

--- a/frontend/benefit/handler/src/components/header/Header.tsx
+++ b/frontend/benefit/handler/src/components/header/Header.tsx
@@ -1,12 +1,28 @@
 import { ROUTES } from 'benefit/handler/constants';
+import useLogin from 'benefit/handler/hooks/useLogin';
+import useLogout from 'benefit/handler/hooks/useLogout';
+import useUserQuery from 'benefit/handler/hooks/useUserQuery';
+import noop from 'lodash/noop';
+import { useRouter } from 'next/router';
 import * as React from 'react';
 import BaseHeader from 'shared/components/header/Header';
+import { getFullName } from 'shared/utils/application.utils';
 
 import { useHeader } from './useHeader';
 
 const Header: React.FC = () => {
   const { t, navigationItems, isNavigationVisible, handleLanguageChange } =
     useHeader();
+
+  const login = useLogin();
+  const logout = useLogout();
+
+  const userQuery = useUserQuery();
+  const { isLoading, isSuccess, data } = userQuery;
+
+  const router = useRouter();
+  const { asPath } = router;
+  const isLoginPage = asPath?.startsWith(ROUTES.LOGIN);
 
   return (
     <BaseHeader
@@ -17,6 +33,17 @@ const Header: React.FC = () => {
       navigationItems={navigationItems}
       onLanguageChange={handleLanguageChange}
       theme="dark"
+      login={{
+        isAuthenticated: !isLoginPage && isSuccess,
+        loginLabel: t('common:header.loginLabel'),
+        logoutLabel: t('common:header.logoutLabel'),
+        onLogin: !isLoading ? login : noop,
+        onLogout: !isLoading ? logout : noop,
+        userName: isSuccess
+          ? getFullName(data?.given_name, data?.family_name)
+          : undefined,
+        userAriaLabelPrefix: t('common:header.userAriaLabelPrefix'),
+      }}
     />
   );
 };

--- a/frontend/benefit/handler/src/constants.ts
+++ b/frontend/benefit/handler/src/constants.ts
@@ -2,6 +2,8 @@ import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 
 export enum ROUTES {
   HOME = '/',
+  LOGIN = '/login',
+
   // temporary urls, not defined yet
   APPLICATIONS_PROCESSED = '/processed',
   APPLICATIONS_ARCHIVE = '/archive',

--- a/frontend/benefit/handler/src/hooks/useLogout.ts
+++ b/frontend/benefit/handler/src/hooks/useLogout.ts
@@ -1,0 +1,17 @@
+import {
+  BackendEndpoint,
+  getBackendUrl,
+} from 'benefit-shared/backend-api/backend-api';
+import { useRouter } from 'next/router';
+import React from 'react';
+
+const useLogout = (): (() => Promise<boolean>) => {
+  const router = useRouter();
+
+  return React.useCallback(
+    () => router.push(getBackendUrl(BackendEndpoint.OAUTH_LOGOUT)),
+    [router]
+  );
+};
+
+export default useLogout;

--- a/frontend/benefit/shared/src/backend-api/backend-api.ts
+++ b/frontend/benefit/shared/src/backend-api/backend-api.ts
@@ -3,6 +3,7 @@ import { Headers } from 'shared/types/common';
 export const BackendEndpoint = {
   LOGIN: '/oidc/authenticate/',
   OAUTH_LOGIN: '/oauth2/login',
+  OAUTH_LOGOUT: '/oauth2/logout',
   LOGOUT: '/oidc/logout/',
   USER: '/oidc/userinfo/',
   USER_ME: 'v1/users/me',


### PR DESCRIPTION
## Description :sparkles:

Header now displays user's full name and has a dropdown link to sign out. ~As far as I'm considered, there's no configured path to local development for OAUTH2:~

* ~https://localhost:8000/oauth2/login~
* ~https://localhost:8000/oauth2/logout~

~Thus, testing this is hard.~

~However, these seem to work on test env backend:~

* ~[See log in / out links here](https://helsinkisolutionoffice.atlassian.net/browse/HL-437)~

~This is enough and fine, I think~ 🤔 🤷‍♂️  

All good now, HL-567 resolves all OAUTH2 / AD login problems.

![login](https://user-images.githubusercontent.com/5328394/218461361-9bbec77c-17a2-428c-887c-9265f10b65ba.gif)



