### PR TITLE
Hl 963 ps

### DIFF
--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -1409,7 +1409,7 @@ def test_application_status_change_as_handler_auto_assign_handler(
         assert response.data["calculation"]["handler_details"] is None
 
 
-def add_attachments_to_application(request, application):
+def add_attachments_to_application(request, application, is_handler_application=False):
     # Add enough attachments so that the state transition is valid. See separete test
     # for attachment validation.
     _add_pdf_attachment(request, application, AttachmentType.PAY_SUBSIDY_DECISION)
@@ -1418,6 +1418,8 @@ def add_attachments_to_application(request, application):
     _add_pdf_attachment(request, application, AttachmentType.COMMISSION_CONTRACT)
     _add_pdf_attachment(request, application, AttachmentType.HELSINKI_BENEFIT_VOUCHER)
     _add_pdf_attachment(request, application, AttachmentType.EMPLOYEE_CONSENT)
+    if is_handler_application:
+        _add_pdf_attachment(request, application, AttachmentType.FULL_APPLICATION)
 
 
 def test_application_modified_at_draft(api_client, application):

--- a/backend/benefit/applications/tests/test_handler_application.py
+++ b/backend/benefit/applications/tests/test_handler_application.py
@@ -9,7 +9,7 @@ from applications.tests.test_applications_api import (
 from calculator.models import Calculation, PaySubsidy
 
 
-def test_application_submit_creates_calculation_and_one_pay_subsidy(
+def test_application_submit_creates_calculation_and_two_paysubsidies(
     request, handler_api_client, application
 ):
     """
@@ -30,6 +30,7 @@ def test_application_submit_creates_calculation_and_one_pay_subsidy(
 
     data["benefit_type"] = BenefitType.SALARY_BENEFIT
     data["pay_subsidy_percent"] = "50"
+    data["additional_pay_subsidy_percent"] = "70"
     data["pay_subsidy_granted"] = True
 
     response = handler_api_client.put(

--- a/backend/benefit/applications/tests/test_handler_application.py
+++ b/backend/benefit/applications/tests/test_handler_application.py
@@ -1,0 +1,65 @@
+from unittest import mock
+
+from applications.api.v1.serializers.application import HandlerApplicationSerializer
+from applications.enums import ApplicationOrigin, ApplicationStatus, BenefitType
+from applications.tests.test_applications_api import (
+    add_attachments_to_application,
+    get_handler_detail_url,
+)
+from calculator.models import Calculation, PaySubsidy
+
+
+def test_application_submit_creates_calculation_and_one_pay_subsidy(
+    request, handler_api_client, application
+):
+    """
+    Test that  submitting as a handler creates a new application with an initial calculation
+    and pay subsidies based on the application data pay subsidy percents
+    """
+    add_attachments_to_application(request, application, True)
+    application.application_origin = ApplicationOrigin.HANDLER
+    application.save()
+
+    data = HandlerApplicationSerializer(application).data
+    response = handler_api_client.get(get_handler_detail_url(application))
+    assert response.status_code == 200
+    assert response.data["submitted_at"] is None
+    assert response.data["calculation"] is None
+    assert len(response.data["pay_subsidies"]) == 0
+    assert len(response.data["training_compensations"]) == 0
+
+    data["benefit_type"] = BenefitType.SALARY_BENEFIT
+    data["pay_subsidy_percent"] = "50"
+    data["pay_subsidy_granted"] = True
+
+    response = handler_api_client.put(
+        get_handler_detail_url(application),
+        data,
+    )
+    assert response.status_code == 200
+
+    response = _submit_handler_application(handler_api_client, data, application)
+    assert response.status_code == 200
+    application.refresh_from_db()
+    assert application.status == ApplicationStatus.RECEIVED
+    assert application.pay_subsidy_percent == 50
+    assert application.additional_pay_subsidy_percent == 70
+
+    calculation = Calculation.objects.get(application_id=application.id)
+    assert calculation is not None
+    pay_subsidies = PaySubsidy.objects.all()
+    # Confirm that the pay subsidies are created correctly into the database
+    assert pay_subsidies.count() == 2
+    assert pay_subsidies[0].pay_subsidy_percent == 50
+    assert pay_subsidies[1].pay_subsidy_percent == 70
+
+
+def _submit_handler_application(api_client, data, application):
+    with mock.patch(
+        "terms.models.ApplicantTermsApproval.terms_approval_needed", return_value=False
+    ):
+        data["status"] = ApplicationStatus.RECEIVED
+        return api_client.put(
+            get_handler_detail_url(application),
+            data,
+        )


### PR DESCRIPTION
## Description :sparkles:
Submitting an application manually as a handler does not create rows into the` bf_calculation_paysubsidy `table in the database, because the JSON payload it submits has an empty `pay_subsidies` list evaluates to not` None `which causes a branch in the calculation logic to skip the database insert.  This PR  fixes the issue by checking if the application is submitted by a handler and then makes sure that `pay_subsidy_data `is `None `and `pay_subsidies` is is not present in the `validated_data` dict.
## Issues :bug:

## Testing :alembic:
Pytest: pytest applications/tests/test_handler_application.py
Manually: create a new application as  a handler and then as a handler process the application.
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
