### PR TITLE
HL-820 | P2P / Ahjo inspection inputs are shown/hidden based on radio button's value

### DIFF
--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -580,18 +580,24 @@ class ApplicationBatch(UUIDModel, TimeStampedModel):
                 self.decision_maker_name,
                 self.section_of_the_law,
                 validate_decision_date(self.decision_date),
-                self.expert_inspector_name,
-                self.expert_inspector_title,
             ]
 
-            required_fields_accepted = required_fields_rejected + [
+            required_fields_accepted_ahjo = required_fields_rejected + [
+                self.expert_inspector_name,
+                self.expert_inspector_title,
+                self.p2p_checker_name,
+            ]
+
+            required_fields_accepted_p2p = required_fields_rejected + [
                 self.p2p_inspector_name,
                 self.p2p_inspector_email,
                 self.p2p_checker_name,
             ]
 
-            if self.status == ApplicationBatchStatus.DECIDED_ACCEPTED and not all(
-                required_fields_accepted
+            if (
+                self.status == ApplicationBatchStatus.DECIDED_ACCEPTED
+                and not all(required_fields_accepted_ahjo)
+                and not all(required_fields_accepted_p2p)
             ):
                 raise_error()
             if self.status == ApplicationBatchStatus.DECIDED_REJECTED and not all(

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1018,6 +1018,10 @@
         "p2pInspectorEmail": "Tarkastajan sähköposti, P2P",
         "p2pCheckerName": "Hyväksyjän nimi, P2P"
       },
+      "headings": {
+        "decisionDetails": "Päätöksen tiedot",
+        "inspectionDetails": "Tarkastuksen tiedot"
+      },
       "errors": {
         "decision_maker_name": "Pakollinen tieto",
         "decision_maker_title": "Pakollinen tieto",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1018,6 +1018,10 @@
         "p2pInspectorEmail": "Tarkastajan sähköposti, P2P",
         "p2pCheckerName": "Hyväksyjän nimi, P2P"
       },
+      "headings": {
+        "decisionDetails": "Päätöksen tiedot",
+        "inspectionDetails": "Tarkastuksen tiedot"
+      },
       "errors": {
         "decision_maker_name": "Pakollinen tieto",
         "decision_maker_title": "Pakollinen tieto",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1024,6 +1024,10 @@
         "p2pInspectorEmail": "Tarkastajan sähköposti, P2P",
         "p2pCheckerName": "Hyväksyjän nimi, P2P"
       },
+      "headings": {
+        "decisionDetails": "Päätöksen tiedot",
+        "inspectionDetails": "Tarkastuksen tiedot"
+      },
       "errors": {
         "decision_maker_name": "Pakollinen tieto",
         "decision_maker_title": "Pakollinen tieto",

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchActionsInspectionForm.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchActionsInspectionForm.tsx
@@ -5,10 +5,16 @@ import {
   PROPOSALS_FOR_DECISION,
 } from 'benefit-shared/constants';
 import { BatchProposal } from 'benefit-shared/types/application';
-import { Button, DateInput, IconArrowUndo, TextInput } from 'hds-react';
+import {
+  Button,
+  DateInput,
+  IconArrowUndo,
+  RadioButton,
+  TextInput,
+} from 'hds-react';
 import noop from 'lodash/noop';
 import { useTranslation } from 'next-i18next';
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import Modal from 'shared/components/modal/Modal';
 
@@ -33,7 +39,8 @@ const BatchActionsInspectionForm: React.FC<BatchProps> = ({
   isInspectionFormSent,
   setInspectionFormSent,
   setBatchCloseAnimation,
-}: BatchProps) => {
+}: // eslint-disable-next-line sonarjs/cognitive-complexity
+BatchProps) => {
   const { id, proposal_for_decision: proposalForDecision } = batch;
   const { t } = useTranslation();
   const { formik, yearFromNow, isSuccess, isError } = useBatchActionsInspected(
@@ -45,6 +52,8 @@ const BatchActionsInspectionForm: React.FC<BatchProps> = ({
   const [isModalBatchToDraft, setModalBatchToDraft] = React.useState(false);
   const [isModalBatchToCompletion, setModalBatchToCompletion] =
     React.useState(false);
+
+  const [inspectorMode, setInspectorMode] = React.useState('ahjo');
 
   React.useEffect(() => {
     if (isError) {
@@ -82,6 +91,10 @@ const BatchActionsInspectionForm: React.FC<BatchProps> = ({
         return false;
       });
 
+  const handleRadioButton = (event: ChangeEvent<HTMLInputElement>): void => {
+    setInspectorMode(event.target.value);
+  };
+
   const handleSubmit = (e: React.FormEvent): void => {
     e.preventDefault();
     formik
@@ -118,6 +131,33 @@ const BatchActionsInspectionForm: React.FC<BatchProps> = ({
 
   return (
     <>
+      {proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED ? (
+        <$FormSection>
+          <$GridCell $colSpan={2}>
+            <RadioButton
+              key={`inspector-mode-${id}-ahjo`}
+              id={`inspector-mode-${id}-ahjo`}
+              value="ahjo"
+              label="Ahjo-tarkastus"
+              name="inspector-mode"
+              checked={inspectorMode === 'ahjo'}
+              onChange={handleRadioButton}
+            />
+          </$GridCell>
+          <$GridCell $colSpan={2}>
+            <RadioButton
+              key={`inspector-mode-${id}-p2p`}
+              id={`inspector-mode-${id}-p2p`}
+              value="p2p"
+              label="P2P-tarkastus"
+              name="inspector-mode"
+              checked={inspectorMode === 'p2p'}
+              onChange={handleRadioButton}
+            />
+          </$GridCell>
+        </$FormSection>
+      ) : null}
+
       <Modal
         id={`batch-confirmation-modal-${id}`}
         isOpen={isModalBatchToDraft || isModalBatchToCompletion}
@@ -209,35 +249,51 @@ const BatchActionsInspectionForm: React.FC<BatchProps> = ({
           </$GridCell>
         </$FormSection>
 
-        <$FormSection>
-          <$GridCell $colSpan={3}>
-            <TextInput
-              onChange={formik.handleChange}
-              label={t('common:batches.form.fields.expertInspectorName')}
-              id={`expert_inspector_name${id}`}
-              name="expert_inspector_name"
-              errorText={getErrorMessage('expert_inspector_name')}
-              invalid={!!formik.errors.expert_inspector_name}
-              value={formik.values.expert_inspector_name ?? ''}
-              required
-            />
-          </$GridCell>
+        {proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED &&
+        inspectorMode === 'ahjo' ? (
+          <$FormSection>
+            <$GridCell $colSpan={3}>
+              <TextInput
+                onChange={formik.handleChange}
+                label={t('common:batches.form.fields.expertInspectorName')}
+                id={`expert_inspector_name${id}`}
+                name="expert_inspector_name"
+                errorText={getErrorMessage('expert_inspector_name')}
+                invalid={!!formik.errors.expert_inspector_name}
+                value={formik.values.expert_inspector_name ?? ''}
+                required
+              />
+            </$GridCell>
 
-          <$GridCell $colSpan={3}>
-            <TextInput
-              onChange={formik.handleChange}
-              label={t('common:batches.form.fields.expertInspectorTitle')}
-              id={`expert_inspector_title_${id}`}
-              name="expert_inspector_title"
-              errorText={getErrorMessage('expert_inspector_title')}
-              invalid={!!formik.errors.expert_inspector_title}
-              value={formik.values.expert_inspector_title ?? ''}
-              required
-            />
-          </$GridCell>
-        </$FormSection>
+            <$GridCell $colSpan={3}>
+              <TextInput
+                onChange={formik.handleChange}
+                label={t('common:batches.form.fields.expertInspectorTitle')}
+                id={`expert_inspector_title_${id}`}
+                name="expert_inspector_title"
+                errorText={getErrorMessage('expert_inspector_title')}
+                invalid={!!formik.errors.expert_inspector_title}
+                value={formik.values.expert_inspector_title ?? ''}
+                required
+              />
+            </$GridCell>
+            <$GridCell $colSpan={3}>
+              <TextInput
+                onChange={formik.handleChange}
+                label={t('common:batches.form.fields.p2pCheckerName')}
+                id={`p2p_checker_name_${id}`}
+                name="p2p_checker_name"
+                errorText={getErrorMessage('p2p_checker_name')}
+                invalid={!!formik.errors.p2p_checker_name}
+                value={formik.values.p2p_checker_name ?? ''}
+                required
+              />
+            </$GridCell>
+          </$FormSection>
+        ) : null}
 
-        {proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED ? (
+        {proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED &&
+        inspectorMode === 'p2p' ? (
           <$FormSection css="border-top: 1pox solid #000;">
             <$GridCell $colSpan={3}>
               <TextInput

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchActionsInspectionForm.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchActionsInspectionForm.tsx
@@ -22,6 +22,8 @@ import ConfirmModalContent from '../applicationReview/actions/ConfirmModalConten
 import { $InspectionTypeContainer } from '../table/BatchCompletion.sc';
 import { $FormSection } from '../table/TableExtras.sc';
 import { useBatchActionsInspected } from './useBatchActionsInspected';
+import theme from 'shared/styles/theme';
+import { CSSProperties } from 'styled-components';
 
 type BatchProps = {
   batch: BatchProposal;
@@ -230,7 +232,7 @@ BatchProps) => {
             <h3>{t('common:batches.form.headings.inspectionDetails')}</h3>
             <$InspectionTypeContainer>
               <$FormSection>
-                <$GridCell $colSpan={2}>
+                <$GridCell $colSpan={12}>
                   <RadioButton
                     key={`inspector-mode-${id}-ahjo`}
                     id={`inspector-mode-${id}-ahjo`}
@@ -239,8 +241,14 @@ BatchProps) => {
                     name="inspection_mode"
                     checked={inspectorMode === 'ahjo'}
                     onChange={handleRadioButton}
+                    style={theme.components.radio as CSSProperties}
                   />
                 </$GridCell>
+                {inspectorMode === 'ahjo' ? (
+                  <$GridCell $colSpan={12}>
+                    <hr />
+                  </$GridCell>
+                ) : null}
               </$FormSection>
 
               {inspectorMode === 'ahjo' ? (
@@ -292,7 +300,7 @@ BatchProps) => {
 
             <$InspectionTypeContainer>
               <$FormSection>
-                <$GridCell $colSpan={2}>
+                <$GridCell $colSpan={12}>
                   <RadioButton
                     key={`inspector-mode-${id}-p2p`}
                     id={`inspector-mode-${id}-p2p`}
@@ -301,8 +309,14 @@ BatchProps) => {
                     name="inspection_mode"
                     checked={inspectorMode === 'p2p'}
                     onChange={handleRadioButton}
+                    style={theme.components.radio as CSSProperties}
                   />
                 </$GridCell>
+                {inspectorMode === 'p2p' ? (
+                  <$GridCell $colSpan={12}>
+                    <hr />
+                  </$GridCell>
+                ) : null}
               </$FormSection>
               {inspectorMode === 'p2p' ? (
                 <$FormSection css="border-top: 1pox solid #000;">

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchActionsInspectionForm.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchActionsInspectionForm.tsx
@@ -19,6 +19,7 @@ import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import Modal from 'shared/components/modal/Modal';
 
 import ConfirmModalContent from '../applicationReview/actions/ConfirmModalContent/confirm';
+import { $InspectionTypeContainer } from '../table/BatchCompletion.sc';
 import { $FormSection } from '../table/TableExtras.sc';
 import { useBatchActionsInspected } from './useBatchActionsInspected';
 
@@ -93,6 +94,7 @@ BatchProps) => {
 
   const handleRadioButton = (event: ChangeEvent<HTMLInputElement>): void => {
     setInspectorMode(event.target.value);
+    formik.handleChange(event);
   };
 
   const handleSubmit = (e: React.FormEvent): void => {
@@ -131,33 +133,6 @@ BatchProps) => {
 
   return (
     <>
-      {proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED ? (
-        <$FormSection>
-          <$GridCell $colSpan={2}>
-            <RadioButton
-              key={`inspector-mode-${id}-ahjo`}
-              id={`inspector-mode-${id}-ahjo`}
-              value="ahjo"
-              label="Ahjo-tarkastus"
-              name="inspector-mode"
-              checked={inspectorMode === 'ahjo'}
-              onChange={handleRadioButton}
-            />
-          </$GridCell>
-          <$GridCell $colSpan={2}>
-            <RadioButton
-              key={`inspector-mode-${id}-p2p`}
-              id={`inspector-mode-${id}-p2p`}
-              value="p2p"
-              label="P2P-tarkastus"
-              name="inspector-mode"
-              checked={inspectorMode === 'p2p'}
-              onChange={handleRadioButton}
-            />
-          </$GridCell>
-        </$FormSection>
-      ) : null}
-
       <Modal
         id={`batch-confirmation-modal-${id}`}
         isOpen={isModalBatchToDraft || isModalBatchToCompletion}
@@ -192,6 +167,7 @@ BatchProps) => {
         }
       />
       <form onSubmit={handleSubmit} noValidate>
+        <h3>{t('common:batches.form.headings.decisionDetails')}</h3>
         <$FormSection>
           <$GridCell $colSpan={3}>
             <TextInput
@@ -249,92 +225,129 @@ BatchProps) => {
           </$GridCell>
         </$FormSection>
 
-        {proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED &&
-        inspectorMode === 'ahjo' ? (
-          <$FormSection>
-            <$GridCell $colSpan={3}>
-              <TextInput
-                onChange={formik.handleChange}
-                label={t('common:batches.form.fields.expertInspectorName')}
-                id={`expert_inspector_name${id}`}
-                name="expert_inspector_name"
-                errorText={getErrorMessage('expert_inspector_name')}
-                invalid={!!formik.errors.expert_inspector_name}
-                value={formik.values.expert_inspector_name ?? ''}
-                required
-              />
-            </$GridCell>
+        {proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED ? (
+          <>
+            <h3>{t('common:batches.form.headings.inspectionDetails')}</h3>
+            <$InspectionTypeContainer>
+              <$FormSection>
+                <$GridCell $colSpan={2}>
+                  <RadioButton
+                    key={`inspector-mode-${id}-ahjo`}
+                    id={`inspector-mode-${id}-ahjo`}
+                    value="ahjo"
+                    label="Ahjo-tarkastus"
+                    name="inspection_mode"
+                    checked={inspectorMode === 'ahjo'}
+                    onChange={handleRadioButton}
+                  />
+                </$GridCell>
+              </$FormSection>
 
-            <$GridCell $colSpan={3}>
-              <TextInput
-                onChange={formik.handleChange}
-                label={t('common:batches.form.fields.expertInspectorTitle')}
-                id={`expert_inspector_title_${id}`}
-                name="expert_inspector_title"
-                errorText={getErrorMessage('expert_inspector_title')}
-                invalid={!!formik.errors.expert_inspector_title}
-                value={formik.values.expert_inspector_title ?? ''}
-                required
-              />
-            </$GridCell>
-            <$GridCell $colSpan={3}>
-              <TextInput
-                onChange={formik.handleChange}
-                label={t('common:batches.form.fields.p2pCheckerName')}
-                id={`p2p_checker_name_${id}`}
-                name="p2p_checker_name"
-                errorText={getErrorMessage('p2p_checker_name')}
-                invalid={!!formik.errors.p2p_checker_name}
-                value={formik.values.p2p_checker_name ?? ''}
-                required
-              />
-            </$GridCell>
-          </$FormSection>
+              {inspectorMode === 'ahjo' ? (
+                <$FormSection>
+                  <$GridCell $colSpan={3}>
+                    <TextInput
+                      onChange={formik.handleChange}
+                      label={t(
+                        'common:batches.form.fields.expertInspectorName'
+                      )}
+                      id={`expert_inspector_name${id}`}
+                      name="expert_inspector_name"
+                      errorText={getErrorMessage('expert_inspector_name')}
+                      invalid={!!formik.errors.expert_inspector_name}
+                      value={formik.values.expert_inspector_name ?? ''}
+                      required={inspectorMode === 'ahjo'}
+                    />
+                  </$GridCell>
+
+                  <$GridCell $colSpan={3}>
+                    <TextInput
+                      onChange={formik.handleChange}
+                      label={t(
+                        'common:batches.form.fields.expertInspectorTitle'
+                      )}
+                      id={`expert_inspector_title_${id}`}
+                      name="expert_inspector_title"
+                      errorText={getErrorMessage('expert_inspector_title')}
+                      invalid={!!formik.errors.expert_inspector_title}
+                      value={formik.values.expert_inspector_title ?? ''}
+                      required={inspectorMode === 'ahjo'}
+                    />
+                  </$GridCell>
+                  <$GridCell $colSpan={3}>
+                    <TextInput
+                      onChange={formik.handleChange}
+                      label={t('common:batches.form.fields.p2pCheckerName')}
+                      id={`p2p_checker_name_${id}`}
+                      name="p2p_checker_name"
+                      errorText={getErrorMessage('p2p_checker_name')}
+                      invalid={!!formik.errors.p2p_checker_name}
+                      value={formik.values.p2p_checker_name ?? ''}
+                      required={inspectorMode === 'ahjo'}
+                    />
+                  </$GridCell>
+                </$FormSection>
+              ) : null}
+            </$InspectionTypeContainer>
+
+            <$InspectionTypeContainer>
+              <$FormSection>
+                <$GridCell $colSpan={2}>
+                  <RadioButton
+                    key={`inspector-mode-${id}-p2p`}
+                    id={`inspector-mode-${id}-p2p`}
+                    value="p2p"
+                    label="P2P-tarkastus"
+                    name="inspection_mode"
+                    checked={inspectorMode === 'p2p'}
+                    onChange={handleRadioButton}
+                  />
+                </$GridCell>
+              </$FormSection>
+              {inspectorMode === 'p2p' ? (
+                <$FormSection css="border-top: 1pox solid #000;">
+                  <$GridCell $colSpan={3}>
+                    <TextInput
+                      onChange={formik.handleChange}
+                      label={t('common:batches.form.fields.p2pInspectorName')}
+                      id={`p2p_inspector_name${id}`}
+                      name="p2p_inspector_name"
+                      errorText={getErrorMessage('p2p_inspector_name')}
+                      invalid={!!formik.errors.p2p_inspector_name}
+                      value={formik.values.p2p_inspector_name ?? ''}
+                      required={inspectorMode === 'p2p'}
+                    />
+                  </$GridCell>
+
+                  <$GridCell $colSpan={3}>
+                    <TextInput
+                      onChange={formik.handleChange}
+                      label={t('common:batches.form.fields.p2pInspectorEmail')}
+                      id={`p2p_inspector_email_${id}`}
+                      name="p2p_inspector_email"
+                      errorText={getErrorMessage('p2p_inspector_email')}
+                      invalid={!!formik.errors.p2p_inspector_email}
+                      value={formik.values.p2p_inspector_email ?? ''}
+                      required={inspectorMode === 'p2p'}
+                    />
+                  </$GridCell>
+                  <$GridCell $colSpan={3}>
+                    <TextInput
+                      onChange={formik.handleChange}
+                      label={t('common:batches.form.fields.p2pCheckerName')}
+                      id={`p2p_checker_name_${id}`}
+                      name="p2p_checker_name"
+                      errorText={getErrorMessage('p2p_checker_name')}
+                      invalid={!!formik.errors.p2p_checker_name}
+                      value={formik.values.p2p_checker_name ?? ''}
+                      required={inspectorMode === 'p2p'}
+                    />
+                  </$GridCell>
+                </$FormSection>
+              ) : null}
+            </$InspectionTypeContainer>
+          </>
         ) : null}
-
-        {proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED &&
-        inspectorMode === 'p2p' ? (
-          <$FormSection css="border-top: 1pox solid #000;">
-            <$GridCell $colSpan={3}>
-              <TextInput
-                onChange={formik.handleChange}
-                label={t('common:batches.form.fields.p2pInspectorName')}
-                id={`p2p_inspector_name${id}`}
-                name="p2p_inspector_name"
-                errorText={getErrorMessage('p2p_inspector_name')}
-                invalid={!!formik.errors.p2p_inspector_name}
-                value={formik.values.p2p_inspector_name ?? ''}
-                required
-              />
-            </$GridCell>
-
-            <$GridCell $colSpan={3}>
-              <TextInput
-                onChange={formik.handleChange}
-                label={t('common:batches.form.fields.p2pInspectorEmail')}
-                id={`p2p_inspector_email_${id}`}
-                name="p2p_inspector_email"
-                errorText={getErrorMessage('p2p_inspector_email')}
-                invalid={!!formik.errors.p2p_inspector_email}
-                value={formik.values.p2p_inspector_email ?? ''}
-                required
-              />
-            </$GridCell>
-            <$GridCell $colSpan={3}>
-              <TextInput
-                onChange={formik.handleChange}
-                label={t('common:batches.form.fields.p2pCheckerName')}
-                id={`p2p_checker_name_${id}`}
-                name="p2p_checker_name"
-                errorText={getErrorMessage('p2p_checker_name')}
-                invalid={!!formik.errors.p2p_checker_name}
-                value={formik.values.p2p_checker_name ?? ''}
-                required
-              />
-            </$GridCell>
-          </$FormSection>
-        ) : null}
-
         <$FormSection>
           <$GridCell $colSpan={3}>
             <Button

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchActionsInspectionForm.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchActionsInspectionForm.tsx
@@ -17,13 +17,13 @@ import { useTranslation } from 'next-i18next';
 import React, { ChangeEvent } from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import Modal from 'shared/components/modal/Modal';
+import theme from 'shared/styles/theme';
+import { CSSProperties } from 'styled-components';
 
 import ConfirmModalContent from '../applicationReview/actions/ConfirmModalContent/confirm';
 import { $InspectionTypeContainer } from '../table/BatchCompletion.sc';
 import { $FormSection } from '../table/TableExtras.sc';
 import { useBatchActionsInspected } from './useBatchActionsInspected';
-import theme from 'shared/styles/theme';
-import { CSSProperties } from 'styled-components';
 
 type BatchProps = {
   batch: BatchProposal;

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
@@ -160,7 +160,17 @@ const BatchApplicationList: React.FC<BatchProps> = ({ batch }: BatchProps) => {
 
   return (
     <$TableGrid animateClose={batchCloseAnimation}>
-      <$TableWrapper>
+      <$TableWrapper
+        borderColor={
+          !isCollapsed &&
+          [
+            BATCH_STATUSES.AWAITING_FOR_DECISION,
+            BATCH_STATUSES.DECIDED_ACCEPTED,
+          ].includes(status)
+            ? theme.colors.fogDark
+            : null
+        }
+      >
         <Modal
           id={`batch-confirmation-modal-app-removal-${id}`}
           isOpen={isConfirmAppRemoval}
@@ -223,7 +233,7 @@ const BatchApplicationList: React.FC<BatchProps> = ({ batch }: BatchProps) => {
                   BATCH_STATUSES.AWAITING_FOR_DECISION,
                   BATCH_STATUSES.DECIDED_ACCEPTED,
                 ].includes(status)
-                  ? theme.colors.fogLight
+                  ? theme.colors.coatOfArmsLight
                   : null
               }
             >

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
@@ -217,7 +217,16 @@ const BatchApplicationList: React.FC<BatchProps> = ({ batch }: BatchProps) => {
               initialSortingOrder="asc"
               cols={cols}
             />
-            <$TableFooter>
+            <$TableFooter
+              backgroundColor={
+                [
+                  BATCH_STATUSES.AWAITING_FOR_DECISION,
+                  BATCH_STATUSES.DECIDED_ACCEPTED,
+                ].includes(status)
+                  ? theme.colors.fogLight
+                  : null
+              }
+            >
               {[
                 BATCH_STATUSES.DRAFT,
                 BATCH_STATUSES.AHJO_REPORT_CREATED,

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
@@ -218,7 +218,7 @@ const BatchApplicationList: React.FC<BatchProps> = ({ batch }: BatchProps) => {
           </div>
         </$HorizontalList>
         {applications?.length ? (
-          <$TableBody isCollapsed={isCollapsed} aria-hidden={isCollapsed}>
+          <$TableBody $isCollapsed={isCollapsed} aria-hidden={isCollapsed}>
             <Table
               indexKey="id"
               theme={theme.components.table}

--- a/frontend/benefit/handler/src/components/batchProcessing/useBatchActionsInspected.ts
+++ b/frontend/benefit/handler/src/components/batchProcessing/useBatchActionsInspected.ts
@@ -135,8 +135,8 @@ const useBatchActionsInspected = (
   };
 
   const schemaRejected = object({
-    decision_maker_name: requiredSchema.decisionMakerAnyString,
-    decision_maker_title: requiredSchema.decisionMakerFullName,
+    decision_maker_name: requiredSchema.decisionMakerFullName,
+    decision_maker_title: requiredSchema.decisionMakerAnyString,
     section_of_the_law: requiredSchema.sectionOfTheLaw,
     decision_date: requiredSchema.finnishDate,
   });

--- a/frontend/benefit/handler/src/components/batchProcessing/useBatchActionsInspected.ts
+++ b/frontend/benefit/handler/src/components/batchProcessing/useBatchActionsInspected.ts
@@ -80,9 +80,24 @@ const useBatchActionsInspected = (
     max: addMonths(now, 3),
   };
   const requiredSchema = {
-    fullName: string()
-      .matches(/^(.*)\s(\w+)/, translations.invalidName)
-      .required(translations.required),
+    inspectionMode: string().required(),
+    decisionMakerFullName: string().when('inspection_mode', {
+      is: 'ahjo',
+      then: string()
+        .matches(/^(.*)\s(\w+)/, translations.invalidName)
+        .required(translations.required),
+    }),
+    decisionMakerAnyString: string().required(translations.required),
+    ahjoFullName: string().when('inspection_mode', {
+      is: 'ahjo',
+      then: string()
+        .matches(/^(.*)\s(\w+)/, translations.invalidName)
+        .required(translations.required),
+    }),
+    ahjoAnyString: string().when('inspection_mode', {
+      is: 'ahjo',
+      then: string().required(translations.required),
+    }),
     sectionOfTheLaw: string()
       .matches(/^§\d+$/, translations.sectionOfTheLaw)
       .required(translations.required),
@@ -101,31 +116,42 @@ const useBatchActionsInspected = (
       )
       .transform(parseLocalizedDateString)
       .required(t('common:form.validation.date.format')),
-    anyString: string().required(translations.required),
-    email: string()
-      .required(translations.required)
-      .email(t('common:form.validation.email.invalid')),
+    p2pAnyString: string().when('inspection_mode', {
+      is: 'p2p',
+      then: string().required(translations.required),
+    }),
+    p2pFullName: string().when('inspection_mode', {
+      is: 'p2p',
+      then: string()
+        .matches(/^(.*)\s(\w+)/, translations.invalidName)
+        .required(translations.required),
+    }),
+    email: string().when('inspection_mode', {
+      is: 'p2p',
+      then: string()
+        .email(t('common:form.validation.email.invalid'))
+        .required(translations.required),
+    }),
   };
 
   const schemaRejected = object({
-    decision_maker_name: requiredSchema.fullName,
-    decision_maker_title: requiredSchema.anyString,
+    decision_maker_name: requiredSchema.decisionMakerAnyString,
+    decision_maker_title: requiredSchema.decisionMakerFullName,
     section_of_the_law: requiredSchema.sectionOfTheLaw,
     decision_date: requiredSchema.finnishDate,
-    expert_inspector_name: requiredSchema.fullName,
-    expert_inspector_title: requiredSchema.anyString,
   });
 
   const schemaAccepted = object({
-    decision_maker_name: requiredSchema.fullName,
-    decision_maker_title: requiredSchema.anyString,
+    inspection_mode: requiredSchema.inspectionMode,
+    decision_maker_name: requiredSchema.decisionMakerFullName,
+    decision_maker_title: requiredSchema.decisionMakerAnyString,
     section_of_the_law: requiredSchema.sectionOfTheLaw,
     decision_date: requiredSchema.finnishDate,
-    expert_inspector_name: requiredSchema.fullName,
-    expert_inspector_title: requiredSchema.anyString,
-    p2p_inspector_name: requiredSchema.anyString,
+    expert_inspector_name: requiredSchema.ahjoFullName,
+    expert_inspector_title: requiredSchema.ahjoAnyString,
+    p2p_inspector_name: requiredSchema.p2pFullName,
     p2p_inspector_email: requiredSchema.email,
-    p2p_checker_name: requiredSchema.anyString,
+    p2p_checker_name: requiredSchema.p2pAnyString,
   });
 
   const markBatchAs = (
@@ -140,6 +166,7 @@ const useBatchActionsInspected = (
 
   const formOptions = {
     initialValues: {
+      inspection_mode: 'ahjo',
       decision_maker_name,
       decision_maker_title,
       expert_inspector_name,

--- a/frontend/benefit/handler/src/components/table/BatchCompletion.sc.ts
+++ b/frontend/benefit/handler/src/components/table/BatchCompletion.sc.ts
@@ -1,0 +1,20 @@
+import theme from 'shared/styles/theme';
+import styled from 'styled-components';
+
+import { $FormSection } from './TableExtras.sc';
+
+type Props = {
+  bgColor?: string;
+};
+
+export const $InspectionTypeContainer = styled.div<Props>`
+  border: 2px solid ${theme.colors.black50};
+  padding: ${theme.spacing.s} ${theme.spacing.l} ${theme.spacing.s}
+    ${theme.spacing.l};
+  background-color: ${theme.colors.white};
+  margin-bottom: ${theme.spacing.xs};
+
+  ${$FormSection}:first-child {
+    margin: ${theme.spacing.xs} 0 ${theme.spacing.xs} 0;
+  }
+`;

--- a/frontend/benefit/handler/src/components/table/BatchCompletion.sc.ts
+++ b/frontend/benefit/handler/src/components/table/BatchCompletion.sc.ts
@@ -17,4 +17,8 @@ export const $InspectionTypeContainer = styled.div<Props>`
   ${$FormSection}:first-child {
     margin: ${theme.spacing.xs} 0 ${theme.spacing.xs} 0;
   }
+
+  hr {
+    border-top: 1px solid ${theme.colors.fog};
+  }
 `;

--- a/frontend/benefit/handler/src/components/table/TableExtras.sc.ts
+++ b/frontend/benefit/handler/src/components/table/TableExtras.sc.ts
@@ -1,9 +1,8 @@
 import FormSection from 'shared/components/forms/section/FormSection';
-import theme from 'shared/styles/theme';
 import styled from 'styled-components';
 
 type CollapsedProps = {
-  isCollapsed: boolean;
+  $isCollapsed: boolean;
 };
 
 export const $HorizontalList = styled.dl`
@@ -74,7 +73,7 @@ export const $TableWrapper = styled.div<TableWrapperProps>`
 `;
 
 export const $TableBody = styled.div<CollapsedProps>`
-  display: ${(props) => (props.isCollapsed ? 'none' : 'block')};
+  display: ${(props) => (props.$isCollapsed ? 'none' : 'block')};
 `;
 
 export const $HintText = styled.p`

--- a/frontend/benefit/handler/src/components/table/TableExtras.sc.ts
+++ b/frontend/benefit/handler/src/components/table/TableExtras.sc.ts
@@ -1,4 +1,5 @@
 import FormSection from 'shared/components/forms/section/FormSection';
+import theme from 'shared/styles/theme';
 import styled from 'styled-components';
 
 type CollapsedProps = {
@@ -60,9 +61,16 @@ export const $TableGrid = styled.div<TableGridProps>`
   margin-bottom: ${(props) => (props.animateClose ? '0' : 'var(--spacing-l)')};
 `;
 
-export const $TableWrapper = styled.div`
+type TableWrapperProps = {
+  borderColor: string;
+};
+
+export const $TableWrapper = styled.div<TableWrapperProps>`
   overflow-y: hidden;
   background: #fff;
+  transition: 0.15s outline ease-in-out;
+  outline: 1px solid
+    ${(props) => (props.borderColor ? props.borderColor : 'transparent')};
 `;
 
 export const $TableBody = styled.div<CollapsedProps>`
@@ -97,7 +105,7 @@ export const $TableFooter = styled.footer<$TableFooterProps>`
   background-color: ${(props) =>
     props.backgroundColor ? props.backgroundColor : '#efefef'};
   width: 100%;
-  padding: var(--spacing-s);
+  padding: var(--spacing-m);
   align-items: center;
   box-sizing: border-box;
 

--- a/frontend/benefit/handler/src/components/table/TableExtras.sc.ts
+++ b/frontend/benefit/handler/src/components/table/TableExtras.sc.ts
@@ -87,10 +87,15 @@ export const $FormSection = styled(FormSection)`
   }
 `;
 
-export const $TableFooter = styled.footer`
+type $TableFooterProps = {
+  backgroundColor?: string;
+  borderColor?: string;
+};
+export const $TableFooter = styled.footer<$TableFooterProps>`
   display: flex;
   flex-flow: row wrap;
-  background: #efefef;
+  background-color: ${(props) =>
+    props.backgroundColor ? props.backgroundColor : '#efefef'};
   width: 100%;
   padding: var(--spacing-s);
   align-items: center;

--- a/frontend/shared/src/styles/theme.ts
+++ b/frontend/shared/src/styles/theme.ts
@@ -1,14 +1,20 @@
 import { DefaultTheme } from 'styled-components';
 
-const colors = {
+const tokens = {
   coatOfArms: 'var(--color-coat-of-arms)',
-  components: {
-    stepper: {
-      black: 'var(--color-black-90)',
-      white: 'var(--color-white)',
-      grey: 'var(--color-black-30)',
-    },
-    radio: {},
+  fog: 'var(--color-fog)',
+};
+
+const componentColors = {
+  stepper: {
+    black: 'var(--color-black-90)',
+    white: 'var(--color-white)',
+    grey: 'var(--color-black-30)',
+  },
+  radio: {
+    base: tokens.coatOfArms,
+    selectedHover: 'var(--color-black-80)',
+    selectedFocus: tokens.fog,
   },
 };
 
@@ -22,7 +28,7 @@ const theme: DefaultTheme = {
     busLight: 'var(--color-bus-light)',
     busMediumLight: 'var(--color-bus-medium-light)',
     busDark: 'var(--color-bus-dark)',
-    coatOfArms: colors.coatOfArms as 'var(--color-coat-of-arms)',
+    coatOfArms: 'var(--color-coat-of-arms)',
     coatOfArmsLight: 'var(--color-coat-of-arms-light)',
     coatOfArmsMediumLight: 'var(--color-coat-of-arms-medium-light)',
     coatOfArmsDark: 'var(--color-coat-of-arms-dark)',
@@ -151,28 +157,28 @@ const theme: DefaultTheme = {
   },
   components: {
     tabs: {
-      '--tab-color': colors.coatOfArms,
+      '--tab-color': tokens.coatOfArms,
       '--tab-active-border-color': 'var(--color-black)',
     },
     table: {
-      '--header-background-color': colors.coatOfArms,
+      '--header-background-color': tokens.coatOfArms,
     },
     stepper: {
-      '--hds-not-selected-step-label-color': colors.components.stepper.black,
-      '--hds-step-background-color': colors.components.stepper.white,
-      '--hds-step-content-color': colors.components.stepper.black,
-      '--hds-stepper-background-color': colors.components.stepper.white,
-      '--hds-stepper-color': colors.components.stepper.black,
-      '--hds-stepper-disabled-color': colors.components.stepper.grey,
-      '--hds-stepper-focus-border-color': colors.components.stepper.black,
+      '--hds-not-selected-step-label-color': componentColors.stepper.black,
+      '--hds-step-background-color': componentColors.stepper.white,
+      '--hds-step-content-color': componentColors.stepper.black,
+      '--hds-stepper-background-color': componentColors.stepper.white,
+      '--hds-stepper-color': componentColors.stepper.black,
+      '--hds-stepper-disabled-color': componentColors.stepper.grey,
+      '--hds-stepper-focus-border-color': componentColors.stepper.black,
     },
     radio: {
-      '--border-color-selected': 'var(--color-coat-of-arms)',
-      '--border-color-selected-hover': 'var(--color-black-80)',
-      '--border-color-selected-focus': 'var(--color-fog)',
-      '--icon-color-selected': 'var(--color-coat-of-arms)',
-      '--icon-color-hover': 'var(--color-coat-of-arms)',
-      '--focus-outline-color': 'var(--color-coat-of-arms)',
+      '--border-color-selected': componentColors.radio.base,
+      '--border-color-selected-hover': componentColors.radio.selectedHover,
+      '--border-color-selected-focus': componentColors.radio.selectedFocus,
+      '--icon-color-selected': componentColors.radio.base,
+      '--icon-color-hover': componentColors.radio.base,
+      '--focus-outline-color': componentColors.radio.base,
     },
   },
 };

--- a/frontend/shared/src/styles/theme.ts
+++ b/frontend/shared/src/styles/theme.ts
@@ -8,6 +8,7 @@ const colors = {
       white: 'var(--color-white)',
       grey: 'var(--color-black-30)',
     },
+    radio: {},
   },
 };
 
@@ -164,6 +165,14 @@ const theme: DefaultTheme = {
       '--hds-stepper-color': colors.components.stepper.black,
       '--hds-stepper-disabled-color': colors.components.stepper.grey,
       '--hds-stepper-focus-border-color': colors.components.stepper.black,
+    },
+    radio: {
+      '--border-color-selected': 'var(--color-coat-of-arms)',
+      '--border-color-selected-hover': 'var(--color-black-80)',
+      '--border-color-selected-focus': 'var(--color-fog)',
+      '--icon-color-selected': 'var(--color-coat-of-arms)',
+      '--icon-color-hover': 'var(--color-coat-of-arms)',
+      '--focus-outline-color': 'var(--color-coat-of-arms)',
     },
   },
 };

--- a/frontend/shared/src/types/styled-components.d.ts
+++ b/frontend/shared/src/types/styled-components.d.ts
@@ -155,6 +155,14 @@ declare module 'styled-components' {
       table: {
         '--header-background-color': string;
       };
+      radio: {
+        '--border-color-selected': string;
+        '--border-color-selected-hover': string;
+        '--border-color-selected-focus': string;
+        '--icon-color-selected': string;
+        '--icon-color-hover': string;
+        '--focus-outline-color': string;
+      };
     };
   }
 }


### PR DESCRIPTION
## Description :sparkles:

Only Ahjo **OR** P2P fields are needed, depending on case. Only display form fields based on which one is better for koonti at hand.

* Renewed colors and design
* Only either / or is required from formik and yup
* Change backend validation rules

![screencapture-localhost-3100-batches-2023-08-07-15_41_07](https://github.com/City-of-Helsinki/yjdh/assets/5328394/ac98d213-1ae1-449e-961d-d6aff3ec3e79)


