### PR TITLE
HL-756 | Validate state_aid_max_percentage

### DIFF
--- a/backend/benefit/calculator/api/v1/serializers.py
+++ b/backend/benefit/calculator/api/v1/serializers.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from dateutil.relativedelta import relativedelta
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
@@ -260,6 +262,11 @@ class PaySubsidySerializer(serializers.ModelSerializer):
             and not self._is_manual_mode()
         )
 
+    def _is_invalid_state_aid_max(self, state_aid_max_input: Union[None, int]) -> bool:
+        return state_aid_max_input is None or state_aid_max_input not in [
+            choice[0] for choice in STATE_AID_MAX_PERCENTAGE_CHOICES
+        ]
+
     def validate(self, data):
         request = self.context.get("request")
         if request is None:
@@ -276,12 +283,7 @@ class PaySubsidySerializer(serializers.ModelSerializer):
             state_aid_max_input = self.context["request"].data["calculation"][
                 "state_aid_max_percentage"
             ]
-            if (
-                state_aid_max_input is None
-                or state_aid_max_input == ""
-                or state_aid_max_input
-                not in [choice[0] for choice in STATE_AID_MAX_PERCENTAGE_CHOICES]
-            ):
+            if self._is_invalid_state_aid_max(state_aid_max_input):
                 raise serializers.ValidationError(
                     {
                         "state_aid_max_percentage": _(

--- a/backend/benefit/calculator/api/v1/serializers.py
+++ b/backend/benefit/calculator/api/v1/serializers.py
@@ -280,7 +280,7 @@ class PaySubsidySerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {"end_date": _("End date cannot be empty")}
                 )
-            state_aid_max_input = self.context["request"].data["calculation"][
+            state_aid_max_input = request.data["calculation"][
                 "state_aid_max_percentage"
             ]
             if self._is_invalid_state_aid_max(state_aid_max_input):

--- a/backend/benefit/calculator/api/v1/serializers.py
+++ b/backend/benefit/calculator/api/v1/serializers.py
@@ -9,6 +9,7 @@ from calculator.models import (
     CalculationRow,
     PaySubsidy,
     PreviousBenefit,
+    STATE_AID_MAX_PERCENTAGE_CHOICES,
     TrainingCompensation,
 )
 from users.api.v1.serializers import UserSerializer
@@ -272,8 +273,15 @@ class PaySubsidySerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {"end_date": _("End date cannot be empty")}
                 )
-            calculation = self.context["request"].data["calculation"]
-            if calculation["state_aid_max_percentage"] is None:
+            state_aid_max_input = self.context["request"].data["calculation"][
+                "state_aid_max_percentage"
+            ]
+            if (
+                state_aid_max_input is None
+                or state_aid_max_input == ""
+                or state_aid_max_input
+                not in [choice[0] for choice in STATE_AID_MAX_PERCENTAGE_CHOICES]
+            ):
                 raise serializers.ValidationError(
                     {
                         "state_aid_max_percentage": _(

--- a/backend/benefit/calculator/api/v1/serializers.py
+++ b/backend/benefit/calculator/api/v1/serializers.py
@@ -272,6 +272,15 @@ class PaySubsidySerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {"end_date": _("End date cannot be empty")}
                 )
+            calculation = self.context["request"].data["calculation"]
+            if calculation["state_aid_max_percentage"] is None:
+                raise serializers.ValidationError(
+                    {
+                        "state_aid_max_percentage": _(
+                            "State aid maximum percentage cannot be empty"
+                        )
+                    }
+                )
         return data
 
     class Meta:

--- a/backend/benefit/locale/en/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/en/LC_MESSAGES/django.po
@@ -513,6 +513,9 @@ msgstr ""
 msgid "State aid maximum %"
 msgstr ""
 
+msgid "State aid maximum percentage cannot be empty"
+msgstr ""
+
 msgid "Pay subsidy/month"
 msgstr ""
 

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -512,6 +512,9 @@ msgstr "Aloituspäivä ei voi olla tyhjä"
 msgid "End date cannot be empty"
 msgstr "Päättymispäivä ei voi olla tyhjä"
 
+msgid "State aid maximum percentage cannot be empty"
+msgstr "Valtiontuen maksimimäärä ei voi olla tyhjä"
+
 msgid "Description row, amount ignored"
 msgstr "Kuvausrivi, rahamäärä ohitettu"
 

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -513,7 +513,7 @@ msgid "End date cannot be empty"
 msgstr "Päättymispäivä ei voi olla tyhjä"
 
 msgid "State aid maximum percentage cannot be empty"
-msgstr "Valtiontuen maksimimäärä ei voi olla tyhjä"
+msgstr "Valtiontuen maksimimäärä ei voi olla tyhjä ja sen täytyy olla yksi alasvetovalikon arvoista"
 
 msgid "Description row, amount ignored"
 msgstr "Kuvausrivi, rahamäärä ohitettu"

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -518,6 +518,9 @@ msgstr "Lönekostnader"
 msgid "State aid maximum %"
 msgstr "Maximalt statsunderstöd %"
 
+msgid "State aid maximum percentage cannot be empty"
+msgstr "Maximalt statsunderstöd får inte vara tom"
+
 msgid "Pay subsidy/month"
 msgstr "Lönesubvention/månad"
 


### PR DESCRIPTION
## Description :sparkles:
The handler form fails silently if there is no option selected from the State Aid Maximum Percentage select element.
This PR extends the backend validations for the pay subsidy calculation to validate that the State Aid Maximum Percentage is selected and displays an error if is it not.

## Issues :bug:

## Testing :alembic:
Navigate to the handler form, open an application for handling, try to create a calculation without selectin the State Aid Maximum Percentage.
## Screenshots :camera_flash:
<img width="1065" alt="Screenshot 2023-06-06 at 15 11 36" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/ede6804d-dc00-4ad7-982a-b09124135d0f">

## Additional notes :spiral_notepad:
Investigating the issue, I noticed that there is some code on the frontend for validating the input fields, but enabling the frontend validation breaks the layout and the validations  as the date inputs use the same keys.
Fixing this is assigned to a separate ticket [HL-826](https://helsinkisolutionoffice.atlassian.net/browse/HL-826?atlOrigin=eyJpIjoiOTczYWI5ZTZlNWRhNGVjY2JlMWU3YzkwMGVjMThhYzkiLCJwIjoiaiJ9)



[HL-826]: https://helsinkisolutionoffice.atlassian.net/browse/HL-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ