### PR TITLE
Small fix | Disable eslint warn about Slack reporter's console.log

### DIFF
--- a/frontend/shared/browser-tests/reporter/slackMessageSender.ts
+++ b/frontend/shared/browser-tests/reporter/slackMessageSender.ts
@@ -59,6 +59,7 @@ export const createSlackMessageSender = (): SlackMessageSender => {
     // send report only when something has failed
     const message = messages.join('\n');
     if (amountOfFailedTests > 0) {
+      // eslint-disable-next-line no-console
       console.log('Slack message', message);
       if (process.env.TESTCAFE_SLACK_WEBHOOK) {
         sendMessage(
@@ -66,7 +67,10 @@ export const createSlackMessageSender = (): SlackMessageSender => {
           amountOfFailedTests
             ? {
                 attachments: [
-                  ...errorMessages.map((msg) => ({ color: 'danger', text: msg })),
+                  ...errorMessages.map((msg) => ({
+                    color: 'danger',
+                    text: msg,
+                  })),
                   {
                     color: 'danger',
                     text: bold(`${amountOfFailedTests} test failed!`),


### PR DESCRIPTION
## Description :sparkles:

Figured new PR would not mess / have effect with other project specific PR as this file is under `shared/`.

Local prettier/Eslint wanted also to make one line look beautiful. 

Fixes these issues:

![image](https://github.com/City-of-Helsinki/yjdh/assets/5328394/1855b898-a88d-4ebf-a887-9ab3deb196a4)
