### PR TITLE
HL-665 | Fix missing variable value that crashed the pdf generator

### DIFF
--- a/backend/benefit/applications/services/pdf_templates/benefit_template.html
+++ b/backend/benefit/applications/services/pdf_templates/benefit_template.html
@@ -28,9 +28,12 @@
                 {% endif %}
                 <td>{{ app.start_date.strftime("%d.%m.%Y") }} - {{ app.end_date.strftime("%d.%m.%Y")}}</td>
                 <td>{{ app.get_benefit_type_display() }}</td>
-                {% if show_sums %}
+                {% if show_sums and app.calculated_benefit_amount and app.calculation.duration_in_months %}
                     <td class="text-right">{{ "%.0f €" | format(app.calculated_benefit_amount/(app.calculation.duration_in_months | round(2)))}} </td>
                     <td class="text-right"><strong>{{ "%.0f €" | format(app.calculated_benefit_amount)}}</strong></td>
+                {% else %}
+                    <td class="text-right">0 €</td>
+                    <td class="text-right"><strong>0 €</strong></td>
                 {% endif %}
             </tr>
             {% else %}
@@ -54,9 +57,18 @@
         {% endfor %}
 
         {% if show_sums %}
+            {% set benefit = namespace(amounts=0) %}
+            {% for app in apps %}
+                {% if app.calculated_benefit_amount is not none %}
+                    {% set benefit.amounts = benefit.amounts + app.calculated_benefit_amount %}
+                {% endif %}
+            {% endfor %}
             <tr>
-                <td colspan="8" class="footer text-right"> Kaikki yhteensä <strong>{{ "%.0f €" | format(apps | sum
-                        (attribute='calculated_benefit_amount'))}}</strong></td>
+                <td colspan="8" class="footer text-right"> Kaikki yhteensä 
+                    <strong>
+                        {{ "%.0f €" | format(benefit.amounts) }}
+                    </strong>
+                </td>
             </tr>
         {% endif %}
     </table>


### PR DESCRIPTION
## Description :sparkles:

Generating PDF's caused a fatal error if some calculations were of `NoneType`. I've modified the PDF frontend so that it takes None into account and PDF's are fine. However, I don't know if these 0 € rows should be included in the first place, this might be a byproduct from a bug elsewhere in the calculation system.

![image](https://user-images.githubusercontent.com/5328394/220051585-86546ebb-930a-4fb0-bfd2-5d6d0d3824dd.png)

