### PR TITLE
fix: only one row per application in Talpa CSV export

### DIFF
--- a/backend/benefit/applications/services/applications_csv_report.py
+++ b/backend/benefit/applications/services/applications_csv_report.py
@@ -391,6 +391,11 @@ class ApplicationsCsvService(CsvExportBase):
             for application in self.get_applications():
                 # for applications with multiple ahjo rows, output the same number of rows.
                 # If no Ahjo rows (calculation incomplete), always output just one row.
+                if self.prune_data_for_talpa:
+                    # For Talpa, only one row per application is needed
+                    application.application_row_idx = 1
+                    yield application
+                    continue
                 for application_row_idx, unused in enumerate(
                     application.ahjo_rows or [None]
                 ):


### PR DESCRIPTION
## Description :sparkles:
Talpa CSV export has multiple rows per application because it uses the same row generation logic as Ahjo export, which generates a row per application calculation row. This PR fixes the Talpa export so, that only one row per application is generated when exporting for Talpa with the prune_data_for_talpa parameter set to True.

## Issues :bug:

## Testing :alembic:
Create a batch with applications and mark them ready for talpa.
Visit the talpa api endpoint at `/v1/applicationbatches/talpa_export`, to download the CSV.
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
