### PR TITLE
Hide handler and applicant from search engines

### DIFF
--- a/frontend/benefit/applicant/public/robots.txt
+++ b/frontend/benefit/applicant/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/frontend/benefit/handler/public/robots.txt
+++ b/frontend/benefit/handler/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/frontend/benefit/handler/src/hooks/useUserQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useUserQuery.ts
@@ -25,13 +25,11 @@ const useUserQuery = <T = User>(
       void router.push(`${locale}/login?logout=true`);
     } else if (/40[13]/.test(error.message)) {
       void router.push(`${locale}/login`);
-    } else {
-      if (
-        !process.env.NEXT_PUBLIC_MOCK_FLAG ||
-        process.env.NEXT_PUBLIC_MOCK_FLAG == '0'
-      ) {
-        void router.push(`${locale}/login?userStateError=true`);
-      }
+    } else if (
+      !process.env.NEXT_PUBLIC_MOCK_FLAG ||
+      process.env.NEXT_PUBLIC_MOCK_FLAG === '0'
+    ) {
+      void router.push(`${locale}/login?userStateError=true`);
     }
   };
 

--- a/frontend/benefit/shared/src/pages/BenefitDocument.tsx
+++ b/frontend/benefit/shared/src/pages/BenefitDocument.tsx
@@ -12,6 +12,7 @@ class BenefitDocument extends ServerDocument {
           <link rel="icon" href="./favicons/favicon.svg" type="image/svg+xml" />
           <link rel="apple-touch-icon" href="./favicons/apple-touch-icon.png" />
           <link rel="manifest" href="./favicons/manifest.webmanifest" />
+          <meta name="robots" content="noindex,follow" />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
## Description :sparkles:

Allow and optimize applicant later, when closed beta ends.

## Test


* Using robots.txt
  * https://localhost:3000/robots.txt
  * https://localhost:3100/robots.txt
* Check for tag `<meta name="robots"... />` inside `<head>`:
  * https://localhost:3000
  * https://localhost:3100
