### PR TITLE
HL-685 | Never send a note via email to an applicant

### DIFF
--- a/backend/benefit/messages/views.py
+++ b/backend/benefit/messages/views.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import NotFound
 from applications.models import Application
 from common.permissions import BFIsApplicant, BFIsHandler, TermsOfServiceAccepted
 from messages.automatic_messages import send_email_to_applicant
-from messages.models import Message
+from messages.models import Message, MessageType
 from messages.permissions import HasMessagePermission
 from messages.serializers import MessageSerializer, NoteSerializer
 from shared.audit_log.viewsets import AuditLoggingModelViewSet
@@ -15,7 +15,6 @@ from users.utils import get_company_from_request
 
 
 class ApplicantMessageViewSet(AuditLoggingModelViewSet):
-
     serializer_class = MessageSerializer
     permission_classes = [
         BFIsApplicant,
@@ -49,7 +48,12 @@ class HandlerMessageViewSet(ApplicantMessageViewSet):
 
     def perform_create(self, serializer):
         message = serializer.save()
-        send_email_to_applicant(message.application)
+        # Never send email if it's a handler's note!
+        if message.message_type in [
+            MessageType.HANDLER_MESSAGE,
+            MessageType.APPLICANT_MESSAGE,
+        ]:
+            send_email_to_applicant(message.application)
 
     def get_queryset(self):
         try:


### PR DESCRIPTION
## Description :sparkles:

Found a issue in a handler session today. Should only send email when appropriate.