### PR TITLE
HL-531 | Alternative address is no longer required

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.tsx
@@ -106,7 +106,6 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
               disabled={isLoading || !!error}
               name={fields.useAlternativeAddress.name}
               label={fields.useAlternativeAddress.label}
-              required
               checked={formik.values.useAlternativeAddress === true}
               errorText={getErrorMessage(fields.useAlternativeAddress.name)}
               onChange={formik.handleChange}

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step3/ApplicationFormStep3.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step3/ApplicationFormStep3.tsx
@@ -30,42 +30,49 @@ const ApplicationFormStep3: React.FC<DynamicFormStepComponentProps> = ({
   return (
     <>
       <AttachmentsIngress />
-      {(benefitType === BENEFIT_TYPES.SALARY ||
-        benefitType === BENEFIT_TYPES.EMPLOYMENT) && (
-        <>
+      <ul>
+        {(benefitType === BENEFIT_TYPES.SALARY ||
+          benefitType === BENEFIT_TYPES.EMPLOYMENT) && (
+          <>
+            <AttachmentsList
+              as="li"
+              attachments={attachments}
+              attachmentType={ATTACHMENT_TYPES.EMPLOYMENT_CONTRACT}
+              required
+            />
+            {apprenticeshipProgram && (
+              <AttachmentsList
+                as="li"
+                attachments={attachments}
+                attachmentType={ATTACHMENT_TYPES.EDUCATION_CONTRACT}
+                required
+              />
+            )}
+            {paySubsidyGranted && (
+              <AttachmentsList
+                as="li"
+                attachments={attachments}
+                attachmentType={ATTACHMENT_TYPES.PAY_SUBSIDY_CONTRACT}
+                showMessage={showSubsidyMessage}
+                required
+              />
+            )}
+          </>
+        )}
+        {benefitType === BENEFIT_TYPES.COMMISSION && (
           <AttachmentsList
+            as="li"
             attachments={attachments}
-            attachmentType={ATTACHMENT_TYPES.EMPLOYMENT_CONTRACT}
+            attachmentType={ATTACHMENT_TYPES.COMMISSION_CONTRACT}
             required
           />
-          {apprenticeshipProgram && (
-            <AttachmentsList
-              attachments={attachments}
-              attachmentType={ATTACHMENT_TYPES.EDUCATION_CONTRACT}
-              required
-            />
-          )}
-          {paySubsidyGranted && (
-            <AttachmentsList
-              attachments={attachments}
-              attachmentType={ATTACHMENT_TYPES.PAY_SUBSIDY_CONTRACT}
-              showMessage={showSubsidyMessage}
-              required
-            />
-          )}
-        </>
-      )}
-      {benefitType === BENEFIT_TYPES.COMMISSION && (
+        )}
         <AttachmentsList
+          as="li"
           attachments={attachments}
-          attachmentType={ATTACHMENT_TYPES.COMMISSION_CONTRACT}
-          required
+          attachmentType={ATTACHMENT_TYPES.HELSINKI_BENEFIT_VOUCHER}
         />
-      )}
-      <AttachmentsList
-        attachments={attachments}
-        attachmentType={ATTACHMENT_TYPES.HELSINKI_BENEFIT_VOUCHER}
-      />
+      </ul>
       <$Hr
         css={`
           margin: ${theme.spacing.l} 0;

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step3/attachmentsList/AttachmentsList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step3/attachmentsList/AttachmentsList.tsx
@@ -11,6 +11,7 @@ export type AttachmentsListProps = {
   showMessage?: boolean;
   attachments?: BenefitAttachment[];
   required?: boolean;
+  as?: 'div' | 'li';
 };
 
 const AttachmentsList: React.FC<AttachmentsListProps> = ({
@@ -18,6 +19,7 @@ const AttachmentsList: React.FC<AttachmentsListProps> = ({
   showMessage = true,
   attachments,
   required,
+  as,
 }) => {
   const {
     t,
@@ -35,6 +37,7 @@ const AttachmentsList: React.FC<AttachmentsListProps> = ({
 
   return (
     <AttachmentsListBase
+      as={as}
       title={t(`${translationsBase}.types.${camelCase(attachmentType)}.title`)}
       attachmentType={attachmentType}
       name={attachmentType}

--- a/frontend/benefit/applicant/src/pages/_app.tsx
+++ b/frontend/benefit/applicant/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import 'react-toastify/dist/ReactToastify.css';
+import '../styles/globals.css';
 
 import AuthProvider from 'benefit/applicant/auth/AuthProvider';
 import Layout from 'benefit/applicant/components/layout/Layout';

--- a/frontend/benefit/applicant/src/styles/globals.css
+++ b/frontend/benefit/applicant/src/styles/globals.css
@@ -1,0 +1,18 @@
+html,
+body {
+  padding: 0;
+  margin: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+ul {
+  list-style: none;
+}
+
+ul, li {
+  margin: 0;
+  padding: 0;
+}

--- a/frontend/shared/src/components/attachments/AttachmentsList.tsx
+++ b/frontend/shared/src/components/attachments/AttachmentsList.tsx
@@ -29,6 +29,7 @@ type Props<T extends Attachment> = {
   required?: boolean;
   buttonRef?: React.Ref<HTMLButtonElement>;
   name?: string;
+  as?: 'div' | 'li';
 };
 
 const AttachmentsList = <T extends Attachment>({
@@ -47,6 +48,7 @@ const AttachmentsList = <T extends Attachment>({
   required,
   name,
   buttonRef,
+  as,
 }: Props<T>): JSX.Element => {
   const { t } = useTranslation();
   const translationsBase = 'common:applications.sections.attachments';
@@ -58,7 +60,7 @@ const AttachmentsList = <T extends Attachment>({
   const uploadText = t(`${translationsBase}.add`);
 
   return (
-    <$Container>
+    <$Container as={as}>
       <$Heading>
         {title} {required && ' *'}
       </$Heading>

--- a/frontend/shared/src/components/attachments/AttachmentsList.tsx
+++ b/frontend/shared/src/components/attachments/AttachmentsList.tsx
@@ -48,7 +48,7 @@ const AttachmentsList = <T extends Attachment>({
   required,
   name,
   buttonRef,
-  as,
+  as = 'div',
 }: Props<T>): JSX.Element => {
   const { t } = useTranslation();
   const translationsBase = 'common:applications.sections.attachments';


### PR DESCRIPTION
## Description :sparkles:

On-screen reader tells user to toggle on alternative address checkbox but actually it's not required by the form validation. Remove `required="true"` HTML-attribute to fix the issue.