### PR TITLE
TETP-276(bug): JobPostingSearch keywords workFeaturesList

### DIFF
--- a/frontend/tet/youth/src/components/jobPostingSearch/JobPostingSearch.tsx
+++ b/frontend/tet/youth/src/components/jobPostingSearch/JobPostingSearch.tsx
@@ -35,7 +35,7 @@ const PostingSearch: React.FC<Props> = ({ initParams, onSearchByFilters }) => {
   const { isLoading, error, workMethodsList, workFeaturesList } = useKeywordType('id');
 
   React.useEffect(() => {
-    if (initParams.keyword) {
+    if (initParams.keyword && workFeaturesList) {
       const paramKeywords = initParams.keyword.split(',');
       const features = workFeaturesList.filter((feature) => paramKeywords.includes(feature.value));
       setChosenWorkFeatures(features.map((feature) => feature.value));


### PR DESCRIPTION
## Description :sparkles:

JobPostingSearch keywords can put cause application to crash if no matching keywords found in workFeaturesList

## Issues :bug:

In useEffect should check to both keywords and workFeaturesList are not undefined

## Testing :alembic:

Testing on local machine

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
