### PR TITLE
fix: allow applicant messages for all but cancelled and archived app (HL-860)

### DIFF
--- a/backend/benefit/messages/tests/test_api.py
+++ b/backend/benefit/messages/tests/test_api.py
@@ -236,15 +236,17 @@ def test_create_handler_message_invalid(handler_api_client, handling_application
 
 
 @pytest.mark.parametrize(
-    "status,expected_result",
+    "status, archived, expected_result",
     [
-        (ApplicationStatus.DRAFT, 400),
-        (ApplicationStatus.RECEIVED, 201),
-        (ApplicationStatus.HANDLING, 201),
-        (ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED, 201),
-        (ApplicationStatus.ACCEPTED, 400),
-        (ApplicationStatus.REJECTED, 400),
-        (ApplicationStatus.CANCELLED, 400),
+        (ApplicationStatus.DRAFT, False, 400),
+        (ApplicationStatus.RECEIVED, False, 201),
+        (ApplicationStatus.HANDLING, False, 201),
+        (ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED, False, 201),
+        (ApplicationStatus.ACCEPTED, False, 201),
+        (ApplicationStatus.REJECTED, False, 201),
+        (ApplicationStatus.ACCEPTED, True, 400),
+        (ApplicationStatus.REJECTED, True, 400),
+        (ApplicationStatus.CANCELLED, False, 400),
     ],
 )
 def test_applicant_send_first_message(
@@ -252,12 +254,14 @@ def test_applicant_send_first_message(
     handling_application,
     mock_get_organisation_roles_and_create_company,
     status,
+    archived,
     expected_result,
 ):
     msg = deepcopy(SAMPLE_MESSAGE_PAYLOAD)
     msg["message_type"] = MessageType.APPLICANT_MESSAGE
     handling_application.company = mock_get_organisation_roles_and_create_company
     handling_application.status = status
+    handling_application.archived = archived
     handling_application.save()
     result = api_client.post(
         reverse(


### PR DESCRIPTION
## Description :sparkles:

* Add more statuses to be ok'd for messaging
* If archived then no message can be sent by applicant
* Fix/add tests for these cases