### PR TITLE
fix: send default paySubsidyPercent value (HL-995)

### DIFF
--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -3,7 +3,7 @@ import {
   getApplicationStepFromString,
   getApplicationStepString,
 } from 'benefit/applicant/utils/common';
-import { BENEFIT_TYPES } from 'benefit-shared/constants';
+import { BENEFIT_TYPES, PAY_SUBSIDY_OPTIONS } from 'benefit-shared/constants';
 import {
   Application,
   ApplicationData,
@@ -115,6 +115,7 @@ const useFormActions = (application: Partial<Application>): FormActions => {
     const normalizedValues = {
       ...currentValues,
       employee,
+      paySubsidyPercent: PAY_SUBSIDY_OPTIONS[0],
       startDate: currentValues.startDate
         ? convertToBackendDateFormat(parseDate(currentValues.startDate))
         : undefined,

--- a/frontend/benefit/handler/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/handler/src/hooks/useFormActions.tsx
@@ -2,7 +2,11 @@ import { APPLICATION_FIELD_KEYS } from 'benefit/handler/constants';
 import DeMinimisContext from 'benefit/handler/context/DeMinimisContext';
 import { StepActionType } from 'benefit/handler/hooks/useSteps';
 import { Application } from 'benefit/handler/types/application';
-import { APPLICATION_STATUSES, BENEFIT_TYPES } from 'benefit-shared/constants';
+import {
+  APPLICATION_STATUSES,
+  BENEFIT_TYPES,
+  PAY_SUBSIDY_OPTIONS,
+} from 'benefit-shared/constants';
 import { ApplicationData, Employee } from 'benefit-shared/types/application';
 import camelcaseKeys from 'camelcase-keys';
 import { useRouter } from 'next/router';
@@ -140,6 +144,7 @@ const useFormActions = (application: Partial<Application>): FormActions => {
 
     const normalizedValues = {
       ...currentValues,
+      paySubsidyPercent: PAY_SUBSIDY_OPTIONS[0],
       employee: employee || {},
       startDate: currentValues.startDate
         ? convertToBackendDateFormat(parseDate(currentValues.startDate))


### PR DESCRIPTION
## Description :sparkles:

Send the default `paySubsidyPercent` with value `50` so that the calculation row creation gets triggered.
