### PR TITLE
For developer convenience do not redirect to login if backend is down

### DIFF
--- a/frontend/benefit/handler/src/hooks/useUserQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useUserQuery.ts
@@ -26,7 +26,12 @@ const useUserQuery = <T = User>(
     } else if (/40[13]/.test(error.message)) {
       void router.push(`${locale}/login`);
     } else {
-      void router.push(`${locale}/login?userStateError=true`);
+      if (
+        !process.env.NEXT_PUBLIC_MOCK_FLAG ||
+        process.env.NEXT_PUBLIC_MOCK_FLAG == '0'
+      ) {
+        void router.push(`${locale}/login?userStateError=true`);
+      }
     }
   };
 


### PR DESCRIPTION
## Description :sparkles:

Related to #2042.

When modifiying backend the frontend would panic and assume that backend is seriously ill. Do not redirect if mock-flag is in use.