### PR TITLE
HL-839 | Tables now sort based on date value

### DIFF
--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
@@ -1,9 +1,10 @@
 import { ROUTES } from 'benefit/handler/constants';
 import { allApplicationStatuses } from 'benefit/handler/pages';
 import {
-  APPLICATION_ORIGINS,
-  APPLICATION_STATUSES,
-} from 'benefit-shared/constants';
+  ApplicationListTableColumns,
+  ApplicationListTableTransforms,
+} from 'benefit/handler/types/applicationList';
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import {
   IconSpeechbubbleText,
   LoadingSpinner,
@@ -13,7 +14,10 @@ import {
 } from 'hds-react';
 import * as React from 'react';
 import { $Link } from 'shared/components/table/Table.sc';
-import { convertToUIDateFormat } from 'shared/utils/date.utils';
+import {
+  convertToUIDateFormat,
+  sortFinnishDate,
+} from 'shared/utils/date.utils';
 import { useTheme } from 'styled-components';
 
 import { $CellContent, $EmptyHeading, $Heading } from './ApplicationList.sc';
@@ -49,25 +53,16 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
 
   const theme = useTheme();
 
-  interface TableTransforms {
-    id?: string;
-    companyName?: string;
-    unreadMessagesCount?: number;
-    additionalInformationNeededBy?: string | Date;
-    status?: APPLICATION_STATUSES;
-    applicationOrigin?: APPLICATION_ORIGINS;
-  }
-
   const isAllStatuses: boolean = status === allApplicationStatuses;
 
   const columns = React.useMemo(() => {
-    const cols = [
+    const cols: ApplicationListTableColumns[] = [
       {
         transform: ({
           id,
           companyName,
           status: applicationStatus,
-        }: TableTransforms) => (
+        }: ApplicationListTableTransforms) => (
           <$Link href={buildApplicationUrl(id, applicationStatus)}>
             {String(companyName)}
           </$Link>
@@ -106,16 +101,21 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
         headerName: getHeader('submittedAt'),
         key: 'submittedAt',
         isSortable: true,
+        customSortCompareFunction: sortFinnishDate,
       });
     }
 
     if (isAllStatuses) {
       cols.push({
-        transform: ({ status: applicationStatus }: TableTransforms) => (
+        transform: ({
+          status: applicationStatus,
+        }: ApplicationListTableTransforms) => (
           <div>
             <Tag>
               {t(
-                `common:applications.list.columns.applicationStatuses.${applicationStatus}`
+                `common:applications.list.columns.applicationStatuses.${String(
+                  applicationStatus
+                )}`
               )}
             </Tag>
           </div>
@@ -128,11 +128,13 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
 
     if (status.includes(APPLICATION_STATUSES.RECEIVED) && !isAllStatuses) {
       cols.push({
-        transform: ({ applicationOrigin }: TableTransforms) => (
+        transform: ({ applicationOrigin }: ApplicationListTableTransforms) => (
           <div>
             <Tag>
               {t(
-                `common:applications.list.columns.applicationOrigins.${applicationOrigin}`
+                `common:applications.list.columns.applicationOrigins.${String(
+                  applicationOrigin
+                )}`
               )}
             </Tag>
           </div>
@@ -148,7 +150,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
         transform: ({
           additionalInformationNeededBy,
           status: itemStatus,
-        }: TableTransforms) => (
+        }: ApplicationListTableTransforms) => (
           <div>
             {itemStatus === APPLICATION_STATUSES.INFO_REQUIRED ? (
               <StatusLabel type="alert">
@@ -169,7 +171,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
     }
 
     cols.push({
-      transform: ({ unreadMessagesCount }: TableTransforms) => (
+      transform: ({ unreadMessagesCount }: ApplicationListTableTransforms) => (
         <$CellContent>
           {Number(unreadMessagesCount) > 0 ? (
             <IconSpeechbubbleText color={theme.colors.coatOfArms} />

--- a/frontend/benefit/handler/src/components/applicationsArchive/ApplicationsArchive.tsx
+++ b/frontend/benefit/handler/src/components/applicationsArchive/ApplicationsArchive.tsx
@@ -10,6 +10,7 @@ import {
 import * as React from 'react';
 import Container from 'shared/components/container/Container';
 import { $Link } from 'shared/components/table/Table.sc';
+import { sortFinnishDate } from 'shared/utils/date.utils';
 import { useTheme } from 'styled-components';
 
 import { $EmptyHeading } from '../applicationList/ApplicationList.sc';
@@ -82,6 +83,7 @@ const ApplicationsArchive: React.FC = () => {
       headerName: getHeader('handledAt'),
       key: 'handledAt',
       isSortable: true,
+      customSortCompareFunction: sortFinnishDate,
     },
     {
       transform: ({ status }: TableTransforms) => (

--- a/frontend/benefit/handler/src/components/batchProcessing/ApplicationsHandled.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/ApplicationsHandled.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import Container from 'shared/components/container/Container';
 import { $Link } from 'shared/components/table/Table.sc';
 import theme from 'shared/styles/theme';
+import { sortFinnishDate } from 'shared/utils/date.utils';
 
 import { $HintText, $TableFooter } from '../table/TableExtras.sc';
 import { useApplicationsHandled } from './useApplicationsHandled';
@@ -75,6 +76,7 @@ const ApplicationsHandled: React.FC<Props> = ({
         headerName: getHeader('handledAt'),
         key: 'handledAt',
         isSortable: true,
+        customSortCompareFunction: sortFinnishDate,
       },
     ];
     return cols.filter(Boolean);

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
@@ -21,7 +21,10 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 import Modal from 'shared/components/modal/Modal';
 import theme from 'shared/styles/theme';
-import { convertToUIDateAndTimeFormat } from 'shared/utils/date.utils';
+import {
+  convertToUIDateAndTimeFormat,
+  sortFinnishDate,
+} from 'shared/utils/date.utils';
 import styled from 'styled-components';
 
 import { $Empty } from '../applicationList/ApplicationList.sc';
@@ -110,6 +113,7 @@ const BatchApplicationList: React.FC<BatchProps> = ({ batch }: BatchProps) => {
       headerName: t('common:applications.list.columns.handledAt'),
       key: 'handled_at',
       isSortable: true,
+      customSortCompareFunction: sortFinnishDate,
     },
     {
       transform: ({ id: appId }: { id: string }) =>

--- a/frontend/benefit/handler/src/types/applicationList.d.ts
+++ b/frontend/benefit/handler/src/types/applicationList.d.ts
@@ -1,0 +1,19 @@
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
+
+export interface ApplicationListTableTransforms {
+  id?: string;
+  companyName?: string;
+  unreadMessagesCount?: number;
+  additionalInformationNeededBy?: string | Date;
+  status?: APPLICATION_STATUSES;
+  applicationOrigin?: APPLICATION_ORIGINS;
+}
+
+export interface ApplicationListTableColumns {
+  isSortable?: boolean;
+  key: string;
+  headerName: string;
+  sortIconType?: 'string' | 'other';
+  transform?: ({ ...args }: TableTransforms) => string | JSX.Element;
+  customSortCompareFunction?: (a: string, b: string) => void;
+}

--- a/frontend/shared/src/utils/date.utils.ts
+++ b/frontend/shared/src/utils/date.utils.ts
@@ -1,6 +1,8 @@
 import { startOfYear } from 'date-fns';
 import formatDateStr from 'date-fns/format';
+import isBefore from 'date-fns/isBefore';
 import isFutureFn from 'date-fns/isFuture';
+import isSameDay from 'date-fns/isSameDay';
 import isValid from 'date-fns/isValid';
 import { enGB as en, fi, sv } from 'date-fns/locale';
 import parse from 'date-fns/parse';
@@ -211,4 +213,19 @@ export const isWithinInterval = (
   const start = parseDate(startDate) ?? 0;
   const end = parseDate(endDate) ?? 0;
   return (!start || start <= curr) && (curr <= end || !end);
+};
+
+export const sortFinnishDate = (a: string, b: string): number => {
+  const aDate = parse(a, 'dd.MM.yyyy', new Date());
+  const bDate = parse(b, 'dd.MM.yyyy', new Date());
+
+  if (isSameDay(aDate, bDate)) {
+    return 0;
+  }
+
+  if (isBefore(aDate, bDate)) {
+    return -1;
+  }
+
+  return 1;
 };


### PR DESCRIPTION
## Description :sparkles:

By default, `<Table>` sorts data as A,B,C... 

Use custom function to change the sort algorithm for dates.

# before

![screencapture-localhost-3100-batches-2023-06-19-14_29_13](https://github.com/City-of-Helsinki/yjdh/assets/5328394/0ecccb5a-c299-4f89-b027-480efbfb951e)


# after

![screencapture-localhost-3100-batches-2023-06-19-14_27_49](https://github.com/City-of-Helsinki/yjdh/assets/5328394/17a23c09-f092-47ad-9e74-bc7cced0910a)
