### PR TITLE
HL-590 | Fix issues with fetching user when backend is down

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -456,6 +456,8 @@
   "login": {
     "login": "Sign in to the service",
     "logoutMessageLabel": "You have logged out",
+    "userStateErrorLabel": "Kirjautumisessa on häiriö",
+    "userStateErrorContent": "Kirjautumisessa on vikaa tai taustajärjestelmään ei saada yhteyttä. Yritä myöhemmin uudelleen.",
     "errorLabel": "An unexpected error occurred. Please, sign in again. ",
     "sessionExpiredLabel": "User session expired. Sign in again",
     "infoLabel": "Using the service requires strong authentication",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -90,8 +90,8 @@
   },
   "error": {
     "generic": {
-      "label": "Error occurred",
-      "text": "Please try again later."
+      "label": "Odottamaton virhe",
+      "text": "Yritä myöhemmin uudestaan."
     },
     "attachments": {
       "title": "Error occurred",
@@ -456,6 +456,8 @@
   "login": {
     "login": "Kirjaudu palveluun",
     "logoutMessageLabel": "Olet kirjautunut ulos",
+    "userStateErrorLabel": "Kirjautumisessa on häiriö",
+    "userStateErrorContent": "Kirjautumisessa on vikaa tai taustajärjestelmään ei saada yhteyttä. Yritä myöhemmin uudelleen.",
     "errorLabel": "Tapahtui tuntematon virhe. Kirjaudu uudelleen sisään",
     "sessionExpiredLabel": "Käyttäjäsessio vanhentui. Kirjaudu uudelleen sisään",
     "infoLabel": "Palvelun käyttäminen edellyttää vahvaa tunnistautumista",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -456,6 +456,8 @@
   "login": {
     "login": "Logga in i tjänsten",
     "logoutMessageLabel": "Du har loggat ut",
+    "userStateErrorLabel": "Kirjautumisessa on häiriö",
+    "userStateErrorContent": "Kirjautumisessa on vikaa tai taustajärjestelmään ei saada yhteyttä. Yritä myöhemmin uudelleen.",
     "errorLabel": "Ett okänt fel inträffade. Logga in på nytt.",
     "sessionExpiredLabel": "Användarsessionen föråldrades. Logga in på nytt.",
     "infoLabel": "Att använda tjänsten kräver stark autentisering",

--- a/frontend/benefit/handler/src/hooks/useUserQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useUserQuery.ts
@@ -1,8 +1,6 @@
 import { BackendEndpoint } from 'benefit-shared/backend-api/backend-api';
 import { useRouter } from 'next/router';
-import { useTranslation } from 'next-i18next';
 import { useQuery, UseQueryResult } from 'react-query';
-import showErrorToast from 'shared/components/toast/show-error-toast';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 import useLocale from 'shared/hooks/useLocale';
 import User from 'shared/types/user';
@@ -13,11 +11,13 @@ const FIVE_MINUTES = 5 * 60 * 1000;
 const useUserQuery = <T = User>(
   select?: (user: User) => T
 ): UseQueryResult<T, Error> => {
-  const { t } = useTranslation();
   const router = useRouter();
-  const logout =
-    router.route === '/login' && router.asPath.includes('logout=true'); // router.query doesn't always contain the logout parameter
   const locale = useLocale();
+  // Don't fetch user state if status is logged out
+  const logout =
+    (router.route === '/login' || router.route === `${locale}/login`) &&
+    (router.asPath.includes('logout=true') ||
+      router.asPath.includes('userStateError=true'));
   const { axios, handleResponse } = useBackendAPI();
 
   const handleError = (error: Error): void => {
@@ -26,10 +26,7 @@ const useUserQuery = <T = User>(
     } else if (/40[13]/.test(error.message)) {
       void router.push(`${locale}/login`);
     } else {
-      showErrorToast(
-        t('common:error.generic.label'),
-        t('common:error.generic.text')
-      );
+      void router.push(`${locale}/login?userStateError=true`);
     }
   };
 

--- a/frontend/benefit/handler/src/pages/login.tsx
+++ b/frontend/benefit/handler/src/pages/login.tsx
@@ -35,18 +35,31 @@ const Login: NextPage = () => {
     if (router.query.logout) {
       return { type: 'info', label: t('common:login.logoutMessageLabel') };
     }
+    if (router.query.userStateError) {
+      return {
+        type: 'error',
+        label: t('common:login.userStateErrorLabel'),
+        content: t('common:login.userStateErrorContent'),
+      };
+    }
     return {
       type: 'info',
       label: t('common:login.infoLabel'),
       content: t('common:login.infoContent'),
     };
-  }, [t, router.query.error, router.query.sessionExpired, router.query.logout]);
+  }, [
+    t,
+    router.query.error,
+    router.query.sessionExpired,
+    router.query.logout,
+    router.query.userStateError,
+  ]);
 
   useEffect(() => {
-    if (router.query.logout) {
-      void queryClient.clear();
+    if (router.query.logout || router.query.userStateError) {
+      queryClient.clear();
     }
-  }, [router.query.logout, queryClient]);
+  }, [router.query.logout, router.query.userStateError, queryClient]);
 
   return (
     <Container>


### PR DESCRIPTION
## Description :sparkles:

**Before:**
When backend was unavailable, frontend kept on insisting that the user was in logged in state and trying to fetch more resources. 

**After:**
In case of an error we now redirect to `/login` and an error shows up.

Not sure if this addresses every known issue with the handler UI showing up without login, but we are getting there.

![dashboardbug](https://github.com/City-of-Helsinki/yjdh/assets/5328394/8c166599-3dcd-482e-ba1c-93f36a848308)
