### PR TITLE
HL-885 | Fix de minimis aid's row deletion

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -86,6 +86,10 @@
           "deMinimisAidMaxAmount": {
             "label": "Maximum amount exceeded",
             "content": "The maximum amount of de minimis aid has been exceeded. Under the EU Regulation, a company may receive a maximum EUR 200,000 of de minimis aid during the current year and the previous two tax years. All forms of de minimis aid granted by various authorities during this period will be taken into account in the maximum amount."
+          },
+          "deMinimisUnfinished": {
+            "label": "Missing de minimis aid information",
+            "content": "Please fill any missing de minimis aid information and press 'Add' button."
           }
         },
         "tooltips": {

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -86,6 +86,10 @@
           "deMinimisAidMaxAmount": {
             "label": "Enimmäismäärä ylitetty",
             "content": "De minimis-tuen enimmäismäärä on ylitetty. Tuki voi olla enintään 200 000 euroa, joka myönnetään yritykselle kuluvan vuoden ja kahden edellisen verovuoden kuluessa. Enimmäismäärässä huomioidaan kaikkien eri viranomaisten kyseisenä ajanjaksona de minimis -tukena myöntämä rahoitus."
+          },
+          "deMinimisUnfinished": {
+            "label": "Puuttuvia de minimis-tuen tietoja",
+            "content": "Täytä puuttuvat de minimis -kentät ja paina 'Lisää' painiketta."
           }
         },
         "tooltips": {

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -86,6 +86,10 @@
           "deMinimisAidMaxAmount": {
             "label": "Maximibeloppet har överskridits",
             "content": "Maximibeloppet för de minimis-stöd har överskridits. Enligt EU:s förordning kan ett företag få de minimis-stöd till ett belopp om högst 200 000 euro under det innevarandet året och under de två föregående skatteåren. I maximibeloppet beaktas samtliga de minimis-stöd som olika myndigheter har beviljat under denna tidsperiod."
+          },
+          "deMinimisUnfinished": {
+            "label": "Information saknar om de minimis stöd",
+            "content": "Vänligen fyll i eventuell saknad de minimis-stöd information och tryck på knappen 'Lägg till'."
           }
         },
         "tooltips": {

--- a/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/DeMinimisAidForm.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/DeMinimisAidForm.tsx
@@ -23,9 +23,13 @@ import { useDeminimisAid } from './useDeminimisAid';
 
 interface DeMinimisAidFormProps {
   data: DeMinimisAid[];
+  setUnfinishedDeMinimisAid: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
+const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({
+  data,
+  setUnfinishedDeMinimisAid,
+}) => {
   const {
     t,
     language,
@@ -37,6 +41,26 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
     grants,
   } = useDeminimisAid(data);
   const theme = useTheme();
+
+  const onSubmit = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ): void => {
+    setUnfinishedDeMinimisAid(false);
+    return handleSubmit(event);
+  };
+
+  const handleBlur = (
+    event: React.FocusEvent<HTMLInputElement, Element>
+  ): void => {
+    setUnfinishedDeMinimisAid(false);
+    const grantValuesAsString = Object.values(formik.values).reduce(
+      (acc, val) => acc + val
+    );
+    if (grantValuesAsString !== '') {
+      setUnfinishedDeMinimisAid(true);
+    }
+    formik.handleBlur(event);
+  };
 
   return (
     <$GridCell
@@ -65,7 +89,7 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
             name={fields.granter.name}
             label={fields.granter.label}
             placeholder={fields.granter.placeholder}
-            onBlur={formik.handleBlur}
+            onBlur={(event) => handleBlur(event)}
             onChange={formik.handleChange}
             value={formik.values.granter}
             invalid={!!getErrorMessage(DE_MINIMIS_AID_KEYS.GRANTER)}
@@ -80,7 +104,7 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
             name={fields.amount.name}
             label={fields.amount.label || ''}
             placeholder={fields.amount.placeholder}
-            onBlur={formik.handleBlur}
+            onBlur={(event) => handleBlur(event)}
             onChange={(e) =>
               formik.setFieldValue(
                 fields.amount.name,
@@ -101,7 +125,7 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
             label={fields.grantedAt.label}
             placeholder={fields.grantedAt.placeholder}
             language={language}
-            onBlur={formik.handleBlur}
+            onBlur={(event) => handleBlur(event)}
             onChange={(value) =>
               formik.setFieldValue(fields.grantedAt.name, value)
             }
@@ -133,7 +157,7 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
             !formik.isValid ||
             sumBy(grants, 'amount') > MAX_DEMINIMIS_AID_TOTAL_AMOUNT
           }
-          onClick={(e) => handleSubmit(e)}
+          onClick={(e) => onSubmit(e)}
           iconLeft={<IconPlusCircle />}
           fullWidth
         >

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
@@ -20,6 +20,9 @@ import { useApplicationFormStep1 } from './useApplicationFormStep1';
 const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
   data,
 }) => {
+  const [isUnfinishedDeMinimisAid, setUnfinishedDeMinimisAid] =
+    React.useState(false);
+
   const {
     t,
     handleSubmit,
@@ -34,7 +37,7 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
     translationsBase,
     formik,
     deMinimisAidSet,
-  } = useApplicationFormStep1(data);
+  } = useApplicationFormStep1(data, Boolean(isUnfinishedDeMinimisAid));
 
   useAlertBeforeLeaving(formik.dirty);
 
@@ -161,56 +164,59 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
       </FormSection>
-    {showDeminimisSection && (
-      <FormSection
-        header={t(`${translationsBase}.heading3`)}
-        tooltip={t(`${translationsBase}.tooltips.heading3`)}
-      >
-        <$GridCell $colSpan={8}>
-          <SelectionGroup
-            id={fields.deMinimisAid.name}
-            label={fields.deMinimisAid.label}
-            direction="vertical"
-            required
-            errorText={getErrorMessage(fields.deMinimisAid.name)}
-          >
-            <$RadioButton
-              id={`${fields.deMinimisAid.name}False`}
-              name={fields.deMinimisAid.name}
-              value="false"
-              label={t(
-                `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID}.no`
-              )}
-              onChange={() => {
-                formik.setFieldValue(fields.deMinimisAid.name, false);
-                setDeMinimisAids([]);
-              }}
-              // 3 states: null (none is selected), true, false
-              checked={formik.values.deMinimisAid === false}
-            />
-            <$RadioButton
-              id={`${fields.deMinimisAid.name}True`}
-              name={fields.deMinimisAid.name}
-              value="true"
-              label={t(
-                `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID}.yes`
-              )}
-              onChange={() =>
-                formik.setFieldValue(fields.deMinimisAid.name, true)
-              }
-              checked={formik.values.deMinimisAid === true}
-            />
-          </SelectionGroup>
-        </$GridCell>
+      {showDeminimisSection && (
+        <FormSection
+          header={t(`${translationsBase}.heading3`)}
+          tooltip={t(`${translationsBase}.tooltips.heading3`)}
+        >
+          <$GridCell $colSpan={8}>
+            <SelectionGroup
+              id={fields.deMinimisAid.name}
+              label={fields.deMinimisAid.label}
+              direction="vertical"
+              required
+              errorText={getErrorMessage(fields.deMinimisAid.name)}
+            >
+              <$RadioButton
+                id={`${fields.deMinimisAid.name}False`}
+                name={fields.deMinimisAid.name}
+                value="false"
+                label={t(
+                  `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID}.no`
+                )}
+                onChange={() => {
+                  formik.setFieldValue(fields.deMinimisAid.name, false);
+                  setDeMinimisAids([]);
+                }}
+                // 3 states: null (none is selected), true, false
+                checked={formik.values.deMinimisAid === false}
+              />
+              <$RadioButton
+                id={`${fields.deMinimisAid.name}True`}
+                name={fields.deMinimisAid.name}
+                value="true"
+                label={t(
+                  `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID}.yes`
+                )}
+                onChange={() =>
+                  formik.setFieldValue(fields.deMinimisAid.name, true)
+                }
+                checked={formik.values.deMinimisAid === true}
+              />
+            </SelectionGroup>
+          </$GridCell>
 
-        {formik.values.deMinimisAid && (
-          <>
-            <DeMinimisAidForm data={deMinimisAidSet} />
-            <DeMinimisAidsList />
-          </>
-        )}
-      </FormSection>
-    )}
+          {formik.values.deMinimisAid && (
+            <>
+              <DeMinimisAidForm
+                data={deMinimisAidSet}
+                setUnfinishedDeMinimisAid={setUnfinishedDeMinimisAid}
+              />
+              <DeMinimisAidsList />
+            </>
+          )}
+        </FormSection>
+      )}
       <FormSection paddingBottom header={t(`${translationsBase}.heading4`)}>
         <$GridCell $colSpan={8}>
           <SelectionGroup

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
@@ -14,6 +14,7 @@ import fromPairs from 'lodash/fromPairs';
 import { TFunction } from 'next-i18next';
 import React, { useState } from 'react';
 import { Field } from 'shared/components/forms/fields/types';
+import showErrorToast from 'shared/components/toast/show-error-toast';
 import { OptionType } from 'shared/types/common';
 import { focusAndScroll } from 'shared/utils/dom.utils';
 
@@ -39,10 +40,12 @@ type ExtendedComponentProps = {
 };
 
 const useApplicationFormStep1 = (
-  application: Partial<Application>
+  application: Partial<Application>,
+  isUnfinishedDeminimisAid: boolean
 ): ExtendedComponentProps => {
   const { t } = useTranslation();
-  const { setDeMinimisAids } = React.useContext(DeMinimisContext);
+  const { deMinimisAids, setDeMinimisAids } =
+    React.useContext(DeMinimisContext);
   const { onNext, onSave, onDelete } = useFormActions(application);
 
   const translationsBase = 'common:applications.sections.company';
@@ -103,6 +106,20 @@ const useApplicationFormStep1 = (
         return focusAndScroll(errorFieldKey);
       }
 
+      if (isUnfinishedDeminimisAid) {
+        showErrorToast(
+          t(`${translationsBase}.deMinimisUnfinished.label`),
+          t(`${translationsBase}.deMinimisUnfinished.content`)
+        );
+        return false;
+      }
+
+      // de minimis fields are empty, set radio to false
+      if (deMinimisAids.length === 0) {
+        void formik.setFieldValue(fields.deMinimisAidSet.name, []);
+        void formik.setFieldValue(fields.deMinimisAid.name, false);
+      }
+
       return formik.submitForm();
     });
   };
@@ -114,8 +131,8 @@ const useApplicationFormStep1 = (
   const applicationId = values?.id;
   const handleDelete = applicationId
     ? () => {
-      void onDelete(applicationId);
-    }
+        void onDelete(applicationId);
+      }
     : undefined;
 
   const clearDeminimisAids = React.useCallback((): void => {


### PR DESCRIPTION
## Description :sparkles:

De minimis aid could not be removed (one aid had to remain, otherwise the rows would not get updated) after application was created. Now additional checks are being done:

* Ensure there is no unfinished aid fields
  * Toast an error if there is
* If there is no aid rows but de minimis toggle radio is on then consider radio is off