### PR TITLE
Fix firstName and lastName render & typing for AD-logged user

### DIFF
--- a/backend/shared/shared/azure_adfs/README.md
+++ b/backend/shared/shared/azure_adfs/README.md
@@ -13,8 +13,8 @@ To start using this package, follow these steps:
     ADFS_CLIENT_ID=
     ADFS_CLIENT_SECRET=
     ADFS_TENANT_ID=
-    ADFS_LOGIN_REDIRECT_URL=
-    ADFS_LOGIN_REDIRECT_URL_FAILURE=
+    ADFS_LOGIN_REDIRECT_URL=          # Specify landing page (front end)
+    ADFS_LOGIN_REDIRECT_URL_FAILURE=  # Specify failed login page (front end)
     ```
 
 2. Add `"django_auth_adfs"` to `INSTALLED_APPS`:
@@ -58,6 +58,8 @@ To start using this package, follow these steps:
     ```
 
 5. The authentication flow can now be initiated from `/oauth2/login`
+
+6. Django tends to use http:// instead of https:// in OAUTH2 for localhost. To send the correct protocol URL you must set `os.environ["HTTPS"] = "on"` in `settings.py`. This enforces HTTPS and tells Django to use HTTPS explicitly.
 
 More information from [this guide](https://django-auth-adfs.readthedocs.io/en/latest/azure_ad_config_guide.html).
 

--- a/backend/shared/shared/azure_adfs/README.md
+++ b/backend/shared/shared/azure_adfs/README.md
@@ -1,6 +1,6 @@
 ## YJDH Azure ADFS component
 
-Azure ADFS authentication using the django library `django-auth-adfs`.
+Azure ADFS authentication using the django library `django-auth-adfs`. More information about `django-auth-adfs` in [this guide](https://django-auth-adfs.readthedocs.io/en/latest/azure_ad_config_guide.html).
 
 Custom logic was written for the callback view `HelsinkiOAuth2CallbackView` and the authentication backend `HelsinkiAdfsAuthCodeBackend`.
 
@@ -60,8 +60,6 @@ To start using this package, follow these steps:
 5. The authentication flow can now be initiated from `/oauth2/login`
 
 6. Django tends to use http:// instead of https:// in OAUTH2 for localhost. To send the correct protocol URL you must set `os.environ["HTTPS"] = "on"` in `settings.py`. This enforces HTTPS and tells Django to use HTTPS explicitly.
-
-More information from [this guide](https://django-auth-adfs.readthedocs.io/en/latest/azure_ad_config_guide.html).
 
 ### Optional Django settings
 

--- a/frontend/benefit/handler/src/components/header/Header.tsx
+++ b/frontend/benefit/handler/src/components/header/Header.tsx
@@ -40,7 +40,7 @@ const Header: React.FC = () => {
         onLogin: !isLoading ? login : noop,
         onLogout: !isLoading ? logout : noop,
         userName: isSuccess
-          ? getFullName(data?.given_name, data?.family_name)
+          ? getFullName(data?.first_name, data?.last_name)
           : undefined,
         userAriaLabelPrefix: t('common:header.userAriaLabelPrefix'),
       }}

--- a/frontend/shared/src/types/user.d.ts
+++ b/frontend/shared/src/types/user.d.ts
@@ -1,4 +1,6 @@
 type User = {
+  first_name?: string;
+  last_name?: string;
   given_name: string;
   family_name: string;
   name: string;


### PR DESCRIPTION
Changes that we forgot in pair review: Active Directory log-in didn't render anything for given_name or family_name.