### PR TITLE
fix: downgrade kesaseteli ssn library as it's not compliant yet

### DIFF
--- a/frontend/kesaseteli/handler/package.json
+++ b/frontend/kesaseteli/handler/package.json
@@ -24,7 +24,7 @@
     "axios": "^0.27.2",
     "babel-plugin-import": "^1.13.3",
     "dotenv": "^16.0.0",
-    "finnish-ssn": "^2.1.1",
+    "finnish-ssn": "2.0.4",
     "hds-react": "^2.10.0",
     "lodash": "^4.17.21",
     "next": "^12.3.4",

--- a/frontend/kesaseteli/shared/package.json
+++ b/frontend/kesaseteli/shared/package.json
@@ -15,12 +15,11 @@
   "dependencies": {
     "@frontend/shared": "*",
     "axios": "^0.27.2",
-    "finnish-ssn": "^2.1.1",
+    "finnish-ssn": "2.0.4",
     "react-query": "^3.34.0"
   },
   "devDependencies": {
     "eslint-config-adjunct": "^4.11.1",
-    "finnish-ssn": "^2.0.4",
     "typescript": "^4.5.5"
   }
 }

--- a/frontend/kesaseteli/youth/package.json
+++ b/frontend/kesaseteli/youth/package.json
@@ -25,7 +25,7 @@
     "axios": "^0.27.2",
     "babel-plugin-import": "^1.13.3",
     "dotenv": "^16.0.0",
-    "finnish-ssn": "^2.1.1",
+    "finnish-ssn": "2.0.4",
     "hds-react": "^2.10.0",
     "lodash": "^4.17.21",
     "next": "^12.3.4",


### PR DESCRIPTION
## Description :sparkles:

Downgrade `finnish-ssn` library so it won't generate new style of ssn in tests.