### PR TITLE
HL-864, HL-875: Fix failing submit for handler

### DIFF
--- a/backend/benefit/applications/admin.py
+++ b/backend/benefit/applications/admin.py
@@ -45,10 +45,11 @@ class ApplicationAdmin(admin.ModelAdmin):
         AttachmentInline,
         CalculationInline,
     )
-    list_filter = ("status", "company")
+    list_filter = ("status", "application_origin", "company")
     list_display = (
         "id",
         "status",
+        "application_origin",
         "application_number",
         "company_name",
         "company_contact_person_email",

--- a/backend/benefit/applications/management/commands/seed.py
+++ b/backend/benefit/applications/management/commands/seed.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         batch_count = 6
-        total_created = (len(ApplicationStatus.values) + batch_count) * options[
+        total_created = ((len(ApplicationStatus.values) * 2) + batch_count) * options[
             "number"
         ]
         if not settings.DEBUG:

--- a/backend/benefit/applications/tests/test_application_tasks.py
+++ b/backend/benefit/applications/tests/test_application_tasks.py
@@ -16,7 +16,7 @@ def test_seed_applications_with_arguments(set_debug_to_true):
     amount = 5
     statuses = ApplicationStatus.values
     batch_count = 6
-    total_created = (len(ApplicationStatus.values) + batch_count) * amount
+    total_created = ((len(ApplicationStatus.values) * 2) + batch_count) * amount
     out = StringIO()
     call_command("seed", number=amount, stdout=out)
 

--- a/backend/benefit/terms/fixtures/default_terms.json
+++ b/backend/benefit/terms/fixtures/default_terms.json
@@ -88,5 +88,70 @@
       "created_at": "2021-01-01T00:00:00+02:00",
       "modified_at": "2021-01-01T00:00:00+02:00"
     }
+  },
+  {
+    "model": "terms.terms",
+    "pk": "c89bac1e-aa94-4d96-b622-9a86b396b687",
+    "fields": {
+      "terms_type": "handler_terms",
+      "effective_from": "2021-01-01",
+      "terms_pdf_fi": "/var/media/please_upload_actual_pdf_manually.pdf",
+      "terms_pdf_sv": "/var/media/please_upload_actual_pdf_manually.pdf",
+      "terms_pdf_en": "/var/media/please_upload_actual_pdf_manually.pdf",
+      "created_at": "2021-01-01T00:00:00+02:00",
+      "modified_at": "2021-01-01T00:00:00+02:00"
+    }
+  },
+  {
+    "model": "terms.applicantconsent",
+    "pk": "50365185-3cd7-4fd4-b11a-1ce43e66b601",
+    "fields": {
+      "terms": "c89bac1e-aa94-4d96-b622-9a86b396b687",
+      "text_fi": "Hakija on hyväksynyt ehdot",
+      "text_sv": "translation TBD",
+      "text_en": "translation TBD",
+      "ordering": 0,
+      "created_at": "2021-01-01T00:00:00+02:00",
+      "modified_at": "2021-01-01T00:00:00+02:00"
+    }
+  },
+  {
+    "model": "terms.applicantconsent",
+    "pk": "66fd80cc-e362-4251-9252-90998e07bb76",
+    "fields": {
+      "terms": "c89bac1e-aa94-4d96-b622-9a86b396b687",
+      "text_fi": "Hakija vakuuttaa, että hänen ilmoittamansa pankkitili on organisaation virallinen tili, hänellä on oikeus asioida organisaation puolesta ja organisaatiolla ei ole verovelkoja.",
+      "text_sv": "translation TBD",
+      "text_en": "translation TBD",
+      "ordering": 1,
+      "created_at": "2021-01-01T00:00:00+02:00",
+      "modified_at": "2021-01-01T00:00:00+02:00"
+    }
+  },
+  {
+    "model": "terms.applicantconsent",
+    "pk": "7832d5e1-7f85-4d8d-9a66-4df18b626925",
+    "fields": {
+      "terms": "c89bac1e-aa94-4d96-b622-9a86b396b687",
+      "text_fi": "Työnantaja on allekirjoittanut hakemuksen",
+      "text_sv": "translation TBD",
+      "text_en": "translation TBD",
+      "ordering": 2,
+      "created_at": "2021-01-01T00:00:00+02:00",
+      "modified_at": "2021-01-01T00:00:00+02:00"
+    }
+  },
+  {
+    "model": "terms.applicantconsent",
+    "pk": "f6fed789-78d8-43bb-a798-652fa0af9287",
+    "fields": {
+      "terms": "c89bac1e-aa94-4d96-b622-9a86b396b687",
+      "text_fi": "Työllistettävä on allekirjoittanut hakemuksen",
+      "text_sv": "translation TBD",
+      "text_en": "translation TBD",
+      "ordering": 3,
+      "created_at": "2021-01-01T00:00:00+02:00",
+      "modified_at": "2021-01-01T00:00:00+02:00"
+    }
   }
 ]

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -112,6 +112,10 @@
     },
     "backend": {
       "Request failed with status code 500": "Virhe taustajärjestelmässä. Kokeile myöhemmin uudestaan."
+    },
+    "terms": {
+      "label": "Ehdot hyväksymättä",
+      "text": "Sinun tulee hyväksyä ehdot jatkaaksesi. Palaa takaisin ja hyväksy ehdot."
     }
   },
   "applications": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -112,6 +112,10 @@
     },
     "backend": {
       "Request failed with status code 500": "Virhe taustajärjestelmässä. Kokeile myöhemmin uudestaan."
+    },
+    "terms": {
+      "label": "Ehdot hyväksymättä",
+      "text": "Sinun tulee hyväksyä ehdot jatkaaksesi. Palaa takaisin ja hyväksy ehdot."
     }
   },
   "applications": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -112,6 +112,10 @@
     },
     "backend": {
       "Request failed with status code 500": "Virhe taustajärjestelmässä. Kokeile myöhemmin uudestaan."
+    },
+    "terms": {
+      "label": "Ehdot hyväksymättä",
+      "text": "Sinun tulee hyväksyä ehdot jatkaaksesi. Palaa takaisin ja hyväksy ehdot."
     }
   },
   "applications": {

--- a/frontend/benefit/handler/src/components/newApplication/useApplicationForm.ts
+++ b/frontend/benefit/handler/src/components/newApplication/useApplicationForm.ts
@@ -120,7 +120,7 @@ export const useApplicationForm = (): ExtendedComponentProps => {
   organizationType = application.company?.organizationType ?? 'company';
 
   const { onSave, onQuietSave, onSubmit, onNext, onDelete } =
-    useFormActions(application, dispatchStep, activeStep);
+    useFormActions(application);
 
   const formik = useFormik({
     initialValues: {
@@ -136,7 +136,7 @@ export const useApplicationForm = (): ExtendedComponentProps => {
     validateOnChange: true,
     validateOnBlur: true,
     enableReinitialize: true,
-    onSubmit: (values) => onNext(values, id),
+    onSubmit: (values) => onNext(values, dispatchStep, activeStep, id),
   });
 
   const { values, setFieldValue } = formik;

--- a/frontend/benefit/handler/src/components/newApplication/useApplicationForm.ts
+++ b/frontend/benefit/handler/src/components/newApplication/useApplicationForm.ts
@@ -120,7 +120,7 @@ export const useApplicationForm = (): ExtendedComponentProps => {
   organizationType = application.company?.organizationType ?? 'company';
 
   const { onSave, onQuietSave, onSubmit, onNext, onDelete } =
-    useFormActions(application);
+    useFormActions(application, dispatchStep, activeStep);
 
   const formik = useFormik({
     initialValues: {
@@ -136,7 +136,7 @@ export const useApplicationForm = (): ExtendedComponentProps => {
     validateOnChange: true,
     validateOnBlur: true,
     enableReinitialize: true,
-    onSubmit: (values) => onNext(values, id, dispatchStep, activeStep),
+    onSubmit: (values) => onNext(values, id),
   });
 
   const { values, setFieldValue } = formik;

--- a/frontend/benefit/handler/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/handler/src/hooks/useFormActions.tsx
@@ -21,6 +21,8 @@ import useUpdateApplicationQuery from './useUpdateApplicationQuery';
 interface FormActions {
   onNext: (
     values: Application,
+    dispatchStep: React.Dispatch<StepActionType>,
+    activeStep: number,
     applicationId: string | undefined
   ) => Promise<ApplicationData | void>;
   onSubmit: (
@@ -42,11 +44,7 @@ interface FormActions {
   ) => Promise<ApplicationData | void>;
 }
 
-const useFormActions = (
-  application: Partial<Application>,
-  dispatchStep: React.Dispatch<StepActionType>,
-  activeStep: number
-): FormActions => {
+const useFormActions = (application: Partial<Application>): FormActions => {
   const router = useRouter();
 
   const { mutateAsync: createApplication, error: createApplicationError } =
@@ -231,6 +229,8 @@ const useFormActions = (
 
   const onNext = async (
     currentValues: Application,
+    dispatchStep: React.Dispatch<StepActionType>,
+    activeStep: number,
     applicationId: string | undefined
   ): Promise<ApplicationData | void> => {
     const data = getData(getModifiedValues(currentValues));

--- a/frontend/benefit/handler/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/handler/src/hooks/useFormActions.tsx
@@ -21,9 +21,7 @@ import useUpdateApplicationQuery from './useUpdateApplicationQuery';
 interface FormActions {
   onNext: (
     values: Application,
-    applicationId: string | undefined,
-    dispatchStep: React.Dispatch<StepActionType>,
-    activeStep: number
+    applicationId: string | undefined
   ) => Promise<ApplicationData | void>;
   onSubmit: (
     values: Application,
@@ -44,7 +42,11 @@ interface FormActions {
   ) => Promise<ApplicationData | void>;
 }
 
-const useFormActions = (application: Partial<Application>): FormActions => {
+const useFormActions = (
+  application: Partial<Application>,
+  dispatchStep: React.Dispatch<StepActionType>,
+  activeStep: number
+): FormActions => {
   const router = useRouter();
 
   const { mutateAsync: createApplication, error: createApplicationError } =
@@ -96,6 +98,9 @@ const useFormActions = (application: Partial<Application>): FormActions => {
                     </a>
                   )
                 )[0];
+              }
+              if (key === 'approveTerms') {
+                return <p>{t('common:error.terms.text')}</p>;
               }
               return (
                 <a key={key} href={`#${key}`}>
@@ -226,9 +231,7 @@ const useFormActions = (application: Partial<Application>): FormActions => {
 
   const onNext = async (
     currentValues: Application,
-    applicationId: string | undefined,
-    dispatchStep: React.Dispatch<StepActionType>,
-    activeStep: number
+    applicationId: string | undefined
   ): Promise<ApplicationData | void> => {
     const data = getData(getModifiedValues(currentValues));
 


### PR DESCRIPTION
## Description :sparkles:

Crashed as the frontend couldn't parse the backend error message related to the missing terms. This fixes error message parsing.

Also, added fixture for handler terms to avoid this happening in the future.

Modified `seed` command to seed handler applications also (HL-875).
