### PR TITLE
HL-849 | Fix insufficient user permissions causing handler application to freeze

### DIFF
--- a/backend/benefit/users/api/v1/serializers.py
+++ b/backend/benefit/users/api/v1/serializers.py
@@ -26,6 +26,7 @@ class UserSerializer(serializers.ModelSerializer):
             "terms_of_service_approvals",
             "terms_of_service_approval_needed",
             "terms_of_service_in_effect",
+            "is_staff",
         ]
         read_only_fields = [
             "id",
@@ -34,6 +35,7 @@ class UserSerializer(serializers.ModelSerializer):
             "terms_of_service_approvals",
             "terms_of_service_approval_needed",
             "terms_of_service_in_effect",
+            "is_staff",
         ]
 
     terms_of_service_in_effect = serializers.SerializerMethodField(

--- a/frontend/benefit/handler/src/auth/AuthProvider.tsx
+++ b/frontend/benefit/handler/src/auth/AuthProvider.tsx
@@ -5,11 +5,11 @@ import AuthContext from 'shared/auth/AuthContext';
 const AuthProvider = <P,>({
   children,
 }: React.PropsWithChildren<P>): JSX.Element => {
-  const userQuery = useUserQuery((user) => Boolean(user));
+  const userQuery = useUserQuery((user) => user);
   return (
     <AuthContext.Provider
       value={{
-        isAuthenticated: userQuery.isSuccess && userQuery.data,
+        isAuthenticated: userQuery.isSuccess && Boolean(userQuery.data),
         isLoading: userQuery.isLoading,
         isError: userQuery.isError,
       }}

--- a/frontend/benefit/handler/src/hooks/useUserQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useUserQuery.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import { BackendEndpoint } from 'benefit-shared/backend-api/backend-api';
 import { useRouter } from 'next/router';
 import { useQuery, UseQueryResult } from 'react-query';
@@ -5,31 +6,43 @@ import useBackendAPI from 'shared/hooks/useBackendAPI';
 import useLocale from 'shared/hooks/useLocale';
 import User from 'shared/types/user';
 
+import { ROUTES } from '../constants';
+import useLogout from './useLogout';
+
 // check that authentication is still alive in every 5 minutes
 const FIVE_MINUTES = 5 * 60 * 1000;
 
-const useUserQuery = <T = User>(
+const useUserQuery = <T extends User>(
   select?: (user: User) => T
-): UseQueryResult<T, Error> => {
+): UseQueryResult<T | User, AxiosError> => {
   const router = useRouter();
   const locale = useLocale();
+  const noPermissionLogout = useLogout();
+
   // Don't fetch user state if status is logged out
   const logout =
-    (router.route === '/login' || router.route === `${locale}/login`) &&
+    (router.route === ROUTES.LOGIN ||
+      router.route === `${locale}${ROUTES.LOGIN}`) &&
     (router.asPath.includes('logout=true') ||
       router.asPath.includes('userStateError=true'));
   const { axios, handleResponse } = useBackendAPI();
 
-  const handleError = (error: Error): void => {
+  const handleError = (error: AxiosError): void => {
     if (logout) {
-      void router.push(`${locale}/login?logout=true`);
+      void router.push(`${locale}${ROUTES.LOGIN}?logout=true`);
     } else if (/40[13]/.test(error.message)) {
-      void router.push(`${locale}/login`);
+      void router.push(`${locale}${ROUTES.LOGIN}`);
     } else if (
       !process.env.NEXT_PUBLIC_MOCK_FLAG ||
       process.env.NEXT_PUBLIC_MOCK_FLAG === '0'
     ) {
-      void router.push(`${locale}/login?userStateError=true`);
+      void router.push(`${locale}${ROUTES.LOGIN}?userStateError=true`);
+    }
+  };
+
+  const checkForStaffStatus = (user: User): void => {
+    if (user && !user.is_staff) {
+      void noPermissionLogout();
     }
   };
 
@@ -41,6 +54,7 @@ const useUserQuery = <T = User>(
       enabled: !logout,
       retry: false,
       select,
+      onSuccess: checkForStaffStatus,
       onError: (error) => handleError(error),
     }
   );

--- a/frontend/shared/src/types/user.d.ts
+++ b/frontend/shared/src/types/user.d.ts
@@ -5,5 +5,6 @@ type User = {
   family_name: string;
   name: string;
   organization_name?: string;
+  is_staff?: boolean;
 };
 export default User;


### PR DESCRIPTION
## Description :sparkles:

Fix issue with wrong user role. If user is logged and has wrong permissions, log the user out.

# Testing

* On local dev: You must set `NEXT_PUBLIC_MOCK_FLAG=0` (or modify DB for `is_staff=false` on currently logged user) and log in as applicant ([https://localhost:3000](https://localhost:3000)). Then go to [https://localhost:3100](https://localhost:3100).
* On dev/test server: log in as applicant, then go to handler. Loaders spin and nothing gets loaded as all the requests will fail continously.