### PR TITLE
HL-525 | Add a11y attributes to custom Stepper component

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -135,7 +135,7 @@ const PageContent: React.FC = () => {
           </$PageHeading>
         </$HeaderItem>
         <$HeaderItem>
-          <Stepper steps={steps} activeStep={currentStep} />
+          <Stepper steps={steps} activeStep={currentStep} as="ol" />
         </$HeaderItem>
       </$PageHeader>
       {id && application?.createdAt && !isSubmittedApplication && (

--- a/frontend/benefit/applicant/src/styles/globals.css
+++ b/frontend/benefit/applicant/src/styles/globals.css
@@ -8,11 +8,11 @@ body {
   box-sizing: border-box;
 }
 
-ul {
+ul, ol {
   list-style: none;
 }
 
-ul, li {
+ul, ol, li {
   margin: 0;
   padding: 0;
 }

--- a/frontend/shared/src/components/stepper/Stepper.sc.ts
+++ b/frontend/shared/src/components/stepper/Stepper.sc.ts
@@ -55,3 +55,21 @@ export const $Divider = styled.div<Props>`
   background: ${({ isActive, theme }) =>
     getActiveColor(isActive || false, theme)};
 `;
+
+type AriaProps = {
+  'aria-current'?:
+    | boolean
+    | 'time'
+    | 'step'
+    | 'false'
+    | 'true'
+    | 'page'
+    | 'location'
+    | 'date';
+  'aria-label'?: string;
+};
+
+export const $StepItem = styled.div<AriaProps>`
+  display: flex;
+  align-items: center;
+`;

--- a/frontend/shared/src/components/stepper/Stepper.sc.ts
+++ b/frontend/shared/src/components/stepper/Stepper.sc.ts
@@ -9,32 +9,20 @@ type $StepContainerProps = Props & {
 const getActiveColor = (isActive: boolean, theme: DefaultTheme): string =>
   isActive ? theme.colors.black90 : theme.colors.black20;
 
-export const $StepsContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  align-items: center;
-`;
-
-export const $StepContainer = styled.div<$StepContainerProps>`
+const circleSize = 36;
+export const $StepCircle = styled.div<Props>`
   display: flex;
   align-items: center;
-  flex-direction: column;
-  z-index: 1;
-  cursor: ${({ isActive }) => (isActive ? 'pointer' : 'auto')};
-`;
-
-export const $StepCircle = styled.div<Props>`
-  height: 36px;
-  width: 36px;
+  justify-content: center;
+  height: ${circleSize}px;
+  width: ${circleSize}px;
   border-radius: 50%;
-  border: 4px solid
+  border: ${(props) => (props.isActive ? '4px' : '2px')} solid
     ${({ isActive, theme }) => getActiveColor(isActive || false, theme)};
   text-align: center;
   color: ${({ isActive, theme }) => getActiveColor(isActive || false, theme)};
   font-weight: 600;
-  line-height: 36px;
   font-size: ${(props) => props.theme.fontSize.body.m};
-  justify-self: center;
 `;
 
 export const $StepTitle = styled.p<Props>`
@@ -50,10 +38,16 @@ export const $StepTitle = styled.p<Props>`
 
 export const $Divider = styled.div<Props>`
   width: 72px;
-  height: 4px;
-  margin: 4px;
+  height: 2px;
+  margin: 2px;
   background: ${({ isActive, theme }) =>
     getActiveColor(isActive || false, theme)};
+`;
+
+export const $StepContainer = styled.div<$StepContainerProps>`
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  align-items: center;
 `;
 
 type AriaProps = {

--- a/frontend/shared/src/components/stepper/Stepper.tsx
+++ b/frontend/shared/src/components/stepper/Stepper.tsx
@@ -5,7 +5,7 @@ import {
   $Divider,
   $StepCircle,
   $StepItem,
-  $StepsContainer,
+  $StepContainer,
   $StepTitle,
 } from './Stepper.sc';
 
@@ -20,7 +20,7 @@ const Stepper: React.FC<StepperProps> = ({
   steps,
   as: containerTag,
 }) => (
-  <$StepsContainer as={containerTag}>
+  <$StepContainer as={containerTag}>
     {steps.map((step, index) => (
       <React.Fragment key={step.title}>
         <$StepItem
@@ -38,7 +38,7 @@ const Stepper: React.FC<StepperProps> = ({
         <$StepTitle isActive={index < activeStep}>{step.title}</$StepTitle>
       </React.Fragment>
     ))}
-  </$StepsContainer>
+  </$StepContainer>
 );
 
 export default Stepper;

--- a/frontend/shared/src/components/stepper/Stepper.tsx
+++ b/frontend/shared/src/components/stepper/Stepper.tsx
@@ -4,28 +4,36 @@ import { StepProps } from './Step';
 import {
   $Divider,
   $StepCircle,
+  $StepItem,
   $StepsContainer,
   $StepTitle,
 } from './Stepper.sc';
 
-type StepperProps = { activeStep?: number; steps: StepProps[] };
+type StepperProps = {
+  activeStep?: number;
+  steps: StepProps[];
+  as?: 'div' | 'ol';
+};
 
-const Stepper: React.FC<StepperProps> = ({ activeStep = 1, steps }) => (
-  <$StepsContainer>
+const Stepper: React.FC<StepperProps> = ({
+  activeStep = 1,
+  steps,
+  as: containerTag,
+}) => (
+  <$StepsContainer as={containerTag}>
     {steps.map((step, index) => (
       <React.Fragment key={step.title}>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-          }}
+        <$StepItem
+          as={containerTag === 'ol' ? 'li' : 'div'}
+          aria-label={`${index + 1}. ${step.title}`}
+          aria-current={activeStep - 1 === index ? 'step' : false}
         >
           <$StepCircle isActive={index < activeStep}>{index + 1}</$StepCircle>
 
           {index < steps.length - 1 && (
             <$Divider isActive={index < activeStep - 1} />
           )}
-        </div>
+        </$StepItem>
 
         <$StepTitle isActive={index < activeStep}>{step.title}</$StepTitle>
       </React.Fragment>

--- a/frontend/shared/src/components/stepper/Stepper.tsx
+++ b/frontend/shared/src/components/stepper/Stepper.tsx
@@ -4,8 +4,8 @@ import { StepProps } from './Step';
 import {
   $Divider,
   $StepCircle,
-  $StepItem,
   $StepContainer,
+  $StepItem,
   $StepTitle,
 } from './Stepper.sc';
 

--- a/frontend/shared/src/components/stepper/Stepper.tsx
+++ b/frontend/shared/src/components/stepper/Stepper.tsx
@@ -28,7 +28,9 @@ const Stepper: React.FC<StepperProps> = ({
           aria-label={`${index + 1}. ${step.title}`}
           aria-current={activeStep - 1 === index ? 'step' : false}
         >
-          <$StepCircle isActive={index < activeStep}>{index + 1}</$StepCircle>
+          <$StepCircle isActive={index < activeStep}>
+            <span>{index + 1}</span>
+          </$StepCircle>
 
           {index < steps.length - 1 && (
             <$Divider isActive={index < activeStep - 1} />


### PR DESCRIPTION
## Description

Turns out the shared component [Stepper is a copy](https://hds.hel.fi/components/stepper/) from the one in design system.

* Make stepper look like HDS Stepper in 2023
* Add aria-label and aria-step to tell screen reader about current progress
* Remove inline css