### PR TITLE
Ensure that sentry files are not ignored

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -15,6 +15,8 @@
 !yarn.lock
 
 !kesaseteli/employer/next.config.js
+!kesaseteli/employer/sentry.client.config.js
+!kesaseteli/employer/sentry.server.config.js
 !kesaseteli/employer/next-i18next.config.js
 !kesaseteli/employer/public
 !kesaseteli/employer/src
@@ -22,6 +24,8 @@
 !kesaseteli/employer/tsconfig.json
 
 !kesaseteli/handler/next.config.js
+!kesaseteli/handler/sentry.client.config.js
+!kesaseteli/handler/sentry.server.config.js
 !kesaseteli/handler/next-i18next.config.js
 !kesaseteli/handler/public
 !kesaseteli/handler/src
@@ -29,6 +33,8 @@
 !kesaseteli/handler/tsconfig.json
 
 !kesaseteli/youth/next.config.js
+!kesaseteli/youth/sentry.client.config.js
+!kesaseteli/youth/sentry.server.config.js
 !kesaseteli/youth/next-i18next.config.js
 !kesaseteli/youth/public
 !kesaseteli/youth/src
@@ -40,6 +46,8 @@
 !kesaseteli/shared/tsconfig.json
 
 !benefit/applicant/next.config.js
+!benefit/applicant/sentry.client.config.js
+!benefit/applicant/sentry.server.config.js
 !benefit/applicant/next-i18next.config.js
 !benefit/applicant/package.json
 !benefit/applicant/public
@@ -47,6 +55,8 @@
 !benefit/applicant/tsconfig.json
 
 !benefit/handler/next.config.js
+!benefit/handler/sentry.client.config.js
+!benefit/handler/sentry.server.config.js
 !benefit/handler/next-i18next.config.js
 !benefit/handler/package.json
 !benefit/handler/public
@@ -58,12 +68,16 @@
 !benefit/shared/tsconfig.json
 
 !tet/youth/next.config.js
+!tet/youth/sentry.client.config.js
+!tet/youth/sentry.server.config.js
 !tet/youth/next-i18next.config.js
 !tet/youth/package.json
 !tet/youth/public
 !tet/youth/src
 !tet/youth/tsconfig.json
 !tet/admin/next.config.js
+!tet/admin/sentry.client.config.js
+!tet/admin/sentry.server.config.js
 !tet/admin/next-i18next.config.js
 !tet/admin/package.json
 !tet/admin/public


### PR DESCRIPTION
## Description :sparkles:
Sentry config files were not excluded in the frontend/.dockerignore, thus they were not copied during the build.
This PR adds the exclusion for all the projects in the repo.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
