### PR TITLE
HL-856 | Show deminimis section for company and association

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
@@ -28,6 +28,7 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
     getErrorMessage,
     clearDeminimisAids,
     getDefaultSelectValue,
+    showDeminimisSection,
     languageOptions,
     fields,
     translationsBase,
@@ -160,7 +161,7 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
       </FormSection>
-    
+    {showDeminimisSection && (
       <FormSection
         header={t(`${translationsBase}.heading3`)}
         tooltip={t(`${translationsBase}.tooltips.heading3`)}
@@ -209,7 +210,7 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
           </>
         )}
       </FormSection>
-     
+    )}
       <FormSection paddingBottom header={t(`${translationsBase}.heading4`)}>
         <$GridCell $colSpan={8}>
           <SelectionGroup

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
@@ -28,7 +28,6 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
     getErrorMessage,
     clearDeminimisAids,
     getDefaultSelectValue,
-    showDeminimisSection,
     languageOptions,
     fields,
     translationsBase,
@@ -161,56 +160,56 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
       </FormSection>
-      {showDeminimisSection && (
-        <FormSection
-          header={t(`${translationsBase}.heading3`)}
-          tooltip={t(`${translationsBase}.tooltips.heading3`)}
-        >
-          <$GridCell $colSpan={8}>
-            <SelectionGroup
-              id={fields.deMinimisAid.name}
-              label={fields.deMinimisAid.label}
-              direction="vertical"
-              required
-              errorText={getErrorMessage(fields.deMinimisAid.name)}
-            >
-              <$RadioButton
-                id={`${fields.deMinimisAid.name}False`}
-                name={fields.deMinimisAid.name}
-                value="false"
-                label={t(
-                  `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID}.no`
-                )}
-                onChange={() => {
-                  formik.setFieldValue(fields.deMinimisAid.name, false);
-                  setDeMinimisAids([]);
-                }}
-                // 3 states: null (none is selected), true, false
-                checked={formik.values.deMinimisAid === false}
-              />
-              <$RadioButton
-                id={`${fields.deMinimisAid.name}True`}
-                name={fields.deMinimisAid.name}
-                value="true"
-                label={t(
-                  `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID}.yes`
-                )}
-                onChange={() =>
-                  formik.setFieldValue(fields.deMinimisAid.name, true)
-                }
-                checked={formik.values.deMinimisAid === true}
-              />
-            </SelectionGroup>
-          </$GridCell>
+    
+      <FormSection
+        header={t(`${translationsBase}.heading3`)}
+        tooltip={t(`${translationsBase}.tooltips.heading3`)}
+      >
+        <$GridCell $colSpan={8}>
+          <SelectionGroup
+            id={fields.deMinimisAid.name}
+            label={fields.deMinimisAid.label}
+            direction="vertical"
+            required
+            errorText={getErrorMessage(fields.deMinimisAid.name)}
+          >
+            <$RadioButton
+              id={`${fields.deMinimisAid.name}False`}
+              name={fields.deMinimisAid.name}
+              value="false"
+              label={t(
+                `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID}.no`
+              )}
+              onChange={() => {
+                formik.setFieldValue(fields.deMinimisAid.name, false);
+                setDeMinimisAids([]);
+              }}
+              // 3 states: null (none is selected), true, false
+              checked={formik.values.deMinimisAid === false}
+            />
+            <$RadioButton
+              id={`${fields.deMinimisAid.name}True`}
+              name={fields.deMinimisAid.name}
+              value="true"
+              label={t(
+                `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID}.yes`
+              )}
+              onChange={() =>
+                formik.setFieldValue(fields.deMinimisAid.name, true)
+              }
+              checked={formik.values.deMinimisAid === true}
+            />
+          </SelectionGroup>
+        </$GridCell>
 
-          {formik.values.deMinimisAid && (
-            <>
-              <DeMinimisAidForm data={deMinimisAidSet} />
-              <DeMinimisAidsList />
-            </>
-          )}
-        </FormSection>
-      )}
+        {formik.values.deMinimisAid && (
+          <>
+            <DeMinimisAidForm data={deMinimisAidSet} />
+            <DeMinimisAidsList />
+          </>
+        )}
+      </FormSection>
+     
       <FormSection paddingBottom header={t(`${translationsBase}.heading4`)}>
         <$GridCell $colSpan={8}>
           <SelectionGroup

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
@@ -26,7 +26,6 @@ type ExtendedComponentProps = {
     Field<APPLICATION_FIELDS_STEP1_KEYS>
   >;
   translationsBase: string;
-  showDeminimisSection: boolean;
   getErrorMessage: (fieldName: string) => string | undefined;
   handleSubmit: () => void;
   handleSave: () => void;
@@ -114,18 +113,14 @@ const useApplicationFormStep1 = (
   const applicationId = values?.id;
   const handleDelete = applicationId
     ? () => {
-        void onDelete(applicationId);
-      }
+      void onDelete(applicationId);
+    }
     : undefined;
 
   const clearDeminimisAids = React.useCallback((): void => {
     setDeMinimisAids([]);
     void setFieldValue(fields.deMinimisAid.name, null);
   }, [fields.deMinimisAid.name, setDeMinimisAids, setFieldValue]);
-
-  const showDeminimisSection =
-    values.associationHasBusinessActivities === true ||
-    organizationType !== ORGANIZATION_TYPES.ASSOCIATION;
 
   const languageOptions = React.useMemo(
     (): OptionType<string>[] => getLanguageOptions(t, 'languages'),
@@ -145,7 +140,6 @@ const useApplicationFormStep1 = (
     fields,
     translationsBase,
     formik,
-    showDeminimisSection,
     getErrorMessage,
     handleSubmit,
     handleSave,

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
@@ -26,6 +26,7 @@ type ExtendedComponentProps = {
     Field<APPLICATION_FIELDS_STEP1_KEYS>
   >;
   translationsBase: string;
+  showDeminimisSection: boolean;
   getErrorMessage: (fieldName: string) => string | undefined;
   handleSubmit: () => void;
   handleSave: () => void;
@@ -122,6 +123,10 @@ const useApplicationFormStep1 = (
     void setFieldValue(fields.deMinimisAid.name, null);
   }, [fields.deMinimisAid.name, setDeMinimisAids, setFieldValue]);
 
+  const showDeminimisSection =
+    values.associationHasBusinessActivities === true ||
+    organizationType === ORGANIZATION_TYPES.COMPANY;
+
   const languageOptions = React.useMemo(
     (): OptionType<string>[] => getLanguageOptions(t, 'languages'),
     [t]
@@ -140,6 +145,7 @@ const useApplicationFormStep1 = (
     fields,
     translationsBase,
     formik,
+    showDeminimisSection,
     getErrorMessage,
     handleSubmit,
     handleSave,

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/utils/validation.ts
@@ -133,7 +133,24 @@ export const getValidationSchema = (
       .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
     [APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID]: Yup.boolean()
       .nullable()
-      .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
+      .when(APPLICATION_FIELDS_STEP1_KEYS.ASSOCIATION_HAS_BUSINESS_ACTIVITIES, {
+        is: true,
+        then: Yup.boolean()
+          .nullable()
+          .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
+      })
+      .test({
+        message: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+        test: (val) => {
+          if (
+            organizationType?.toLowerCase() ===
+            ORGANIZATION_TYPES.COMPANY.toLowerCase()
+          ) {
+            return typeof val === 'boolean';
+          }
+          return true;
+        },
+      }),
     [APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID_SET]: Yup.array().of(
       getDeminimisValidationSchema(t).nullable()
     ),


### PR DESCRIPTION
## Description :sparkles:
Making it mandatory to choose a value from deminimis aid radio button in #2132 made it possible for an association user to get stuck on the first step of the form. This PR fixes the validation for the deminimis input so that when user is from an association, and has no business activity, the deminimis yes/no radio input is not visible and is not require. When the user represents a company, the deminimis yes/no radio input is visible and  required .
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
<img width="949" alt="Screenshot 2023-06-21 at 17 55 14" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/8f06ccc0-f67e-4051-8ee8-07969fd98a97">

## Additional notes :spiral_notepad:
