### PR TITLE
Use Finnish locale in benefit factories, add more chars to faked username

### DIFF
--- a/backend/benefit/applications/tests/factories.py
+++ b/backend/benefit/applications/tests/factories.py
@@ -39,7 +39,7 @@ class AttachmentFactory(factory.django.DjangoModelFactory):
 
 
 class DeMinimisAidFactory(factory.django.DjangoModelFactory):
-    granter = factory.Faker("sentence", nb_words=2)
+    granter = factory.Faker("sentence", nb_words=2, locale="fi_FI")
 
     # delay evaluation of date_start and date_end so that any freeze_time takes effect
     granted_at = factory.Faker(
@@ -74,21 +74,21 @@ class ApplicationFactory(factory.django.DjangoModelFactory):
     company_name = factory.Faker("sentence", nb_words=2)
     company_form = factory.Faker("sentence", nb_words=1)
     company_form_code = YtjOrganizationCode.COMPANY_FORM_CODE_DEFAULT
-    company_department = factory.Faker("street_address")
-    official_company_street_address = factory.Faker("street_address")
-    official_company_city = factory.Faker("city")
-    official_company_postcode = factory.Faker("postcode")
+    company_department = factory.Faker("street_address", locale="fi_FI")
+    official_company_street_address = factory.Faker("street_address", locale="fi_FI")
+    official_company_city = factory.Faker("city", locale="fi_FI")
+    official_company_postcode = factory.Faker("postcode", locale="fi_FI")
     use_alternative_address = factory.Faker("boolean")
-    alternative_company_street_address = factory.Faker("street_address")
-    alternative_company_city = factory.Faker("city")
+    alternative_company_street_address = factory.Faker("street_address", locale="fi_FI")
+    alternative_company_city = factory.Faker("city", locale="fi_FI")
     alternative_company_postcode = factory.Faker("postcode", locale="fi_FI")
     company_bank_account_number = factory.Faker("iban", locale="fi_FI")
     company_contact_person_phone_number = factory.Sequence(
         lambda n: f"050-10000{n}"
     )  # max.length in validation seems to be 10 digits
-    company_contact_person_email = factory.Faker("email")
-    company_contact_person_first_name = factory.Faker("first_name")
-    company_contact_person_last_name = factory.Faker("last_name")
+    company_contact_person_email = factory.Faker("email", locale="fi_FI")
+    company_contact_person_first_name = factory.Faker("first_name", locale="fi_FI")
+    company_contact_person_last_name = factory.Faker("last_name", locale="fi_FI")
     association_has_business_activities = None
     applicant_language = factory.Faker(
         "random_element", elements=[v[0] for v in APPLICATION_LANGUAGE_CHOICES]
@@ -253,16 +253,16 @@ class RejectedApplicationFactory(HandlingApplicationFactory):
 class EmployeeFactory(factory.django.DjangoModelFactory):
     # pass employee=None to prevent ApplicationFactory from creating another employee
     application = factory.SubFactory(ApplicationFactory, employee=None)
-    first_name = factory.Faker("first_name")
-    last_name = factory.Faker("last_name")
+    first_name = factory.Faker("first_name", locale="fi_FI")
+    last_name = factory.Faker("last_name", locale="fi_FI")
     social_security_number = factory.Faker("ssn", locale="fi_FI")
     phone_number = factory.Sequence(lambda n: f"050-10000{n}")
-    email = factory.Faker("email")
+    email = factory.Faker("email", locale="fi_FI")
 
     employee_language = factory.Faker(
         "random_element", elements=[v[0] for v in APPLICATION_LANGUAGE_CHOICES]
     )
-    job_title = factory.Faker("job")
+    job_title = factory.Faker("job", locale="fi_FI")
     monthly_pay = factory.Faker("random_int", max=5000)
     vacation_money = factory.Faker("random_int", max=5000)
     other_expenses = factory.Faker("random_int", max=5000)
@@ -288,17 +288,17 @@ class ApplicationBatchFactory(factory.django.DjangoModelFactory):
         factory_related_name="batch",
         status=factory.SelfAttribute("batch.proposal_for_decision"),
     )
-    decision_maker_title = factory.Faker("sentence", nb_words=2)
-    decision_maker_name = factory.Faker("name")
-    section_of_the_law = factory.Faker("word")
+    decision_maker_title = factory.Faker("job", locale="fi_FI")
+    decision_maker_name = factory.Faker("name", locale="fi_FI")
+    section_of_the_law = factory.Faker("word", locale="fi_FI")
     decision_date = factory.Faker(
         "date_between_dates",
         date_start=factory.LazyAttribute(lambda _: date.today() - timedelta(days=30)),
         date_end=factory.LazyAttribute(lambda _: date.today()),
     )
 
-    expert_inspector_name = factory.Faker("name")
-    expert_inspector_email = factory.Faker("email")
+    expert_inspector_name = factory.Faker("name", locale="fi_FI")
+    expert_inspector_email = factory.Faker("email", locale="fi_FI")
 
     class Meta:
         model = ApplicationBatch

--- a/backend/benefit/companies/tests/factories.py
+++ b/backend/benefit/companies/tests/factories.py
@@ -5,15 +5,15 @@ from shared.service_bus.enums import YtjOrganizationCode
 
 
 class CompanyFactory(factory.django.DjangoModelFactory):
-    name = factory.Faker("company")
+    name = factory.Faker("company", locale="fi_FI")
     business_id = factory.Faker("numerify", text="#######-#")
     company_form = "oy"
     company_form_code = YtjOrganizationCode.COMPANY_FORM_CODE_DEFAULT
     bank_account_number = factory.Faker("iban", locale="fi_FI")
 
-    street_address = factory.Faker("street_address")
-    postcode = factory.Faker("postcode")
-    city = factory.Faker("city")
+    street_address = factory.Faker("street_address", locale="fi_FI")
+    postcode = factory.Faker("postcode", locale="fi_FI")
+    city = factory.Faker("city", locale="fi_FI")
 
     class Meta:
         model = Company

--- a/backend/shared/shared/common/tests/factories.py
+++ b/backend/shared/shared/common/tests/factories.py
@@ -9,11 +9,19 @@ class UserFactory(factory.django.DjangoModelFactory):
 
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
-    username = factory.Faker("user_name")
     email = factory.Faker("email")
+
+    username_base = factory.Faker("user_name")
+    username_suffix = factory.Faker(
+        "password", length=6, special_chars=False, upper_case=False
+    )
+    username = factory.LazyAttribute(
+        lambda p: "{}_{}".format(p.username_base, p.username_suffix)
+    )
 
     class Meta:
         model = get_user_model()
+        exclude = ("username_base", "username_suffix")
 
 
 class DuplicateAllowingUserFactory(UserFactory):


### PR DESCRIPTION
## Description :sparkles:

* Benefit: I grew tired of using English seeds, use fi locale now as it reflects the real app behaviour better
* Shared: More unique faked usernames so that `benefit` seeded applications and tests won't have username namespace errors anymore
  * More details: [c5d4bf3f3a2a2](https://github.com/City-of-Helsinki/yjdh/commit/c5d4bf3f3a2a22e7415c8ec3ef559b8314a1d8b2#diff-cb4c93c6e1947a9c35a5449e03d3a00cb22c0b16ca4a5e3cf3b100f883ad88f9L16) (`As we generate applications for batches too, faker usernames start to conflict which means a failing test...`)