### PR TITLE
Add http-cache-semantics to audit-ci whitelist

### DIFF
--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -8,6 +8,7 @@
     "loader-utils",         // next
     "moment",               // testcafe
     "jsonwebtoken",         // testcafe 
+    "http-cache-semantics", // testcafe
     "requestretry"          // slack-node
   ]
 }


### PR DESCRIPTION
## Description :sparkles:

Audit-ci is failing constantly. Add `http-cache-semantics` package to whitelist.

<img width="483" alt="image" src="https://user-images.githubusercontent.com/5328394/223723044-237f9cb1-c173-4fcb-96ff-b4d259a942fa.png">
