### PR TITLE
HL-974 | Batch animation bug

### DIFF
--- a/frontend/benefit/handler/src/components/batchProcessing/BatchActionsInspectionForm.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchActionsInspectionForm.tsx
@@ -51,7 +51,7 @@ BatchProps) => {
     setBatchCloseAnimation
   );
 
-  const { mutate: changeBatchStatus } = useBatchStatus();
+  const { mutate: changeBatchStatus } = useBatchStatus(setBatchCloseAnimation);
   const [isModalBatchToDraft, setModalBatchToDraft] = React.useState(false);
   const [isModalBatchToCompletion, setModalBatchToCompletion] =
     React.useState(false);
@@ -76,7 +76,10 @@ BatchProps) => {
   };
 
   const handleBatchStatusChange = (): void => {
-    changeBatchStatus({ id, status: BATCH_STATUSES.DRAFT });
+    changeBatchStatus({
+      id,
+      status: BATCH_STATUSES.DRAFT,
+    });
     setModalBatchToDraft(false);
   };
 


### PR DESCRIPTION
## Description :sparkles:

Forgot to add animation callback to hook which resulted to UI not doing animation when returning batch as draft. This also broke the error toast from showing up.