### PR TITLE
HL-882 | Add new messenger style and fix translations on handler side

### DIFF
--- a/frontend/benefit/applicant/src/components/messenger/Messages.tsx
+++ b/frontend/benefit/applicant/src/components/messenger/Messages.tsx
@@ -38,6 +38,8 @@ const Messages: React.FC<ComponentProps> = ({ data, variant, withScroll }) => {
           date={message.modifiedAt || ''}
           text={message.content}
           isPrimary={message.messageType === MESSAGE_TYPES.APPLICANT_MESSAGE}
+          wrapAsColumn
+          alignRight={message.messageType === MESSAGE_TYPES.APPLICANT_MESSAGE}
           variant={variant}
         />
       ))}

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -32,6 +32,11 @@
         }
       }
     },
+    "titles": {
+      "applicantMessage": "Hakija",
+      "handlerMessage": "Käsittelijä",
+      "note": ""
+    },
     "showEveryone": "Nämä viestit näkyvät hakijalle",
     "showToHanlderOnly": "Näkyy vain käsittelijöille",
     "compose": "Kirjoita viesti",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -32,6 +32,11 @@
         }
       }
     },
+    "titles": {
+      "applicantMessage": "Hakija",
+      "handlerMessage": "Käsittelijä",
+      "note": ""
+    },
     "showEveryone": "Nämä viestit näkyvät hakijalle",
     "showToHanlderOnly": "Näkyy vain käsittelijöille",
     "compose": "Kirjoita viesti",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -32,6 +32,11 @@
         }
       }
     },
+    "titles": {
+      "applicantMessage": "Hakija",
+      "handlerMessage": "Käsittelijä",
+      "note": ""
+    },
     "showEveryone": "Nämä viestit näkyvät hakijalle",
     "showToHanlderOnly": "Näkyy vain käsittelijöille",
     "compose": "Kirjoita viesti",

--- a/frontend/benefit/handler/src/components/messenger/Messages.tsx
+++ b/frontend/benefit/handler/src/components/messenger/Messages.tsx
@@ -39,6 +39,8 @@ const Messages: React.FC<ComponentProps> = ({ data, variant, withScroll }) => {
           text={message.content}
           isPrimary={message.messageType === MESSAGE_TYPES.HANDLER_MESSAGE}
           variant={variant}
+          alignRight={message.messageType === MESSAGE_TYPES.HANDLER_MESSAGE}
+          wrapAsColumn
         />
       ))}
       {data.length === 0 && (

--- a/frontend/shared/src/components/messaging/Message.tsx
+++ b/frontend/shared/src/components/messaging/Message.tsx
@@ -15,6 +15,8 @@ export interface MessageProps {
   date: string;
   text: string;
   isPrimary?: boolean;
+  alignRight?: boolean;
+  wrapAsColumn?: boolean;
   variant: MessageVariant;
 }
 
@@ -24,13 +26,15 @@ const Message: React.FC<MessageProps> = ({
   text,
   isPrimary,
   variant,
+  alignRight,
+  wrapAsColumn,
 }) => (
   <$MessageContainer>
-    <$Meta>
+    <$Meta alignRight={alignRight} wrapAsColumn={wrapAsColumn}>
       <$Sender>{sender}</$Sender>
       <$Date>{date}</$Date>
     </$Meta>
-    <$Message isPrimary={isPrimary} variant={variant}>
+    <$Message isPrimary={isPrimary} variant={variant} alignRight={alignRight}>
       {text}
     </$Message>
     {variant === 'note' && <$Hr />}

--- a/frontend/shared/src/components/messaging/Messaging.sc.tsx
+++ b/frontend/shared/src/components/messaging/Messaging.sc.tsx
@@ -3,7 +3,13 @@ import styled from 'styled-components';
 
 interface MessageProps {
   isPrimary?: boolean;
+  alignRight?: boolean;
   variant: MessageVariant;
+}
+
+interface MetaProps {
+  wrapAsColumn?: boolean;
+  alignRight?: boolean;
 }
 
 interface MessageListProps {
@@ -23,11 +29,13 @@ export const $MessagesList = styled.div<MessageListProps>`
   padding: ${({ theme }) => theme.spacing.xs};
 `;
 
-export const $Meta = styled.div`
+export const $Meta = styled.div<MetaProps>`
   width: 100%;
   display: flex;
   justify-content: space-between;
   margin-top: ${({ theme }) => theme.spacing.s};
+  flex-flow: ${(props) => (props.wrapAsColumn ? 'column' : 'row')};
+  text-align: ${(props) => (props.alignRight ? 'right' : 'left')};
 `;
 
 export const $Sender = styled.span`
@@ -56,6 +64,7 @@ export const $Message = styled.div<MessageProps>`
   margin-top: ${(props) => props.variant !== 'note' && props.theme.spacing.s};
   color: ${(props) => props.theme.colors.black90};
   white-space: pre-line;
+  margin-left: ${(props) => (props.alignRight ? 'auto' : '0')};
 `;
 
 export const $Actions = styled.div`


### PR DESCRIPTION
## Description :sparkles:

* New style of messenger with own chat bubbles on the right hand side and other person's bubbles on the left
  * Defaults to old style so TET and KS is not affected by the change
* Add missing translations

<img width="992" alt="image" src="https://github.com/City-of-Helsinki/yjdh/assets/5328394/453382ec-c3f5-4f14-a054-8d61eb367e1d">
