### PR TITLE
feat: upload terms into a subfolder that can be made public

### DIFF
--- a/backend/benefit/terms/models.py
+++ b/backend/benefit/terms/models.py
@@ -41,9 +41,9 @@ class Terms(UUIDModel, TimeStampedModel):
         verbose_name=_("first day these terms are in effect"), null=True, blank=True
     )
 
-    terms_pdf_fi = models.FileField(verbose_name=_("finnish terms (pdf file)"))
-    terms_pdf_en = models.FileField(verbose_name=_("english terms (pdf file)"))
-    terms_pdf_sv = models.FileField(verbose_name=_("swedish terms (pdf file)"))
+    terms_pdf_fi = models.FileField(upload_to='terms/', verbose_name=_("finnish terms (pdf file)"))
+    terms_pdf_en = models.FileField(upload_to='terms/', verbose_name=_("english terms (pdf file)"))
+    terms_pdf_sv = models.FileField(upload_to='terms/', verbose_name=_("swedish terms (pdf file)"))
 
     @property
     def is_editable(self):


### PR DESCRIPTION
## Description :sparkles:
Upload terms pdf-files into a directory named "terms", which can be made public in the blob storage if needed.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
