### PR TITLE
fix(dateinput): clear validation errors when a datepicker selects a date

### DIFF
--- a/frontend/kesaseteli/employer/src/components/application/form/DateInput.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/DateInput.tsx
@@ -30,8 +30,15 @@ const DateInput = ({
 }: Props): ReturnType<typeof HdsDateInput> => {
   const { t } = useTranslation();
 
-  const { defaultLabel, getValue, getError, getErrorText, setError } =
-    useApplicationFormField<string>(id);
+  const {
+    defaultLabel,
+    getValue,
+    setValue,
+    getError,
+    getErrorText,
+    setError,
+    clearErrors,
+  } = useApplicationFormField<string>(id);
 
   const date = convertToUIDateFormat(getValue());
 
@@ -61,6 +68,14 @@ const DateInput = ({
       initialValue={date}
       errorText={getErrorText()}
       label={defaultLabel}
+      onChange={(value) => {
+        // FIXME: Since the react-hook-forms onBlur is not called when a datepicker is used,
+        // the clear errors function needs to be called with a value setter.
+        // Otherwise the error message won't be cleared and
+        // the value remains invalid after the date has been picked.
+        clearErrors();
+        setValue(value);
+      }}
       {...$gridCellProps}
     />
   );


### PR DESCRIPTION
YJDH-684.

Since the HDS DateInput has a compatibility issue with React-hook-forms,
The onChange should include processes to
1) clear the input validation errors and
2) set the input value.
Otherwise the errors are not cleared when a datepicker is used.

The onChange is currently not in the same format
as the HDS dateinput is expecting it to be.

HDS DateInputProps are waiting for (value: string, valueAsDate: Date),
but onChange from the InputProps is (value: string).
OnChange of the React-hook-Forms waits a SyntheticEvent as a parameter.

NOTE: The HDS v. 3.0.0 will change the DateInput onChange to have an Event as a parameter.
