### PR TITLE
HL-706 | NodeJS 14 to 16 upgrade

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/bf-applicant-frontend-tests.yml
+++ b/.github/workflows/bf-applicant-frontend-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/bf-handler-frontend-tests.yml
+++ b/.github/workflows/bf-handler-frontend-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/bf-review.yml
+++ b/.github/workflows/bf-review.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/bf-shared-frontend-tests.yml
+++ b/.github/workflows/bf-shared-frontend-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/ks-empl-frontend-tests.yml
+++ b/.github/workflows/ks-empl-frontend-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/ks-handler-frontend-tests.yml
+++ b/.github/workflows/ks-handler-frontend-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/ks-review.yml
+++ b/.github/workflows/ks-review.yml
@@ -256,7 +256,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/ks-shared-frontend-tests.yml
+++ b/.github/workflows/ks-shared-frontend-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/ks-youth-frontend-tests.yml
+++ b/.github/workflows/ks-youth-frontend-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/shared-frontend-tests.yml
+++ b/.github/workflows/shared-frontend-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/te-admn-frontend-tests.yml
+++ b/.github/workflows/te-admn-frontend-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/te-review.yml
+++ b/.github/workflows/te-review.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/te-shared-frontend-tests.yml
+++ b/.github/workflows/te-shared-frontend-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/te-yout-frontend-tests.yml
+++ b/.github/workflows/te-yout-frontend-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/yarn-audit-scheduled.yml
+++ b/.github/workflows/yarn-audit-scheduled.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This monorepo contains code for four different employment services:
 ## Requirements
 
 * Docker@^19.03.0 (or higher)
-* NodeJS@^14.0.0
+* NodeJS@^16.19.0
 * Yarn@^1.22
 
 ---

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # =======================================
-FROM helsinkitest/node:14-slim as appbase
+FROM helsinkitest/node:16-slim as appbase
 # =======================================
 
 # Use non-root user
@@ -95,7 +95,7 @@ RUN rm -rf node_modules
 RUN yarn cache clean
 
 # ==========================================
-FROM helsinkitest/node:14-slim AS production
+FROM helsinkitest/node:16-slim AS production
 # ==========================================
 
 ARG PORT

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,14 +9,14 @@ Project is automatically deployed to testing environment when pushing to develop
 
 ## Requirements
 
-- Node 14.x (It's good to use same major version as the dockerfile: helsinkitest/node:14-slim)
+- Node 16.x (match with dockerfile: helsinkitest/node:16-slim)
 - Yarn
 - Git
 - Docker
 
 ### install node with nvm
 
-    nvm install 14 --lts
+    nvm install 16 --lts
 
 
 ## Available Scripts

--- a/frontend/benefit/README.md
+++ b/frontend/benefit/README.md
@@ -9,16 +9,20 @@ Project is automatically deployed to testing environment when pushing to develop
 
 ## Requirements
 
-- Node 14.x
+- Node 16.x
 - Lerna  
 - Yarn
 - Git
 - Docker
 
-### install node with nvm
+### Install NodeJS
 
-    nvm install 14 --lts
-
+    # Use node manager (n or nvm, for example)
+    n 16
+    nvm install 16 --lts
+    # Alternative methods
+    https://nodejs.org/dist/
+    https://nodejs.org/en/download/package-manager
 
 ## Available Scripts
 

--- a/frontend/kesaseteli/README.md
+++ b/frontend/kesaseteli/README.md
@@ -19,15 +19,15 @@ Project is automatically deployed to testing environment when pushing to develop
 
 ## Requirements
 
-- Node 14.x
-- Lerna  
+- Node 16.x
+- Lerna
 - Yarn
 - Git
 - Docker
 
 ### install node with nvm
 
-    nvm install 14 --lts
+    nvm install 16 --lts
 
 
 ## Available Scripts

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,9 @@
     "tet/*",
     "shared"
   ],
+  "engines" : { 
+    "node" : ">=16.19.0 <17.0.0"
+  },
   "scripts": {
     "audit": "npx lerna-audit --level=high --groups=dependencies",
     "build": "npx lerna run build",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "cross-env": "^7.0.3",
     "husky": "^8.0.1"
   },
+  "engines" : { 
+    "node" : ">=16.19.0 <17.0.0"
+  },
   "scripts": {
     "prepare": "husky install",
     "// clean: stop and remove docker containers and database volume" : "",


### PR DESCRIPTION
## Description :sparkles:

Upgrade NodeJS 14 to 16. 

Some good reasons to this upgrade:

* NodeJS 14 is end-of-life in one month
  * Upgrade old node container in local development & online envs
  * Upgrade .github actions
* Pave the way to yarn and lerna upgrade
* Pave the way to nextjs 12-13 upgrade
* And last but not least: upgrading has infinite intrinsic value

What could go wrong :godmode: 

---

## Easter update (2023-04-06)

Tested thoroughly at https://github.com/City-of-Helsinki/yjdh/pull/1945 and works great.