### PR TITLE
chore(ks-backend): update CHANGELOG.md manually

### DIFF
--- a/backend/kesaseteli/CHANGELOG.md
+++ b/backend/kesaseteli/CHANGELOG.md
@@ -1,16 +1,8 @@
 # Changelog
 
-## [1.1.0](https://github.com/City-of-Helsinki/yjdh/compare/kesaseteli-backend-v1.0.0...kesaseteli-backend-v1.1.0) (2023-06-01)
+## [1.1.0](https://github.com/City-of-Helsinki/yjdh/compare/kesaseteli-backend-v1.0.0...kesaseteli-backend-v1.1.0) (2023-06-02)
 
 
 ### Features
 
 * **ks-backend:** Add fetch_employee_data endpoint to fill employee form ([5a9cdd7](https://github.com/City-of-Helsinki/yjdh/commit/5a9cdd78b995a87a7cf87dd3ff128024ec409d4c))
-* **yjdh-422:** Clean jobs for youth applications ([e5de0cd](https://github.com/City-of-Helsinki/yjdh/commit/e5de0cd44d1638e97fc431e2cbf4b47e0480496f))
-* **yjdh-422:** Log scheduled job results ([957617a](https://github.com/City-of-Helsinki/yjdh/commit/957617ad7974cd8ae877b22e828f6ff31b4ac2bb))
-* **yjdh-422:** Run existing application jobs daily instead of monthly ([126425d](https://github.com/City-of-Helsinki/yjdh/commit/126425dc2e5a50023b3283f5b6305fb90b26617a))
-
-
-### Bug Fixes
-
-* Change youth summer voucher email's year from 2022 to 2023 ([c0f0293](https://github.com/City-of-Helsinki/yjdh/commit/c0f0293b7cb3a7a30fa95b4d7c83624664aebeac))


### PR DESCRIPTION
## Description :sparkles:

### chore(ks-backend): update CHANGELOG.md manually

No tag was created by release-please, CHANGELOG.md contained wrong information.

Update CHANGELOG.md manually.

refs YJDH-677

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
