### PR TITLE
HL-865: Can't remove drafts as handler

### DIFF
--- a/frontend/benefit/handler/src/hooks/useDeleteApplicationQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useDeleteApplicationQuery.ts
@@ -16,7 +16,7 @@ const useDeleteApplicationQuery = (): UseMutationResult<
     'deleteApplication',
     (id: string) =>
       handleResponse<null>(
-        axios.delete(`${BackendEndpoint.APPLICATIONS}${id}/`)
+        axios.delete(`${BackendEndpoint.HANDLER_APPLICATIONS}${id}/`)
       ),
     {
       onSuccess: () => {


### PR DESCRIPTION
## Description :sparkles:

Once again, the applicant endpoint was used instead of the handler endpoint. Over-aggressive mocking prevented catching this in the development environment.
