### PR TITLE
HL-988 | Require salary and expenses to be 0 - 99999

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
@@ -1,6 +1,7 @@
 import {
   EMPLOYEE_MAX_WORKING_HOURS,
   EMPLOYEE_MIN_WORKING_HOURS,
+  MAX_MONTHLY_PAY,
   MAX_SHORT_STRING_LENGTH,
 } from 'benefit/applicant/constants';
 import {
@@ -106,19 +107,40 @@ export const getValidationSchema = (
         }))
         .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
       [EMPLOYEE_KEYS.VACATION_MONEY]: Yup.number()
+        .min(0, (param) => ({
+          min: param.min,
+          key: VALIDATION_MESSAGE_KEYS.NUMBER_MIN,
+        }))
+        .max(MAX_MONTHLY_PAY, (param) => ({
+          max: param.max,
+          key: VALIDATION_MESSAGE_KEYS.NUMBER_MAX,
+        }))
         .transform((_value, originalValue) => getNumberValue(originalValue))
         .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
-        .nullable()
         .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
       [EMPLOYEE_KEYS.MONTHLY_PAY]: Yup.number()
+        .min(0, (param) => ({
+          min: param.min,
+          key: VALIDATION_MESSAGE_KEYS.NUMBER_MIN,
+        }))
+        .max(MAX_MONTHLY_PAY, (param) => ({
+          max: param.max,
+          key: VALIDATION_MESSAGE_KEYS.NUMBER_MAX,
+        }))
         .transform((_value, originalValue) => getNumberValue(originalValue))
         .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
-        .nullable()
         .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
       [EMPLOYEE_KEYS.OTHER_EXPENSES]: Yup.number()
+        .min(0, (param) => ({
+          min: param.min,
+          key: VALIDATION_MESSAGE_KEYS.NUMBER_MIN,
+        }))
+        .max(MAX_MONTHLY_PAY, (param) => ({
+          max: param.max,
+          key: VALIDATION_MESSAGE_KEYS.NUMBER_MAX,
+        }))
         .transform((_value, originalValue) => getNumberValue(originalValue))
         .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
-        .nullable()
         .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
     }),
   });

--- a/frontend/benefit/applicant/src/constants.ts
+++ b/frontend/benefit/applicant/src/constants.ts
@@ -16,6 +16,7 @@ export enum ROUTES {
 }
 
 export const MAX_DEMINIMIS_AID_TOTAL_AMOUNT = 200_000;
+export const MAX_MONTHLY_PAY = 99_999;
 
 export enum SUPPORTED_LANGUAGES {
   FI = 'fi',


### PR DESCRIPTION
## Description :sparkles:

Fix validation schema for salaries.