### PR TITLE
fix: non-date string crash in trainingCompensationEndDate

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -532,12 +532,12 @@ const SalaryBenefitCalculatorView: React.FC<
                 setNewTrainingCompensation((prevValue) => ({
                   ...prevValue,
                   endDate:
-                    getCorrectEndDate(prevValue.startDate, value).toString() ??
+                    getCorrectEndDate(prevValue.startDate, value)?.toString() ??
                     '',
                 }))
               }
               value={convertToUIDateFormat(newTrainingCompensation.endDate)}
-              invalid={!!getErrorMessage(fields.trainingCompensationEndDate.name)}
+              invalid={fields.trainingCompensationEndDate && !!getErrorMessage(fields.trainingCompensationEndDate.name)}
               aria-invalid={!!getErrorMessage(fields.trainingCompensationEndDate.name)}
               errorText={getErrorMessage(fields.trainingCompensationEndDate.name)}
               style={{ paddingRight: `${theme.spacing.s}` }}


### PR DESCRIPTION
## Description :sparkles:
User is able to input anything into the handler application training compensation end date field and it crashes the app.
This happens because the getCorrectEndDate() function returns undefined when it cannot convert either of the supplied date strings into dates. This PR fixes the issue by making the return value optional.
## Issues :bug:

## Testing :alembic:
Navigate to the handler application and into an application that has one or more training compensation rows, try to type something into the training compensation end date.
## Screenshots :camera_flash:
<img width="995" alt="Screenshot 2023-09-08 at 16 50 23" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/53281818-4a4e-4d9c-9d96-cca36eaada29">

## Additional notes :spiral_notepad:
