### PR TITLE
fix: wrap i18n key with translation fuction (HL-1037)

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
@@ -245,7 +245,9 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
             direction="vertical"
             required
             errorText={getErrorMessage(fields.coOperationNegotiations.name)}
-            tooltipText={`${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.CO_OPERATION_NEGOTIATIONS}.tooltipText`}
+            tooltipText={t(
+              `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.CO_OPERATION_NEGOTIATIONS}.tooltipText`
+            )}
           >
             <$RadioButton
               id={`${fields.coOperationNegotiations.name}False`}


### PR DESCRIPTION
## Description :sparkles:

Add a missing function call, only the key was shown before.

<img width="818" alt="Screenshot 2023-11-17 at 10 00 53" src="https://github.com/City-of-Helsinki/yjdh/assets/5328394/692d95b0-5bcc-4e98-bb1c-38c58b721a51">
