### PR TITLE
HL-308 | Add generic errors and fix some toast-related issues

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -492,6 +492,11 @@
       "title": "Error occurred",
       "tooBig": "The attachemnt size is too big.",
       "fileType": "The attachment file type is not allowed."
+    },
+    "notFound": {
+      "title": "Sorry, the page you were looking for was not found.",
+      "text": "Error 404: Check that you have typed in the page address correctly. We may have deleted or moved the content."
+    }
     }
   },
   "upload": {

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -496,7 +496,9 @@
     "notFound": {
       "title": "Sorry, the page you were looking for was not found.",
       "text": "Error 404: Check that you have typed in the page address correctly. We may have deleted or moved the content."
-    }
+    },
+    "backend": {
+      "Request failed with status code 500": "System error. Please try again later."
     }
   },
   "upload": {

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -492,6 +492,11 @@
       "title": "Tapahtui virhe",
       "tooBig": "Liite on liian suuri.",
       "fileType": "Liite on väärässä muodossa."
+    },
+    "notFound": {
+      "title": "Pahoittelut, sivua ei löytynyt.",
+      "text": "Virhe 404: Hakemasi sivun osoite on voinut muuttua tai sivu on poistettu."
+    }
     }
   },
   "upload": {

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -80,8 +80,8 @@
         "deMinimisAidsNo": "Onko hakijalle myönnetty deminimis-tukea?",
         "notifications": {
           "companyInformation": {
-            "label": "Tiedot haettu Yritys- ja yhteisötietojärjestelmästä",
-            "content": "Organisaatiosi perustiedot on haettu Yritys- ja yhteisötietojärjestelmästä. Halutessasi voit vaihtaa tilalle toisen postiosoitteen, johon Helsinki-lisä-päätös toimitetaan."
+            "label": "Tiedot haetaan Yritys- ja yhteisötietojärjestelmästä",
+            "content": "Organisaatiosi perustiedot haetaan Yritys- ja yhteisötietojärjestelmästä. Halutessasi voit vaihtaa tilalle toisen postiosoitteen, johon Helsinki-lisä-päätös toimitetaan."
           },
           "deMinimisAidMaxAmount": {
             "label": "Enimmäismäärä ylitetty",
@@ -496,7 +496,9 @@
     "notFound": {
       "title": "Pahoittelut, sivua ei löytynyt.",
       "text": "Virhe 404: Hakemasi sivun osoite on voinut muuttua tai sivu on poistettu."
-    }
+    },
+    "backend": {
+      "Request failed with status code 500": "Virhe taustajärjestelmässä. Kokeile myöhemmin uudestaan."
     }
   },
   "upload": {

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -492,6 +492,11 @@
       "title": "Ett fel uppstod",
       "tooBig": "Storleken på bilagan är för stor.",
       "fileType": "Typen av bilaga är inte tillåten."
+    },
+    "notFound": {
+      "title": "Tyvärr hittas inte sidan du sökte.",
+      "text": "Fel 404: Kontrollera att sidans adress är rätt skriven. Vi kan också ha tagit bort eller flyttat sidan."
+    }
     }
   },
   "upload": {

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -496,7 +496,9 @@
     "notFound": {
       "title": "Tyvärr hittas inte sidan du sökte.",
       "text": "Fel 404: Kontrollera att sidans adress är rätt skriven. Vi kan också ha tagit bort eller flyttat sidan."
-    }
+    },
+    "backend": {
+      "Request failed with status code 500": "Fel i systemet. Vänligen försök igen senare."
     }
   },
   "upload": {

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.tsx
@@ -1,4 +1,5 @@
 import { useDependentFieldsEffect } from 'benefit/applicant/hooks/useDependentFieldsEffect';
+import { translateBackendErrorMessage } from 'benefit/applicant/utils/common';
 import { ORGANIZATION_TYPES } from 'benefit-shared/constants';
 import { Application } from 'benefit-shared/types/application';
 import { FormikProps } from 'formik';
@@ -89,15 +90,20 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
           </$GridCell>
           <$GridCell $colSpan={6} $rowSpan={2}>
             <$Notification
-              label={t(
-                `${translationsBase}.notifications.companyInformation.label`
-              )}
+              label={
+                error?.message
+                  ? t('error.generic.label')
+                  : t(
+                      `${translationsBase}.notifications.companyInformation.label`
+                    )
+              }
               type={error ? 'error' : 'info'}
             >
-              {error?.message ||
-                t(
-                  `${translationsBase}.notifications.companyInformation.content`
-                )}
+              {error?.message && translateBackendErrorMessage(t, error)
+                ? translateBackendErrorMessage(t, error)
+                : t(
+                    `${translationsBase}.notifications.companyInformation.content`
+                  )}
             </$Notification>
           </$GridCell>
           <$GridCell $colSpan={6}>

--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -68,7 +68,7 @@ const PageContent: React.FC = () => {
       <ErrorPage
         title={t('common:errorPage.title')}
         message={t('common:errorPage.message')}
-        showActions
+        showActions={{ linkToRoot: true, linkToLogout: true }}
       />
     );
   }
@@ -120,7 +120,7 @@ const PageContent: React.FC = () => {
         <ErrorPage
           title={t('common:errorPage.title')}
           message={t('common:errorPage.message')}
-          showActions
+          showActions={{ linkToRoot: true, linkToLogout: true }}
         />
       </Container>
     );

--- a/frontend/benefit/applicant/src/components/errorPage/ErrorPage.tsx
+++ b/frontend/benefit/applicant/src/components/errorPage/ErrorPage.tsx
@@ -14,13 +14,16 @@ import { useErrorPage } from './useErrorPage';
 export interface ErrorPageProps {
   title: string;
   message: string;
-  showActions?: boolean;
+  showActions?: {
+    linkToRoot: boolean;
+    linkToLogout: boolean;
+  };
 }
 
 const ErrorPage: React.FC<ErrorPageProps> = ({
   title,
   message,
-  showActions = false,
+  showActions,
 }) => {
   const { t, handleBackClick, handleLogout } = useErrorPage();
   return (
@@ -29,14 +32,18 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
         <$IconAlertCircle size="xl" />
         <$ErrorPageTitle>{title}</$ErrorPageTitle>
         <$ErrorPageMessage>{message}</$ErrorPageMessage>
-        {showActions && (
+        {!!showActions && (
           <$ActionsContainer>
-            <Button theme="coat" onClick={handleBackClick}>
-              {t('common:errorPage.home')}
-            </Button>
-            <Button theme="coat" onClick={handleLogout}>
-              {t('common:errorPage.logout')}
-            </Button>
+            {showActions?.linkToRoot && (
+              <Button theme="coat" onClick={handleBackClick}>
+                {t('common:errorPage.home')}
+              </Button>
+            )}
+            {showActions?.linkToLogout && (
+              <Button theme="coat" onClick={handleLogout}>
+                {t('common:errorPage.logout')}
+              </Button>
+            )}
           </$ActionsContainer>
         )}
       </$ErrorPageContainer>

--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -67,16 +67,18 @@ const useFormActions = (application: Partial<Application>): FormActions => {
 
     if (error) {
       const errorData = camelcaseKeys(error.response?.data ?? {});
-
+      const isContentTypeHTML = typeof errorData === 'string';
       hdsToast({
         autoDismissTime: 0,
         type: 'error',
         labelText: t('common:error.generic.label'),
-        text: Object.entries(errorData).map(([key, value]) => (
-          <a key={key} href={`#${key}`}>
-            {value}
-          </a>
-        )),
+        text: isContentTypeHTML
+          ? t('common:error.generic.text')
+          : Object.entries(errorData).map(([key, value]) => (
+              <a key={key} href={`#${key}`}>
+                {value}
+              </a>
+            )),
       });
     }
   }, [

--- a/frontend/benefit/applicant/src/pages/404.tsx
+++ b/frontend/benefit/applicant/src/pages/404.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'benefit/applicant/i18n';
+import { GetStaticProps, NextPage } from 'next';
+import Head from 'next/head';
+import * as React from 'react';
+import withAuth from 'shared/components/hocs/withAuth';
+import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+
+import ErrorPage from '../components/errorPage/ErrorPage';
+import FrontPageProvider from '../context/FrontPageProvider';
+
+const ApplicantIndex: NextPage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Head>
+        <title>{t('common:appName')}</title>
+      </Head>
+
+      <FrontPageProvider>
+        <ErrorPage
+          title={t('common:error.notFound.title')}
+          message={t('common:error.notFound.text')}
+          showActions={{ linkToRoot: true, linkToLogout: false }}
+        />
+      </FrontPageProvider>
+    </>
+  );
+};
+
+export const getStaticProps: GetStaticProps =
+  getServerSideTranslations('common');
+
+export default withAuth(ApplicantIndex);

--- a/frontend/benefit/applicant/src/utils/common.ts
+++ b/frontend/benefit/applicant/src/utils/common.ts
@@ -17,6 +17,12 @@ export const getLanguageOptions = (
   return createOptions(Object.values(SUPPORTED_LANGUAGES));
 };
 
+export const translateBackendErrorMessage = (
+  t: TFunction,
+  error: Error
+): string =>
+  t(`common:error.backend.${error.message}`) || t('common:notifications.error.title');
+
 export const getApplicationStepFromString = (step: string): number => {
   try {
     return parseInt(step.split('_')[1], 10);

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -98,6 +98,10 @@
       "title": "Error occurred",
       "tooBig": "The attachemnt size is too big.",
       "fileType": "The attachment file type is not allowed."
+    },
+    "notFound": {
+      "title": "Pahoittelut, sivua ei löytynyt.",
+      "text": "Virhe 404: Hakemasi sivun osoite on voinut muuttua tai sivu on poistettu."
     }
   },
   "applications": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -97,6 +97,10 @@
       "title": "Error occurred",
       "tooBig": "The attachemnt size is too big.",
       "fileType": "The attachment file type is not allowed."
+    },
+    "notFound": {
+      "title": "Pahoittelut, sivua ei löytynyt.",
+      "text": "Virhe 404: Hakemasi sivun osoite on voinut muuttua tai sivu on poistettu."
     }
   },
   "applications": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -98,6 +98,10 @@
       "title": "Error occurred",
       "tooBig": "The attachemnt size is too big.",
       "fileType": "The attachment file type is not allowed."
+    },
+    "notFound": {
+      "title": "Pahoittelut, sivua ei löytynyt.",
+      "text": "Virhe 404: Hakemasi sivun osoite on voinut muuttua tai sivu on poistettu."
     }
   },
   "applications": {

--- a/frontend/benefit/handler/src/pages/404.tsx
+++ b/frontend/benefit/handler/src/pages/404.tsx
@@ -1,0 +1,47 @@
+import AppContext from 'benefit/handler/context/AppContext';
+import FrontPageProvider from 'benefit/handler/context/FrontPageProvider';
+import { GetStaticProps, NextPage } from 'next';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import * as React from 'react';
+import { useEffect } from 'react';
+import ErrorPage from 'shared/components/pages/ErrorPage';
+import theme from 'shared/styles/theme';
+
+const ApplicantIndex: NextPage = () => {
+  const {
+    setIsFooterVisible,
+    setIsNavigationVisible,
+    setLayoutBackgroundColor,
+  } = React.useContext(AppContext);
+
+  // configure page specific settings
+  useEffect(() => {
+    setIsNavigationVisible(true);
+    setIsFooterVisible(true);
+    setLayoutBackgroundColor(theme.colors.silverLight);
+    return () => {
+      setIsNavigationVisible(false);
+      setLayoutBackgroundColor(theme.colors.white);
+    };
+  }, [setIsFooterVisible, setIsNavigationVisible, setLayoutBackgroundColor]);
+
+  const { t } = useTranslation();
+
+  return (
+    <FrontPageProvider>
+      <ErrorPage
+        title={t('common:error.notFound.title')}
+        message={t('common:error.notFound.text')}
+      />
+    </FrontPageProvider>
+  );
+};
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(locale || '', ['common'])),
+  },
+});
+
+export default ApplicantIndex;


### PR DESCRIPTION
## Description :sparkles:

* Add 404 page to handler & applicant
* Fix mapping and displaying backend error in toast when contentType was a string (text/html)
* Change YTJ/Yrtti backend failure to human-readable format

### Before

<img width="885" alt="image" src="https://user-images.githubusercontent.com/5328394/223668125-60ac35de-ef12-4695-b179-bdf935dd2c7c.png">

### After

![virhe](https://user-images.githubusercontent.com/5328394/223668761-dc7e6c4c-3696-49ce-a33b-18c24840c796.gif)