### PR TITLE
Hl 739 talpa csv

### DIFF
--- a/backend/benefit/applications/api/v1/views.py
+++ b/backend/benefit/applications/api/v1/views.py
@@ -424,7 +424,7 @@ class HandlerApplicationViewSet(BaseApplicationViewSet):
         csv_filename = f"{export_filename_without_suffix}.csv"
         zip_filename = f"{export_filename_without_suffix}.zip"
         ordered_queryset = queryset.order_by(self.APPLICATION_ORDERING)
-        csv_service = ApplicationsCsvService(ordered_queryset)
+        csv_service = ApplicationsCsvService(ordered_queryset, True)
         csv_file_content: bytes = csv_service.get_csv_string().encode("utf-8")
         csv_file_info: ExportFileInfo = ExportFileInfo(
             filename=csv_filename,

--- a/backend/benefit/applications/services/applications_csv_report.py
+++ b/backend/benefit/applications/services/applications_csv_report.py
@@ -77,12 +77,41 @@ class ApplicationsCsvService(CsvExportBase):
 
     """
 
-    def __init__(self, applications):
+    def __init__(self, applications, prune_data_for_talpa=False):
         self.applications = applications
         self.export_notes = []
+        self.prune_data_for_talpa = prune_data_for_talpa
 
     @property
     def CSV_COLUMNS(self):
+        """Return only columns that are needed for Talpa"""
+        if self.prune_data_for_talpa:
+            talpa_columns = [
+                CsvColumn("Hakemusnumero", "application_number"),
+                CsvColumn("Työnantajan tyyppi", get_organization_type),
+                CsvColumn("Työnantajan tilinumero", "company_bank_account_number"),
+                CsvColumn("Työnantajan nimi", "company_name"),
+                CsvColumn("Työnantajan Y-tunnus", "company.business_id"),
+                CsvColumn("Työnantajan katuosoite", "effective_company_street_address"),
+                CsvColumn("Työnantajan postinumero", "effective_company_postcode"),
+                CsvColumn("Työnantajan postitoimipaikka", "effective_company_city"),
+                CsvDefaultColumn(
+                    "Helsinki-lisän määrä lopullinen",
+                    "calculation.calculated_benefit_amount",
+                ),
+                CsvDefaultColumn("Päättäjän nimike", "batch.decision_maker_title"),
+                CsvDefaultColumn("Päättäjän nimi", "batch.decision_maker_name"),
+                CsvDefaultColumn("Päätöspykälä", "batch.section_of_the_law"),
+                CsvDefaultColumn("Päätöspäivä", "batch.decision_date"),
+                CsvDefaultColumn(
+                    "Asiantarkastajan nimi", "batch.expert_inspector_name"
+                ),
+                CsvDefaultColumn(
+                    "Asiantarkastajan email", "batch.expert_inspector_email"
+                ),
+            ]
+            return talpa_columns
+
         columns = [
             CsvColumn("Hakemusnumero", "application_number"),
             CsvColumn("Hakemusrivi", "application_row_idx"),
@@ -332,6 +361,7 @@ class ApplicationsCsvService(CsvExportBase):
             )
 
         columns.append(CsvColumn("Huom", get_export_notes))
+
         return columns
 
     MAX_AHJO_ROWS = 2

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -98,7 +98,12 @@ def applications_csv_service():
 def applications_csv_service_with_one_application(applications_csv_service):
     application1 = DecidedApplicationFactory(application_number=100001)
     return ApplicationsCsvService(Application.objects.filter(pk=application1.pk))
-    return applications_csv_service
+
+
+@pytest.fixture
+def pruned_applications_csv_service_with_one_application(applications_csv_service, application_batch):
+    application1 = application_batch.applications.all().first()
+    return ApplicationsCsvService(Application.objects.filter(pk=application1.pk), True)
 
 
 @pytest.fixture

--- a/backend/benefit/applications/tests/test_applications_report.py
+++ b/backend/benefit/applications/tests/test_applications_report.py
@@ -277,6 +277,57 @@ def test_applications_csv_export_with_date_range(handler_api_client):
     )
 
 
+def test_pruned_applications_csv_output(
+    pruned_applications_csv_service_with_one_application,
+):
+    csv_lines = split_lines_at_semicolon(
+        pruned_applications_csv_service_with_one_application.get_csv_string()
+    )
+    application = (
+        pruned_applications_csv_service_with_one_application.get_applications()[0]
+    )
+    # Assert that there are 15 column headers in the pruned CSV
+    assert len(csv_lines[0]) == 15
+
+    assert csv_lines[0][0] == '"Hakemusnumero"'
+    assert csv_lines[0][1] == '"Työnantajan tyyppi"'
+    assert csv_lines[0][2] == '"Työnantajan tilinumero"'
+    assert csv_lines[0][3] == '"Työnantajan nimi"'
+    assert csv_lines[0][4] == '"Työnantajan Y-tunnus"'
+    assert csv_lines[0][5] == '"Työnantajan katuosoite"'
+    assert csv_lines[0][6] == '"Työnantajan postinumero"'
+    assert csv_lines[0][7] == '"Työnantajan postitoimipaikka"'
+    assert csv_lines[0][8] == '"Helsinki-lisän määrä lopullinen"'
+    assert csv_lines[0][9] == '"Päättäjän nimike"'
+    assert csv_lines[0][10] == '"Päättäjän nimi"'
+    assert csv_lines[0][11] == '"Päätöspykälä"'
+    assert csv_lines[0][12] == '"Päätöspäivä"'
+    assert csv_lines[0][13] == '"Asiantarkastajan nimi"'
+    assert csv_lines[0][14] == '"Asiantarkastajan email"'
+
+    # Assert that there are 15 columns in the pruned CSV
+    assert len(csv_lines[1]) == 15
+
+    assert int(csv_lines[1][0]) == application.application_number
+    assert csv_lines[1][1] == '"Yritys"'
+    assert csv_lines[1][2] == f'"{application.company_bank_account_number}"'
+    assert csv_lines[1][3] == f'"{application.company_name}"'
+    assert csv_lines[1][4] == f'"{application.company.business_id}"'
+    assert csv_lines[1][5] == f'"{application.effective_company_street_address}"'
+    assert csv_lines[1][6] == f'"{application.effective_company_postcode}"'
+    assert csv_lines[1][7] == f'"{application.effective_company_city}"'
+    assert str(csv_lines[1][8]) == str(
+        application.calculation.calculated_benefit_amount
+    )
+
+    assert csv_lines[1][9] == f'"{application.batch.decision_maker_title}"'
+    assert csv_lines[1][10] == f'"{application.batch.decision_maker_name}"'
+    assert csv_lines[1][11] == f'"{application.batch.section_of_the_law}"'
+    assert csv_lines[1][12] == f'"{application.batch.decision_date}"'
+    assert csv_lines[1][13] == f'"{application.batch.expert_inspector_name}"'
+    assert csv_lines[1][14] == f'"{application.batch.expert_inspector_email}"'
+
+
 def test_applications_csv_output(applications_csv_service):  # noqa: C901
     csv_lines = split_lines_at_semicolon(applications_csv_service.get_csv_string())
     assert csv_lines[0][0] == '"Hakemusnumero"'


### PR DESCRIPTION
## Description :sparkles:
Remove unnecessary columns from the csv report that is downloaded from the handlers reports view and sent to Talpa.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
