### PR TITLE
HL-698 | Applications and AHJO batch post-processing

### DIFF
--- a/backend/benefit/applications/api/v1/application_batch_views.py
+++ b/backend/benefit/applications/api/v1/application_batch_views.py
@@ -11,7 +11,10 @@ from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
-from applications.api.v1.serializers.batch import ApplicationBatchSerializer
+from applications.api.v1.serializers.batch import (
+    ApplicationBatchListSerializer,
+    ApplicationBatchSerializer,
+)
 from applications.enums import ApplicationBatchStatus, ApplicationStatus
 from applications.models import Application, ApplicationBatch
 from applications.services.ahjo_integration import export_application_batch
@@ -60,6 +63,15 @@ class ApplicationBatchViewSet(AuditLoggingModelViewSet):
         "applications__company_contact_person_email",
     ]
 
+    def get_serializer_class(self):
+        """
+        ApplicationBatchSerializer for default behaviour on mutation functions,
+        ApplicationBatchListSerializer for listing applications on a batch
+        """
+        if self.action in ["create", "update", "partial_update", "destroy"]:
+            return ApplicationBatchSerializer
+
+        return ApplicationBatchListSerializer
     @action(methods=("GET",), detail=True, url_path="export")
     def export_batch(self, request, *args, **kwargs):
         """

--- a/backend/benefit/applications/api/v1/serializers/utils.py
+++ b/backend/benefit/applications/api/v1/serializers/utils.py
@@ -5,8 +5,7 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
     """
     A ModelSerializer that takes an additional `fields` argument that
     controls which fields should be displayed and exclude_fields parameter argument that controls
-    which fields should not be displayed and exclude_fields parameter argument that controls which
-    fields should not be displayed.
+    which fields should not be displayed.
     """
 
     def __init__(self, *args, **kwargs):
@@ -19,3 +18,9 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
         allowed = set(fields) - set(exclude_fields)
         for field_name in existing - allowed:
             self.fields.pop(field_name)
+
+
+class ReadOnlySerializer(serializers.ModelSerializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        setattr(self.Meta, "read_only_fields", [*self.fields])

--- a/backend/benefit/applications/api/v1/views.py
+++ b/backend/benefit/applications/api/v1/views.py
@@ -368,6 +368,15 @@ class HandlerApplicationViewSet(BaseApplicationViewSet):
 
     @action(methods=["GET"], detail=False)
     @transaction.atomic
+    def export_applications_in_batch(self, request) -> HttpResponse:
+        batch_id = request.GET.get("batch_id")
+        if batch_id:
+            apps = Application.objects.filter(batch_id=batch_id)
+            return self._csv_pdf_response(apps)
+        return Response(status=status.HTTP_400_BAD_REQUEST)
+
+    @action(methods=["GET"], detail=False)
+    @transaction.atomic
     def export_new_accepted_applications_csv_pdf(self, request) -> HttpResponse:
         return self._csv_pdf_response(
             self._create_application_batch(ApplicationStatus.ACCEPTED), True

--- a/backend/benefit/applications/tests/test_application_tasks.py
+++ b/backend/benefit/applications/tests/test_application_tasks.py
@@ -15,7 +15,8 @@ from applications.tests.factories import CancelledApplicationFactory
 def test_seed_applications_with_arguments(set_debug_to_true):
     amount = 10
     statuses = ApplicationStatus.values
-    total_created = len(ApplicationStatus.values) * amount
+    batch_count = 2
+    total_created = (len(ApplicationStatus.values) + batch_count) * amount
     out = StringIO()
     call_command("seed", number=amount, stdout=out)
 

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -387,7 +387,8 @@
     "no": "Ei",
     "and": "ja",
     "home": "Palaa etusivulle",
-    "check": "Tarkastele"
+    "check": "Tarkastele",
+    "loading": "Ladataan …"
   },
   "upload": {
     "isUploading": "Uploading...",
@@ -464,13 +465,39 @@
   },
   "select": "Valitse",
   "batches": {
+    "single": "Koonti",
+    "multiple": "Koonnit",
+    "tabs": {
+      "pending": "Odottaa Ahjoon vientiä"
+    },
+    "list": {
+      "columns": {
+        "createdAt": "Luotu",
+        "status": "Tila",
+        "statuses": {
+          "accepted": "Myönteiset",
+          "rejected": "Kielteiset"
+        },
+        "handler": "Käsittelijä"
+      },
+      "empty": "Tyhjä koonti"
+    },
     "notifications": {
       "addToBatch": {
         "success": {
           "heading": "Koontiin siirto onnistui!",
           "text": "Olet muodostanut {{ count }} hakemuksesta koonnin."
         }
+      },
+      "registerToAhjo": {
+        "awaiting_ahjo_decision": "Koonti merkitty Ahjoon viedyksi",
+        "draft": "Koonti palautettu takaisin odottamaan päätösvalmistelua"
       }
+    },
+    "actions": {
+      "markAsRegisteredToAhjo": "Merkitse Ahjoon viedyksi",
+      "markedAsRegisteredToAhjo": "Viety Ahjoon",
+      "downloadFiles": "Lataa liitteet"
     }
   }
 }

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -143,7 +143,8 @@
         "handling": "Käsittelyssä",
         "accepted": "Myönteiset",
         "rejected": "Kielteiset",
-        "infoRequired": "Odottaa lisätietoja"
+        "infoRequired": "Odottaa lisätietoja",
+        "decisions": "päätökset"
       },
       "errors": {
         "fetch": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -387,7 +387,8 @@
     "no": "Ei",
     "and": "ja",
     "home": "Palaa etusivulle",
-    "check": "Tarkastele"
+    "check": "Tarkastele",
+    "loading": "Ladataan …"
   },
   "upload": {
     "isUploading": "Uploading...",
@@ -464,13 +465,39 @@
   },
   "select": "Valitse",
   "batches": {
+    "single": "Koonti",
+    "multiple": "Koonnit",
+    "tabs": {
+      "pending": "Odottaa Ahjoon vientiä"
+    },
+    "list": {
+      "columns": {
+        "createdAt": "Luotu",
+        "status": "Tila",
+        "statuses": {
+          "accepted": "Myönteiset",
+          "rejected": "Kielteiset"
+        },
+        "handler": "Käsittelijä"
+      },
+      "empty": "Tyhjä koonti"
+    },
     "notifications": {
       "addToBatch": {
         "success": {
           "heading": "Koontiin siirto onnistui!",
           "text": "Olet muodostanut {{ count }} hakemuksesta koonnin."
         }
+      },
+      "registerToAhjo": {
+        "awaiting_ahjo_decision": "Koonti merkitty Ahjoon viedyksi",
+        "draft": "Koonti palautettu takaisin odottamaan päätösvalmistelua"
       }
+    },
+    "actions": {
+      "markAsRegisteredToAhjo": "Merkitse Ahjoon viedyksi",
+      "markedAsRegisteredToAhjo": "Viety Ahjoon",
+      "downloadFiles": "Lataa liitteet"
     }
   }
 }

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -143,7 +143,8 @@
         "handling": "Käsittelyssä",
         "accepted": "Myönteiset",
         "rejected": "Kielteiset",
-        "infoRequired": "Odottaa lisätietoja"
+        "infoRequired": "Odottaa lisätietoja",
+        "decisions": "päätökset"
       },
       "errors": {
         "fetch": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -387,7 +387,8 @@
     "no": "Ei",
     "and": "ja",
     "home": "Palaa etusivulle",
-    "check": "Tarkastele"
+    "check": "Tarkastele",
+    "loading": "Ladataan …"
   },
   "upload": {
     "isUploading": "Uploading...",
@@ -464,13 +465,39 @@
   },
   "select": "Valitse",
   "batches": {
+    "single": "Koonti",
+    "multiple": "Koonnit",
+    "tabs": {
+      "pending": "Odottaa Ahjoon vientiä"
+    },
+    "list": {
+      "columns": {
+        "createdAt": "Luotu",
+        "status": "Tila",
+        "statuses": {
+          "accepted": "Myönteiset",
+          "rejected": "Kielteiset"
+        },
+        "handler": "Käsittelijä"
+      },
+      "empty": "Tyhjä koonti"
+    },
     "notifications": {
       "addToBatch": {
         "success": {
           "heading": "Koontiin siirto onnistui!",
           "text": "Olet muodostanut {{ count }} hakemuksesta koonnin."
         }
+      },
+      "registerToAhjo": {
+        "awaiting_ahjo_decision": "Koonti merkitty Ahjoon viedyksi",
+        "draft": "Koonti palautettu takaisin odottamaan päätösvalmistelua"
       }
+    },
+    "actions": {
+      "markAsRegisteredToAhjo": "Merkitse Ahjoon viedyksi",
+      "markedAsRegisteredToAhjo": "Viety Ahjoon",
+      "downloadFiles": "Lataa liitteet"
     }
   }
 }

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -143,7 +143,8 @@
         "handling": "Käsittelyssä",
         "accepted": "Myönteiset",
         "rejected": "Kielteiset",
-        "infoRequired": "Odottaa lisätietoja"
+        "infoRequired": "Odottaa lisätietoja",
+        "decisions": "päätökset"
       },
       "errors": {
         "fetch": {

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.sc.ts
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.sc.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const $Heading = styled.h2`
-  font-size: ${(props) => props.theme.fontSize.heading.s};
+  margin-top: var(--spacing-xl);
 `;
 
 export const $Empty = styled.div`

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
@@ -127,7 +127,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
   if (shouldShowSkeleton) {
     return (
       <>
-        {heading && <$Heading>{`${heading} (0)`}</$Heading>}
+        {heading && <$Heading>{`${heading}`}</$Heading>}
         <LoadingSpinner small />
       </>
     );

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
@@ -6,7 +6,6 @@ import {
   Table,
 } from 'hds-react';
 import * as React from 'react';
-import Container from 'shared/components/container/Container';
 import { $Link } from 'shared/components/table/Table.sc';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
 import { useTheme } from 'styled-components';
@@ -127,20 +126,20 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
 
   if (shouldShowSkeleton) {
     return (
-      <Container>
+      <>
         {heading && <$Heading>{`${heading} (0)`}</$Heading>}
         <LoadingSpinner small />
-      </Container>
+      </>
     );
   }
 
   const statusAsString = status.join(',');
   return (
-    <Container data-testid={`application-list-${statusAsString}`}>
+    <React.Fragment data-testid={`application-list-${statusAsString}`}>
       {!shouldHideList ? (
         <>
-          <$Heading>{`${heading} (${list.length})`}</$Heading>
           <Table
+            heading={`${heading} (${list.length})`}
             theme={theme.components.table}
             indexKey="id"
             rows={list}
@@ -152,7 +151,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
           {t(`${translationsBase}.messages.empty.${statusAsString}`)}
         </$EmptyHeading>
       )}
-    </Container>
+    </React.Fragment>
   );
 };
 

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
@@ -135,23 +135,21 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
 
   const statusAsString = status.join(',');
   return (
-    <React.Fragment data-testid={`application-list-${statusAsString}`}>
+    <div data-testid={`application-list-${statusAsString}`}>
       {!shouldHideList ? (
-        <>
-          <Table
-            heading={`${heading} (${list.length})`}
-            theme={theme.components.table}
-            indexKey="id"
-            rows={list}
-            cols={columns}
-          />
-        </>
+        <Table
+          heading={`${heading} (${list.length})`}
+          theme={theme.components.table}
+          indexKey="id"
+          rows={list}
+          cols={columns}
+        />
       ) : (
         <$EmptyHeading>
           {t(`${translationsBase}.messages.empty.${statusAsString}`)}
         </$EmptyHeading>
       )}
-    </React.Fragment>
+    </div>
   );
 };
 

--- a/frontend/benefit/handler/src/components/applicationReports/ApplicationReports.tsx
+++ b/frontend/benefit/handler/src/components/applicationReports/ApplicationReports.tsx
@@ -1,7 +1,5 @@
-import {
-  EXPORT_APPLICATIONS_ROUTES,
-  PROPOSALS_FOR_DESISION,
-} from 'benefit/handler/constants';
+import { EXPORT_APPLICATIONS_ROUTES } from 'benefit/handler/constants';
+import { PROPOSALS_FOR_DECISION } from 'benefit-shared/constants';
 import { DateInput } from 'hds-react';
 import * as React from 'react';
 import Container from 'shared/components/container/Container';
@@ -39,7 +37,7 @@ const ApplicationReports: React.FC = () => {
           exportApplications(
             type,
             EXPORT_APPLICATIONS_ROUTES.ACCEPTED,
-            PROPOSALS_FOR_DESISION.ACCEPTED
+            PROPOSALS_FOR_DECISION.ACCEPTED
           )
         }
         header={`${t(
@@ -65,7 +63,7 @@ const ApplicationReports: React.FC = () => {
           exportApplications(
             type,
             EXPORT_APPLICATIONS_ROUTES.REJECTED,
-            PROPOSALS_FOR_DESISION.REJECTED
+            PROPOSALS_FOR_DECISION.REJECTED
           )
         }
         header={`${t(

--- a/frontend/benefit/handler/src/components/applicationReports/useApplicationReports.ts
+++ b/frontend/benefit/handler/src/components/applicationReports/useApplicationReports.ts
@@ -1,13 +1,13 @@
 import {
   EXPORT_APPLICATIONS_IN_TIME_RANGE_FORM_KEYS,
   EXPORT_APPLICATIONS_ROUTES,
-  PROPOSALS_FOR_DESISION,
 } from 'benefit/handler/constants';
 import useReportsApplicationBatchesQuery, {
   getReportsApplicationBatchesQueryKey,
 } from 'benefit/handler/hooks/useReportsApplicationBatchesQuery';
 import { ExportApplicationInTimeRangeFormProps } from 'benefit/handler/types/application';
 import { BackendEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { PROPOSALS_FOR_DECISION } from 'benefit-shared/constants';
 import { FormikProps, useFormik } from 'formik';
 import fromPairs from 'lodash/fromPairs';
 import noop from 'lodash/noop';
@@ -34,7 +34,7 @@ type ExtendedComponentProps = {
   exportApplications: (
     type: ExportFileType,
     exportApplicationsRoute: string,
-    proposalForDecision: PROPOSALS_FOR_DESISION
+    proposalForDecision: PROPOSALS_FOR_DECISION
   ) => void;
   formik: FormikProps<ExportApplicationInTimeRangeFormProps>;
   fields: {
@@ -56,7 +56,7 @@ const useApplicationReports = (): ExtendedComponentProps => {
   const queryClient = useQueryClient();
 
   const { data: lastAcceptedApplicationBatches } =
-    useReportsApplicationBatchesQuery(PROPOSALS_FOR_DESISION.ACCEPTED);
+    useReportsApplicationBatchesQuery(PROPOSALS_FOR_DECISION.ACCEPTED);
   const lastAcceptedApplicationsExportDate =
     lastAcceptedApplicationBatches && lastAcceptedApplicationBatches.length > 0
       ? convertToUIDateFormat(
@@ -67,7 +67,7 @@ const useApplicationReports = (): ExtendedComponentProps => {
       : '';
 
   const { data: lastRejectedApplicationBatches } =
-    useReportsApplicationBatchesQuery(PROPOSALS_FOR_DESISION.REJECTED);
+    useReportsApplicationBatchesQuery(PROPOSALS_FOR_DECISION.REJECTED);
   const lastRejectedApplicationsExportDate =
     lastRejectedApplicationBatches && lastRejectedApplicationBatches.length > 0
       ? convertToUIDateFormat(
@@ -81,7 +81,7 @@ const useApplicationReports = (): ExtendedComponentProps => {
     async (
       type: ExportFileType,
       exportApplicationsRoute: EXPORT_APPLICATIONS_ROUTES,
-      proposalForDecision: PROPOSALS_FOR_DESISION
+      proposalForDecision: PROPOSALS_FOR_DECISION
     ) => {
       const urlSafeType: string = String(type).toLowerCase().replace('/', '_');
       const data = await handleResponse<string>(

--- a/frontend/benefit/handler/src/components/applicationsArchive/ApplicationsArchive.sc.ts
+++ b/frontend/benefit/handler/src/components/applicationsArchive/ApplicationsArchive.sc.ts
@@ -5,14 +5,13 @@ type StatusProps = {
   status: APPLICATION_STATUSES;
 };
 
-export const $Heading = styled.p`
+export const $Heading = styled.h1`
+  font-weight: 400;
   font-size: ${(props) => props.theme.fontSize.heading.xl};
 `;
 
 export const $ArchiveCount = styled.p`
-  font-size: ${(props) => props.theme.fontSize.heading.m};
-  color: ${(props) => props.theme.colors.coatOfArms};
-  font-weight: 500;
+  font-size: ${(props) => props.theme.fontSize.heading.s};
 `;
 
 export const $Status = styled.p<StatusProps>`

--- a/frontend/benefit/handler/src/components/applicationsArchive/ApplicationsArchive.tsx
+++ b/frontend/benefit/handler/src/components/applicationsArchive/ApplicationsArchive.tsx
@@ -1,17 +1,13 @@
 import { ApplicationListItemData } from 'benefit-shared/types/application';
+import { LoadingSpinner } from 'hds-react';
 import * as React from 'react';
-import LoadingSkeleton from 'react-loading-skeleton';
 import Container from 'shared/components/container/Container';
 import { COLUMN_WIDTH } from 'shared/components/table/constants';
 import Table, { Column } from 'shared/components/table/Table';
 import { $Link } from 'shared/components/table/Table.sc';
 
-import {
-  $ArchiveCount,
-  $Empty,
-  $Heading,
-  $Status,
-} from './ApplicationsArchive.sc';
+import { $EmptyHeading } from '../applicationList/ApplicationList.sc';
+import { $ArchiveCount, $Heading, $Status } from './ApplicationsArchive.sc';
 import { useApplicationsArchive } from './useApplicationsArchive';
 
 type ColumnType = Column<ApplicationListItemData>;
@@ -108,7 +104,13 @@ const ApplicationsArchive: React.FC = () => {
   if (shouldShowSkeleton) {
     return (
       <Container>
-        <LoadingSkeleton width="100%" height="50px" />
+        <$Heading as="h1">{`${t(
+          'common:header.navigation.archive'
+        )}`}</$Heading>
+        <$ArchiveCount>{`${t(`${translationsBase}.total.count`, {
+          count: 0,
+        })}`}</$ArchiveCount>
+        <LoadingSpinner small />
       </Container>
     );
   }
@@ -118,15 +120,15 @@ const ApplicationsArchive: React.FC = () => {
       <$Heading as="h1" data-testid="main-ingress">{`${t(
         'common:header.navigation.archive'
       )}`}</$Heading>
-      {list.length > 0 && (
-        <$ArchiveCount>{`${t(`${translationsBase}.total.count`, {
-          count: list.length,
-        })}`}</$ArchiveCount>
-      )}
+      <$ArchiveCount>{`${t(`${translationsBase}.total.count`, {
+        count: list.length,
+      })}`}</$ArchiveCount>
       {!shouldHideList ? (
         <Table data={list} columns={columns} />
       ) : (
-        <$Empty>{t(`${translationsBase}.messages.empty.archive`)}</$Empty>
+        <$EmptyHeading>
+          {t(`${translationsBase}.messages.empty.archived`)}
+        </$EmptyHeading>
       )}
     </Container>
   );

--- a/frontend/benefit/handler/src/components/batchProcessing/ApplicationsHandled.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/ApplicationsHandled.tsx
@@ -9,30 +9,9 @@ import React, { useEffect, useMemo, useState } from 'react';
 import Container from 'shared/components/container/Container';
 import { $Link } from 'shared/components/table/Table.sc';
 import theme from 'shared/styles/theme';
-import styled from 'styled-components';
 
 import { useApplicationsHandled } from './useApplicationsHandled';
-
-const $HintText = styled.p`
-  margin-top: 0;
-  margin-bottom: var(--spacing-s);
-`;
-
-export const $TableFooter = styled.footer`
-  background: ${(props) => props.theme.colors.black10};
-  width: 100%;
-  padding: var(--spacing-s);
-  display: flex;
-  flex-flow: row wrap;
-  box-sizing: border-box;
-  ${$HintText} {
-    flex-basis: 100%;
-    margin-top: 0;
-    &:empty {
-      margin: 0;
-    }
-  }
-`;
+import { $HintText, $TableFooter } from './BatchProposal.sc';
 
 type Props = {
   status: APPLICATION_STATUSES;

--- a/frontend/benefit/handler/src/components/batchProcessing/ApplicationsHandled.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/ApplicationsHandled.tsx
@@ -107,7 +107,7 @@ const ApplicationsHandled: React.FC<Props> = ({
   }
 
   return (
-    <Container data-testid="application-list-archived">
+    <div data-testid="application-list-archived">
       {!shouldHideList ? (
         <>
           <Table
@@ -153,7 +153,7 @@ const ApplicationsHandled: React.FC<Props> = ({
           {t(`${translationsBase}.messages.empty.${status}`)}
         </$EmptyHeading>
       )}
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/benefit/handler/src/components/batchProcessing/ApplicationsHandled.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/ApplicationsHandled.tsx
@@ -1,4 +1,7 @@
-import { $EmptyHeading } from 'benefit/handler/components/applicationList/ApplicationList.sc';
+import {
+  $EmptyHeading,
+  $Heading,
+} from 'benefit/handler/components/applicationList/ApplicationList.sc';
 import useAddToBatchQuery from 'benefit/handler/hooks/useApplicationToBatch';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { Button, LoadingSpinner, Table } from 'hds-react';
@@ -101,6 +104,10 @@ const ApplicationsHandled: React.FC<Props> = ({
   if (shouldShowSkeleton) {
     return (
       <Container>
+        <$Heading>
+          {t(`common:applications.list.headings.${status}`)}{' '}
+          {t(`common:applications.list.headings.decisions`)}
+        </$Heading>
         <LoadingSpinner small />
       </Container>
     );
@@ -116,9 +123,9 @@ const ApplicationsHandled: React.FC<Props> = ({
             rows={applications}
             initialSortingColumnKey="applicationNum"
             initialSortingOrder="asc"
-            heading={`${t(
-              `common:applications.list.headings.${status}`
-            )} päätökset (${applications.length})`}
+            heading={`${t(`common:applications.list.headings.${status}`)} ${t(
+              `common:applications.list.headings.decisions`
+            )} (${applications.length})`}
             cols={columns}
             checkboxSelection
             selectedRows={selectedRows}

--- a/frontend/benefit/handler/src/components/batchProcessing/ApplicationsHandled.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/ApplicationsHandled.tsx
@@ -10,8 +10,8 @@ import Container from 'shared/components/container/Container';
 import { $Link } from 'shared/components/table/Table.sc';
 import theme from 'shared/styles/theme';
 
-import { useApplicationsHandled } from './useApplicationsHandled';
 import { $HintText, $TableFooter } from './BatchProposal.sc';
+import { useApplicationsHandled } from './useApplicationsHandled';
 
 type Props = {
   status: APPLICATION_STATUSES;

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
@@ -1,0 +1,226 @@
+import useBatchStatus from 'benefit/handler/hooks/useBatchStatus';
+import useDownloadBatchFiles from 'benefit/handler/hooks/useDownloadBatchFiles';
+import useRemoveAppFromBatch from 'benefit/handler/hooks/useRemoveAppFromBatch';
+import {
+  BATCH_STATUSES,
+  PROPOSALS_FOR_DECISION,
+} from 'benefit-shared/constants';
+import { BatchProposal } from 'benefit-shared/types/application';
+import {
+  Button,
+  IconArrowUndo,
+  IconCheckCircleFill,
+  IconCrossCircleFill,
+  IconDownload,
+  Table,
+} from 'hds-react';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+import theme from 'shared/styles/theme';
+import { convertToUIDateAndTimeFormat } from 'shared/utils/date.utils';
+import styled from 'styled-components';
+
+import { $Empty } from '../applicationList/ApplicationList.sc';
+import {
+  $HorizontalList,
+  $TableBody,
+  $TableFooter,
+  $TableWrapper,
+} from './BatchProposal.sc';
+
+type ButtonAhjoStates = 'primary' | 'secondary';
+
+type BatchProps = {
+  batch: BatchProposal;
+};
+
+const $BatchStatusValue = styled.span`
+  margin-left: 6px;
+  margin-top: 4px;
+`;
+
+const BatchApplicationList: React.FC<BatchProps> = ({ batch }: BatchProps) => {
+  const { t } = useTranslation();
+  const {
+    id,
+    status,
+    created_at,
+    applications,
+    proposal_for_decision: proposalForDecision,
+  } = batch;
+
+  const [isAtAhjo, setIsAtAhjo] = React.useState<ButtonAhjoStates>('primary');
+  const [isDownloadingAttachments, setIsDownloadingAttachments] =
+    React.useState(false);
+
+  const { isLoading: isDownloading, mutate: downloadBatchFiles } =
+    useDownloadBatchFiles();
+  const { mutate: removeApp } = useRemoveAppFromBatch();
+  const { mutate: changeBatchStatus } = useBatchStatus();
+
+  React.useEffect(() => {
+    if (!isDownloading) {
+      setIsDownloadingAttachments(false);
+    }
+  }, [isDownloading]);
+
+  const handleBatchStatusChange = (): void => {
+    if (isAtAhjo === 'secondary') {
+      changeBatchStatus({ batchId: id, status: BATCH_STATUSES.DRAFT });
+      setIsAtAhjo('primary');
+    } else {
+      changeBatchStatus({
+        batchId: id,
+        status: BATCH_STATUSES.AWAITING_FOR_DECISION,
+      });
+      setIsAtAhjo('secondary');
+    }
+  };
+
+  const handleDownloadBatchFiles = (): void => {
+    setIsDownloadingAttachments(true);
+    downloadBatchFiles(id);
+  };
+
+  const handleAppRemoval = (appId: string): void => {
+    const selectedApp = applications.find((app) => app.id === appId);
+    if (
+      // eslint-disable-next-line no-alert
+      window.confirm(
+        `Ota hakemus ${selectedApp.application_number} pois koonnista?`
+      )
+    ) {
+      removeApp({ appIds: [selectedApp.id], batchId: id });
+    }
+  };
+
+  const cols = [
+    {
+      headerName: t('common:applications.list.columns.companyName'),
+      key: 'company_name',
+      isSortable: true,
+    },
+    {
+      headerName: t('common:applications.list.columns.companyId'),
+      key: 'business_id',
+      isSortable: true,
+    },
+    {
+      headerName: t('common:applications.list.columns.applicationNum'),
+      key: 'application_number',
+      isSortable: true,
+    },
+    {
+      headerName: t(
+        `common:applications.list.columns.employeeNameArchive`
+      )?.toString(),
+      key: 'employee_name',
+      isSortable: true,
+    },
+    {
+      headerName: t('common:applications.list.columns.handledAt'),
+      key: 'handled_at',
+      isSortable: true,
+    },
+    {
+      transform: ({ id: appId }: { id: string }) => (
+        <Button
+          theme="black"
+          variant="supplementary"
+          iconLeft={<IconArrowUndo />}
+          onClick={() => handleAppRemoval(appId)}
+        >
+          {' '}
+        </Button>
+      ),
+      headerName: '',
+      key: 'remove',
+    },
+  ];
+
+  const proposalForDecisionHeader = (): JSX.Element => {
+    if (proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED) {
+      return (
+        <>
+          <IconCheckCircleFill color="var(--color-tram)" />
+          <$BatchStatusValue>
+            {`${t('common:batches.list.columns.statuses.accepted')} (${
+              applications?.length
+            })`}
+          </$BatchStatusValue>
+        </>
+      );
+    }
+    return (
+      <>
+        <IconCrossCircleFill color="var(--color-brick)" />
+        <$BatchStatusValue>
+          {`${t('common:batches.list.columns.statuses.rejected')} (${
+            applications?.length
+          })`}
+        </$BatchStatusValue>
+      </>
+    );
+  };
+
+  return (
+    <$TableWrapper>
+      <$HorizontalList>
+        <div>
+          <dt>{t('common:batches.single')}</dt>
+          <dd>{proposalForDecisionHeader()}</dd>
+        </div>
+        <div>
+          <dt>{t('common:batches.list.columns.createdAt')}</dt>
+          <dd>{convertToUIDateAndTimeFormat(created_at)}</dd>
+        </div>
+      </$HorizontalList>
+      {applications?.length ? (
+        <$TableBody>
+          <Table
+            indexKey="id"
+            theme={{ '--header-background-color': theme.colors.coatOfArms }}
+            rows={applications}
+            initialSortingColumnKey="application_number"
+            initialSortingOrder="asc"
+            cols={cols}
+          />
+          <$TableFooter>
+            <Button
+              theme="black"
+              variant="secondary"
+              iconLeft={<IconDownload />}
+              isLoading={isDownloadingAttachments}
+              disabled={isDownloadingAttachments}
+              loadingText={t('common:utility.loading')}
+              onClick={() => handleDownloadBatchFiles()}
+            >
+              {t('common:batches.actions.downloadFiles')}
+            </Button>
+            <Button
+              theme="coat"
+              style={{ marginLeft: 'var(--spacing-s)' }}
+              variant={isAtAhjo}
+              iconLeft={
+                isAtAhjo === 'secondary' ? <IconCheckCircleFill /> : null
+              }
+              disabled={status === BATCH_STATUSES.AWAITING_FOR_DECISION}
+              className="table-custom-action"
+              onClick={() => handleBatchStatusChange()}
+            >
+              {isAtAhjo === 'primary'
+                ? t('common:batches.actions.markAsRegisteredToAhjo')
+                : t('common:batches.actions.markedAsRegisteredToAhjo')}
+            </Button>
+          </$TableFooter>
+        </$TableBody>
+      ) : (
+        <$Empty css="margin: var(--spacing-s) 0;">
+          {t('common:batches.list.empty')}
+        </$Empty>
+      )}
+    </$TableWrapper>
+  );
+};
+
+export default BatchApplicationList;

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchProposal.sc.ts
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchProposal.sc.ts
@@ -34,11 +34,22 @@ export const $TableWrapper = styled.div`
 
 export const $TableBody = styled.div``;
 
+export const $HintText = styled.p`
+  margin-top: 0;
+  margin-bottom: var(--spacing-s);
+  flex-basis: 100%;
+  margin-top: 0;
+  &:empty {
+    margin: 0;
+  }
+`;
+
 export const $TableFooter = styled.footer`
+  display: flex;
+  flex-flow: row wrap;
   background: #efefef;
   width: 100%;
   padding: var(--spacing-s);
-  display: flex;
   align-items: center;
   box-sizing: border-box;
 `;

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchProposal.sc.ts
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchProposal.sc.ts
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+
+export const $HorizontalList = styled.dl`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: flex-start;
+  width: 100%;
+  padding: var(--spacing-m) var(--spacing-m) var(--spacing-xs) var(--spacing-m);
+
+  div {
+    min-width: 200px;
+    max-width: 300px;
+    margin-right: auto;
+  }
+
+  dt,
+  dd {
+    margin: 0;
+    padding: 0;
+  }
+
+  dd {
+    margin-top: calc(var(--spacing-xs) / 2);
+    display: flex;
+    align-items: center;
+    font-weight: 500;
+  }
+`;
+
+export const $TableWrapper = styled.div`
+  background: #fff;
+  margin-bottom: var(--spacing-l);
+`;
+
+export const $TableBody = styled.div``;
+
+export const $TableFooter = styled.footer`
+  background: #efefef;
+  width: 100%;
+  padding: var(--spacing-s);
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+`;

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchProposals.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchProposals.tsx
@@ -1,0 +1,38 @@
+import { BatchProposal } from 'benefit-shared/types/application';
+import { LoadingSpinner } from 'hds-react';
+import * as React from 'react';
+
+import { $Empty } from '../applicationList/ApplicationList.sc';
+import BatchApplicationList from './BatchApplicationList';
+import { BatchListProps, useBatchProposal } from './useBatches';
+
+const BatchProposals: React.FC = () => {
+  const {
+    t,
+    batches,
+    shouldShowSkeleton,
+    shouldHideList,
+    translationsBase,
+  }: BatchListProps = useBatchProposal();
+  const list = React.useMemo(() => batches, [batches]);
+
+  if (shouldShowSkeleton) {
+    return <LoadingSpinner small />;
+  }
+
+  return (
+    <div data-testid="batch-application-list">
+      {!shouldHideList ? (
+        list.map((batch: BatchProposal) =>
+          batch?.status === 'draft' ? (
+            <BatchApplicationList batch={batch} key={batch.id} />
+          ) : null
+        )
+      ) : (
+        <$Empty>{t(`${translationsBase}.messages.empty.handling`)}</$Empty>
+      )}
+    </div>
+  );
+};
+
+export default BatchProposals;

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchProposals.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchProposals.tsx
@@ -23,11 +23,9 @@ const BatchProposals: React.FC = () => {
   return (
     <div data-testid="batch-application-list">
       {!shouldHideList ? (
-        list.map((batch: BatchProposal) =>
-          batch?.status === 'draft' ? (
-            <BatchApplicationList batch={batch} key={batch.id} />
-          ) : null
-        )
+        list.map((batch: BatchProposal) => (
+          <BatchApplicationList batch={batch} key={batch.id} />
+        ))
       ) : (
         <$Empty>{t(`${translationsBase}.messages.empty.handling`)}</$Empty>
       )}

--- a/frontend/benefit/handler/src/components/batchProcessing/useBatches.ts
+++ b/frontend/benefit/handler/src/components/batchProcessing/useBatches.ts
@@ -1,0 +1,80 @@
+import useBatchQuery from 'benefit/handler/hooks/useBatchQuery';
+import {
+  ApplicationInBatch,
+  BatchProposal,
+} from 'benefit-shared/types/application';
+import { TFunction, useTranslation } from 'next-i18next';
+import { getFullName } from 'shared/utils/application.utils';
+import { convertToUIDateFormat } from 'shared/utils/date.utils';
+
+export interface BatchListProps {
+  t: TFunction;
+  batches: BatchProposal[] | [];
+  shouldShowSkeleton: boolean;
+  shouldHideList: boolean;
+  getHeader: (id: string) => string;
+  translationsBase: string;
+}
+
+const translationsBase = 'common:applications.list';
+
+const useBatchProposal = (): BatchListProps => {
+  const { t } = useTranslation();
+  const query = useBatchQuery();
+
+  let batches: BatchProposal[] = [];
+  if (query.data) {
+    batches = query.data?.map((batchProposal: BatchProposal): BatchProposal => {
+      const applications = batchProposal.applications.map(
+        (app): ApplicationInBatch => {
+          const {
+            id,
+            status,
+            company,
+            company_name,
+            application_number,
+            employee,
+            handled_at,
+          } = app;
+
+          return {
+            id,
+            application_number,
+            employee_name:
+              getFullName(employee?.first_name, employee?.last_name) || '-',
+            status,
+            handled_at: convertToUIDateFormat(handled_at),
+            company_name: company?.name || company_name,
+            business_id: company?.business_id,
+          };
+        }
+      );
+
+      return {
+        ...batchProposal,
+        applications,
+      };
+    });
+  }
+
+  const shouldShowSkeleton = query.isLoading;
+
+  const shouldHideList =
+    Boolean(query.error) ||
+    (!shouldShowSkeleton &&
+      Array.isArray(query.data) &&
+      query.data.length === 0);
+
+  const getHeader = (id: string): string =>
+    t(`${translationsBase}.columns.${id}`);
+  return {
+    t,
+    batches,
+    shouldShowSkeleton,
+    shouldHideList,
+    getHeader,
+    translationsBase,
+  };
+};
+
+export { useBatchProposal };

--- a/frontend/benefit/handler/src/components/header/useHeader.ts
+++ b/frontend/benefit/handler/src/components/header/useHeader.ts
@@ -33,6 +33,10 @@ const useHeader = (): ExtendedComponentProps => {
     (): NavigationItem[] => [
       { label: t('common:header.navigation.applications'), url: ROUTES.HOME },
       {
+        label: t('common:header.navigation.batches'),
+        url: ROUTES.APPLICATIONS_BATCHES,
+      },
+      {
         label: t('common:header.navigation.archive'),
         url: ROUTES.APPLICATIONS_ARCHIVE,
       },

--- a/frontend/benefit/handler/src/constants.ts
+++ b/frontend/benefit/handler/src/constants.ts
@@ -5,7 +5,7 @@ export enum ROUTES {
   LOGIN = '/login',
 
   // temporary urls, not defined yet
-  APPLICATIONS_PROCESSED = '/processed',
+  APPLICATIONS_BATCHES = '/batches',
   APPLICATIONS_ARCHIVE = '/archive',
   APPLICATIONS_REPORTS = '/reports',
 }

--- a/frontend/benefit/handler/src/constants.ts
+++ b/frontend/benefit/handler/src/constants.ts
@@ -22,11 +22,6 @@ export enum SUPPORTED_LANGUAGES {
   EN = 'en',
 }
 
-export enum PROPOSALS_FOR_DESISION {
-  ACCEPTED = 'accepted',
-  REJECTED = 'rejected',
-}
-
 export const DEFAULT_LANGUAGE = SUPPORTED_LANGUAGES.FI;
 
 export const COMMON_I18N_NAMESPACES = ['common'] as const;

--- a/frontend/benefit/handler/src/hooks/useApplicationToBatch.ts
+++ b/frontend/benefit/handler/src/hooks/useApplicationToBatch.ts
@@ -1,4 +1,4 @@
-import { BackendEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { useTranslation } from 'next-i18next';
 import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
@@ -27,13 +27,10 @@ const useAddToBatchQuery = (): UseMutationResult<Payload, Error> => {
     'addApplicationToBatch',
     ({ applicationIds, status }: Payload) =>
       handleResponse<Payload>(
-        axios.post<Payload>(
-          `${BackendEndpoint.APPLICATION_BATCHES}add_to_batch/`,
-          {
-            application_ids: applicationIds,
-            status,
-          }
-        )
+        axios.patch<Payload>(`${HandlerEndpoint.BATCH_ASSIGN}`, {
+          application_ids: applicationIds,
+          status,
+        })
       ),
     {
       onSuccess: (_, { applicationIds }) => {

--- a/frontend/benefit/handler/src/hooks/useApplicationToBatch.ts
+++ b/frontend/benefit/handler/src/hooks/useApplicationToBatch.ts
@@ -27,7 +27,7 @@ const useAddToBatchQuery = (): UseMutationResult<Payload, Error> => {
     'addApplicationToBatch',
     ({ applicationIds, status }: Payload) =>
       handleResponse<Payload>(
-        axios.patch<Payload>(`${HandlerEndpoint.BATCH_ASSIGN}`, {
+        axios.patch<Payload>(`${HandlerEndpoint.BATCH_APP_ASSIGN}`, {
           application_ids: applicationIds,
           status,
         })

--- a/frontend/benefit/handler/src/hooks/useBatchQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useBatchQuery.ts
@@ -20,7 +20,7 @@ const useBatchQuery = (): UseQueryResult<BatchProposal[], Error> => {
     ['applicationsList'],
     async () => {
       const res = axios.get<BatchProposal[]>(
-        BackendEndpoint.APPLICATION_BATCHES
+        `${BackendEndpoint.APPLICATION_BATCHES}?status=draft`
       );
       return handleResponse(res);
     },

--- a/frontend/benefit/handler/src/hooks/useBatchQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useBatchQuery.ts
@@ -1,0 +1,33 @@
+import { BackendEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { BatchProposal } from 'benefit-shared/types/application';
+import { useTranslation } from 'next-i18next';
+import { useQuery, UseQueryResult } from 'react-query';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+const useBatchQuery = (): UseQueryResult<BatchProposal[], Error> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const { t } = useTranslation();
+
+  const handleError = (): void => {
+    showErrorToast(
+      t('common:applications.list.errors.fetch.label'),
+      t('common:applications.list.errors.fetch.text', { status: 'error' })
+    );
+  };
+
+  return useQuery<BatchProposal[], Error>(
+    ['applicationsList'],
+    async () => {
+      const res = axios.get<BatchProposal[]>(
+        BackendEndpoint.APPLICATION_BATCHES
+      );
+      return handleResponse(res);
+    },
+    {
+      onError: () => handleError(),
+    }
+  );
+};
+
+export default useBatchQuery;

--- a/frontend/benefit/handler/src/hooks/useBatchStatus.ts
+++ b/frontend/benefit/handler/src/hooks/useBatchStatus.ts
@@ -1,0 +1,44 @@
+import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult } from 'react-query';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import showSuccessToast from 'shared/components/toast/show-success-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+type Payload = {
+  batchId: string;
+  status: string;
+};
+
+const useBatchStatus = (): UseMutationResult<null, Error, Payload> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const { t } = useTranslation();
+
+  const handleError = (): void => {
+    showErrorToast(
+      t('common:applications.list.errors.fetch.label'),
+      t('common:applications.list.errors.fetch.text', { status: 'error' })
+    );
+  };
+
+  return useMutation<null, Error, Payload>(
+    'changeBatchStatus',
+    ({ batchId, status }: Payload) =>
+      handleResponse<null>(
+        axios.patch<null>(HandlerEndpoint.BATCH_STATUS_ASSIGN(batchId), {
+          status,
+        })
+      ),
+    {
+      onSuccess: (_, { status }) => {
+        showSuccessToast(
+          t(`common:batches.notifications.registerToAhjo.${status}`),
+          ''
+        );
+      },
+      onError: () => handleError(),
+    }
+  );
+};
+
+export default useBatchStatus;

--- a/frontend/benefit/handler/src/hooks/useBatchStatus.ts
+++ b/frontend/benefit/handler/src/hooks/useBatchStatus.ts
@@ -25,7 +25,7 @@ const useBatchStatus = (): UseMutationResult<null, Error, Payload> => {
     'changeBatchStatus',
     ({ batchId, status }: Payload) =>
       handleResponse<null>(
-        axios.patch<null>(HandlerEndpoint.BATCH_STATUS_ASSIGN(batchId), {
+        axios.patch<null>(HandlerEndpoint.BATCH_STATUS_CHANGE(batchId), {
           status,
         })
       ),

--- a/frontend/benefit/handler/src/hooks/useDownloadBatchFiles.ts
+++ b/frontend/benefit/handler/src/hooks/useDownloadBatchFiles.ts
@@ -1,0 +1,44 @@
+import { BackendEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult } from 'react-query';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+import { downloadFile } from 'shared/utils/file.utils';
+
+type BatchID = string;
+type ArrayBufferData = string;
+
+const useDownloadBatchFiles = (): UseMutationResult<
+  ArrayBufferData,
+  Error,
+  BatchID
+> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const { t } = useTranslation();
+
+  const handleError = (): void => {
+    showErrorToast(
+      t('common:applications.list.errors.fetch.label'),
+      t('common:applications.list.errors.fetch.text', { status: 'error' })
+    );
+  };
+
+  return useMutation<ArrayBufferData, Error, BatchID>(
+    'downloadBatchFiles',
+    (batchId: BatchID) => {
+      const res = axios.get<ArrayBufferData>(
+        `${BackendEndpoint.HANDLER_APPLICATIONS}export_applications_in_batch/?batch_id=${batchId}`,
+        { responseType: 'arraybuffer' }
+      );
+      return handleResponse<ArrayBufferData>(res);
+    },
+    {
+      onSuccess: (data) => {
+        downloadFile(data, 'csv/pdf');
+      },
+      onError: () => handleError(),
+    }
+  );
+};
+
+export default useDownloadBatchFiles;

--- a/frontend/benefit/handler/src/hooks/useRemoveAppFromBatch.ts
+++ b/frontend/benefit/handler/src/hooks/useRemoveAppFromBatch.ts
@@ -1,0 +1,38 @@
+import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult } from 'react-query';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+interface Payload {
+  appIds?: string[];
+  batchId?: string;
+}
+
+const useRemoveAppFromBatch = (): UseMutationResult<Payload, Error> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const { t } = useTranslation();
+
+  const handleError = (): void => {
+    showErrorToast(
+      t('common:applications.list.errors.fetch.label'),
+      t('common:applications.list.errors.fetch.text', { status: 'error' })
+    );
+  };
+
+  return useMutation<Payload, Error, Payload>(
+    'removeApplicationFromBatch',
+    ({ appIds, batchId }: Payload) =>
+      handleResponse<Payload>(
+        axios.patch<Payload>(HandlerEndpoint.BATCH_DEASSIGN(batchId), {
+          application_ids: appIds,
+        })
+      ),
+    {
+      onSuccess: () => {},
+      onError: () => handleError(),
+    }
+  );
+};
+
+export default useRemoveAppFromBatch;

--- a/frontend/benefit/handler/src/hooks/useRemoveAppFromBatch.ts
+++ b/frontend/benefit/handler/src/hooks/useRemoveAppFromBatch.ts
@@ -24,7 +24,7 @@ const useRemoveAppFromBatch = (): UseMutationResult<Payload, Error> => {
     'removeApplicationFromBatch',
     ({ appIds, batchId }: Payload) =>
       handleResponse<Payload>(
-        axios.patch<Payload>(HandlerEndpoint.BATCH_DEASSIGN(batchId), {
+        axios.patch<Payload>(HandlerEndpoint.BATCH_APP_DEASSIGN(batchId), {
           application_ids: appIds,
         })
       ),

--- a/frontend/benefit/handler/src/hooks/useReportsApplicationBatchesQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useReportsApplicationBatchesQuery.ts
@@ -1,16 +1,15 @@
 import { BackendEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { PROPOSALS_FOR_DECISION } from 'benefit-shared/constants';
 import { BatchData } from 'benefit-shared/types/application';
 import { useQuery, UseQueryResult } from 'react-query';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 
-import { PROPOSALS_FOR_DESISION } from '../constants';
-
 export const getReportsApplicationBatchesQueryKey = (
-  proposalForDecision: PROPOSALS_FOR_DESISION
+  proposalForDecision: PROPOSALS_FOR_DECISION
 ): string => `${BackendEndpoint.APPLICATION_BATCHES}${proposalForDecision}`;
 
 const useReportsApplicationBatchesQuery = (
-  proposalForDecision: PROPOSALS_FOR_DESISION
+  proposalForDecision: PROPOSALS_FOR_DECISION
 ): UseQueryResult<BatchData[], Error> => {
   const { axios, handleResponse } = useBackendAPI();
 

--- a/frontend/benefit/handler/src/pages/_app.tsx
+++ b/frontend/benefit/handler/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import 'react-toastify/dist/ReactToastify.css';
 import '../styles/tabs.css';
+import '../styles/tables.css';
 
 import AuthProvider from 'benefit/handler/auth/AuthProvider';
 import Footer from 'benefit/handler/components/footer/Footer';

--- a/frontend/benefit/handler/src/pages/batches/index.tsx
+++ b/frontend/benefit/handler/src/pages/batches/index.tsx
@@ -1,4 +1,6 @@
 import { $Heading } from 'benefit/handler/components/applicationsArchive/ApplicationsArchive.sc';
+import BatchProposals from 'benefit/handler/components/batchProcessing/BatchProposals';
+import { $BackgroundWrapper } from 'benefit/handler/components/layout/Layout';
 import AppContext from 'benefit/handler/context/AppContext';
 import { Tabs } from 'hds-react';
 import { GetStaticProps, NextPage } from 'next';
@@ -8,12 +10,6 @@ import * as React from 'react';
 import { useEffect } from 'react';
 import Container from 'shared/components/container/Container';
 import theme from 'shared/styles/theme';
-import styled from 'styled-components';
-
-export const $Wrapper = styled.aside`
-  background-color: ${(props) => props.style.backgroundColor};
-  height: 100%;
-`;
 
 const BatchIndex: NextPage = () => {
   const {
@@ -37,7 +33,7 @@ const BatchIndex: NextPage = () => {
   }, [setIsFooterVisible, setIsNavigationVisible, setLayoutBackgroundColor]);
 
   return (
-    <$Wrapper style={{ backgroundColor: layoutBackgroundColor }}>
+    <$BackgroundWrapper backgroundColor={layoutBackgroundColor}>
       <Container data-testid="batch-proposal">
         <$Heading data-testid="main-ingress">
           {`${t('common:header.navigation.batches')}`}
@@ -45,15 +41,15 @@ const BatchIndex: NextPage = () => {
 
         <Tabs>
           <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
-            <Tabs.Tab>Odottaa Ahjoon vientiä</Tabs.Tab>
+            <Tabs.Tab>{t('common:batches.tabs.pending')}</Tabs.Tab>
           </Tabs.TabList>
 
           <Tabs.TabPanel>
-            <p>Ahjoon vienti taulukko</p>
+            <BatchProposals />
           </Tabs.TabPanel>
         </Tabs>
       </Container>
-    </$Wrapper>
+    </$BackgroundWrapper>
   );
 };
 

--- a/frontend/benefit/handler/src/pages/batches/index.tsx
+++ b/frontend/benefit/handler/src/pages/batches/index.tsx
@@ -1,0 +1,66 @@
+import { $Heading } from 'benefit/handler/components/applicationsArchive/ApplicationsArchive.sc';
+import AppContext from 'benefit/handler/context/AppContext';
+import { Tabs } from 'hds-react';
+import { GetStaticProps, NextPage } from 'next';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import * as React from 'react';
+import { useEffect } from 'react';
+import Container from 'shared/components/container/Container';
+import theme from 'shared/styles/theme';
+import styled from 'styled-components';
+
+export const $Wrapper = styled.aside`
+  background-color: ${(props) => props.style.backgroundColor};
+  height: 100%;
+`;
+
+const BatchIndex: NextPage = () => {
+  const {
+    setIsFooterVisible,
+    setIsNavigationVisible,
+    setLayoutBackgroundColor,
+    layoutBackgroundColor,
+  } = React.useContext(AppContext);
+
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    setIsNavigationVisible(true);
+    setIsFooterVisible(true);
+    setLayoutBackgroundColor(theme.colors.silverLight);
+    return () => {
+      setIsNavigationVisible(false);
+      setIsFooterVisible(true);
+      setLayoutBackgroundColor(theme.colors.silverLight);
+    };
+  }, [setIsFooterVisible, setIsNavigationVisible, setLayoutBackgroundColor]);
+
+  return (
+    <$Wrapper style={{ backgroundColor: layoutBackgroundColor }}>
+      <Container data-testid="batch-proposal">
+        <$Heading data-testid="main-ingress">
+          {`${t('common:header.navigation.batches')}`}
+        </$Heading>
+
+        <Tabs>
+          <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+            <Tabs.Tab>Odottaa Ahjoon vientiä</Tabs.Tab>
+          </Tabs.TabList>
+
+          <Tabs.TabPanel>
+            <p>Ahjoon vienti taulukko</p>
+          </Tabs.TabPanel>
+        </Tabs>
+      </Container>
+    </$Wrapper>
+  );
+};
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(locale || '', ['common'])),
+  },
+});
+
+export default BatchIndex;

--- a/frontend/benefit/handler/src/pages/index.tsx
+++ b/frontend/benefit/handler/src/pages/index.tsx
@@ -47,10 +47,15 @@ const ApplicantIndex: NextPage = () => {
     true
   );
 
-  const getListLengthByStatus = (statuses: APPLICATION_STATUSES[]): number =>
+  const getListHeadingByStatus = (
+    headingStatus: APPLICATION_STATUSES | 'all',
+    statuses: APPLICATION_STATUSES[]
+  ): string =>
     list && list?.length > 0
-      ? list.filter((app) => statuses.includes(app.status)).length
-      : 0;
+      ? `${t(`${translationBase}.${headingStatus}`)} (${
+          list.filter((app) => statuses.includes(app.status)).length
+        })`
+      : `${t(`${translationBase}.${headingStatus}`)}`;
 
   return (
     <FrontPageProvider>
@@ -60,33 +65,32 @@ const ApplicantIndex: NextPage = () => {
           <Tabs theme={theme.components.tabs}>
             <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
               <Tabs.Tab>
-                {t(`${translationBase}.all`)} (
-                {getListLengthByStatus([
+                {getListHeadingByStatus('all', [
                   APPLICATION_STATUSES.RECEIVED,
                   APPLICATION_STATUSES.HANDLING,
                   APPLICATION_STATUSES.INFO_REQUIRED,
                 ])}
-                )
               </Tabs.Tab>
               <Tabs.Tab>
-                {t(`${translationBase}.received`)} (
-                {getListLengthByStatus([APPLICATION_STATUSES.RECEIVED])})
+                {getListHeadingByStatus(APPLICATION_STATUSES.RECEIVED, [
+                  APPLICATION_STATUSES.RECEIVED,
+                ])}
               </Tabs.Tab>
               <Tabs.Tab>
-                {t(`${translationBase}.handling`)} (
-                {getListLengthByStatus([
+                {getListHeadingByStatus(APPLICATION_STATUSES.HANDLING, [
                   APPLICATION_STATUSES.HANDLING,
                   APPLICATION_STATUSES.INFO_REQUIRED,
                 ])}
-                )
               </Tabs.Tab>
               <Tabs.Tab>
-                {t(`${translationBase}.accepted`)} (
-                {getListLengthByStatus([APPLICATION_STATUSES.ACCEPTED])})
+                {getListHeadingByStatus(APPLICATION_STATUSES.ACCEPTED, [
+                  APPLICATION_STATUSES.ACCEPTED,
+                ])}
               </Tabs.Tab>
               <Tabs.Tab>
-                {t(`${translationBase}.rejected`)} (
-                {getListLengthByStatus([APPLICATION_STATUSES.REJECTED])})
+                {getListHeadingByStatus(APPLICATION_STATUSES.REJECTED, [
+                  APPLICATION_STATUSES.REJECTED,
+                ])}
               </Tabs.Tab>
             </Tabs.TabList>
 

--- a/frontend/benefit/handler/src/styles/tables.css
+++ b/frontend/benefit/handler/src/styles/tables.css
@@ -3,3 +3,8 @@
 [class*='Table-module_actionContainer'] {
   min-height: 44px;
 }
+
+[class*='Table-module_actionContainer']
+  [class*='Table-module_heading'][role='heading'] {
+  font-weight: 500;
+}

--- a/frontend/benefit/handler/src/styles/tables.css
+++ b/frontend/benefit/handler/src/styles/tables.css
@@ -2,6 +2,7 @@
 /* Reported to HDS team, this can be removed if heights are unified in the lib */
 [class*='Table-module_actionContainer'] {
   min-height: 44px;
+  margin-top: var(--spacing-m);
 }
 
 [class*='Table-module_actionContainer']

--- a/frontend/benefit/handler/src/styles/tables.css
+++ b/frontend/benefit/handler/src/styles/tables.css
@@ -1,0 +1,5 @@
+/* Unify table's heading area height when selection buttons are used */
+/* Reported to HDS team, this can be removed if heights are unified in the lib */
+[class*='Table-module_actionContainer'] {
+  min-height: 44px;
+}

--- a/frontend/benefit/shared/src/backend-api/backend-api.ts
+++ b/frontend/benefit/shared/src/backend-api/backend-api.ts
@@ -19,10 +19,10 @@ export const BackendEndpoint = {
 const singleBatchBase = (id: string): string =>
   `${BackendEndpoint.APPLICATION_BATCHES}${id}/`;
 export const HandlerEndpoint = {
-  BATCH_ASSIGN: `${BackendEndpoint.APPLICATION_BATCHES}assign_applications/`,
-  BATCH_DEASSIGN: (id: string): string =>
+  BATCH_APP_ASSIGN: `${BackendEndpoint.APPLICATION_BATCHES}assign_applications/`,
+  BATCH_APP_DEASSIGN: (id: string): string =>
     `${singleBatchBase(id)}deassign_applications/`,
-  BATCH_STATUS_ASSIGN: (id: string): string => `${singleBatchBase(id)}status/`,
+  BATCH_STATUS_CHANGE: (id: string): string => `${singleBatchBase(id)}status/`,
 } as const;
 
 export const BackendEndPoints = Object.values(BackendEndpoint);

--- a/frontend/benefit/shared/src/backend-api/backend-api.ts
+++ b/frontend/benefit/shared/src/backend-api/backend-api.ts
@@ -16,6 +16,15 @@ export const BackendEndpoint = {
   APPLICATION_BATCHES: '/v1/applicationbatches/',
 } as const;
 
+const singleBatchBase = (id: string): string =>
+  `${BackendEndpoint.APPLICATION_BATCHES}${id}/`;
+export const HandlerEndpoint = {
+  BATCH_ASSIGN: `${BackendEndpoint.APPLICATION_BATCHES}assign_applications/`,
+  BATCH_DEASSIGN: (id: string): string =>
+    `${singleBatchBase(id)}deassign_applications/`,
+  BATCH_STATUS_ASSIGN: (id: string): string => `${singleBatchBase(id)}status/`,
+} as const;
+
 export const BackendEndPoints = Object.values(BackendEndpoint);
 
 export type BackendPath = typeof BackendEndpoint[keyof typeof BackendEndpoint];

--- a/frontend/benefit/shared/src/constants.ts
+++ b/frontend/benefit/shared/src/constants.ts
@@ -138,3 +138,13 @@ export enum APPLICATION_STATUSES {
   CANCELLED = 'cancelled',
   HANDLING = 'handling',
 }
+
+export enum BATCH_STATUSES {
+  DRAFT = 'draft',
+  AWAITING_FOR_DECISION = 'awaiting_ahjo_decision',
+}
+
+export enum PROPOSALS_FOR_DECISION {
+  ACCEPTED = 'accepted',
+  REJECTED = 'rejected',
+}

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -7,6 +7,7 @@ import {
   APPLICATION_FIELDS_STEP2_KEYS,
   APPLICATION_STATUSES,
   ATTACHMENT_TYPES,
+  BATCH_STATUSES,
   BENEFIT_TYPES,
   CALCULATION_EMPLOYMENT_KEYS,
   DE_MINIMIS_AID_KEYS,
@@ -14,7 +15,7 @@ import {
   MESSAGE_TYPES,
   ORGANIZATION_TYPES,
   PAY_SUBSIDY_OPTIONS,
-  PROPOSALS_FOR_DESISION,
+  PROPOSALS_FOR_DECISION,
 } from '../constants';
 
 // handler
@@ -23,7 +24,7 @@ export type BatchData = {
   id: string;
   status: APPLICATION_STATUSES;
   applications: string[];
-  proposal_for_decision: PROPOSALS_FOR_DESISION;
+  proposal_for_decision: PROPOSALS_FOR_DECISION;
   decision_maker_title?: string;
   decision_maker_name?: string;
   section_of_the_law?: string;
@@ -31,6 +32,32 @@ export type BatchData = {
   expert_inspector_name?: string;
   expert_inspector_email?: string;
   created_at: string;
+};
+
+export type BatchProposal = {
+  id: string;
+  status: BATCH_STATUSES;
+  applications?: ApplicationInBatch[];
+  proposal_for_decision: PROPOSALS_FOR_DECISION;
+  decision_maker_title?: string;
+  decision_maker_name?: string;
+  section_of_the_law?: string;
+  decision_date?: string;
+  expert_inspector_name?: string;
+  expert_inspector_email?: string;
+  created_at: string;
+};
+
+export type ApplicationInBatch = {
+  id: string;
+  status: APPLICATION_STATUSES;
+  company?: CompanyData;
+  company_name: string;
+  employee?: EmployeeData;
+  application_number: number;
+  employee_name: string;
+  handled_at: string;
+  business_id: string;
 };
 
 interface ApplicationAllowedAction {
@@ -104,8 +131,8 @@ export type ApproveTerms = {
 export type Batch = {
   id: string;
   status: APPLICATION_STATUSES;
-  applications: string[];
-  proposalForDecision: PROPOSALS_FOR_DESISION;
+  applications: string[] | ApplicationData[];
+  proposalForDecision: PROPOSALS_FOR_DECISION;
   decisionMakerTitle?: string;
   decisionMakerName?: string;
   sectionOfTheLaw?: string;
@@ -438,7 +465,7 @@ export type ApplicationListItemData = {
   allowedAction?: ApplicationAllowedAction;
   dataReceived?: string;
   unreadMessagesCount?: number;
-  batch: BatchData | null;
+  batch?: BatchData | string;
 };
 
 export type TextProp = 'textFi' | 'textEn' | 'textSv';


### PR DESCRIPTION
## Description :sparkles:

First iteration of sending applications to Ahjo, manually.

* View batches accepted / rejected
* Remove applications from a batch
* Download application's export files
* Mark as "Sent to Ahjo" or undo

This one is missing some features, such as: safeguards on (de-)assigning apps on a batch, neat looking popups to prevent accidentally sending proposal to ahjo processing etc. These will be introduced later on.

## Testing :alembic:

https://localhost:3100/batches
