### PR TITLE
Validate  granted_at so that it cannot be more than 4 years in the past

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/DeMinimisAidForm.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/DeMinimisAidForm.tsx
@@ -1,5 +1,6 @@
 import {
   DE_MINIMIS_AID_GRANTED_AT_MAX_DATE,
+  DE_MINIMIS_AID_GRANTED_AT_MIN_DATE,
   MAX_DEMINIMIS_AID_TOTAL_AMOUNT,
 } from 'benefit/applicant/constants';
 import { DE_MINIMIS_AID_KEYS } from 'benefit-shared/constants';
@@ -108,6 +109,7 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
             invalid={!!getErrorMessage(DE_MINIMIS_AID_KEYS.GRANTED_AT)}
             aria-invalid={!!getErrorMessage(DE_MINIMIS_AID_KEYS.GRANTED_AT)}
             errorText={getErrorMessage(DE_MINIMIS_AID_KEYS.GRANTED_AT)}
+            minDate={DE_MINIMIS_AID_GRANTED_AT_MIN_DATE}
             maxDate={DE_MINIMIS_AID_GRANTED_AT_MAX_DATE}
             required
           />

--- a/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/utils/validation.ts
@@ -1,10 +1,13 @@
-import { DE_MINIMIS_AID_GRANTED_AT_MAX_DATE } from 'benefit/applicant/constants';
+import {
+  DE_MINIMIS_AID_GRANTED_AT_MAX_DATE,
+  DE_MINIMIS_AID_GRANTED_AT_MIN_DATE,
+} from 'benefit/applicant/constants';
 import {
   DE_MINIMIS_AID_KEYS,
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
 import { DeMinimisAid } from 'benefit-shared/types/application';
-import isFuture from 'date-fns/isFuture';
+import { isBefore, isFuture } from 'date-fns';
 import { TFunction } from 'next-i18next';
 import { convertToUIDateFormat, parseDate } from 'shared/utils/date.utils';
 import { getNumberValue } from 'shared/utils/string.utils';
@@ -38,6 +41,21 @@ export const getValidationSchema = (t: TFunction): Yup.SchemaOf<DeMinimisAid> =>
           const date = parseDate(value);
 
           if (date && isFuture(date)) {
+            return false;
+          }
+          return true;
+        },
+      })
+      .test({
+        message: t(VALIDATION_MESSAGE_KEYS.DATE_MIN, {
+          min: convertToUIDateFormat(DE_MINIMIS_AID_GRANTED_AT_MIN_DATE),
+        }),
+        test: (value) => {
+          if (!value) return false;
+
+          const date = parseDate(value);
+
+          if (date && isBefore(date, DE_MINIMIS_AID_GRANTED_AT_MIN_DATE)) {
             return false;
           }
           return true;

--- a/frontend/benefit/applicant/src/constants.ts
+++ b/frontend/benefit/applicant/src/constants.ts
@@ -43,6 +43,9 @@ export const PRIVACY_POLICY_LINKS = {
 
 export const DE_MINIMIS_AID_GRANTED_AT_MAX_DATE = new Date();
 
+// Set the minimum date of the deMinimimis aid granted at datepicker to the beginning of the year 4 years ago
+export const DE_MINIMIS_AID_GRANTED_AT_MIN_DATE = new Date(new Date().getFullYear() - 4, 0, 1);
+
 export const APPLICATION_START_DATE = new Date(new Date().getFullYear(), 0, 1);
 
 export const APPLICATION_INITIAL_VALUES = {


### PR DESCRIPTION
## Description :sparkles:
DeMinimis aid date allows the manual input of dates  such as 1.1.1900 or 31.12.2000 which crash the app when navigating to next step. This PR adds a validation that checks that the given date cannot be older than January first, four years ago.
The minimum date is also enforced in the datepicker component via props.
## Issues :bug:

## Testing :alembic:
Navigate to the first step of the form and try to input past  dates into the deMinimis granted at  element.
## Screenshots :camera_flash:
<img width="501" alt="Screenshot 2023-06-21 at 10 57 13" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/0ee81b87-3fec-47b3-b47c-253e72069886">
<img width="743" alt="Screenshot 2023-06-21 at 10 57 30" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/0a003ece-773a-4350-8917-f5e86a5f99bf">
<img width="716" alt="Screenshot 2023-06-21 at 10 57 50" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/693619c1-10c6-4e83-b017-93b26592b4fc">

## Additional notes :spiral_notepad:
