### PR TITLE
Switch to new Platta test Linked Events

### DIFF
--- a/.env.tet.example
+++ b/.env.tet.example
@@ -9,7 +9,7 @@ HANDLER_URL=https://localhost:3100
 NEXT_PUBLIC_BACKEND_URL=https://localhost:8000
 
 # Linked Events
-LINKEDEVENTS_URL=https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/
+LINKEDEVENTS_URL=https://linkedevents.api.test.hel.ninja/v1/
 LINKEDEVENTS_API_KEY=
 
 # Authentication

--- a/backend/tet/events/tests/data/linked_events_responses.py
+++ b/backend/tet/events/tests/data/linked_events_responses.py
@@ -10,7 +10,7 @@ ADD_EVENT_PAYLOAD = json.loads(
         "fi": "Testaaja"
     },
     "location": {
-        "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/place/tprek:15417/"
+        "@id": "https://linkedevents.api.test.hel.ninja/v1/place/tprek:15417/"
     },
     "description": {
         "fi": "test description"
@@ -20,16 +20,16 @@ ADD_EVENT_PAYLOAD = json.loads(
     "date_published": null,
     "keywords": [
         {
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:1/"
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:1/"
         },
         {
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:11/"
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:11/"
         },
         {
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:12/"
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:12/"
         },
         {
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/yso:p3971/"
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/yso:p3971/"
         }
     ],
     "custom_data": {
@@ -59,20 +59,20 @@ ADD_EVENT_RESPONSE = json.loads(
 {
     "id": "tet:af7w5v5m6e",
     "location": {
-        "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/place/tprek:15417/"
+        "@id": "https://linkedevents.api.test.hel.ninja/v1/place/tprek:15417/"
     },
     "keywords": [
         {
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:1/"
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:1/"
         },
         {
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:11/"
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:11/"
         },
         {
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:12/"
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:12/"
         },
         {
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/yso:p3971/"
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/yso:p3971/"
         }
     ],
     "registration": null,
@@ -155,7 +155,7 @@ ADD_EVENT_RESPONSE = json.loads(
     "short_description": {
         "fi": "TET-paikan kuvaus"
     },
-    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/event/tet:af7w5v5m6e/",
+    "@id": "https://linkedevents.api.test.hel.ninja/v1/event/tet:af7w5v5m6e/",
     "@context": "http://schema.org",
     "@type": "Event/LinkedEvent"
 }
@@ -167,11 +167,11 @@ EVENT_RESPONSE_TESTUSER_EMAIL = json.loads(
         {
             "id": "tet:test-user-email-set",
             "location": {
-                "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/place/tprek:20780/"
+                "@id": "https://linkedevents.api.test.hel.ninja/v1/place/tprek:20780/"
             },
             "keywords": [
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:2/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:2/"
                 }
             ],
             "registration": null,
@@ -203,7 +203,7 @@ EVENT_RESPONSE_TESTUSER_EMAIL = json.loads(
             "videos": [],
             "in_language": [
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/language/fi/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/language/fi/"
                 }
             ],
             "audience": [],
@@ -252,7 +252,7 @@ EVENT_RESPONSE_TESTUSER_EMAIL = json.loads(
             "short_description": {
                 "fi": "xx"
             },
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/event/tet:af7w4jmjla/",
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/event/tet:af7w4jmjla/",
             "@context": "http://schema.org",
             "@type": "Event/LinkedEvent"
         }
@@ -265,35 +265,35 @@ EVENT_RESPONSE_TESTUSER_OID_EXPIRED = json.loads(
         {
             "id": "tet:test-user-oid-set",
             "location": {
-                "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/place/tprek:56379/"
+                "@id": "https://linkedevents.api.test.hel.ninja/v1/place/tprek:56379/"
             },
             "keywords": [
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:12/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:12/"
                 },
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:1/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:1/"
                 },
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/yso:p16557/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/yso:p16557/"
                 },
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/yso:p9903/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/yso:p9903/"
                 },
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/yso:p13310/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/yso:p13310/"
                 },
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:6/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:6/"
                 },
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:4/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:4/"
                 },
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:10/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:10/"
                 },
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:9/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:9/"
                 }
             ],
             "registration": null,
@@ -325,7 +325,7 @@ EVENT_RESPONSE_TESTUSER_OID_EXPIRED = json.loads(
             "videos": [],
             "in_language": [
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/language/fi/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/language/fi/"
                 }
             ],
             "audience": [],
@@ -374,7 +374,7 @@ EVENT_RESPONSE_TESTUSER_OID_EXPIRED = json.loads(
             "short_description": {
                 "fi": "täällä pääset maalaamaan"
             },
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/event/tet:af7wtenvii/",
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/event/tet:af7wtenvii/",
             "@context": "http://schema.org",
             "@type": "Event/LinkedEvent"
         }
@@ -391,11 +391,11 @@ EVENT_RESPONSE_OTHERUSER = json.loads(
         {
             "id": "tet:other-user",
             "location": {
-                "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/place/tprek:8740/"
+                "@id": "https://linkedevents.api.test.hel.ninja/v1/place/tprek:8740/"
             },
             "keywords": [
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:1/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:1/"
                 }
             ],
             "registration": null,
@@ -427,7 +427,7 @@ EVENT_RESPONSE_OTHERUSER = json.loads(
             "videos": [],
             "in_language": [
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/language/fi/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/language/fi/"
                 }
             ],
             "audience": [],
@@ -476,7 +476,7 @@ EVENT_RESPONSE_OTHERUSER = json.loads(
             "short_description": {
                 "fi": "kuvaus"
             },
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/event/tet:af7wto6nze/",
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/event/tet:af7wto6nze/",
             "@context": "http://schema.org",
             "@type": "Event/LinkedEvent"
         }
@@ -489,11 +489,11 @@ EVENT_RESPONSE_TEST_COMPANY = json.loads(
         {
             "id": "tet:companyuser",
             "location": {
-                "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/place/tprek:352/"
+                "@id": "https://linkedevents.api.test.hel.ninja/v1/place/tprek:352/"
             },
             "keywords": [
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:1/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:1/"
                 }
             ],
             "registration": null,
@@ -525,7 +525,7 @@ EVENT_RESPONSE_TEST_COMPANY = json.loads(
             "videos": [],
             "in_language": [
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/language/fi/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/language/fi/"
                 }
             ],
             "audience": [],
@@ -571,7 +571,7 @@ EVENT_RESPONSE_TEST_COMPANY = json.loads(
             "short_description": {
                 "fi": "x"
             },
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/event/tet:af7scpy2de/",
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/event/tet:af7scpy2de/",
             "@context": "http://schema.org",
             "@type": "Event/LinkedEvent"
         }
@@ -589,11 +589,11 @@ EVENT_RESPONSE_NO_CUSTOM_DATA = json.loads(
         {
             "id": "tet:no-custom-data",
             "location": {
-                "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/place/tprek:37497/"
+                "@id": "https://linkedevents.api.test.hel.ninja/v1/place/tprek:37497/"
             },
             "keywords": [
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:1/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/keyword/tet:1/"
                 }
             ],
             "registration": null,
@@ -625,7 +625,7 @@ EVENT_RESPONSE_NO_CUSTOM_DATA = json.loads(
             "videos": [],
             "in_language": [
                 {
-                    "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/language/fi/"
+                    "@id": "https://linkedevents.api.test.hel.ninja/v1/language/fi/"
                 }
             ],
             "audience": [],
@@ -665,7 +665,7 @@ EVENT_RESPONSE_NO_CUSTOM_DATA = json.loads(
             "short_description": {
                 "fi": "kuvaus"
             },
-            "@id": "https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/event/tet:af7wjlxpyy/",
+            "@id": "https://linkedevents.api.test.hel.ninja/v1/event/tet:af7wjlxpyy/",
             "@context": "http://schema.org",
             "@type": "Event/LinkedEvent"
         }

--- a/frontend/tet/admin/next.config.js
+++ b/frontend/tet/admin/next.config.js
@@ -3,4 +3,4 @@ const { i18n } = require('./next-i18next.config');
 const { parsed: env } = require('dotenv').config({
   path: '../../../.env.tet',
 });
-module.exports = nextConfig({ i18n, env, images: { domains: ['linkedevents-api.dev.hel.ninja'] } });
+module.exports = nextConfig({ i18n, env, images: { domains: ['linkedevents.api.test.hel.ninja'] } });

--- a/frontend/tet/admin/src/__tests__/utils/backend/backend-nocks.ts
+++ b/frontend/tet/admin/src/__tests__/utils/backend/backend-nocks.ts
@@ -52,7 +52,7 @@ export const expectToGetEventssErrorFromBackend = (errorCode: 400 | 404 | 500): 
 };
 
 export const expectPlacesFromLinkedEvents = (): nock.Scope =>
-  nock('https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1')
+  nock('https://linkedevents.api.test.hel.ninja/v1')
     .get('/place/?show_all_places=true&nocache=true&text=')
     .reply(
       200,
@@ -64,7 +64,7 @@ export const expectPlacesFromLinkedEvents = (): nock.Scope =>
     );
 
 export const expectKeyWordsFromLinkedEvents = (): nock.Scope =>
-  nock('https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1')
+  nock('https://linkedevents.api.test.hel.ninja/v1')
     .get('/keyword')
     .reply(
       200,
@@ -80,14 +80,14 @@ export const expectKeyWordsFromLinkedEvents = (): nock.Scope =>
 // TODO don't hardcode url
 // this is needed when testing the Editor form and can be refactored then
 export const expectWorkingMethodsFromLinkedEvents = (): nock.Scope =>
-  nock('https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1')
+  nock('https://linkedevents.api.test.hel.ninja/v1')
     .get('/keyword_set/tet:wm/?include=keywords')
     .reply(
       200,
       {
         keywords: [
           {
-            '@id': 'https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:4/',
+            '@id': 'https://linkedevents.api.test.hel.ninja/v1/keyword/tet:4/',
             name: {
               fi: 'Tee oikeita töitä',
             },
@@ -100,14 +100,14 @@ export const expectWorkingMethodsFromLinkedEvents = (): nock.Scope =>
 // TODO don't hardcode url
 // this is needed when testing the Editor form and can be refactored then
 export const expectAttributesFromLinkedEvents = (): nock.Scope =>
-  nock('https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1')
+  nock('https://linkedevents.api.test.hel.ninja/v1')
     .get('/keyword_set/tet:attr/?include=keywords')
     .reply(
       200,
       {
         keywords: [
           {
-            '@id': 'https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:1/',
+            '@id': 'https://linkedevents.api.test.hel.ninja/v1/keyword/tet:1/',
             name: {
               fi: 'Soveltuu näkövammaisille',
             },

--- a/frontend/tet/shared/src/backend-api/linked-events-api.ts
+++ b/frontend/tet/shared/src/backend-api/linked-events-api.ts
@@ -18,7 +18,7 @@ type Keyword = IdObject & {
 const linkedEvents = Axios.create({
   baseURL:
     process.env.NEXT_PUBLIC_LINKEDEVENTS_URL ||
-    'https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1',
+    'https://linkedevents.api.test.hel.ninja/v1',
   timeout: 4000,
   headers: {
     'Content-Type': 'application/json',

--- a/frontend/tet/youth/browser-tests/search.testcafe.ts
+++ b/frontend/tet/youth/browser-tests/search.testcafe.ts
@@ -53,7 +53,7 @@ test('user can search and navigate', async (t) => {
   const end = faker.date.soon(100, start);
   const startDate = formatDate(start);
   const endDate = formatDate(end);
-  // Should find working method https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/tet:2/
+  // Should find working method https://linkedevents.api.test.hel.ninja/v1/keyword/tet:2/
   const workMethodText = 'Varjostus';
   const languageText = 'Suomi';
   const searchTerm = faker.lorem.word();

--- a/frontend/tet/youth/src/backend-api/backend-api.ts
+++ b/frontend/tet/youth/src/backend-api/backend-api.ts
@@ -1,7 +1,7 @@
 import Axios, { AxiosInstance, AxiosResponse } from 'axios';
 
 export const linkedEventsUrl =
-  process.env.NEXT_PUBLIC_LINKEDEVENTS_URL || 'https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/';
+  process.env.NEXT_PUBLIC_LINKEDEVENTS_URL || 'https://linkedevents.api.test.hel.ninja/v1/';
 
 export const BackendEndpoint = {
   EVENT: 'event/?include=location,keywords&sort=-name',


### PR DESCRIPTION
## Description :sparkles:

Old dev/test Linked Events instances are deprecated and replaced by Platta LE instances. It is recommended that outside services use TEST Platta Linked Events, so that is used here.

## Issues :bug:

[TETP-279](https://helsinkisolutionoffice.atlassian.net/browse/TETP-279)

## Testing :alembic:

Tested manually locally.

[TETP-279]: https://helsinkisolutionoffice.atlassian.net/browse/TETP-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ