### PR TITLE
feat: add platform definitions to docker compose files

### DIFF
--- a/compose.benefit.yml
+++ b/compose.benefit.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: ./backend
       dockerfile: ./docker/finnish_postgres.Dockerfile
+    platform: linux/amd64
     restart: on-failure
     environment:
       POSTGRES_USER: benefit
@@ -23,6 +24,7 @@ services:
       context: ./backend
       dockerfile: ./docker/benefit.Dockerfile
       target: development
+    platform: linux/amd64
     env_file:
       - .env.benefit-backend
     environment:
@@ -43,6 +45,7 @@ services:
         PORT: 3000
         PROJECT: benefit
         FOLDER: applicant
+    platform: linux/amd64
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -59,6 +62,7 @@ services:
         PORT: 3100
         PROJECT: benefit
         FOLDER: handler
+    platform: linux/amd64
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -75,6 +79,7 @@ services:
       - handler
     build:
       context: ./localdevelopment/benefit/nginx
+    platform: linux/amd64
     container_name: benefit-local-proxy
     volumes:
       - ./localdevelopment/benefit/nginx/:/etc/nginx/

--- a/compose.employer.yml
+++ b/compose.employer.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: ./backend
       dockerfile: ./docker/finnish_postgres.Dockerfile
+    platform: linux/amd64
     restart: on-failure
     environment:
       POSTGRES_USER: kesaseteli
@@ -23,6 +24,7 @@ services:
       context: ./backend
       dockerfile: ./docker/kesaseteli.Dockerfile
       target: development
+    platform: linux/amd64
     env_file:
       - .env.kesaseteli
     environment:
@@ -44,6 +46,7 @@ services:
         PORT: 3100
         PROJECT: kesaseteli
         FOLDER: employer
+    platform: linux/amd64
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -61,6 +64,7 @@ services:
       - employer
     build:
       context: ./localdevelopment/employer/nginx
+    platform: linux/amd64
     container_name: kesaseteli-employer-local-proxy
     volumes:
       - ./localdevelopment/employer/nginx/:/etc/nginx/

--- a/compose.handler.yml
+++ b/compose.handler.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: ./backend
       dockerfile: ./docker/finnish_postgres.Dockerfile
+    platform: linux/amd64
     restart: on-failure
     environment:
       POSTGRES_USER: kesaseteli
@@ -23,6 +24,7 @@ services:
       context: ./backend
       dockerfile: ./docker/kesaseteli.Dockerfile
       target: development
+    platform: linux/amd64
     env_file:
       - .env.kesaseteli
     environment:
@@ -44,6 +46,7 @@ services:
         PORT: 3100
         PROJECT: kesaseteli
         FOLDER: youth
+    platform: linux/amd64
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -60,6 +63,7 @@ services:
         PORT: 3200
         PROJECT: kesaseteli
         FOLDER: handler
+    platform: linux/amd64
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -76,6 +80,7 @@ services:
       - youth
     build:
       context: ./localdevelopment/handler/nginx
+    platform: linux/amd64
     container_name: kesaseteli-handler-local-proxy
     volumes:
       - ./localdevelopment/handler/nginx/:/etc/nginx/

--- a/compose.tet-admin.yml
+++ b/compose.tet-admin.yml
@@ -5,6 +5,7 @@ services:
     build:
       dockerfile: ./docker/finnish_postgres.Dockerfile
       context: ./backend
+    platform: linux/amd64
     restart: on-failure
     environment:
       POSTGRES_USER: tet
@@ -21,6 +22,7 @@ services:
       context: ./backend
       dockerfile: ./docker/tet.Dockerfile
       target: development
+    platform: linux/amd64
     env_file:
       - .env.tet
     environment:
@@ -35,22 +37,23 @@ services:
     container_name: te-backend
 
   admin:
-     build:
-       context: ./frontend
-       target: development
-       args:
-         PORT: 3000
-         PROJECT: tet
-         FOLDER: admin
-     volumes:
-       - ./frontend:/app
-       - /app/node_modules
-       - /app/.next
-     env_file:
-       - .env.tet
-     environment:
-       NEXT_PUBLIC_MOCK_FLAG: 1
-     container_name: te-admin
+    build:
+      context: ./frontend
+      target: development
+      args:
+        PORT: 3000
+        PROJECT: tet
+        FOLDER: admin
+    platform: linux/amd64
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - /app/.next
+    env_file:
+      - .env.tet
+    environment:
+      NEXT_PUBLIC_MOCK_FLAG: 1
+    container_name: te-admin
 
   local-proxy:
     depends_on:
@@ -59,6 +62,7 @@ services:
       - admin
     build:
       context: ./localdevelopment/tet-admin/nginx
+    platform: linux/amd64
     container_name: te-local-proxy
     volumes:
       - ./localdevelopment/tet-admin/nginx/:/etc/nginx/

--- a/compose.tet-youth.yml
+++ b/compose.tet-youth.yml
@@ -5,6 +5,7 @@ services:
     build:
       dockerfile: ./docker/finnish_postgres.Dockerfile
       context: ./backend
+    platform: linux/amd64
     restart: on-failure
     environment:
       POSTGRES_USER: tet
@@ -21,6 +22,7 @@ services:
       context: ./backend
       dockerfile: ./docker/tet.Dockerfile
       target: development
+    platform: linux/amd64
     env_file:
       - .env.tet
     environment:
@@ -35,22 +37,23 @@ services:
     container_name: te-backend
 
   youth:
-     build:
-       context: ./frontend
-       target: development
-       args:
-         PORT: 3000
-         PROJECT: tet
-         FOLDER: youth
-     volumes:
-       - ./frontend:/app
-       - /app/node_modules
-       - /app/.next
-     env_file:
-       - .env.tet
-     environment:
-       NEXT_PUBLIC_MOCK_FLAG: 1
-     container_name: te-youth
+    build:
+      context: ./frontend
+      target: development
+      args:
+        PORT: 3000
+        PROJECT: tet
+        FOLDER: youth
+    platform: linux/amd64
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - /app/.next
+    env_file:
+      - .env.tet
+    environment:
+      NEXT_PUBLIC_MOCK_FLAG: 1
+    container_name: te-youth
 
   local-proxy:
     depends_on:
@@ -59,6 +62,7 @@ services:
       - youth
     build:
       context: ./localdevelopment/tet-youth/nginx
+    platform: linux/amd64
     container_name: te-local-proxy
     volumes:
       - ./localdevelopment/tet-youth/nginx/:/etc/nginx/

--- a/compose.tet.yml
+++ b/compose.tet.yml
@@ -5,6 +5,7 @@ services:
     build:
       dockerfile: ./docker/finnish_postgres.Dockerfile
       context: ./backend
+    platform: linux/amd64
     restart: on-failure
     environment:
       POSTGRES_USER: tet
@@ -23,6 +24,7 @@ services:
       context: ./backend
       dockerfile: ./docker/tet.Dockerfile
       target: development
+    platform: linux/amd64
     env_file:
       - .env.tet
     environment:
@@ -37,36 +39,38 @@ services:
     container_name: te-backend
 
   youth:
-     build:
-       context: ./frontend
-       target: development
-       args:
-         PORT: 3000
-         PROJECT: tet
-         FOLDER: youth
-     volumes:
-       - ./frontend:/app
-       - /app/node_modules
-       - /app/.next
-     env_file:
-       - .env.tet
-     container_name: te-youth
+    build:
+      context: ./frontend
+      target: development
+      args:
+        PORT: 3000
+        PROJECT: tet
+        FOLDER: youth
+    platform: linux/amd64
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - /app/.next
+    env_file:
+      - .env.tet
+    container_name: te-youth
 
   admin:
-     build:
-       context: ./frontend
-       target: development
-       args:
-         PORT: 3000
-         PROJECT: tet
-         FOLDER: admin
-     volumes:
-       - ./frontend:/app
-       - /app/node_modules
-       - /app/.next
-     env_file:
-       - .env.tet
-     container_name: te-admin
+    build:
+      context: ./frontend
+      target: development
+      args:
+        PORT: 3000
+        PROJECT: tet
+        FOLDER: admin
+    platform: linux/amd64
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - /app/.next
+    env_file:
+      - .env.tet
+    container_name: te-admin
 
   local-proxy:
     depends_on:
@@ -76,6 +80,7 @@ services:
       - youth
     build:
       context: ./localdevelopment/tet/nginx
+    platform: linux/amd64
     container_name: te-local-proxy
     volumes:
       - ./localdevelopment/tet/nginx/:/etc/nginx/


### PR DESCRIPTION
To ensure that mac m1&m2 chips use amd images instead of the arm ones. This way we all should be using the same base images.
