### PR TITLE
fix: some favicons had wrong asset path

### DIFF
--- a/frontend/benefit/applicant/public/favicons/manifest.webmanifest
+++ b/frontend/benefit/applicant/public/favicons/manifest.webmanifest
@@ -1,6 +1,14 @@
 {
-    "icons": [
-        { "src": "/favicon-192x192.png", "type": "image/png", "sizes": "192x192" },
-        { "src": "/favicon-512x512.png", "type": "image/png", "sizes": "512x512" }
-    ]
+  "icons": [
+    {
+      "src": "/favicons/favicon-192x192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "/favicons/favicon-512x512.png",
+      "type": "image/png",
+      "sizes": "512x512"
+    }
+  ]
 }

--- a/frontend/benefit/handler/public/favicons/manifest.webmanifest
+++ b/frontend/benefit/handler/public/favicons/manifest.webmanifest
@@ -1,6 +1,14 @@
 {
-    "icons": [
-        { "src": "/favicon-192x192.png", "type": "image/png", "sizes": "192x192" },
-        { "src": "/favicon-512x512.png", "type": "image/png", "sizes": "512x512" }
-    ]
+  "icons": [
+    {
+      "src": "/favicons/favicon-192x192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "/favicons/favicon-512x512.png",
+      "type": "image/png",
+      "sizes": "512x512"
+    }
+  ]
 }


### PR DESCRIPTION
## Description :sparkles:

Some favicon assets are 404'ing. Manifest file's path should have `/favicons/` in front.

Compare:

* [with /favicon/](https://yjdh-helsinkilisa-ui-hki-kanslia-yjdh-helsinkilisa-test.agw.arodevtest.hel.fi/favicons/favicon-512x512.png)
* [no /favicon/](https://yjdh-helsinkilisa-ui-hki-kanslia-yjdh-helsinkilisa-test.agw.arodevtest.hel.fi/favicon-512x512.png)