### PR TITLE
Change de minimis aid radio input validation to always required

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/utils/validation.ts
@@ -133,12 +133,7 @@ export const getValidationSchema = (
       .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
     [APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID]: Yup.boolean()
       .nullable()
-      .when(APPLICATION_FIELDS_STEP1_KEYS.ASSOCIATION_HAS_BUSINESS_ACTIVITIES, {
-        is: true,
-        then: Yup.boolean()
-          .nullable()
-          .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
-      }),
+      .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
     [APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID_SET]: Yup.array().of(
       getDeminimisValidationSchema(t).nullable()
     ),


### PR DESCRIPTION
## Description :sparkles:
Selecting yes or no on the DeMinimis aid radio button was not required in the frontend validation rules.
This PR changes the validation so that  selecting yes or no is mandatory even if the applicant is represeting and association.

## Testing :alembic:
Navigate to the step 1 of the application and try to submit without selecting yes or no from the DeMinimisAid radio button.
## Screenshots :camera_flash:

<img width="1009" alt="Screenshot 2023-06-16 at 13 05 43" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/20f18b7d-797d-421f-8ce7-20ef48bd1113">
