### PR TITLE
HL-836 | Fix pdf viewer issues 

### DIFF
--- a/frontend/benefit/applicant/package.json
+++ b/frontend/benefit/applicant/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@frontend/shared": "*",
     "@frontend/benefit-shared": "*",
-    "@react-pdf/renderer": "^3.1.10",
+    "@react-pdf/renderer": "^3.1.12",
     "@sentry/browser": "^7.16.0",
     "@sentry/nextjs": "^7.16.0",
     "axios": "^0.27.2",
@@ -39,7 +39,7 @@
     "react-dom": "^18.0.0",
     "react-input-mask": "^2.0.4",
     "react-loading-skeleton": "^3.0.3",
-    "react-pdf": "^7.0.3",
+    "react-pdf": "^7.1.2",
     "react-query": "^3.34.0",
     "react-toastify": "^9.0.4",
     "snakecase-keys": "^5.4.2",

--- a/frontend/benefit/applicant/src/components/pdfViewer/PdfViewer.tsx
+++ b/frontend/benefit/applicant/src/components/pdfViewer/PdfViewer.tsx
@@ -1,8 +1,10 @@
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
+import 'react-pdf/dist/esm/Page/TextLayer.css';
 
 import { Button } from 'hds-react';
+import url from 'pdfjs-dist/build/pdf.worker';
 import React from 'react';
-import { Document, Page } from 'react-pdf';
+import { Document, Page, pdfjs } from 'react-pdf';
 import {
   $Grid,
   $GridCell,
@@ -11,6 +13,8 @@ import { useTheme } from 'styled-components';
 
 import { $ActionsWrapper, $ViewerWrapper } from './PdfViewer.sc';
 import { usePdfViewer } from './usePdfViewer';
+
+pdfjs.GlobalWorkerOptions.workerSrc = String(url);
 
 type PdfViewerProps = {
   file: string;

--- a/frontend/benefit/applicant/tsconfig.json
+++ b/frontend/benefit/applicant/tsconfig.json
@@ -5,7 +5,7 @@
     "paths": {
       "benefit/applicant/*": ["benefit/applicant/src/*"],
       "benefit-shared/*": ["benefit/shared/src/*"],
-      "shared/*": ["shared/src/*","shared/browser-tests/*"]
+      "shared/*": ["shared/src/*", "shared/browser-tests/*"]
     }
   },
   "include": [

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -33,6 +33,16 @@ const NEXTJS_SENTRY_TRACING = trueEnv.includes(
   process.env?.NEXTJS_SENTRY_TRACING ?? 'false'
 );
 
+// Get the app context ...
+let appName;
+if (process.cwd().indexOf('/app/') === 0) {
+  // ... from docker system
+  appName = process.cwd().split('/app/').pop();
+} else if (process.cwd().includes('/frontend/')) {
+  // ... from local system
+  appName = process.cwd().split('/frontend/').pop();
+}
+
 /**
  * A way to allow CI optimization when the build done there is not used
  * to deliver an image or deploy the files.
@@ -114,6 +124,17 @@ const nextConfig = (override) => ({
       test: /\.test.tsx$/,
       loader: 'ignore-loader',
     });
+
+    if (appName && appName === 'benefit/applicant') {
+      config.module.rules.push({
+        test: /pdfjs-dist\/build\/pdf\.worker\.js$/,
+        type: 'asset/resource',
+        generator: {
+          filename: 'static/chunks/[name].[hash][ext]',
+        },
+      });
+    }
+
     return config;
   },
   env: {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2730,10 +2730,10 @@
     parse-svg-path "^0.1.2"
     svg-arc-to-cubic-bezier "^3.2.0"
 
-"@react-pdf/renderer@^3.1.10":
-  version "3.1.11"
-  resolved "https://registry.yarnpkg.com/@react-pdf/renderer/-/renderer-3.1.11.tgz#7a7f80e2a021de6e12a1463847e5bc9ca39586c0"
-  integrity sha512-te/RTcyTkIg6zlvuoUYs5cEXPyZPjADrhcm/6EA2OudMmmwHlTrsinMgLuB8aGlSjmgo3anlu1soIC2j+KsyTQ==
+"@react-pdf/renderer@^3.1.12":
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/@react-pdf/renderer/-/renderer-3.1.12.tgz#3c208a35662c561712acad1e06ccd0b753b2472a"
+  integrity sha512-y4H2ELH0okJP7+ig+uNjFAfuAanWiF3mxsKsE7ZBuhF4tabbMt9fX+pQ7qn4xrzEWX0vlso6s6ebkkeGdSGWzA==
   dependencies:
     "@babel/runtime" "^7.20.13"
     "@react-pdf/font" "^2.3.6"
@@ -11644,10 +11644,10 @@ react-merge-refs@1.1.0:
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
-react-pdf@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-7.0.3.tgz#3d566cef40be8a761d33e53226cba8aeca131214"
-  integrity sha512-S+xF0dWo1mebcTgOpVejAdNscYY8MkoTantTFNJwvCs76ENZhoKXNS9AEPaa4/Aqw+01ByeejPX7RX4ypN3yHQ==
+react-pdf@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-7.1.2.tgz#c6979cff9ac09c3e5ab7ea9e0182f79a499768e5"
+  integrity sha512-hmTUKh3WVYDJlP8XvebGN8HH0Gk/tXh9WgNAtvdHn79FHL78UEPSbVj3veHHGqmMa2hz1wJCItLUqGVP68Qsjw==
   dependencies:
     clsx "^1.2.1"
     make-cancellable-promise "^1.0.0"


### PR DESCRIPTION
## Description :sparkles:

* Resolve rendering issues
* Update react-pdf again

## Issues

~Loading the worker from `public/` is not elegant and webpack should probably load it but webpack is keen on generating the file with hash included in the name for cache busting purposes. That won't allow the resource to be loaded from a single static path so we need to revisit that after NextJs12 upgrade, which has changes in the asset pipeline.~

UPDATE: Loads from webpack now, with considerably smaller JS footprint ~500KB.