### PR TITLE
HL-531 | Alternative address is no longer required

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.tsx
@@ -106,7 +106,6 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
               disabled={isLoading || !!error}
               name={fields.useAlternativeAddress.name}
               label={fields.useAlternativeAddress.label}
-              required
               checked={formik.values.useAlternativeAddress === true}
               errorText={getErrorMessage(fields.useAlternativeAddress.name)}
               onChange={formik.handleChange}


### PR DESCRIPTION
## Description :sparkles:

On-screen reader tells user to toggle on alternative address checkbox but actually it's not required by the form validation. Remove `required="true"` HTML-attribute to fix the issue.