### PR TITLE
feat: Change  some Talpa csv export column titles

### DIFF
--- a/backend/benefit/applications/services/applications_csv_report.py
+++ b/backend/benefit/applications/services/applications_csv_report.py
@@ -111,11 +111,9 @@ class ApplicationsCsvService(CsvExportBase):
                 csv_default_column(
                     "Asiantarkastajan titteli Ahjo", "batch.expert_inspector_title"
                 ),
+                csv_default_column("Tarkastajan nimi, P2P", "batch.p2p_inspector_name"),
                 csv_default_column(
-                    "Asiantarkastajan nimi P2P", "batch.p2p_inspector_name"
-                ),
-                csv_default_column(
-                    "Asiantarkastajan email P2P", "batch.p2p_inspector_email"
+                    "Tarkastajan sähköposti, P2P", "batch.p2p_inspector_email"
                 ),
                 csv_default_column("Hyväksyjän nimi P2P", "batch.p2p_checker_name"),
             ]
@@ -263,9 +261,9 @@ class ApplicationsCsvService(CsvExportBase):
             csv_default_column(
                 "Asiantarkastajan titteli Ahjo", "batch.expert_inspector_title"
             ),
-            csv_default_column("Asiantarkastajan nimi P2P", "batch.p2p_inspector_name"),
+            csv_default_column("Tarkastajan nimi, P2P", "batch.p2p_inspector_name"),
             csv_default_column(
-                "Asiantarkastajan email P2P", "batch.p2p_inspector_email"
+                "Tarkastajan sähköposti, P2P", "batch.p2p_inspector_email"
             ),
             csv_default_column("Hyväksyjän nimi P2P", "batch.p2p_checker_name"),
             # In case there are multiple rows per application, always have the nth ahjo row

--- a/backend/benefit/applications/tests/test_applications_report.py
+++ b/backend/benefit/applications/tests/test_applications_report.py
@@ -325,8 +325,8 @@ def test_pruned_applications_csv_output(
     assert csv_lines[0][12] == '"Päätöspäivä"'
     assert csv_lines[0][13] == '"Asiantarkastajan nimi Ahjo"'
     assert csv_lines[0][14] == '"Asiantarkastajan titteli Ahjo"'
-    assert csv_lines[0][15] == '"Asiantarkastajan nimi P2P"'
-    assert csv_lines[0][16] == '"Asiantarkastajan email P2P"'
+    assert csv_lines[0][15] == '"Tarkastajan nimi, P2P"'
+    assert csv_lines[0][16] == '"Tarkastajan sähköposti, P2P"'
     assert csv_lines[0][17] == '"Hyväksyjän nimi P2P"'
 
     # Assert that there are 15 columns in the pruned CSV


### PR DESCRIPTION
## Description :sparkles:
Change talpa export column titles like so
Asiantarkastajan email P2P → Tarkastajan sähköposti, P2P
Asiantarkastajan nimi P2P → Tarkastajan nimi, P2P

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
