### PR TITLE
HL-829 | Add more mime types as allowed uploads

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/consentView/consentActions/ConsentActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/consentView/consentActions/ConsentActions.tsx
@@ -8,7 +8,10 @@ import {
   $Grid,
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
-import { ATTACHMENT_MAX_SIZE } from 'shared/constants/attachment-constants';
+import {
+  ATTACHMENT_CONTENT_TYPES,
+  ATTACHMENT_MAX_SIZE,
+} from 'shared/constants/attachment-constants';
 import { useTheme } from 'styled-components';
 
 import { $ActionsWrapper } from '../../ApplicationReview.sc';
@@ -39,7 +42,7 @@ const ConsentActions: React.FC<UploadProps> = ({
             onUpload={handleUpload}
             isUploading={isUploading}
             attachmentType={ATTACHMENT_TYPES.EMPLOYEE_CONSENT}
-            allowedFileTypes={['application/pdf']}
+            allowedFileTypes={ATTACHMENT_CONTENT_TYPES}
             maxSize={ATTACHMENT_MAX_SIZE}
             uploadText={t(`${translationsBase}.addAttachment`)}
             loadingText={t(`common:upload.isUploading`)}

--- a/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeActions/EmployeeActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeActions/EmployeeActions.tsx
@@ -12,7 +12,10 @@ import {
   $Grid,
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
-import { ATTACHMENT_MAX_SIZE } from 'shared/constants/attachment-constants';
+import {
+  ATTACHMENT_CONTENT_TYPES,
+  ATTACHMENT_MAX_SIZE,
+} from 'shared/constants/attachment-constants';
 import { useTheme } from 'styled-components';
 
 import { $ActionsWrapper } from '../../ApplicationReview.sc';
@@ -49,7 +52,7 @@ const EmployeeActions: React.FC<UploadProps> = ({
             onUpload={handleUpload}
             isUploading={isUploading}
             attachmentType={ATTACHMENT_TYPES.HELSINKI_BENEFIT_VOUCHER}
-            allowedFileTypes={['application/pdf']}
+            allowedFileTypes={ATTACHMENT_CONTENT_TYPES}
             maxSize={ATTACHMENT_MAX_SIZE}
             uploadText={t(`${translationsBase}.addAttachment`)}
             loadingText={t(`common:upload.isUploading`)}

--- a/frontend/benefit/handler/src/components/applicationReview/employmentView/employmentActions/EmploymentActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentView/employmentActions/EmploymentActions.tsx
@@ -8,7 +8,10 @@ import {
   $Grid,
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
-import { ATTACHMENT_MAX_SIZE } from 'shared/constants/attachment-constants';
+import {
+  ATTACHMENT_CONTENT_TYPES,
+  ATTACHMENT_MAX_SIZE,
+} from 'shared/constants/attachment-constants';
 import { useTheme } from 'styled-components';
 
 import { $ActionsWrapper } from '../../ApplicationReview.sc';
@@ -39,7 +42,7 @@ const EmploymentActions: React.FC<UploadProps> = ({
             onUpload={handleUpload}
             isUploading={isUploading}
             attachmentType={ATTACHMENT_TYPES.EMPLOYMENT_CONTRACT}
-            allowedFileTypes={['application/pdf']}
+            allowedFileTypes={ATTACHMENT_CONTENT_TYPES}
             maxSize={ATTACHMENT_MAX_SIZE}
             uploadText={t(`${translationsBase}.addAttachment`)}
             loadingText={t(`common:upload.isUploading`)}

--- a/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyActions/PaysubsidyActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/paySubsidyView/PaySubsidyActions/PaysubsidyActions.tsx
@@ -10,7 +10,10 @@ import {
   $Grid,
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
-import { ATTACHMENT_MAX_SIZE } from 'shared/constants/attachment-constants';
+import {
+  ATTACHMENT_CONTENT_TYPES,
+  ATTACHMENT_MAX_SIZE,
+} from 'shared/constants/attachment-constants';
 import { useTheme } from 'styled-components';
 
 import { $ActionsWrapper } from '../../ApplicationReview.sc';
@@ -42,7 +45,7 @@ const PaySubsidyActions: React.FC<UploadProps> = ({
             onUpload={handleUpload}
             isUploading={isUploading}
             attachmentType={ATTACHMENT_TYPES.PAY_SUBSIDY_CONTRACT}
-            allowedFileTypes={['application/pdf']}
+            allowedFileTypes={ATTACHMENT_CONTENT_TYPES}
             maxSize={ATTACHMENT_MAX_SIZE}
             uploadText={t(`${translationsBase}.addAttachment`)}
             loadingText={t(`common:upload.isUploading`)}


### PR DESCRIPTION
## Description :sparkles:

Attachments can be JPG and PNG files also.