### PR TITLE
Fix nasty redirect issue which happens in every view for both apps

### DIFF
--- a/frontend/benefit/shared/src/backend-api/backend-api.ts
+++ b/frontend/benefit/shared/src/backend-api/backend-api.ts
@@ -6,7 +6,7 @@ export const BackendEndpoint = {
   OAUTH_LOGOUT: '/oauth2/logout',
   LOGOUT: '/oidc/logout/',
   USER: '/oidc/userinfo/',
-  USER_ME: 'v1/users/me',
+  USER_ME: 'v1/users/me/',
   COMPANY: '/v1/company/',
   APPLICATIONS: '/v1/applications/',
   APPLICATIONS_SIMPLIFIED: '/v1/applications/simplified_list/',


### PR DESCRIPTION
## Description :sparkles:

A route without slash results to Django redirecting every request to `/me/`. This happens on every SPA page view change and when user clicks outside the browser tab and returns to the app.

These are used as kind of an authorization health check for both handler and the applicant app. This PR fixes the redirect issue as we only want to call the version with the slash.

### Here's the network for a couple of page visits without the slash:

<img width="1678" alt="image" src="https://user-images.githubusercontent.com/5328394/231772599-02842196-d63f-4452-bde0-59714320faed.png">
