### PR TITLE
Hl 898 handler validation

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/employmentAppliedMoreView/utils/validation.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentAppliedMoreView/utils/validation.ts
@@ -9,8 +9,8 @@ export const getValidationSchema = (): Yup.SchemaOf<CalculationCommon> =>
   Yup.object().shape({
     [CALCULATION_EMPLOYMENT_KEYS.START_DATE]: Yup.string().typeError(
       VALIDATION_MESSAGE_KEYS.DATE_FORMAT
-    ),
+    ).required(VALIDATION_MESSAGE_KEYS.REQUIRED),
     [CALCULATION_EMPLOYMENT_KEYS.END_DATE]: Yup.string().typeError(
       VALIDATION_MESSAGE_KEYS.DATE_FORMAT
-    ),
+    ).required(VALIDATION_MESSAGE_KEYS.REQUIRED),
   });

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -506,8 +506,8 @@ const SalaryBenefitCalculatorView: React.FC<
 
           <$GridCell $colStart={3} $colSpan={3}>
             <DateInputWithSeparator
-              id={fields.startDate.name}
-              name={fields.startDate.name}
+              id={fields.trainingCompensationStartDate.name}
+              name={fields.trainingCompensationStartDate.name}
               placeholder={fields.startDate.placeholder}
               language={language}
               onChange={(value) =>
@@ -517,16 +517,16 @@ const SalaryBenefitCalculatorView: React.FC<
                 }))
               }
               value={convertToUIDateFormat(newTrainingCompensation.startDate)}
-              invalid={!!getErrorMessage(fields.startDate.name)}
-              aria-invalid={!!getErrorMessage(fields.startDate.name)}
-              errorText={getErrorMessage(fields.startDate.name)}
+              invalid={!!getErrorMessage(fields.trainingCompensationStartDate.name)}
+              aria-invalid={!!getErrorMessage(fields.trainingCompensationStartDate.name)}
+              errorText={getErrorMessage(fields.trainingCompensationStartDate.name)}
             />
           </$GridCell>
 
           <$GridCell $colStart={6} $colSpan={3}>
             <DateInput
-              id={fields.endDate.name}
-              name={fields.endDate.name}
+              id={fields.trainingCompensationEndDate.name}
+              name={fields.trainingCompensationEndDate.name}
               placeholder={fields.endDate.placeholder}
               language={language}
               onChange={(value) =>
@@ -538,9 +538,9 @@ const SalaryBenefitCalculatorView: React.FC<
                 }))
               }
               value={convertToUIDateFormat(newTrainingCompensation.endDate)}
-              invalid={!!getErrorMessage(fields.endDate.name)}
-              aria-invalid={!!getErrorMessage(fields.endDate.name)}
-              errorText={getErrorMessage(fields.endDate.name)}
+              invalid={!!getErrorMessage(fields.trainingCompensationEndDate.name)}
+              aria-invalid={!!getErrorMessage(fields.trainingCompensationEndDate.name)}
+              errorText={getErrorMessage(fields.trainingCompensationEndDate.name)}
               style={{ paddingRight: `${theme.spacing.s}` }}
             />
           </$GridCell>

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -13,7 +13,6 @@ import {
 } from 'hds-react';
 import * as React from 'react';
 import { $ViewField } from 'shared/components/benefit/summaryView/SummaryView.sc';
-import DateInputWithSeparator from 'shared/components/forms/fields/dateInputWithSeparator/DateInputWithSeparator';
 import { $Checkbox } from 'shared/components/forms/fields/Fields.sc';
 import { Option } from 'shared/components/forms/fields/types';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
@@ -283,7 +282,7 @@ const SalaryBenefitCalculatorView: React.FC<
                   $colStart={item.paySubsidyPercent === 100 ? 6 : 3}
                   $colSpan={3}
                 >
-                  <DateInputWithSeparator
+                  <DateInput
                     id={fields.startDate.name}
                     name={fields.startDate.name}
                     placeholder={fields.startDate.placeholder}
@@ -353,7 +352,7 @@ const SalaryBenefitCalculatorView: React.FC<
       </$GridCell>
 
       <$GridCell $colStart={1} $colSpan={2}>
-        <DateInputWithSeparator
+        <DateInput
           id={fields.startDate.name}
           name={fields.startDate.name}
           placeholder={fields.startDate.placeholder}
@@ -505,7 +504,7 @@ const SalaryBenefitCalculatorView: React.FC<
           </$GridCell>
 
           <$GridCell $colStart={3} $colSpan={3}>
-            <DateInputWithSeparator
+            <DateInput
               id={fields.trainingCompensationStartDate.name}
               name={fields.trainingCompensationStartDate.name}
               placeholder={fields.startDate.placeholder}

--- a/frontend/benefit/handler/src/constants.ts
+++ b/frontend/benefit/handler/src/constants.ts
@@ -58,6 +58,8 @@ export enum CALCULATION_SALARY_KEYS {
   PAY_SUBSIDIES = 'paySubsidies',
   TRAINING_COMPENSATIONS = 'trainingCompensations',
   MONTHLY_AMOUNT = 'monthlyAmount',
+  TRAINING_COMPENSATION_START_DATE = 'trainingCompensationStartDate',
+  TRAINING_COMPENSATION_END_DATE = 'trainingCompensationEndDate',
 }
 
 export const STATE_AID_MAX_PERCENTAGE_OPTIONS = [50, 100];

--- a/frontend/benefit/shared/src/constants.ts
+++ b/frontend/benefit/shared/src/constants.ts
@@ -107,6 +107,8 @@ export enum DE_MINIMIS_AID_KEYS {
 export enum CALCULATION_EMPLOYMENT_KEYS {
   START_DATE = 'startDate',
   END_DATE = 'endDate',
+  TRAINING_COMPENSATION_START_DATE = 'trainingCompensationStartDate',
+  TRAINING_COMPENSATION_END_DATE = 'trainingCompensationEndDate',
 }
 
 export enum ORGANIZATION_TYPES {


### PR DESCRIPTION
## Description :sparkles:
The handler form does not give any error when the user presses the calculate without a start date or an end date in the date input fields for the Helsinki benefit granted date range. This PR activates the frontend validation for the fields, fixes a naming collision with the startDate and endDate fields of the training compensation input fields, and fixes the frontend validation error message layout breaking because of the DateInputWithSeparator component not having enough space for the message.

## Issues :bug:

## Testing :alembic:
Login as a handler, open an application and press the calculate button without start or end date in the benefit granted period fields.

## Screenshots :camera_flash:
<img width="1072" alt="Screenshot 2023-08-18 at 8 57 40" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/ff694d85-d70c-43a1-a48a-ddc4c701ea2e">
<img width="658" alt="Screenshot 2023-08-18 at 8 57 48" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/4e96e478-fce2-4721-be41-95d4c9fd1468">


## Additional notes :spiral_notepad:
Discovered the bug https://helsinkisolutionoffice.atlassian.net/browse/HL-910 where typing text into the training compensation end date input field crashes the frontend.
