### PR TITLE
HL-868 | Hide archived / batched app's actions

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActions.tsx
@@ -63,18 +63,21 @@ const HandlingApplicationActions: React.FC<Props> = ({
             }`
           )}
         </Button>
-        {(application.status === APPLICATION_STATUSES.ACCEPTED ||
-          application.status === APPLICATION_STATUSES.REJECTED) && (
-          <Button
-            onClick={onBackToHandling}
-            theme="black"
-            variant="secondary"
-            disabled={!!application.batch}
-            iconLeft={<IconArrowUndo />}
-          >
-            {t(`${translationsBase}.backToHandling`)}
-          </Button>
-        )}
+        {[
+          APPLICATION_STATUSES.ACCEPTED,
+          APPLICATION_STATUSES.REJECTED,
+        ].includes(application.status) &&
+          !application.batch &&
+          !application.archived && (
+            <Button
+              onClick={onBackToHandling}
+              theme="black"
+              variant="secondary"
+              iconLeft={<IconArrowUndo />}
+            >
+              {t(`${translationsBase}.backToHandling`)}
+            </Button>
+          )}
         <Button
           onClick={toggleMessagesDrawerVisiblity}
           theme="black"
@@ -84,18 +87,20 @@ const HandlingApplicationActions: React.FC<Props> = ({
           {t(`${translationsBase}.handlingPanel`)}
         </Button>
       </$Column>
-      {application.status !== APPLICATION_STATUSES.CANCELLED && (
-        <$Column>
-          <Button
-            onClick={openDialog}
-            theme="black"
-            variant="supplementary"
-            iconLeft={<IconTrash />}
-          >
-            {t(`${translationsBase}.cancel`)}
-          </Button>
-        </$Column>
-      )}
+      {application.status !== APPLICATION_STATUSES.CANCELLED &&
+        !application.batch &&
+        !application.archived && (
+          <$Column>
+            <Button
+              onClick={openDialog}
+              theme="black"
+              variant="supplementary"
+              iconLeft={<IconTrash />}
+            >
+              {t(`${translationsBase}.cancel`)}
+            </Button>
+          </$Column>
+        )}
 
       {isConfirmationModalOpen && (
         <Modal


### PR DESCRIPTION
## Description :sparkles:

Remove buttons that affect application status if app is already in a batch or it is archived ("done"). 


Hidden buttons are:

* Take application to re-evaluation
* Cancel application