### PR TITLE
Add the missing shared sentry-config.js

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -11,6 +11,7 @@
 !shared/src
 !shared/package.json
 !shared/tsconfig.json
+!shared/sentry-config.js
 !tsconfig.json
 !yarn.lock
 


### PR DESCRIPTION
## Description :sparkles:
Adds the missing shared sentry-config.js into the .dockerignore exceptions.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
