### PR TITLE
fix: wrong object accessed for English terms

### DIFF
--- a/frontend/benefit/applicant/src/hooks/useTermsOfServiceData.ts
+++ b/frontend/benefit/applicant/src/hooks/useTermsOfServiceData.ts
@@ -60,7 +60,7 @@ const useTermsOfServiceData = (
         return String(user.termsOfServiceInEffect?.termsMdSv);
 
       case 'en':
-        return String(user.termsOfServiceInEffect?.termsMdSv);
+        return String(user.termsOfServiceInEffect?.termsMdEn);
 
       default:
         return '';


### PR DESCRIPTION
## Description :sparkles:

Access the right object for English markdown terms.