### PR TITLE
feat: add utility for hashing Ahjo attachments

### DIFF
--- a/backend/benefit/common/tests/test_utils.py
+++ b/backend/benefit/common/tests/test_utils.py
@@ -1,15 +1,18 @@
 import decimal
+import hashlib
 import os
 from datetime import date
 
 import pytest
 from dateutil.relativedelta import relativedelta
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from common.utils import (
     date_range_overlap,
     days360,
     duration_in_months,
     get_date_range_end_with_days360,
+    hash_file,
 )
 
 
@@ -128,3 +131,17 @@ def test_get_date_range_end_with_days360_combinations():
                 )
                 assert result_difference <= previous_day_difference
                 assert result_difference <= next_day_difference
+
+
+@pytest.mark.django_db
+def test_hash_file():
+    # Create a dummy file with known content
+    dummy_file_content = b"Ea ullamco aliqua amet ut deserunt. Excepteur aliqua non excepteur pariatur exercitation."
+    dummy_file = SimpleUploadedFile("dummy.txt", dummy_file_content)
+    expected_hash = hashlib.sha256(dummy_file_content).hexdigest()
+
+    # Calculate the actual hash of the file using the hash_file function
+    actual_hash = hash_file(dummy_file)
+
+    # Assert that the actual hash matches the expected hash
+    assert actual_hash == expected_hash

--- a/backend/benefit/common/utils.py
+++ b/backend/benefit/common/utils.py
@@ -1,10 +1,12 @@
 import decimal
 import functools
+import hashlib
 import itertools
 from datetime import date, timedelta
 from typing import Iterator, Tuple, Union
 
 from dateutil.relativedelta import relativedelta
+from django.core.files import File
 from phonenumber_field.serializerfields import (
     PhoneNumberField as DefaultPhoneNumberField,
 )
@@ -425,3 +427,17 @@ def get_date_range_end_with_days360(start_date: date, n_months: int):
         return None
 
     return end_date
+
+
+def hash_file(file: File) -> str:
+    """Hash attachment file"""
+    # Create a new SHA256 hash object
+    sha256 = hashlib.sha256()
+
+    with file.open() as f:
+        # Read and update hash in chunks for efficiency
+        for chunk in iter(lambda: f.read(4096), b""):
+            sha256.update(chunk)
+
+        # Return the hexadecimal representation of the hash
+    return sha256.hexdigest()


### PR DESCRIPTION
## Description :sparkles:
A SHA-256 hash of each attachment needs to be sent to Ahjo when opening a case, this PR adds a small utility for the hash.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
