### PR TITLE
HL-715 | Add missing ENV declarations to enable GraphQL and fetch SSN

### DIFF
--- a/.env.benefit-backend.example
+++ b/.env.benefit-backend.example
@@ -22,6 +22,10 @@ OIDC_RP_CLIENT_SECRET=
 OIDC_OP_BASE_URL=https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect
 OIDC_OP_LOGOUT_CALLBACK_URL=https://localhost:8000/oidc/logout_callback/
 
+TUNNISTAMO_API_TOKENS_ENDPOINT=https://tunnistamo.test.hel.ninja/api-tokens/
+HELSINKI_PROFILE_API_URL=https://profile-api.test.hel.ninja/graphql/
+HELSINKI_PROFILE_SCOPE=https://api.hel.fi/auth/helsinkiprofile
+
 LOGIN_REDIRECT_URL=https://localhost:3000/
 LOGIN_REDIRECT_URL_FAILURE=https://localhost:3000/login?error=true
 LOGOUT_REDIRECT_URL=https://localhost:3000/login?logout=true

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -81,10 +81,13 @@ env = environ.Env(
     OIDC_RP_CLIENT_SECRET=(str, ""),
     OIDC_OP_BASE_URL=(str, ""),
     OIDC_SAVE_PERSONALLY_IDENTIFIABLE_INFO=(bool, True),
+    OIDC_OP_LOGOUT_CALLBACK_URL=(str, "/"),
+    TUNNISTAMO_API_TOKENS_ENDPOINT=(str, ""),
+    HELSINKI_PROFILE_SCOPE=(str, "https://api.hel.fi/auth/helsinkiprofile"),
+    HELSINKI_PROFILE_API_URL=(str, "https://api.hel.fi/profiili/graphql/"),
     LOGIN_REDIRECT_URL=(str, "/"),
     LOGIN_REDIRECT_URL_FAILURE=(str, "/"),
     LOGOUT_REDIRECT_URL=(str, "/"),
-    OIDC_OP_LOGOUT_CALLBACK_URL=(str, "/"),
     ADFS_LOGIN_REDIRECT_URL=(str, "/"),
     ADFS_LOGIN_REDIRECT_URL_FAILURE=(str, "/"),
     EAUTHORIZATIONS_BASE_URL=(str, "https://asiointivaltuustarkastus.test.suomi.fi"),
@@ -367,10 +370,14 @@ OIDC_API_TOKEN_AUTH = {
     "USER_RESOLVER": "users.api.v1.authentications.resolve_user",
 }
 
+TUNNISTAMO_API_TOKENS_ENDPOINT = env.str("TUNNISTAMO_API_TOKENS_ENDPOINT")
+HELSINKI_PROFILE_SCOPE = env.str("HELSINKI_PROFILE_SCOPE")
+HELSINKI_PROFILE_API_URL = env.str("HELSINKI_PROFILE_API_URL")
+
+OIDC_RP_SCOPES = f"openid profile {HELSINKI_PROFILE_SCOPE}"
 OIDC_AUTH = {"OIDC_LEEWAY": env.int("OIDC_LEEWAY")}
 
 OIDC_RP_SIGN_ALGO = "RS256"
-OIDC_RP_SCOPES = "openid profile"
 
 OIDC_RP_CLIENT_ID = env.str("OIDC_RP_CLIENT_ID")
 OIDC_RP_CLIENT_SECRET = env.str("OIDC_RP_CLIENT_SECRET")


### PR DESCRIPTION
# Description

Cont. from https://github.com/City-of-Helsinki/yjdh/pull/1920

We are currently logged in as a private person but the app crashes on eauthorization the graphql query fails because of some missing envs (these are already in place in TET).

For more information, search for "Tunnistamo" at https://github.com/City-of-Helsinki/yjdh/blob/develop/backend/README.md

# Update

Deployed to dev / test works now. Yeehaw !! 🤠 