### PR TITLE
YJDH-587, YJDH-667 | feat(ks-backend): add fetch_employee_data endpoint to fill employee form

### DIFF
--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -126,6 +126,12 @@ class YouthApplicationQuerySet(MatchesAnyOfQuerySet, models.QuerySet):
         """
         return self.exclude(status=YouthApplicationStatus.REJECTED.value)
 
+    def accepted(self):
+        """
+        Return accepted youth applications
+        """
+        return self.filter(status=YouthApplicationStatus.ACCEPTED.value)
+
     def created_this_year(self):
         """
         Return youth applications created this year


### PR DESCRIPTION
## Description :sparkles:

### feat(ks-backend): add fetch_employee_data endpoint to fill employee form

fetch_employee_data POST endpoint can be used to fetch employee's data
using the employee's name and summer voucher serial number.

refs YJDH-587 (The backend endpoint)
refs YJDH-667 (Audit log writing)

## Issues :bug:

 - [YJDH-587](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-587)
 - [YJDH-667](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-667)

## Testing :alembic:

Added automated backend tests:
 - test_security_with_anonymous_user.py:
   - test_youth_application_fetch_employee_data_forbidden_to_anonymous_user
 - test_security_with_non_staff_user.py:
   - test_youth_application_fetch_employee_data
   - test_youth_application_fetch_employee_data_success_writes_audit_log
   - test_youth_application_fetch_employee_data_not_found_writes_audit_log
   - test_youth_application_fetch_employee_data_unallowed_methods

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-587]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[YJDH-667]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ