### PR TITLE
HL-818 | Improve application front page responsiveness

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
@@ -27,6 +27,10 @@ export const $ItemContent = styled.div`
   width: 100%;
   margin-bottom: var(--spacing-s);
 
+  ${respondAbove('xs')`
+    grid-template-columns: 1fr 1fr;
+  `};
+
   ${respondAbove('sm')`
     grid-template-columns: 60px 3fr repeat(4, minmax(100px, 3fr));
   `};
@@ -47,6 +51,10 @@ export const $Avatar = styled.div<AvatarProps>`
   width: 60px;
   min-height: 60px;
   min-width: 60px;
+  grid-column: 1 / -1;
+  ${respondAbove('sm')`
+    grid-column: 1;
+  `};
 `;
 
 export const $DataColumn = styled.div`

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
@@ -1,3 +1,4 @@
+import { respondAbove } from 'shared/styles/mediaQueries';
 import styled, { DefaultTheme } from 'styled-components';
 
 interface AvatarProps {
@@ -10,17 +11,25 @@ export const $ListItemWrapper = styled.div`
 `;
 
 export const $ListItem = styled.li`
-  display: flex;
+  display: block;
   background-color: ${(props) => props.theme.colors.white};
   padding: ${(props) => props.theme.spacing.xs};
   justify-content: space-between;
+
+  ${respondAbove('md')`
+    display: flex;
+  `};
 `;
 
 export const $ItemContent = styled.div`
   display: grid;
-  grid-template-columns: 60px 3fr repeat(4, minmax(100px, 2fr));
   grid-gap: ${(props) => props.theme.spacing.m};
   width: 100%;
+  margin-bottom: var(--spacing-s);
+
+  ${respondAbove('sm')`
+    grid-template-columns: 60px 3fr repeat(4, minmax(100px, 3fr));
+  `};
 `;
 
 export const $Avatar = styled.div<AvatarProps>`

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.tsx
@@ -6,6 +6,8 @@ import { Button, IconSpeechbubbleText, StatusLabel } from 'hds-react';
 import React from 'react';
 import LoadingSkeleton from 'react-loading-skeleton';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { respondAbove } from 'shared/styles/mediaQueries';
+import styled from 'styled-components';
 
 import {
   $Avatar,
@@ -22,6 +24,17 @@ import {
 } from './ListItem.sc';
 
 export type ListItemProps = ApplicationListItemData | Loading;
+
+const $StatusLabel = styled(StatusLabel)`
+  font-weight: 600;
+  text-align: center;
+  box-sizing: border-box;
+  max-width: 160px;
+  margin-right: var(--spacing-s);
+  ${respondAbove('sm')`
+    max-width: none;
+  `}
+`;
 
 const ListItem: React.FC<ListItemProps> = (props) => {
   const { t } = useTranslation();
@@ -99,15 +112,7 @@ const ListItem: React.FC<ListItemProps> = (props) => {
               <$DataHeader>
                 {t(`${translationBase}.common.editEndDate`)}
               </$DataHeader>
-              <StatusLabel
-                css={`
-                  font-weight: 600;
-                  text-align: center;
-                `}
-                type="alert"
-              >
-                {editEndDate}
-              </StatusLabel>
+              <$StatusLabel type="alert">{editEndDate}</$StatusLabel>
             </$DataColumn>
           )}
         </$ItemContent>

--- a/frontend/benefit/applicant/src/components/mainIngress/MainIngress.sc.ts
+++ b/frontend/benefit/applicant/src/components/mainIngress/MainIngress.sc.ts
@@ -1,4 +1,5 @@
 import { $Notification as NotificationBase } from 'benefit/applicant/components/Notification/Notification.sc';
+import { respondAbove } from 'shared/styles/mediaQueries';
 import styled from 'styled-components';
 
 export const $Container = styled.div`
@@ -8,6 +9,10 @@ export const $Container = styled.div`
 export const $TextContainer = styled.div`
   display: flex;
   box-sizing: border-box;
+  flex-direction: column;
+  ${respondAbove('sm')`
+    flex-direction: row;
+  `}
 `;
 
 export const $Heading = styled.h1`
@@ -18,6 +23,7 @@ export const $Heading = styled.h1`
 export const $Description = styled.p`
   font-size: ${(props) => props.theme.fontSize.heading.s};
   line-height: ${(props) => props.theme.lineHeight.l};
+  margin-right: var(--spacing-s);
 `;
 
 export const $Link = styled.span`
@@ -27,10 +33,12 @@ export const $Link = styled.span`
 
 export const $ActionContainer = styled.div`
   display: flex;
-  justify-content: flex-end;
   align-items: center;
   flex: 1 0 30%;
   box-sizing: border-box;
+  ${respondAbove('sm')`
+    justify-content: flex-end;
+  `}
 `;
 
 export const $Notification = styled(NotificationBase)`


### PR DESCRIPTION
## Description :sparkles:

Previously some elements were squashed and hidden when screen was small. Add in some responsiveness via breakpoints. I didn't have the guts to go with custom pixel widths to get this perfect in terms of design, but hey, at least it works.

* Fix page title and action button for "create new application"
  * Switch to row view at >= 768px
* Fix list view
  * Everything is stacked at 0 - 576px
  * Switch to two columns at 576 - 768px (not presented in gif)
  * Switch to row view at 768px
  * Button "edit" to same row at >= 1024px

![responsive](https://github.com/City-of-Helsinki/yjdh/assets/5328394/86faace5-94b0-4156-8b62-126f202f4c6c)
