### PR TITLE
HL-687 | Fix SSR error by only rendering footer on client side

### DIFF
--- a/frontend/benefit/applicant/src/components/layout/Layout.tsx
+++ b/frontend/benefit/applicant/src/components/layout/Layout.tsx
@@ -1,12 +1,17 @@
-import Footer from 'benefit/applicant/components/footer/Footer';
 import Header from 'benefit/applicant/components/header/Header';
 import SupportingContent from 'benefit/applicant/components/supportingContent/SupportingContent';
 import TermsOfService from 'benefit/applicant/components/termsOfService/TermsOfService';
 import { IS_CLIENT, LOCAL_STORAGE_KEYS } from 'benefit/applicant/constants';
+import dynamic from 'next/dynamic';
 import * as React from 'react';
 import useAuth from 'shared/hooks/useAuth';
 
 import { $Main } from './Layout.sc';
+
+const Footer = dynamic(
+  () => import('benefit/applicant/components/footer/Footer'),
+  { ssr: false }
+);
 
 type Props = { children: React.ReactNode };
 


### PR DESCRIPTION
## Description :sparkles:

Fixes critical error caused by HDS Koros effect: 

![image](https://user-images.githubusercontent.com/5328394/222412397-ce46a03c-87cf-42fd-91e5-e096eec2f37f.png)

### Error 

```Warning: Prop `id` did not match. Server: "koros_basic-xxx" Client: "koros_basic-xxx"```

![image](https://user-images.githubusercontent.com/5328394/222411989-c45cea8d-6b97-4dc8-81be-6fb35af46554.png)

## Testing :alembic:

Branch out, load https://localhost:3000. No more red error in console.