### PR TITLE
HL-838: Use language for strong identification

### DIFF
--- a/frontend/benefit/applicant/src/hooks/useLogin.ts
+++ b/frontend/benefit/applicant/src/hooks/useLogin.ts
@@ -4,12 +4,14 @@ import {
 } from 'benefit-shared/backend-api/backend-api';
 import { useRouter } from 'next/router';
 import React from 'react';
+import useLocale from 'shared/hooks/useLocale';
 
 const useLogin = (): (() => Promise<boolean>) => {
   const router = useRouter();
+  const locale = useLocale();
   return React.useCallback(
-    () => router.push(getBackendUrl(BackendEndpoint.LOGIN)),
-    [router]
+    () => router.push(`${getBackendUrl(BackendEndpoint.LOGIN)}?lang=${locale}`),
+    [router, locale]
   );
 };
 


### PR DESCRIPTION
## Description :sparkles:

The backend accepts `lang` query parameter. Pass that to the backend.
