### PR TITLE
Hl 791 talpa csv

### DIFF
--- a/backend/benefit/applications/api/v1/views.py
+++ b/backend/benefit/applications/api/v1/views.py
@@ -370,7 +370,7 @@ class HandlerApplicationViewSet(BaseApplicationViewSet):
     @transaction.atomic
     def export_new_accepted_applications_csv_pdf(self, request) -> HttpResponse:
         return self._csv_pdf_response(
-            self._create_application_batch(ApplicationStatus.ACCEPTED), True
+            self._create_application_batch(ApplicationStatus.ACCEPTED), True, True
         )
 
     @action(methods=["GET"], detail=False)
@@ -419,17 +419,24 @@ class HandlerApplicationViewSet(BaseApplicationViewSet):
         )
         return response
 
-    """Generate a response with a CSV file and PDF files containing application data."""
+    """Generate a response with a CSV file and PDF files containing application data.
+        Optionally prune data and remove quotes from the CSV file for Talpa.
+    """
 
     def _csv_pdf_response(
-        self, queryset: QuerySet[Application], prune_data_for_talpa: bool = False
+        self,
+        queryset: QuerySet[Application],
+        prune_data_for_talpa: bool = False,
+        remove_quotes: bool = False,
     ) -> HttpResponse:
         export_filename_without_suffix = self._export_filename_without_suffix()
         csv_filename = f"{export_filename_without_suffix}.csv"
         zip_filename = f"{export_filename_without_suffix}.zip"
         ordered_queryset = queryset.order_by(self.APPLICATION_ORDERING)
         csv_service = ApplicationsCsvService(ordered_queryset, prune_data_for_talpa)
-        csv_file_content: bytes = csv_service.get_csv_string().encode("utf-8")
+        csv_file_content: bytes = csv_service.get_csv_string(
+            prune_data_for_talpa
+        ).encode("utf-8")
         csv_file_info: ExportFileInfo = ExportFileInfo(
             filename=csv_filename,
             file_content=csv_file_content,

--- a/backend/benefit/applications/api/v1/views.py
+++ b/backend/benefit/applications/api/v1/views.py
@@ -403,7 +403,7 @@ class HandlerApplicationViewSet(BaseApplicationViewSet):
     @staticmethod
     def _export_filename_without_suffix():
         return format_lazy(
-            _("Helsinki-lisän hakemukset viety {date}"),
+            _("Helsinki-lisan hakemukset viety {date}"),
             date=timezone.now().strftime("%Y%m%d_%H%M%S"),
         )
 

--- a/backend/benefit/applications/services/csv_export_base.py
+++ b/backend/benefit/applications/services/csv_export_base.py
@@ -73,9 +73,9 @@ class CsvExportBase:
         with open(path, encoding=self.FILE_ENCODING, mode="w") as f:
             f.write(csv_string)
 
-    def get_csv_string(self) -> str:
+    def get_csv_string(self, remove_quotes: bool = False) -> str:
         return "".join(  # Lines end with '\r\n' already so no need to add newlines here
-            self.get_csv_string_lines_generator()
+            self.get_csv_string_lines_generator(remove_quotes=remove_quotes)
         )
 
     def get_csv_cell_list_lines_generator(
@@ -116,16 +116,19 @@ class CsvExportBase:
                 line.append(cell_value)
             yield line
 
-    def get_csv_string_lines_generator(self) -> Generator[str, None, None]:
+    def get_csv_string_lines_generator(
+        self, remove_quotes: bool = False
+    ) -> Generator[str, None, None]:
         """
         Generate CSV's string lines using self.get_csv_cell_list_lines_generator().
 
         :return: Generator which generates list of strings that each end with '\r\n'.
+        Passing remove_quotes=True will disable quoting of values as it is required by the Talpa integration.
         """
+        quoting = csv.QUOTE_NONE if remove_quotes else csv.QUOTE_NONNUMERIC
+
         io = StringIO()
-        csv_writer = csv.writer(
-            io, delimiter=self.CSV_DELIMITER, quoting=csv.QUOTE_NONNUMERIC
-        )
+        csv_writer = csv.writer(io, delimiter=self.CSV_DELIMITER, quoting=quoting)
         line_length_set = set()
         for line in self.get_csv_cell_list_lines_generator():
             line_length_set.add(len(line))

--- a/backend/benefit/applications/tests/test_applications_report.py
+++ b/backend/benefit/applications/tests/test_applications_report.py
@@ -38,13 +38,23 @@ def get_filenames_grouped_by_extension_from_zip(
 
 
 def _test_csv(
-    csv_lines: List[List[str]], expected_application_numbers: List[int]
+    csv_lines: List[List[str]],
+    expected_application_numbers: List[int],
+    expected_without_quotes: bool = False,
 ) -> None:
+    # print(expected_without_quotes)
+    if expected_without_quotes:
+        not_found_message = "Ei löytynyt ehdot täyttäviä hakemuksia"
+        application_number = "Hakemusnumero"
+    else:
+        not_found_message = '"Ei löytynyt ehdot täyttäviä hakemuksia"'
+        application_number = '"Hakemusnumero"'
+
     if not expected_application_numbers:
         assert len(csv_lines) == 2
-        assert csv_lines[1][0] == '"Ei löytynyt ehdot täyttäviä hakemuksia"'
+        assert csv_lines[1][0] == not_found_message
     else:
-        assert csv_lines[0][0] == '"Hakemusnumero"'
+        assert csv_lines[0][0] == application_number
         assert len(csv_lines) == len(expected_application_numbers) + 1
         for line, expected_application_number in zip(
             csv_lines[1:], expected_application_numbers
@@ -64,6 +74,7 @@ def _get_csv(
     url: str,
     expected_application_numbers: List[int],
     from_zip: bool = False,
+    expected_without_quotes: bool = False,
 ) -> List[List[str]]:
     response = handler_api_client.get(url)
     assert response.status_code == 200
@@ -74,7 +85,7 @@ def _get_csv(
         assert isinstance(response, StreamingHttpResponse)
         csv_content: bytes = response.getvalue()
     csv_lines = split_lines_at_semicolon(csv_content.decode("utf-8"))
-    _test_csv(csv_lines, expected_application_numbers)
+    _test_csv(csv_lines, expected_application_numbers, expected_without_quotes)
     return csv_lines
 
 
@@ -139,6 +150,7 @@ def test_applications_csv_export_new_applications(handler_api_client):
         + "export_new_accepted_applications_csv_pdf/",
         [application1.application_number, application2.application_number],
         from_zip=True,
+        expected_without_quotes=True,
     )
     assert ApplicationBatch.objects.all().count() == 2
     assert set(
@@ -166,6 +178,7 @@ def test_applications_csv_export_new_applications(handler_api_client):
         + "export_new_accepted_applications_csv_pdf/",
         [],
         from_zip=True,
+        expected_without_quotes=True,
     )
     assert ApplicationBatch.objects.all().count() == 2
 


### PR DESCRIPTION
## Description :sparkles:
The Talpa integration requires that the CSV-file has no scandics in the filename and no quotes surrounding the strings.
This PR renames the export without the letter "ä" and removes the double quotes from the CSV file generated for Talpa while preserving the quotes for the export that has all applications from a  selected period.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
