### PR TITLE
Add application_number to search filters

### DIFF
--- a/backend/benefit/applications/api/v1/views.py
+++ b/backend/benefit/applications/api/v1/views.py
@@ -88,6 +88,7 @@ class HandlerApplicationFilter(BaseApplicationFilter):
         fields = {
             "batch": ["exact", "isnull"],
             "archived": ["exact"],
+            "application_number": ["exact"],
             "employee__social_security_number": ["exact"],
             "company__business_id": ["exact"],
             "benefit_type": ["exact"],

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -152,6 +152,22 @@ def test_applications_filter_by_ssn(api_client, application, association_applica
     assert response.status_code == 200
 
 
+def test_applications_filter_by_application_number(
+    handler_api_client, received_application
+):
+    url = (
+        reverse("v1:handler-application-list")
+        + f"?application_number={received_application.application_number}"
+    )
+    response = handler_api_client.get(url)
+    assert len(response.data) == 1
+    assert (
+        response.data[0]["application_number"]
+        == received_application.application_number
+    )
+    assert response.status_code == 200
+
+
 def test_applications_simple_list_as_handler(handler_api_client, received_application):
     response = handler_api_client.get(
         reverse("v1:handler-application-simplified-application-list")


### PR DESCRIPTION
## Description :sparkles:
Adds application_number as a search filter to the handler's list.
## Issues :bug:

## Testing :alembic:
Visit the Swagger API documentation at [https://localhost:8000/api_docs/swagger/#/v1/v1_handlerapplications_list](https://localhost:8000/api_docs/swagger/#/v1/v1_handlerapplications_list) and input an application_number into the query parameters and click "execute".

With pytest run `USE_S3=False pytest applications/tests/test_applications_api.py -k 'test_applications_filter_by_application_number'`.

## Screenshots :camera_flash:
<img width="1422" alt="Screenshot 2023-02-23 at 15 15 18" src="https://user-images.githubusercontent.com/33894149/220917351-ecf2eb37-cc13-4864-9d83-871349f42077.png">
<img width="1415" alt="Screenshot 2023-02-23 at 15 15 48" src="https://user-images.githubusercontent.com/33894149/220917395-9f2468af-3979-4b36-b88b-2321df30d394.png">
<img width="1429" alt="Screenshot 2023-02-23 at 15 16 09" src="https://user-images.githubusercontent.com/33894149/220917445-64f50a2c-aaa7-44e7-839c-5ef9f40a0ff7.png">


## Additional notes :spiral_notepad:
