### PR TITLE
HL-883 | Fix some issues with opening and locking application on handler's side

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1078,26 +1078,6 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
             if instance.application_origin == ApplicationOrigin.HANDLER:
                 return
 
-            # Ignore updated applicant's terms if all term consents have been previously accepted
-            # This is "good enough" (confirmed this from City's benefit team)
-            if instance.applicant_terms_approval.selected_applicant_consents:
-                all_consents = sorted(
-                    list(
-                        instance.applicant_terms_approval.selected_applicant_consents.values_list(
-                            "id"
-                        )
-                    )
-                )
-                accepted_consents = sorted(
-                    list(
-                        instance.applicant_terms_approval.terms.applicant_consents.values_list(
-                            "id"
-                        )
-                    )
-                )
-                if accepted_consents == all_consents:
-                    return
-
             if not approve_terms:
                 raise serializers.ValidationError(
                     {"approve_terms": _("Terms must be approved")}

--- a/backend/benefit/applications/tests/factories.py
+++ b/backend/benefit/applications/tests/factories.py
@@ -136,10 +136,51 @@ class ApplicationFactory(factory.django.DjangoModelFactory):
         model = Application
 
 
+attachment_factory_string = "applications.tests.factories.AttachmentFactory"
+
+
 class ApplicationWithAttachmentFactory(ApplicationFactory):
     attachment = factory.RelatedFactory(
-        "applications.tests.factories.AttachmentFactory",
+        attachment_factory_string,
         factory_related_name="application",
+        attachment_type="employment_contract",
+    )
+    attachment_2 = factory.RelatedFactory(
+        attachment_factory_string,
+        factory_related_name="application",
+        attachment_type="pay_subsidy_decision",
+    )
+
+    attachment_3 = factory.RelatedFactory(
+        attachment_factory_string,
+        factory_related_name="application",
+        attachment_type="commission_contract",
+    )
+
+    attachment_4 = factory.RelatedFactory(
+        attachment_factory_string,
+        factory_related_name="application",
+        attachment_type="education_contract",
+    )
+    attachment_5 = factory.RelatedFactory(
+        attachment_factory_string,
+        factory_related_name="application",
+        attachment_type="helsinki_benefit_voucher",
+    )
+    attachment_6 = factory.RelatedFactory(
+        attachment_factory_string,
+        factory_related_name="application",
+        attachment_type="employee_consent",
+    )
+    attachment_7 = factory.RelatedFactory(
+        attachment_factory_string,
+        factory_related_name="application",
+        attachment_type="full_application",
+    )
+    attachment_8 = factory.RelatedFactory(
+        attachment_factory_string,
+        factory_related_name="application",
+        attachment_type="other_attachment",
     )
 
 

--- a/frontend/benefit/handler/src/hooks/useUpdateApplicationQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useUpdateApplicationQuery.ts
@@ -1,7 +1,9 @@
 import { AxiosError } from 'axios';
 import { BackendEndpoint } from 'benefit-shared/backend-api/backend-api';
 import { ApplicationData } from 'benefit-shared/types/application';
+import { useTranslation } from 'next-i18next';
 import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+import showErrorToast from 'shared/components/toast/show-error-toast';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 
 import { ErrorData } from '../types/common';
@@ -12,7 +14,9 @@ const useUpdateApplicationQuery = (): UseMutationResult<
   ApplicationData
 > => {
   const { axios, handleResponse } = useBackendAPI();
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
+
   return useMutation<ApplicationData, AxiosError<ErrorData>, ApplicationData>(
     'updateApplication',
     (application: ApplicationData) =>
@@ -26,6 +30,17 @@ const useUpdateApplicationQuery = (): UseMutationResult<
       onSuccess: () => {
         void queryClient.invalidateQueries('applications');
         void queryClient.invalidateQueries('application');
+      },
+      onError: (error: AxiosError) => {
+        const errorStatus = error.response?.data
+          ? Object.values(error.response.data)
+          : error.code;
+        showErrorToast(
+          t('common:applications.list.errors.fetch.label'),
+          t('common:applications.list.errors.fetch.text', {
+            status: errorStatus,
+          })
+        );
       },
     }
   );


### PR DESCRIPTION
## Description :sparkles:

* Fix seeded applications not being able to be opened / locked by adding more required attachments
* Fix all  handler-generated applications throwing a validation violation by skipping user terms validation altogether
* Add toast error reporting if something goes wrong

### Note

On handler's side, there's still problems locking or opening an application when terms have been changed and old (although accepted) ones  are not in effect anymore. The locking and opening action uses general `PUT` on `/applications/{app_id}/` so it's an error prone process because of rigorous model validation. [There's a new ticket for this](https://helsinkisolutionoffice.atlassian.net/browse/HL-916).

There are two ways to implement a fix:

* Make custom endpoint
  * a new field to set application lock property on/off
  * or just change application status like now (possible status transition problems might arise)
* Loosen the requirements for term consent's approval
* Try using a different Serializer for `PATCH (partial_update)` actions and implement frontend to call endpoint with `PATCH instead of `PUT`