### PR TITLE
feat: use MJML to generate HTML emails (HL-999)

### DIFF
--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -51,6 +51,9 @@ from companies.tests.conftest import *  # noqa
 from companies.tests.factories import CompanyFactory
 from helsinkibenefit.settings import MAX_UPLOAD_SIZE
 from helsinkibenefit.tests.conftest import *  # noqa
+from messages.automatic_messages import (
+    get_additional_information_email_notification_subject,
+)
 from shared.audit_log import models as audit_models
 from shared.service_bus.enums import YtjOrganizationCode
 from terms.models import TermsOfServiceApproval
@@ -1282,7 +1285,10 @@ def test_application_status_change_as_handler(
                 in application.messages.first().content
             )
             assert len(mailoutbox) == 1
-            assert "You have received a new message" in mailoutbox[0].subject
+            assert (
+                get_additional_information_email_notification_subject()
+                in mailoutbox[0].subject
+            )
 
         if to_status in [
             ApplicationStatus.CANCELLED,

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -272,10 +272,15 @@ MIDDLEWARE = [
     "simple_history.middleware.HistoryRequestMiddleware",
 ]
 
+MJML_COMPILED_EMAIL_TEMPLATE_PATHS = [
+    os.path.join(BASE_DIR, "helsinkibenefit/templates/emails/mjml-generated/html"),
+    os.path.join(BASE_DIR, "helsinkibenefit/templates/emails/mjml-generated/txt"),
+]
+
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [] + MJML_COMPILED_EMAIL_TEMPLATE_PATHS,
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_en.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_en.html
@@ -1,0 +1,795 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}
+    <title>Your application requires additional information</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+  
+    <style type="text/css">
+    
+    
+    </style>
+    <style type="text/css">
+    @font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: 0;
+}
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#ffffff;">
+    
+    
+      <div
+         style="background-color:#ffffff;"
+      >
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#D8D8D8" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#D8D8D8;background-color:#D8D8D8;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#D8D8D8;background-color:#D8D8D8;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:10px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki benefit: Your application requires additional information</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:30px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: top"
+        width="100%"
+        height="80"
+      >
+        <tbody>
+          <tr>
+            <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word">
+              <table
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                width="100%"
+                border="0"
+                height="80"
+                style="
+                  color: #222222;
+                  font-family: HelsinkiGrotesk, system-ui, Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  table-layout: auto;
+                  width: 100%;
+                  border: 0;
+                "
+              >
+                <tbody>
+                  <tr height="66">
+                    <td width="146" height="66" style="width: 146px; height: 60px">
+                      <img
+                        src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png"
+                        style="width: 130px; height: 60px; margin: 0; padding: 0"
+                        width="130"
+                        height="60"
+                      />
+                    </td>
+                    <td
+                      height="66"
+                      style="font-size: 26px; font-weight: 600; line-height: 1; padding-bottom: 8px; height: 66px"
+                    >
+                      Helsinki-lisä
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Your Helsinki benefit application requires additional information</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:10px;padding-bottom:20px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Hello!</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >The Helsinki benefit application you submitted is missing required information. Log in to the Helsinki benefit service and fill in the missing information by {{ additional_information_deadline_time }} on {{ additional_information_deadline_date }}.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >If you have any questions, please send us a message via the Helsinki benefit e-service.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Best regards,</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >The Helsinki benefit team</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:18px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Application details</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#222222;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;line-height:22px;table-layout:auto;width:100%;border:none;"
+      >
+        <tr style="border-top: 1px solid #ecedee; border-bottom: 1px solid #ecedee; text-align: left">
+            <td style="padding: 15px 0">Application number</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">Application status</td>
+            <td style="padding: 15px 0; text-align: right">
+              <span style="background: #fef4d4; padding: 7px 14px"
+                >Additional information required</span
+              >
+            </td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">Application submission date</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.created_at }}</td>
+          </tr>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tbody>
+          <tr>
+            <td
+               align="center" bgcolor="#0072c6" role="presentation" style="border:none;border-radius:0;cursor:auto;mso-padding-alt:16px 32px;background:#0072c6;" valign="middle"
+            >
+              <a
+                 href="https://helsinkilisa.hel.fi" style="display:inline-block;background:#0072c6;color:#FFFFFF;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:16px 32px;mso-padding-alt:0px;border-radius:0;" target="_blank"
+              >
+                Log in and complete your application
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:30px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:14px;font-weight:400;line-height:150%;text-align:left;color:#666666;"
+      >This is an automatic notification of an online message sent to you. Please do not reply to this message, as responses will not be processed. Please do not hesitate to contact the advisory service by e-mail at helsinkilisa@hel.fi.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><v:rect style="width:960px;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0.5, 0" position="0.5, 0" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" type="tile" size="190px" aspect="atmost" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><![endif]-->
+          
+      <div  style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;margin:0px auto;max-width:960px;">
+        <div  style="line-height:0;font-size:0;">
+        <table
+           align="center" background="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:31px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+    
+        <!--[if mso | IE]></v:textbox></v:rect></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#F2F2F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:40px;padding-top:60px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:20px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki benefit</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Information about the Helsinki benefit</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Customer service and contact details</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >© City of Helsinki {{current_year}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_fi.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_fi.html
@@ -1,0 +1,795 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}
+    <title>Hakemuksesi tarvitsee lisätietoja</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+  
+    <style type="text/css">
+    
+    
+    </style>
+    <style type="text/css">
+    @font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: 0;
+}
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#ffffff;">
+    
+    
+      <div
+         style="background-color:#ffffff;"
+      >
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#D8D8D8" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#D8D8D8;background-color:#D8D8D8;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#D8D8D8;background-color:#D8D8D8;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:10px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki-lisä: Hakemuksesi tarvitsee lisätietoja</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:30px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: top"
+        width="100%"
+        height="80"
+      >
+        <tbody>
+          <tr>
+            <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word">
+              <table
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                width="100%"
+                border="0"
+                height="80"
+                style="
+                  color: #222222;
+                  font-family: HelsinkiGrotesk, system-ui, Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  table-layout: auto;
+                  width: 100%;
+                  border: 0;
+                "
+              >
+                <tbody>
+                  <tr height="66">
+                    <td width="146" height="66" style="width: 146px; height: 60px">
+                      <img
+                        src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png"
+                        style="width: 130px; height: 60px; margin: 0; padding: 0"
+                        width="130"
+                        height="60"
+                      />
+                    </td>
+                    <td
+                      height="66"
+                      style="font-size: 26px; font-weight: 600; line-height: 1; padding-bottom: 8px; height: 66px"
+                    >
+                      Helsinki-lisä
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki-lisä -hakemus tarvitsee lisätietoja</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:10px;padding-bottom:20px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Hei!</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Lähettämästäsi Helsinki-lisä-hakemuksesta puuttuu tarvittavia tietoja. Kirjaudu Helsinki-lisän asiointipalveluun ja täytä puttuvat tiedot {{ additional_information_deadline_date }} klo {{ additional_information_deadline_time }} mennessä.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Mikäli sinulla herää kysyttävää, lähetä meille viesti Helsinki-lisän asiointipalvelun kautta.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Ystävällisin terveisin,</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Helsinki-lisän tiimi</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:18px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Hakemuksen tiedot</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#222222;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;line-height:22px;table-layout:auto;width:100%;border:none;"
+      >
+        <tr style="border-top: 1px solid #ecedee; border-bottom: 1px solid #ecedee; text-align: left">
+            <td style="padding: 15px 0">Hakemusnumero</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">Hakemuksen tila</td>
+            <td style="padding: 15px 0; text-align: right">
+              <span style="background: #fef4d4; padding: 7px 14px"
+                >Odottaa lisätietoja</span
+              >
+            </td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">Hakemuksen lähetyspäivä</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.created_at }}</td>
+          </tr>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tbody>
+          <tr>
+            <td
+               align="center" bgcolor="#0072c6" role="presentation" style="border:none;border-radius:0;cursor:auto;mso-padding-alt:16px 32px;background:#0072c6;" valign="middle"
+            >
+              <a
+                 href="https://helsinkilisa.hel.fi" style="display:inline-block;background:#0072c6;color:#FFFFFF;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:16px 32px;mso-padding-alt:0px;border-radius:0;" target="_blank"
+              >
+                Kirjaudu palveluun ja täydennä hakemusta
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:30px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:14px;font-weight:400;line-height:150%;text-align:left;color:#666666;"
+      >Tämä on automaattinen ilmoitus sinulle lähetetystä verkkoviestistä. Ethän vastaa tähän sähköpostiin, sillä vastauksia ei käsitellä. Ota tarvittaessa yhteyttä neuvontaan sähköpostitse helsinkilisa@hel.fi.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><v:rect style="width:960px;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0.5, 0" position="0.5, 0" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" type="tile" size="190px" aspect="atmost" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><![endif]-->
+          
+      <div  style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;margin:0px auto;max-width:960px;">
+        <div  style="line-height:0;font-size:0;">
+        <table
+           align="center" background="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:31px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+    
+        <!--[if mso | IE]></v:textbox></v:rect></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#F2F2F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:40px;padding-top:60px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:20px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki-lisä</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Tietoa Helsinki-lisästä</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Asiakaspalvelu ja yhteystiedot</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >© Helsingin kaupunki {{current_year}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_sv.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_sv.html
@@ -1,0 +1,795 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}
+    <title>Din ansökan behöver ytterligare information</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+  
+    <style type="text/css">
+    
+    
+    </style>
+    <style type="text/css">
+    @font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: 0;
+}
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#ffffff;">
+    
+    
+      <div
+         style="background-color:#ffffff;"
+      >
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#D8D8D8" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#D8D8D8;background-color:#D8D8D8;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#D8D8D8;background-color:#D8D8D8;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:10px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Helsingforstillägg: Din ansökan behöver ytterligare information</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:30px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: top"
+        width="100%"
+        height="80"
+      >
+        <tbody>
+          <tr>
+            <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word">
+              <table
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                width="100%"
+                border="0"
+                height="80"
+                style="
+                  color: #222222;
+                  font-family: HelsinkiGrotesk, system-ui, Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  table-layout: auto;
+                  width: 100%;
+                  border: 0;
+                "
+              >
+                <tbody>
+                  <tr height="66">
+                    <td width="146" height="66" style="width: 146px; height: 60px">
+                      <img
+                        src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png"
+                        style="width: 130px; height: 60px; margin: 0; padding: 0"
+                        width="130"
+                        height="60"
+                      />
+                    </td>
+                    <td
+                      height="66"
+                      style="font-size: 26px; font-weight: 600; line-height: 1; padding-bottom: 8px; height: 66px"
+                    >
+                      Helsinki-lisä
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Ansökan om Helsingforstillägget behöver ytterligare information</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:10px;padding-bottom:20px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Hej!</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Den ansökan om Helsingforstillägget du skickade saknar nödvändiga uppgifter. Logg in på e-tjänst för sysselsättning Helsingforstillägg och fyll in de saknande uppgifterna senast {{ additional_information_deadline_date }} kl. {{ additional_information_deadline_time }}.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Om du har frågor, skicka oss ett meddelande genom e-tjänst för sysselsättning Helsingforstillägg.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Med vänliga hälsningar</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >teamet för Helsingforstillägget</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:18px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Uppgifter om ansökningen</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#222222;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;line-height:22px;table-layout:auto;width:100%;border:none;"
+      >
+        <tr style="border-top: 1px solid #ecedee; border-bottom: 1px solid #ecedee; text-align: left">
+            <td style="padding: 15px 0">Ansökningsnummer</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">Ansökningsstatus</td>
+            <td style="padding: 15px 0; text-align: right">
+              <span style="background: #fef4d4; padding: 7px 14px"
+                >Väntar på mer information</span
+              >
+            </td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">Datum då ansökningen skickades</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.created_at }}</td>
+          </tr>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tbody>
+          <tr>
+            <td
+               align="center" bgcolor="#0072c6" role="presentation" style="border:none;border-radius:0;cursor:auto;mso-padding-alt:16px 32px;background:#0072c6;" valign="middle"
+            >
+              <a
+                 href="https://helsinkilisa.hel.fi" style="display:inline-block;background:#0072c6;color:#FFFFFF;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:16px 32px;mso-padding-alt:0px;border-radius:0;" target="_blank"
+              >
+                Logg in på tjänsten och komplettera ansökningen
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:30px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:14px;font-weight:400;line-height:150%;text-align:left;color:#666666;"
+      >Detta är ett automatiskt meddelande om ett nätmeddelande som skickades till dig. Svara inte på detta meddelande. Svaren behandlas inte. Vid behov ta kontakt till rådgivningen per e-post helsinkilisa@hel.fi.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><v:rect style="width:960px;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0.5, 0" position="0.5, 0" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" type="tile" size="190px" aspect="atmost" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><![endif]-->
+          
+      <div  style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;margin:0px auto;max-width:960px;">
+        <div  style="line-height:0;font-size:0;">
+        <table
+           align="center" background="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:31px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+    
+        <!--[if mso | IE]></v:textbox></v:rect></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#F2F2F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:40px;padding-top:60px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:20px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsingforstillägg</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Information om Helsingforstillägget</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Kundtjänst och kontaktuppgifter</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >© Helsingfors stad {{current_year}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_en.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_en.html
@@ -1,0 +1,813 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}
+    <title>Your draft application will expire</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+  
+    <style type="text/css">
+    
+    
+    </style>
+    <style type="text/css">
+    @font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: 0;
+}
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#ffffff;">
+    
+    
+      <div
+         style="background-color:#ffffff;"
+      >
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#D8D8D8" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#D8D8D8;background-color:#D8D8D8;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#D8D8D8;background-color:#D8D8D8;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:10px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki benefit: Your draft application will expire</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:30px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: top"
+        width="100%"
+        height="80"
+      >
+        <tbody>
+          <tr>
+            <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word">
+              <table
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                width="100%"
+                border="0"
+                height="80"
+                style="
+                  color: #222222;
+                  font-family: HelsinkiGrotesk, system-ui, Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  table-layout: auto;
+                  width: 100%;
+                  border: 0;
+                "
+              >
+                <tbody>
+                  <tr height="66">
+                    <td width="146" height="66" style="width: 146px; height: 60px">
+                      <img
+                        src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png"
+                        style="width: 130px; height: 60px; margin: 0; padding: 0"
+                        width="130"
+                        height="60"
+                      />
+                    </td>
+                    <td
+                      height="66"
+                      style="font-size: 26px; font-weight: 600; line-height: 1; padding-bottom: 8px; height: 66px"
+                    >
+                      Helsinki-lisä
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Your draft application will expire on {{ application_deletion_date }}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:10px;padding-bottom:20px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Hello!</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Your Helsinki benefit draft application {{application.application_number}} will expire in two weeks on {{ application_deletion_date }}. You can update the information in your Helsinki benefit application or delete your application by logging in to the Helsinki benefit e-service and opening your application.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tbody>
+          <tr>
+            <td
+               align="center" bgcolor="#0072c6" role="presentation" style="border:none;border-radius:0;cursor:auto;mso-padding-alt:16px 32px;background:#0072c6;" valign="middle"
+            >
+              <a
+                 href="https://helsinkilisa.hel.fi" style="display:inline-block;background:#0072c6;color:#FFFFFF;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:16px 32px;mso-padding-alt:0px;border-radius:0;" target="_blank"
+              >
+                Continue filling in the Helsinki benefit application
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Visit the City of Helsinki’s website for instructions and more information on completing the application form.</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Read more about applying for the Helsinki benefit</a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Best regards,</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >The Helsinki benefit team</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:18px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Application details</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#222222;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;line-height:22px;table-layout:auto;width:100%;border:none;"
+      >
+        <tr style="border-top: 1px solid #ecedee; border-bottom: 1px solid #ecedee; text-align: left">
+            <td style="padding: 15px 0">Application number</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">Application status</td>
+            <td style="padding: 15px 0; text-align: right">
+              <span style="background: #fef4d4; padding: 7px 14px">Unfinished</span>
+            </td>
+          </tr>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:30px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:14px;font-weight:400;line-height:150%;text-align:left;color:#666666;"
+      >This is an automatic notification of an online message sent to you. Please do not reply to this message, as responses will not be processed. Please do not hesitate to contact the advisory service by e-mail at helsinkilisa@hel.fi.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><v:rect style="width:960px;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0.5, 0" position="0.5, 0" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" type="tile" size="190px" aspect="atmost" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><![endif]-->
+          
+      <div  style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;margin:0px auto;max-width:960px;">
+        <div  style="line-height:0;font-size:0;">
+        <table
+           align="center" background="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:31px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+    
+        <!--[if mso | IE]></v:textbox></v:rect></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#F2F2F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:40px;padding-top:60px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:20px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki benefit</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Information about the Helsinki benefit</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Customer service and contact details</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >© City of Helsinki {{current_year}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_fi.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_fi.html
@@ -1,0 +1,813 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}
+    <title>Helsinki-lisä -hakemuksesi luonnos vanhenee</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+  
+    <style type="text/css">
+    
+    
+    </style>
+    <style type="text/css">
+    @font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: 0;
+}
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#ffffff;">
+    
+    
+      <div
+         style="background-color:#ffffff;"
+      >
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#D8D8D8" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#D8D8D8;background-color:#D8D8D8;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#D8D8D8;background-color:#D8D8D8;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:10px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki-lisä: Helsinki-lisä -hakemuksesi luonnos vanhenee</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:30px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: top"
+        width="100%"
+        height="80"
+      >
+        <tbody>
+          <tr>
+            <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word">
+              <table
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                width="100%"
+                border="0"
+                height="80"
+                style="
+                  color: #222222;
+                  font-family: HelsinkiGrotesk, system-ui, Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  table-layout: auto;
+                  width: 100%;
+                  border: 0;
+                "
+              >
+                <tbody>
+                  <tr height="66">
+                    <td width="146" height="66" style="width: 146px; height: 60px">
+                      <img
+                        src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png"
+                        style="width: 130px; height: 60px; margin: 0; padding: 0"
+                        width="130"
+                        height="60"
+                      />
+                    </td>
+                    <td
+                      height="66"
+                      style="font-size: 26px; font-weight: 600; line-height: 1; padding-bottom: 8px; height: 66px"
+                    >
+                      Helsinki-lisä
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki-lisä -hakemuksesi luonnos vanhenee {{ application_deletion_date }}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:10px;padding-bottom:20px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Hei!</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki-lisä -hakemuksesi {{application.application_number}} luonnos vanhentuu kahden viikon kuluttua {{ application_deletion_date }}. Voit päivittää Helsinki-lisä-hakemuksesi tietoja tai poistaa hakemuksen kirjautumalla Helsinki-lisä palveluun ja avaamalla hakemuksesi.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tbody>
+          <tr>
+            <td
+               align="center" bgcolor="#0072c6" role="presentation" style="border:none;border-radius:0;cursor:auto;mso-padding-alt:16px 32px;background:#0072c6;" valign="middle"
+            >
+              <a
+                 href="https://helsinkilisa.hel.fi" style="display:inline-block;background:#0072c6;color:#FFFFFF;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:16px 32px;mso-padding-alt:0px;border-radius:0;" target="_blank"
+              >
+                Jatka Helsinki-lisä -hakemuksen täyttöä
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Ohjeet ja lisätietoa hakulomakkeen täyttämiseen löydät Helsingin kaupungin sivuilta.</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Lue lisãä Helsinki-lisän hakemisesta</a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Ystävällisin terveisin,</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Helsinki-lisän tiimi</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:18px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Hakemuksen tiedot</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#222222;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;line-height:22px;table-layout:auto;width:100%;border:none;"
+      >
+        <tr style="border-top: 1px solid #ecedee; border-bottom: 1px solid #ecedee; text-align: left">
+            <td style="padding: 15px 0">Hakemusnumero</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">Hakemuksen tila</td>
+            <td style="padding: 15px 0; text-align: right">
+              <span style="background: #fef4d4; padding: 7px 14px">Keskeneräinen</span>
+            </td>
+          </tr>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:30px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:14px;font-weight:400;line-height:150%;text-align:left;color:#666666;"
+      >Tämä on automaattinen ilmoitus sinulle lähetetystä verkkoviestistä. Ethän vastaa tähän sähköpostiin, sillä vastauksia ei käsitellä. Ota tarvittaessa yhteyttä neuvontaan sähköpostitse helsinkilisa@hel.fi.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><v:rect style="width:960px;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0.5, 0" position="0.5, 0" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" type="tile" size="190px" aspect="atmost" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><![endif]-->
+          
+      <div  style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;margin:0px auto;max-width:960px;">
+        <div  style="line-height:0;font-size:0;">
+        <table
+           align="center" background="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:31px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+    
+        <!--[if mso | IE]></v:textbox></v:rect></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#F2F2F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:40px;padding-top:60px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:20px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki-lisä</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Tietoa Helsinki-lisästä</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Asiakaspalvelu ja yhteystiedot</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >© Helsingin kaupunki {{current_year}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_sv.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_sv.html
@@ -1,0 +1,813 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}
+    <title>Ditt utkast för ansökan går ut</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+  
+    <style type="text/css">
+    
+    
+    </style>
+    <style type="text/css">
+    @font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: 0;
+}
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#ffffff;">
+    
+    
+      <div
+         style="background-color:#ffffff;"
+      >
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#D8D8D8" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#D8D8D8;background-color:#D8D8D8;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#D8D8D8;background-color:#D8D8D8;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:10px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Helsingforstillägg: Ditt utkast för ansökan går ut</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:30px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: top"
+        width="100%"
+        height="80"
+      >
+        <tbody>
+          <tr>
+            <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word">
+              <table
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                width="100%"
+                border="0"
+                height="80"
+                style="
+                  color: #222222;
+                  font-family: HelsinkiGrotesk, system-ui, Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  table-layout: auto;
+                  width: 100%;
+                  border: 0;
+                "
+              >
+                <tbody>
+                  <tr height="66">
+                    <td width="146" height="66" style="width: 146px; height: 60px">
+                      <img
+                        src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png"
+                        style="width: 130px; height: 60px; margin: 0; padding: 0"
+                        width="130"
+                        height="60"
+                      />
+                    </td>
+                    <td
+                      height="66"
+                      style="font-size: 26px; font-weight: 600; line-height: 1; padding-bottom: 8px; height: 66px"
+                    >
+                      Helsinki-lisä
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Ditt utkast för ansökan on Helsingforstillägget går ut {{application_deletion_date}}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:10px;padding-bottom:20px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Hej!</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Ditt utkast för ansökan om Helsingforstillägget {{application.application_number}} går ut om två veckor {{ application_deletion_date }}. Du kan uppdatera uppgifterna för din ansökan om Helsingforstillägget eller avlägsna ansökan genom att logga in på tjänsten för Helsingforstillägget och öppna din ansökan.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tbody>
+          <tr>
+            <td
+               align="center" bgcolor="#0072c6" role="presentation" style="border:none;border-radius:0;cursor:auto;mso-padding-alt:16px 32px;background:#0072c6;" valign="middle"
+            >
+              <a
+                 href="https://helsinkilisa.hel.fi" style="display:inline-block;background:#0072c6;color:#FFFFFF;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:16px 32px;mso-padding-alt:0px;border-radius:0;" target="_blank"
+              >
+                Fortsätt fylla in ansökan om Helsingforstillägget
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Anvisningar och ytterligare information om hur du ska fylla in ansökan hittar du på Helsingfors stads webbplats.</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Läs mer om att ansöka om Helsingforstillägget</a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Med vänliga hälsningar</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >teamet för Helsingforstillägget</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:18px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Uppgifter om ansökningen</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#222222;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;line-height:22px;table-layout:auto;width:100%;border:none;"
+      >
+        <tr style="border-top: 1px solid #ecedee; border-bottom: 1px solid #ecedee; text-align: left">
+            <td style="padding: 15px 0">Ansökningsnummer</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">Ansökningsstatus</td>
+            <td style="padding: 15px 0; text-align: right">
+              <span style="background: #fef4d4; padding: 7px 14px">Oavslutat</span>
+            </td>
+          </tr>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:30px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:14px;font-weight:400;line-height:150%;text-align:left;color:#666666;"
+      >Detta är ett automatiskt meddelande om ett nätmeddelande som skickades till dig. Svara inte på detta meddelande. Svaren behandlas inte. Vid behov ta kontakt till rådgivningen per e-post helsinkilisa@hel.fi.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><v:rect style="width:960px;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0.5, 0" position="0.5, 0" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" type="tile" size="190px" aspect="atmost" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><![endif]-->
+          
+      <div  style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;margin:0px auto;max-width:960px;">
+        <div  style="line-height:0;font-size:0;">
+        <table
+           align="center" background="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:31px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+    
+        <!--[if mso | IE]></v:textbox></v:rect></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#F2F2F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:40px;padding-top:60px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:20px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsingforstillägg</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Information om Helsingforstillägget</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Kundtjänst och kontaktuppgifter</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >© Helsingfors stad {{current_year}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_en.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_en.html
@@ -1,0 +1,751 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}
+    <title>You have received a new message</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+  
+    <style type="text/css">
+    
+    
+    </style>
+    <style type="text/css">
+    @font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: 0;
+}
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#ffffff;">
+    
+    
+      <div
+         style="background-color:#ffffff;"
+      >
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#D8D8D8" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#D8D8D8;background-color:#D8D8D8;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#D8D8D8;background-color:#D8D8D8;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:10px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki benefit: You have received a new message</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:30px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: top"
+        width="100%"
+        height="80"
+      >
+        <tbody>
+          <tr>
+            <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word">
+              <table
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                width="100%"
+                border="0"
+                height="80"
+                style="
+                  color: #222222;
+                  font-family: HelsinkiGrotesk, system-ui, Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  table-layout: auto;
+                  width: 100%;
+                  border: 0;
+                "
+              >
+                <tbody>
+                  <tr height="66">
+                    <td width="146" height="66" style="width: 146px; height: 60px">
+                      <img
+                        src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png"
+                        style="width: 130px; height: 60px; margin: 0; padding: 0"
+                        width="130"
+                        height="60"
+                      />
+                    </td>
+                    <td
+                      height="66"
+                      style="font-size: 26px; font-weight: 600; line-height: 1; padding-bottom: 8px; height: 66px"
+                    >
+                      Helsinki-lisä
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >You have received a new message regarding your Helsinki benefit application</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:10px;padding-bottom:20px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Hello!</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >You have received a new message regarding your Helsinki benefit application. You can read the message in the Helsinki benefit service.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Best regards,</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >The Helsinki benefit team</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:18px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Application details</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#222222;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;line-height:22px;table-layout:auto;width:100%;border:none;"
+      >
+        <tr
+            style="
+              border-top: 1px solid #ecedee;
+              border-bottom: 1px solid #ecedee;
+              text-align: left;
+              mso-border-top-alt: solid #ecedee 1pt;
+              mso-border-bottom-alt: solid #ecedee 1pt;
+            "
+          >
+            <td style="padding: 15px 0">Application number</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr
+            style="
+              border-bottom: 1px solid #ecedee;
+              mso-border-top-alt: solid #ecedee 1pt;
+              mso-border-bottom-alt: solid #ecedee 1pt;
+            "
+          >
+            <td style="padding: 15px 0">Application submission date</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.created_at }}</td>
+          </tr>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tbody>
+          <tr>
+            <td
+               align="center" bgcolor="#0072c6" role="presentation" style="border:none;border-radius:0;cursor:auto;mso-padding-alt:16px 32px;background:#0072c6;" valign="middle"
+            >
+              <a
+                 href="https://helsinkilisa.hel.fi" style="display:inline-block;background:#0072c6;color:#FFFFFF;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:16px 32px;mso-padding-alt:0px;border-radius:0;" target="_blank"
+              >
+                Log in to the service and read the message
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:30px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:14px;font-weight:400;line-height:150%;text-align:left;color:#666666;"
+      >This is an automatic notification of an online message sent to you. Please do not reply to this message, as responses will not be processed. Please do not hesitate to contact the advisory service by e-mail at helsinkilisa@hel.fi.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><v:rect style="width:960px;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0.5, 0" position="0.5, 0" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" type="tile" size="190px" aspect="atmost" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><![endif]-->
+          
+      <div  style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;margin:0px auto;max-width:960px;">
+        <div  style="line-height:0;font-size:0;">
+        <table
+           align="center" background="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:31px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+    
+        <!--[if mso | IE]></v:textbox></v:rect></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#F2F2F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:40px;padding-top:60px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:20px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki benefit</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Information about the Helsinki benefit</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Customer service and contact details</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >© City of Helsinki {{current_year}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_fi.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_fi.html
@@ -1,0 +1,751 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}
+    <title>Olet saanut uuden viestin</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+  
+    <style type="text/css">
+    
+    
+    </style>
+    <style type="text/css">
+    @font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: 0;
+}
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#ffffff;">
+    
+    
+      <div
+         style="background-color:#ffffff;"
+      >
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#D8D8D8" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#D8D8D8;background-color:#D8D8D8;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#D8D8D8;background-color:#D8D8D8;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:10px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki-lisä: Olet saanut uuden viestin</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:30px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: top"
+        width="100%"
+        height="80"
+      >
+        <tbody>
+          <tr>
+            <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word">
+              <table
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                width="100%"
+                border="0"
+                height="80"
+                style="
+                  color: #222222;
+                  font-family: HelsinkiGrotesk, system-ui, Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  table-layout: auto;
+                  width: 100%;
+                  border: 0;
+                "
+              >
+                <tbody>
+                  <tr height="66">
+                    <td width="146" height="66" style="width: 146px; height: 60px">
+                      <img
+                        src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png"
+                        style="width: 130px; height: 60px; margin: 0; padding: 0"
+                        width="130"
+                        height="60"
+                      />
+                    </td>
+                    <td
+                      height="66"
+                      style="font-size: 26px; font-weight: 600; line-height: 1; padding-bottom: 8px; height: 66px"
+                    >
+                      Helsinki-lisä
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:10px;padding-bottom:20px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Hei!</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen. Voit lukea viestin Helsinki-lisän asiointipalvelussa.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Ystävällisin terveisin,</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Helsinki-lisän tiimi</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:18px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Hakemuksen tiedot</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#222222;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;line-height:22px;table-layout:auto;width:100%;border:none;"
+      >
+        <tr
+            style="
+              border-top: 1px solid #ecedee;
+              border-bottom: 1px solid #ecedee;
+              text-align: left;
+              mso-border-top-alt: solid #ecedee 1pt;
+              mso-border-bottom-alt: solid #ecedee 1pt;
+            "
+          >
+            <td style="padding: 15px 0">Hakemusnumero</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr
+            style="
+              border-bottom: 1px solid #ecedee;
+              mso-border-top-alt: solid #ecedee 1pt;
+              mso-border-bottom-alt: solid #ecedee 1pt;
+            "
+          >
+            <td style="padding: 15px 0">Hakemuksen lähetyspäivä</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.created_at }}</td>
+          </tr>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tbody>
+          <tr>
+            <td
+               align="center" bgcolor="#0072c6" role="presentation" style="border:none;border-radius:0;cursor:auto;mso-padding-alt:16px 32px;background:#0072c6;" valign="middle"
+            >
+              <a
+                 href="https://helsinkilisa.hel.fi" style="display:inline-block;background:#0072c6;color:#FFFFFF;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:16px 32px;mso-padding-alt:0px;border-radius:0;" target="_blank"
+              >
+                Kirjaudu palveluun ja lue viesti
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:30px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:14px;font-weight:400;line-height:150%;text-align:left;color:#666666;"
+      >Tämä on automaattinen ilmoitus sinulle lähetetystä verkkoviestistä. Ethän vastaa tähän sähköpostiin, sillä vastauksia ei käsitellä. Ota tarvittaessa yhteyttä neuvontaan sähköpostitse helsinkilisa@hel.fi.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><v:rect style="width:960px;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0.5, 0" position="0.5, 0" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" type="tile" size="190px" aspect="atmost" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><![endif]-->
+          
+      <div  style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;margin:0px auto;max-width:960px;">
+        <div  style="line-height:0;font-size:0;">
+        <table
+           align="center" background="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:31px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+    
+        <!--[if mso | IE]></v:textbox></v:rect></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#F2F2F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:40px;padding-top:60px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:20px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsinki-lisä</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Tietoa Helsinki-lisästä</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Asiakaspalvelu ja yhteystiedot</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >© Helsingin kaupunki {{current_year}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_sv.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_sv.html
@@ -1,0 +1,751 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}
+    <title>Du har fått ett nytt meddelande</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+  
+    <style type="text/css">
+    
+    
+    </style>
+    <style type="text/css">
+    @font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: 0;
+}
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#ffffff;">
+    
+    
+      <div
+         style="background-color:#ffffff;"
+      >
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#D8D8D8" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#D8D8D8;background-color:#D8D8D8;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#D8D8D8;background-color:#D8D8D8;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:10px;padding-top:10px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Helsingforstillägg: Du har fått ett nytt meddelande</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:30px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: top"
+        width="100%"
+        height="80"
+      >
+        <tbody>
+          <tr>
+            <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word">
+              <table
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                width="100%"
+                border="0"
+                height="80"
+                style="
+                  color: #222222;
+                  font-family: HelsinkiGrotesk, system-ui, Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  table-layout: auto;
+                  width: 100%;
+                  border: 0;
+                "
+              >
+                <tbody>
+                  <tr height="66">
+                    <td width="146" height="66" style="width: 146px; height: 60px">
+                      <img
+                        src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png"
+                        style="width: 130px; height: 60px; margin: 0; padding: 0"
+                        width="130"
+                        height="60"
+                      />
+                    </td>
+                    <td
+                      height="66"
+                      style="font-size: 26px; font-weight: 600; line-height: 1; padding-bottom: 8px; height: 66px"
+                    >
+                      Helsinki-lisä
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 4px #0072c6;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:10px;padding-bottom:20px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Hej!</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget. Du kan läsa meddelandet i e-tjänst för sysselsättning Helsingforstillägg.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >Med vänliga hälsningar</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:100%;text-align:left;color:#222222;"
+      >teamet för Helsingforstillägget</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:18px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Uppgifter om ansökningen</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#222222;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:15px;line-height:22px;table-layout:auto;width:100%;border:none;"
+      >
+        <tr
+            style="
+              border-top: 1px solid #ecedee;
+              border-bottom: 1px solid #ecedee;
+              text-align: left;
+              mso-border-top-alt: solid #ecedee 1pt;
+              mso-border-bottom-alt: solid #ecedee 1pt;
+            "
+          >
+            <td style="padding: 15px 0">Ansökningsnummer</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr
+            style="
+              border-bottom: 1px solid #ecedee;
+              mso-border-top-alt: solid #ecedee 1pt;
+              mso-border-bottom-alt: solid #ecedee 1pt;
+            "
+          >
+            <td style="padding: 15px 0">Datum då ansökningen skickades</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.created_at }}</td>
+          </tr>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tbody>
+          <tr>
+            <td
+               align="center" bgcolor="#0072c6" role="presentation" style="border:none;border-radius:0;cursor:auto;mso-padding-alt:16px 32px;background:#0072c6;" valign="middle"
+            >
+              <a
+                 href="https://helsinkilisa.hel.fi" style="display:inline-block;background:#0072c6;color:#FFFFFF;font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:16px 32px;mso-padding-alt:0px;border-radius:0;" target="_blank"
+              >
+                Logg in i tjänsten och läs meddelandet
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:30px;padding-top:0px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:20px;line-height:20px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:14px;font-weight:400;line-height:150%;text-align:left;color:#666666;"
+      >Detta är ett automatiskt meddelande om ett nätmeddelande som skickades till dig. Svara inte på detta meddelande. Svaren behandlas inte. Vid behov ta kontakt till rådgivningen per e-post helsinkilisa@hel.fi.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><v:rect style="width:960px;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0.5, 0" position="0.5, 0" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" type="tile" size="190px" aspect="atmost" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><![endif]-->
+          
+      <div  style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;margin:0px auto;max-width:960px;">
+        <div  style="line-height:0;font-size:0;">
+        <table
+           align="center" background="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg==') center top / 190px repeat;background-position:center top;background-repeat:repeat;background-size:190px;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:31px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+    
+        <!--[if mso | IE]></v:textbox></v:rect></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" bgcolor="#F2F2F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:960px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:40px;padding-top:60px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:20px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
+      >Helsingforstillägg</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Information om Helsingforstillägget</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      ><a href="#">Kundtjänst och kontaktuppgifter</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   style="font-size:0px;word-break:break-word;"
+                >
+                  
+      <div
+         style="height:8px;line-height:8px;"
+      >&#8202;</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <p
+         style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:100%;"
+      >
+      </p>
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #000000;font-size:1px;margin:0px auto;width:910px;" role="presentation" width="910px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;padding-bottom:4px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
+      >© Helsingfors stad {{current_year}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/additional-information-required_en.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/additional-information-required_en.txt
@@ -1,0 +1,12 @@
+{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hello!
+
+The Helsinki benefit application you submitted is missing required information. Log in to the Helsinki benefit service and fill in the missing information by {{ additional_information_deadline_time }} on {{ additional_information_deadline_date }}.
+If you have any questions, please send us a message via the Helsinki benefit e-service.
+
+Application details
+Application number: {{application.application_number}}
+Application status: Additional information required
+Application submission date: {{ application.created_at }}
+
+Best regards,
+The Helsinki benefit team

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/additional-information-required_fi.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/additional-information-required_fi.txt
@@ -1,0 +1,12 @@
+{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hei!
+
+Lähettämästäsi Helsinki-lisä-hakemuksesta puuttuu tarvittavia tietoja. Kirjaudu Helsinki-lisän asiointipalveluun ja täytä puttuvat tiedot {{ additional_information_deadline_date }} klo {{ additional_information_deadline_time }} mennessä.
+Mikäli sinulla herää kysyttävää, lähetä meille viesti Helsinki-lisän asiointipalvelun kautta.
+
+Hakemuksen tiedot
+Hakemusnumero: {{application.application_number}}
+Hakemuksen tila: Odottaa lisätietoja
+Hakemuksen lähetyspäivä: {{ application.created_at }}
+
+Ystävällisin terveisin,
+Helsinki-lisän tiimi

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/additional-information-required_sv.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/additional-information-required_sv.txt
@@ -1,0 +1,12 @@
+{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hej!
+
+Den ansökan om Helsingforstillägget du skickade saknar nödvändiga uppgifter. Logg in på e-tjänst för sysselsättning Helsingforstillägg och fyll in de saknande uppgifterna senast {{ additional_information_deadline_date }} kl. {{ additional_information_deadline_time }}.
+Om du har frågor, skicka oss ett meddelande genom e-tjänst för sysselsättning Helsingforstillägg.
+
+Uppgifter om ansökningen
+Ansökningsnummer: {{application.application_number}}
+Ansökningsstatus: Väntar på mer information
+Datum då ansökningen skickades: {{ application.created_at }}
+
+Med vänliga hälsningar
+teamet för Helsingforstillägget

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/draft-notice_en.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/draft-notice_en.txt
@@ -1,0 +1,17 @@
+{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hello!
+
+Your Helsinki benefit draft application {{application.application_number}} will expire in two weeks on {{ application_deletion_date }}. You can update the information in your Helsinki benefit application or delete your application by logging in to the Helsinki benefit e-service and opening your application.
+
+Continue filling in the Helsinki benefit application: https://helsinkilisa.hel.fi/
+
+Visit the City of Helsinki’s website for instructions and more information on completing the application form.
+
+Read more about applying for the Helsinki benefit: # 
+
+Best regards,
+The Helsinki benefit team
+
+Application number: {{application.application_number}}
+Application status: Unfinished
+
+This is an automatic notification of an online message sent to you. Please do not reply to this message, as responses will not be processed. Please do not hesitate to contact the advisory service by e-mail at helsinkilisa@hel.fi.

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/draft-notice_fi.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/draft-notice_fi.txt
@@ -1,0 +1,17 @@
+{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hei!
+
+Helsinki-lisä -hakemuksesi {{application.application_number}} luonnos vanhentuu kahden viikon kuluttua {{ application_deletion_date }}. Voit päivittää Helsinki-lisä-hakemuksesi tietoja tai poistaa hakemuksen kirjautumalla Helsinki-lisä palveluun ja avaamalla hakemuksesi.
+
+Jatka Helsinki-lisä -hakemuksen täyttöä: https://helsinkilisa.hel.fi/
+
+Ohjeet ja lisätietoa hakulomakkeen täyttämiseen löydät Helsingin kaupungin sivuilta.
+
+Lue lisãä Helsinki-lisän hakemisesta: # 
+
+Ystävällisin terveisin,
+Helsinki-lisän tiimi
+
+Hakemusnumero: {{application.application_number}}
+Hakemuksen tila: Keskeneräinen
+
+Tämä on automaattinen ilmoitus sinulle lähetetystä verkkoviestistä. Ethän vastaa tähän sähköpostiin, sillä vastauksia ei käsitellä. Ota tarvittaessa yhteyttä neuvontaan sähköpostitse helsinkilisa@hel.fi.

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/draft-notice_sv.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/draft-notice_sv.txt
@@ -1,0 +1,17 @@
+{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hej!
+
+Ditt utkast för ansökan om Helsingforstillägget {{application.application_number}} går ut om två veckor {{ application_deletion_date }}. Du kan uppdatera uppgifterna för din ansökan om Helsingforstillägget eller avlägsna ansökan genom att logga in på tjänsten för Helsingforstillägget och öppna din ansökan.
+
+Fortsätt fylla in ansökan om Helsingforstillägget: https://helsinkilisa.hel.fi/
+
+Anvisningar och ytterligare information om hur du ska fylla in ansökan hittar du på Helsingfors stads webbplats.
+
+Läs mer om att ansöka om Helsingforstillägget: # 
+
+Med vänliga hälsningar
+teamet för Helsingforstillägget
+
+Ansökningsnummer: {{application.application_number}}
+Ansökningsstatus: Oavslutat
+
+Detta är ett automatiskt meddelande om ett nätmeddelande som skickades till dig. Svara inte på detta meddelande. Svaren behandlas inte. Vid behov ta kontakt till rådgivningen per e-post helsinkilisa@hel.fi.

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/received-message_en.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/received-message_en.txt
@@ -1,0 +1,14 @@
+{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hello!
+
+You have received a new message regarding your Helsinki benefit application. You can read the message in the Helsinki benefit service.
+
+Application details
+Application number: {{application.application_number}}
+Application submission date: {{ application.created_at }}
+
+Log in to the service and read the message: https://helsinkilisa.hel.fi
+
+Best regards,
+The Helsinki benefit team
+
+This is an automatic notification of an online message sent to you. Please do not reply to this message, as responses will not be processed. Please do not hesitate to contact the advisory service by e-mail at helsinkilisa@hel.fi.

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/received-message_fi.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/received-message_fi.txt
@@ -1,0 +1,14 @@
+{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hei!
+
+Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen. Voit lukea viestin Helsinki-lisän asiointipalvelussa.
+
+Hakemuksen tiedot
+Hakemusnumero: {{application.application_number}}
+Hakemuksen lähetyspäivä: {{ application.created_at }}
+
+Kirjaudu palveluun ja lue viesti: https://helsinkilisa.hel.fi
+
+Ystävällisin terveisin,
+Helsinki-lisän tiimi
+
+Tämä on automaattinen ilmoitus sinulle lähetetystä verkkoviestistä. Ethän vastaa tähän sähköpostiin, sillä vastauksia ei käsitellä. Ota tarvittaessa yhteyttä neuvontaan sähköpostitse helsinkilisa@hel.fi.

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/received-message_sv.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/received-message_sv.txt
@@ -1,0 +1,14 @@
+{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hej!
+
+Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget. Du kan läsa meddelandet i e-tjänst för sysselsättning Helsingforstillägg.
+
+Uppgifter om ansökningen
+Ansökningsnummer: {{application.application_number}}
+Datum då ansökningen skickades: {{ application.created_at }}
+
+Logg in i tjänsten och läs meddelandet: https://helsinkilisa.hel.fi
+
+Med vänliga hälsningar
+teamet för Helsingforstillägget
+
+Detta är ett automatiskt meddelande om ett nätmeddelande som skickades till dig. Svara inte på detta meddelande. Svaren behandlas inte. Vid behov ta kontakt till rådgivningen per e-post helsinkilisa@hel.fi.

--- a/backend/benefit/locale/en/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/en/LC_MESSAGES/django.po
@@ -650,7 +650,7 @@ msgid ""
 "processed."
 msgstr ""
 
-msgid "You have received a new message from Helsinki benefit"
+msgid "You have received a new message regarding your Helsinki benefit application"
 msgstr ""
 
 #, python-format
@@ -819,3 +819,6 @@ msgstr "The Helsinki Benefit card"
 
 msgid "employee_consent"
 msgstr "Employee's consent for processing personal data"
+
+msgid "Your Helsinki benefit application requires additional information"
+msgstr ""

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -660,8 +660,8 @@ msgstr ""
 "{additional_information_needed_by} mennessä, muuten hakemusta ei voida "
 "käsitellä."
 
-msgid "You have received a new message from Helsinki benefit"
-msgstr "Olet saanut uuden viestin Helsinki-lisä -hakemukseen"
+msgid "You have received a new message regarding your Helsinki benefit application"
+msgstr "Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen"
 
 #, python-format
 msgid ""
@@ -989,3 +989,9 @@ msgstr "Ei myönnetty"
 
 msgid "Printed at"
 msgstr "Tulostettu"
+
+msgid "Your Helsinki benefit draft application will expire"
+msgstr "Helsinki-lisä -hakemuksesi luonnos vanhenee"
+
+msgid "Your Helsinki benefit application requires additional information"
+msgstr "Helsinki-lisä -hakemus tarvitsee lisätietoja"

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -657,8 +657,8 @@ msgstr ""
 "Din ansökan har öppnats för redigering. Gör ändringarna senast "
 "{additional_information_needed_by}, annars kan ansökan inte behandlas."
 
-msgid "You have received a new message from Helsinki benefit"
-msgstr "Du har fått ett nytt meddelande om Helsingforstilläg"
+msgid "You have received a new message regarding your Helsinki benefit application"
+msgstr "Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget"
 
 #, python-format
 msgid ""
@@ -981,3 +981,9 @@ msgstr "Inget stöd"
 
 msgid "Printed at"
 msgstr "Tryckt"
+
+msgid "Your Helsinki benefit draft application will expire"
+msgstr "Ditt utkast för ansökan går ut"
+
+msgid "Your Helsinki benefit application requires additional information"
+msgstr "Ansökan om Helsingforstillägget behöver ytterligare information"

--- a/frontend/benefit/common/.gitignore
+++ b/frontend/benefit/common/.gitignore
@@ -1,0 +1,1 @@
+src/emails/build/*

--- a/frontend/benefit/common/package.json
+++ b/frontend/benefit/common/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@frontend/emails",
+  "version": "1.0.0",
+  "license": "MIT",
+  "scripts": {
+    "compile": "node src/emails/generate-emails.mjs",
+    "clean": "rm -Rf src/emails/build/**",
+    "export": "yarn clean && yarn compile && cp -R src/emails/build/ ../../../backend/benefit/helsinkibenefit/templates/emails/mjml-generated/"
+  },
+  "dependencies": {
+    "mjml": "^4.14.1"
+  }
+}

--- a/frontend/benefit/common/src/emails/generate-emails.mjs
+++ b/frontend/benefit/common/src/emails/generate-emails.mjs
@@ -1,0 +1,100 @@
+import mjml from 'mjml';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const templateFolder = path.join(__dirname, 'templates');
+const i18nFolder = path.join(__dirname, 'i18n');
+const translations = { '': {} }; // the empty string key is for untranslated texts
+
+const doNotModifyNag = `{% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}`;
+
+const flattenJSON = (obj = {}, res = {}, extraKey = '') => {
+  for (let key in obj) {
+    if (typeof obj[key] !== 'object') {
+      res[extraKey + key] = obj[key];
+    } else {
+      flattenJSON(obj[key], res, `${extraKey}${key}.`);
+    }
+  }
+  return res;
+};
+
+const translateContent = (content, i18n) => {
+  if (content && i18n)
+    for (let key in i18n) {
+      // escaped version of reg.exp literal with variable embedded: /\$\{\s*PROP\s*\}/g
+      content = content.replaceAll(new RegExp(`\\$\\{\\s*${key}\\s*\\}`, 'g'), i18n[key]);
+    }
+  return content;
+};
+const writeEmailFile = (templateName, fileContent, emailType, emailLang) => {
+  const fileName = templateName.replace('.template.mjml', emailLang ? `_${emailLang}.${emailType}` : `.${emailType}`);
+  const emailFile = path.join(__dirname, `/build/${emailType}/` + fileName);
+
+  fs.writeFileSync(emailFile, fileContent);
+  console.log(`Write: ${fileName}`);
+};
+
+const main = () => {
+  console.log('Loading i18n for MJML');
+  // ensure that the html folders exist
+  fs.mkdirSync(path.join(__dirname, '/build/'), { recursive: true });
+  fs.mkdirSync(path.join(__dirname, '/build/html/'), { recursive: true });
+  fs.mkdirSync(path.join(__dirname, '/build/txt/'), { recursive: true });
+
+  // first read the translations of static texts
+  fs.readdirSync(i18nFolder, { withFileTypes: true })
+    .filter((entity) => entity.isFile())
+    .map((file) => file.name)
+    .forEach((jsonFile) => {
+      const lang = jsonFile.replace('.json', '');
+      try {
+        const json = JSON.parse(fs.readFileSync(path.join(__dirname, 'i18n', jsonFile)));
+        // flatten the object structure: { "a": { "b": "c" } } becomes { "a.b": "c" } etc.
+        translations[lang] = flattenJSON(json);
+      } catch (e) {
+        console.log(`!! FAILED !! - Parse error in i18n file: ${jsonFile}`, e);
+      }
+    });
+
+  // then read, convert and translate the templates
+  fs.readdirSync(templateFolder, { withFileTypes: true })
+    .filter((entity) => entity.isFile())
+    .map((file) => file.name)
+    .forEach((templateFile) => {
+      if (templateFile.startsWith('.')) return; // skip hidden system files
+      // convert mjml to html
+      let fileContent = fs.readFileSync(path.join(__dirname, 'templates', templateFile));
+      let htmlContent = mjml(fileContent.toString(), {
+        filePath: path.join(__dirname, 'templates'),
+      }).html;
+
+      // translate also the text version if it exists
+      let textFile = path.join(__dirname, 'text-templates', templateFile.replace('.mjml', '.txt'));
+      let textContent = fs.existsSync(textFile) ? fs.readFileSync(textFile).toString() : '';
+
+      // repeat for each languge in addition to untranslated html
+      Object.keys(translations).forEach((lang) => {
+        if (lang) {
+          let translatedContent = translateContent(htmlContent, translations[lang]);
+          translatedContent = translatedContent.replace('<head>', `<head>${doNotModifyNag}`);
+          if (new RegExp(/\${(.*)}/).test(translatedContent))
+            console.log(`!! WARNING !! - ${templateFile} contains untranslated text: ${lang}`);
+          writeEmailFile(templateFile, translatedContent, 'html', lang);
+
+          if (textContent) {
+            translatedContent = translateContent(textContent, translations[lang]);
+            writeEmailFile(templateFile, doNotModifyNag + translatedContent, 'txt', lang);
+          }
+        } else {
+          // the untranslated raw html version (text not relevant, would be identical to the template)
+          // writeEmailFile(templateFile, htmlContent, 'html');
+        }
+      });
+    });
+};
+
+main();

--- a/frontend/benefit/common/src/emails/i18n/en.json
+++ b/frontend/benefit/common/src/emails/i18n/en.json
@@ -1,0 +1,60 @@
+{
+  "footer": {
+    "links": {
+      "aboutHelsinkiBenefit": {
+        "title": "Information about the Helsinki benefit",
+        "url": "#"
+      },
+      "customerService": {
+        "title": "Customer service and contact details",
+        "url": "#"
+      }
+    }
+  },
+  "general": {
+    "greeting": "Hello!",
+    "cityOfHelsinki": "City of Helsinki",
+    "serviceName": "Helsinki benefit",
+    "bestRegards1": "Best regards,",
+    "bestRegards2": "The Helsinki benefit team",
+    "automaticReplyDisclaimer": "This is an automatic notification of an online message sent to you. Please do not reply to this message, as responses will not be processed. Please do not hesitate to contact the advisory service by e-mail at helsinkilisa@hel.fi."
+  },
+  "receivedMessage": {
+    "headerText": "You have received a new message",
+    "heading": "You have received a new message regarding your Helsinki benefit application",
+    "bodyText": "You have received a new message regarding your Helsinki benefit application. You can read the message in the Helsinki benefit service.",
+    "ctaButton": "Log in to the service and read the message"
+  },
+  "draftExpiring": {
+    "headerText": "Your draft application will expire",
+    "heading": "Your draft application will expire on {{ application_deletion_date }}",
+    "bodyText": "Your Helsinki benefit draft application {{application.application_number}} will expire in two weeks on {{ application_deletion_date }}. You can update the information in your Helsinki benefit application or delete your application by logging in to the Helsinki benefit e-service and opening your application.",
+    "ctaButton": "Continue filling in the Helsinki benefit application",
+    "helper": {
+      "text": "Visit the City of Helsinki’s website for instructions and more information on completing the application form.",
+      "link": {
+        "title": "Read more about applying for the Helsinki benefit",
+        "url": "#"
+      }
+    }
+  },
+  "additionalInformationRequired": {
+    "headerText": "Your application requires additional information",
+    "heading": "Your Helsinki benefit application requires additional information",
+    "bodyText": "The Helsinki benefit application you submitted is missing required information. Log in to the Helsinki benefit service and fill in the missing information by {{ additional_information_deadline_time }} on {{ additional_information_deadline_date }}.",
+    "ctaButton": "Log in and complete your application",
+    "helper": {
+      "text": "If you have any questions, please send us a message via the Helsinki benefit e-service."
+    }
+  },
+  "application": {
+    "applicationDetails": "Application details",
+    "applicationNumber": "Application number",
+    "createdAt": "Application submission date",
+    "status": {
+      "title": "Application status",
+      "unfinished": "Unfinished",
+      "additionalInformationRequired": "Additional information required"
+    }
+  }
+}

--- a/frontend/benefit/common/src/emails/i18n/fi.json
+++ b/frontend/benefit/common/src/emails/i18n/fi.json
@@ -1,0 +1,60 @@
+{
+  "footer": {
+    "links": {
+      "aboutHelsinkiBenefit": {
+        "title": "Tietoa Helsinki-lisästä",
+        "url": "#"
+      },
+      "customerService": {
+        "title": "Asiakaspalvelu ja yhteystiedot",
+        "url": "#"
+      }
+    }
+  },
+  "general": {
+    "greeting": "Hei!",
+    "cityOfHelsinki": "Helsingin kaupunki",
+    "serviceName": "Helsinki-lisä",
+    "bestRegards1": "Ystävällisin terveisin,",
+    "bestRegards2": "Helsinki-lisän tiimi",
+    "automaticReplyDisclaimer": "Tämä on automaattinen ilmoitus sinulle lähetetystä verkkoviestistä. Ethän vastaa tähän sähköpostiin, sillä vastauksia ei käsitellä. Ota tarvittaessa yhteyttä neuvontaan sähköpostitse helsinkilisa@hel.fi."
+  },
+  "receivedMessage": {
+    "headerText": "Olet saanut uuden viestin",
+    "heading": "Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen",
+    "bodyText": "Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen. Voit lukea viestin Helsinki-lisän asiointipalvelussa.",
+    "ctaButton": "Kirjaudu palveluun ja lue viesti"
+  },
+  "draftExpiring": {
+    "headerText": "Helsinki-lisä -hakemuksesi luonnos vanhenee",
+    "heading": "Helsinki-lisä -hakemuksesi luonnos vanhenee {{ application_deletion_date }}",
+    "bodyText": "Helsinki-lisä -hakemuksesi {{application.application_number}} luonnos vanhentuu kahden viikon kuluttua {{ application_deletion_date }}. Voit päivittää Helsinki-lisä-hakemuksesi tietoja tai poistaa hakemuksen kirjautumalla Helsinki-lisä palveluun ja avaamalla hakemuksesi.",
+    "ctaButton": "Jatka Helsinki-lisä -hakemuksen täyttöä",
+    "helper": {
+      "text": "Ohjeet ja lisätietoa hakulomakkeen täyttämiseen löydät Helsingin kaupungin sivuilta.",
+      "link": {
+        "title": "Lue lisãä Helsinki-lisän hakemisesta",
+        "url": "#"
+      }
+    }
+  },
+  "additionalInformationRequired": {
+    "headerText": "Hakemuksesi tarvitsee lisätietoja",
+    "heading": "Helsinki-lisä -hakemus tarvitsee lisätietoja",
+    "bodyText": "Lähettämästäsi Helsinki-lisä-hakemuksesta puuttuu tarvittavia tietoja. Kirjaudu Helsinki-lisän asiointipalveluun ja täytä puttuvat tiedot {{ additional_information_deadline_date }} klo {{ additional_information_deadline_time }} mennessä.",
+    "ctaButton": "Kirjaudu palveluun ja täydennä hakemusta",
+    "helper": {
+      "text": "Mikäli sinulla herää kysyttävää, lähetä meille viesti Helsinki-lisän asiointipalvelun kautta."
+    }
+  },
+  "application": {
+    "applicationDetails": "Hakemuksen tiedot",
+    "applicationNumber": "Hakemusnumero",
+    "createdAt": "Hakemuksen lähetyspäivä",
+    "status": {
+      "title": "Hakemuksen tila",
+      "unfinished": "Keskeneräinen",
+      "additionalInformationRequired": "Odottaa lisätietoja"
+    }
+  }
+}

--- a/frontend/benefit/common/src/emails/i18n/sv.json
+++ b/frontend/benefit/common/src/emails/i18n/sv.json
@@ -1,0 +1,60 @@
+{
+  "footer": {
+    "links": {
+      "aboutHelsinkiBenefit": {
+        "title": "Information om Helsingforstillägget",
+        "url": "#"
+      },
+      "customerService": {
+        "title": "Kundtjänst och kontaktuppgifter",
+        "url": "#"
+      }
+    }
+  },
+  "general": {
+    "greeting": "Hej!",
+    "cityOfHelsinki": "Helsingfors stad",
+    "serviceName": "Helsingforstillägg",
+    "bestRegards1": "Med vänliga hälsningar",
+    "bestRegards2": "teamet för Helsingforstillägget",
+    "automaticReplyDisclaimer": "Detta är ett automatiskt meddelande om ett nätmeddelande som skickades till dig. Svara inte på detta meddelande. Svaren behandlas inte. Vid behov ta kontakt till rådgivningen per e-post helsinkilisa@hel.fi."
+  },
+  "receivedMessage": {
+    "headerText": "Du har fått ett nytt meddelande",
+    "heading": "Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget",
+    "bodyText": "Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget. Du kan läsa meddelandet i e-tjänst för sysselsättning Helsingforstillägg.",
+    "ctaButton": "Logg in i tjänsten och läs meddelandet"
+  },
+  "draftExpiring": {
+    "headerText": "Ditt utkast för ansökan går ut",
+    "heading": "Ditt utkast för ansökan on Helsingforstillägget går ut {{application_deletion_date}}",
+    "bodyText": "Ditt utkast för ansökan om Helsingforstillägget {{application.application_number}} går ut om två veckor {{ application_deletion_date }}. Du kan uppdatera uppgifterna för din ansökan om Helsingforstillägget eller avlägsna ansökan genom att logga in på tjänsten för Helsingforstillägget och öppna din ansökan.",
+    "ctaButton": "Fortsätt fylla in ansökan om Helsingforstillägget",
+    "helper": {
+      "text": "Anvisningar och ytterligare information om hur du ska fylla in ansökan hittar du på Helsingfors stads webbplats.",
+      "link": {
+        "title": "Läs mer om att ansöka om Helsingforstillägget",
+        "url": "#"
+      }
+    }
+  },
+  "additionalInformationRequired": {
+    "headerText": "Din ansökan behöver ytterligare information",
+    "heading": "Ansökan om Helsingforstillägget behöver ytterligare information",
+    "bodyText": "Den ansökan om Helsingforstillägget du skickade saknar nödvändiga uppgifter. Logg in på e-tjänst för sysselsättning Helsingforstillägg och fyll in de saknande uppgifterna senast {{ additional_information_deadline_date }} kl. {{ additional_information_deadline_time }}.",
+    "ctaButton": "Logg in på tjänsten och komplettera ansökningen",
+    "helper": {
+      "text": "Om du har frågor, skicka oss ett meddelande genom e-tjänst för sysselsättning Helsingforstillägg."
+    }
+  },
+  "application": {
+    "applicationDetails": "Uppgifter om ansökningen",
+    "applicationNumber": "Ansökningsnummer",
+    "createdAt": "Datum då ansökningen skickades",
+    "status": {
+      "title": "Ansökningsstatus",
+      "unfinished": "Oavslutat",
+      "additionalInformationRequired": "Väntar på mer information"
+    }
+  }
+}

--- a/frontend/benefit/common/src/emails/templates/additional-information-required.template.mjml
+++ b/frontend/benefit/common/src/emails/templates/additional-information-required.template.mjml
@@ -1,0 +1,74 @@
+<mjml>
+  <mj-head>
+    <mj-include path="partials/base.css" type="css" />
+    <mj-include path="partials/attributes.mjml" />
+    <mj-title>${additionalInformationRequired.headerText}</mj-title>
+  </mj-head>
+  <mj-body>
+    <mj-section background-color="#D8D8D8" padding-bottom="10px" padding-top="10px">
+      <mj-column>
+        <mj-text font-size="15px">${general.serviceName}: ${additionalInformationRequired.headerText}</mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-include path="partials/header-service.mjml" />
+
+    <mj-section background-color="#fff" padding-bottom="0px">
+      <mj-column>
+        <mj-text font-weight="600" font-size="34px">${additionalInformationRequired.heading}</mj-text>
+        <mj-divider border-color="#0072c6" />
+        <mj-text padding-bottom="20px" padding-top="10px">${general.greeting}</mj-text>
+        <mj-text>${additionalInformationRequired.bodyText}</mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-top="10px">
+      <mj-column>
+        <mj-text>${additionalInformationRequired.helper.text}</mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-bottom="0px">
+      <mj-column>
+        <mj-text line-height="100%">${general.bestRegards1}</mj-text>
+        <mj-text line-height="100%">${general.bestRegards2}</mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-bottom="0px">
+      <mj-column>
+        <mj-text font-weight="600" font-size="18px">${application.applicationDetails}</mj-text>
+        <mj-table font-size="15px">
+          <tr style="border-top: 1px solid #ecedee; border-bottom: 1px solid #ecedee; text-align: left">
+            <td style="padding: 15px 0">${application.applicationNumber}</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">${application.status.title}</td>
+            <td style="padding: 15px 0; text-align: right">
+              <span style="background: #fef4d4; padding: 7px 14px"
+                >${application.status.additionalInformationRequired}</span
+              >
+            </td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">${application.createdAt}</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.created_at }}</td>
+          </tr>
+        </mj-table>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-top="0px" padding-bottom="0px">
+      <mj-column>
+        <mj-button align="left" background-color="#0072c6" href="https://helsinkilisa.hel.fi"
+          >${additionalInformationRequired.ctaButton}</mj-button
+        >
+      </mj-column>
+    </mj-section>
+
+    <mj-include path="partials/automaticReplyDisclaimer.mjml" />
+
+    <mj-include path="partials/footer.mjml" />
+  </mj-body>
+</mjml>

--- a/frontend/benefit/common/src/emails/templates/draft-notice.template.mjml
+++ b/frontend/benefit/common/src/emails/templates/draft-notice.template.mjml
@@ -1,0 +1,72 @@
+<mjml>
+  <mj-head>
+    <mj-include path="partials/base.css" type="css" />
+    <mj-include path="partials/attributes.mjml" />
+    <mj-title>${draftExpiring.headerText}</mj-title>
+  </mj-head>
+  <mj-body>
+    <mj-section background-color="#D8D8D8" padding-bottom="10px" padding-top="10px">
+      <mj-column>
+        <mj-text font-size="15px">${general.serviceName}: ${draftExpiring.headerText}</mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-include path="partials/header-service.mjml" />
+
+    <mj-section background-color="#fff" padding-bottom="0px">
+      <mj-column>
+        <mj-text font-weight="600" font-size="34px">${draftExpiring.heading}</mj-text>
+        <mj-divider border-color="#0072c6" />
+        <mj-text padding-bottom="20px" padding-top="10px">${general.greeting}</mj-text>
+        <mj-text>${draftExpiring.bodyText}</mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-top="0px" padding-bottom="0px">
+      <mj-column>
+        <mj-button align="left" background-color="#0072c6" href="https://helsinkilisa.hel.fi"
+          >${draftExpiring.ctaButton}</mj-button
+        >
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-top="10px">
+      <mj-column>
+        <mj-text>${draftExpiring.helper.text}</mj-text>
+        <mj-spacer />
+        <mj-text>
+          <a href="${draftExpiring.helper.link.url}">${draftExpiring.helper.link.title}</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-bottom="0px">
+      <mj-column>
+        <mj-text line-height="100%">${general.bestRegards1}</mj-text>
+        <mj-text line-height="100%">${general.bestRegards2}</mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-bottom="0px">
+      <mj-column>
+        <mj-text font-weight="600" font-size="18px">${application.applicationDetails}</mj-text>
+        <mj-table font-size="15px">
+          <tr style="border-top: 1px solid #ecedee; border-bottom: 1px solid #ecedee; text-align: left">
+            <td style="padding: 15px 0">${application.applicationNumber}</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #ecedee">
+            <td style="padding: 15px 0">${application.status.title}</td>
+            <td style="padding: 15px 0; text-align: right">
+              <span style="background: #fef4d4; padding: 7px 14px">${application.status.unfinished}</span>
+            </td>
+          </tr>
+        </mj-table>
+      </mj-column>
+    </mj-section>
+
+    <mj-include path="partials/automaticReplyDisclaimer.mjml" />
+
+    <mj-include path="partials/footer.mjml" />
+  </mj-body>
+</mjml>

--- a/frontend/benefit/common/src/emails/templates/partials/attributes.mjml
+++ b/frontend/benefit/common/src/emails/templates/partials/attributes.mjml
@@ -1,0 +1,7 @@
+<mj-attributes>
+  <mj-text line-height="150%" font-weight="400" font-size="16px" padding-top="4px" padding-bottom="4px" />
+  <mj-button background-color="#0072c6" font-size="16px" color="#FFFFFF" border-radius="0" inner-padding="16px 32px" align="left" />
+  <mj-body background-color="#ffffff" width="960px" />
+  <mj-section padding-bottom="0px" />
+  <mj-all font-family="HelsinkiGrotesk,system-ui,sans-serif" color="#222" font-size="16px">
+</mj-attributes>

--- a/frontend/benefit/common/src/emails/templates/partials/automaticReplyDisclaimer.mjml
+++ b/frontend/benefit/common/src/emails/templates/partials/automaticReplyDisclaimer.mjml
@@ -1,0 +1,6 @@
+<mj-section padding-top="0px" padding-bottom="30px">
+  <mj-column>
+    <mj-spacer />
+    <mj-text font-size="14px" color="#666">${general.automaticReplyDisclaimer}</mj-text>
+  </mj-column>
+</mj-section>

--- a/frontend/benefit/common/src/emails/templates/partials/base.css
+++ b/frontend/benefit/common/src/emails/templates/partials/base.css
@@ -1,0 +1,17 @@
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: 0;
+}

--- a/frontend/benefit/common/src/emails/templates/partials/footer.mjml
+++ b/frontend/benefit/common/src/emails/templates/partials/footer.mjml
@@ -1,0 +1,30 @@
+<mj-section
+  padding-top="31px"
+  background-size="190px"
+  background-height="31px"
+  background-reoeat="repeat"
+  mode="fixed-height"
+  background-url="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAL4AAAAfCAMAAABu6ofkAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAABFUlEQVR42u3Xh3HlMAwAUTATBLb/dm/SJWcb4qc841fBSszy4yTA3WzpHK3mJPeWSutD1zJ3AIT/mY6abxle+zSeEl7g2rPcSG7TeJHwCp81yR2UYbxKeIPWdLzdeYvwJh9ZjkndgEg+oEWOyAOI54O1JI9WFOL5hz6gLAjkBz5gR3w8H6zKQ2SFDfmwimyXJmzKB82b4wdszIeRZJ/mbM7He5I9ikE8/9Aazgrx/ENrOE94WD5oObhi4/mg+bp4J5R/cgTyIEAIWC1JTJlwLD/4HkhtwdH8wBCUSZxAnLYsn5LqdLhLPmCjpg+ml764inAd017T2+VtLq4kXMxNR2+15PQnOudS+5jLuZywkbs7Wwnf2i8LApgKO+qCJwAAAABJRU5ErkJggg=="
+  <!--
+  background-url="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlgAAAAfCAMAAAAMekMTAAAAKlBMVEX////+/v79/f38/Pz7+/v6+vr5+fn4+Pj39/f29vb19fX09PTz8/Py8vKhYjBHAAACVUlEQVR42u3bBxagPAgEYCA9MPc/7l+299Uoiu/5nWAwEDu9Xq/Xc9Q25lQzfGSmOkdvJQtTeJzKk/Oz5Nr6+CY+zD7Erw85/P/n/+7wf8lP+D0drQjFxLl2xUd/yJ8l7ET0afgjm60kjpq//iU/4S9sVKFYpPylp2Ln59wmNpst8xPzEzawHqe41BR/ETk/l4HdRmEKQurEJoSNRuYIXWVYECU/l4lFs3CErlJsRdjMmtCd+C9lRc+fBw4Z+UlTQdhjZrqLNBw30n1TYTjMKj8mP2EfvWdLTgMLwuTnZjiFNX7IVNMTxiZNLAvQWtJxoutP6DKwH2E/Kxy/rcK0FjecrPEDxoIWlybQuCzQHL+tYrQWd6whrJkpSF2h83MxLAtw0uCKVYRVQ0KMe+T8WeFGM7k7MhbkvyH71hU3f5pwNYVcJcUB5P9cxbeuqPm5w13nuNe25L8h+9YVMz83XKJx1LGgkFfB0nGVmYJdswe4iueKw8h/afzHPdh7nqK4kJaIb59A/jdYvq8/wuXPiotpDrjbUrCplwZ/fvm5KG6ghf13K7/G8v9gKHU4cMjvsCwBbnDlxJMF4TTW5IbP4OLkTx236snhe7Fl5Dv2/ssSJL80xe20isO3uWsIJxsLP/Zw7gZ/bvlTVQQxqzj8R7CAcD5tmff8SDThzy2/lG4Ixfqe2ZA6XPITfOiombf8XAd/TvlZchuGkGzDL5UspU23/ARHpqPVkpPwd/XIxx9oDe4c8jNLyqX1oQhPR/8Y/xf5p3N+wkXsIzzV8+NfWwDBwev1L2J66MRqciTsAAAAAElFTkSuQmCC"
+  --
+>
+  >
+</mj-section>
+
+<mj-section background-color="#F2F2F2" padding-top="60px" padding-bottom="40px">
+  <mj-column>
+    <mj-text font-weight="600" font-size="20px">${general.serviceName}</mj-text>
+    <mj-divider border-width="1px" />
+    <mj-spacer height="8px" />
+    <mj-text>
+      <a href="${footer.links.aboutHelsinkiBenefit.url}">${footer.links.aboutHelsinkiBenefit.title}</a>
+    </mj-text>
+    <mj-text>
+      <a href="${footer.links.customerService.url}">${footer.links.customerService.title}</a>
+    </mj-text>
+    <mj-spacer height="8px" />
+    <mj-divider border-width="1px" />
+    <mj-text>© ${general.cityOfHelsinki} {{current_year}} </mj-text>
+  </mj-column>
+</mj-section>

--- a/frontend/benefit/common/src/emails/templates/partials/header-service.mjml
+++ b/frontend/benefit/common/src/emails/templates/partials/header-service.mjml
@@ -1,0 +1,58 @@
+<mj-section background-color="#fff" padding-top="30px">
+  <mj-column>
+    <mj-raw>
+      <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: top"
+        width="100%"
+        height="80"
+      >
+        <tbody>
+          <tr>
+            <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word">
+              <table
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                width="100%"
+                border="0"
+                height="80"
+                style="
+                  color: #222222;
+                  font-family: HelsinkiGrotesk, system-ui, Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  table-layout: auto;
+                  width: 100%;
+                  border: 0;
+                "
+              >
+                <tbody>
+                  <tr height="66">
+                    <td width="146" height="66" style="width: 146px; height: 60px">
+                      <img
+                        src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png"
+                        style="width: 130px; height: 60px; margin: 0; padding: 0"
+                        width="130"
+                        height="60"
+                      />
+                    </td>
+                    <td
+                      height="66"
+                      style="font-size: 26px; font-weight: 600; line-height: 1; padding-bottom: 8px; height: 66px"
+                    >
+                      Helsinki-lisä
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </mj-raw>
+  </mj-column>
+</mj-section>

--- a/frontend/benefit/common/src/emails/templates/partials/helsinki-logo.mjml
+++ b/frontend/benefit/common/src/emails/templates/partials/helsinki-logo.mjml
@@ -1,0 +1,1 @@
+<img width="130px" src=https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png />

--- a/frontend/benefit/common/src/emails/templates/received-message.template.mjml
+++ b/frontend/benefit/common/src/emails/templates/received-message.template.mjml
@@ -1,0 +1,72 @@
+<mjml>
+  <mj-head>
+    <mj-include path="partials/base.css" type="css" />
+    <mj-include path="partials/attributes.mjml" />
+    <mj-title>${receivedMessage.headerText}</mj-title>
+  </mj-head>
+  <mj-body>
+    <mj-section background-color="#D8D8D8" padding-bottom="10px" padding-top="10px">
+      <mj-column>
+        <mj-text font-size="15px">${general.serviceName}: ${receivedMessage.headerText}</mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-include path="partials/header-service.mjml" />
+
+    <mj-section background-color="#fff" padding-bottom="0px">
+      <mj-column>
+        <mj-text font-weight="600" font-size="34px">${receivedMessage.heading}</mj-text>
+        <mj-divider border-color="#0072c6" />
+        <mj-text padding-bottom="20px" padding-top="10px">${general.greeting}</mj-text>
+        <mj-text>${receivedMessage.bodyText}</mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section padding-bottom="0px">
+      <mj-column>
+        <mj-text line-height="100%">${general.bestRegards1}</mj-text>
+        <mj-text line-height="100%">${general.bestRegards2}</mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section padding-bottom="0px">
+      <mj-column>
+        <mj-text font-weight="600" font-size="18px">${application.applicationDetails}</mj-text>
+        <mj-table font-size="15px">
+          <tr
+            style="
+              border-top: 1px solid #ecedee;
+              border-bottom: 1px solid #ecedee;
+              text-align: left;
+              mso-border-top-alt: solid #ecedee 1pt;
+              mso-border-bottom-alt: solid #ecedee 1pt;
+            "
+          >
+            <td style="padding: 15px 0">${application.applicationNumber}</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.application_number }}</td>
+          </tr>
+          <tr
+            style="
+              border-bottom: 1px solid #ecedee;
+              mso-border-top-alt: solid #ecedee 1pt;
+              mso-border-bottom-alt: solid #ecedee 1pt;
+            "
+          >
+            <td style="padding: 15px 0">${application.createdAt}</td>
+            <td style="padding: 15px 0; text-align: right">{{ application.created_at }}</td>
+          </tr>
+        </mj-table>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-bottom="0px">
+      <mj-column>
+        <mj-button align="left" background-color="#0072c6" href="https://helsinkilisa.hel.fi"
+          >${receivedMessage.ctaButton}</mj-button
+        >
+      </mj-column>
+    </mj-section>
+
+    <mj-include path="partials/automaticReplyDisclaimer.mjml" />
+
+    <mj-include path="partials/footer.mjml" />
+  </mj-body>
+</mjml>

--- a/frontend/benefit/common/src/emails/text-templates/additional-information-required.template.txt
+++ b/frontend/benefit/common/src/emails/text-templates/additional-information-required.template.txt
@@ -1,0 +1,12 @@
+${general.greeting}
+
+${additionalInformationRequired.bodyText}
+${additionalInformationRequired.helper.text}
+
+${application.applicationDetails}
+${application.applicationNumber}: {{application.application_number}}
+${application.status.title}: ${application.status.additionalInformationRequired}
+${application.createdAt}: {{ application.created_at }}
+
+${general.bestRegards1}
+${general.bestRegards2}

--- a/frontend/benefit/common/src/emails/text-templates/draft-notice.template.txt
+++ b/frontend/benefit/common/src/emails/text-templates/draft-notice.template.txt
@@ -1,0 +1,17 @@
+${general.greeting}
+
+${draftExpiring.bodyText}
+
+${draftExpiring.ctaButton}: https://helsinkilisa.hel.fi/
+
+${draftExpiring.helper.text}
+
+${draftExpiring.helper.link.title}: ${draftExpiring.helper.link.url} 
+
+${general.bestRegards1}
+${general.bestRegards2}
+
+${application.applicationNumber}: {{application.application_number}}
+${application.status.title}: ${application.status.unfinished}
+
+${general.automaticReplyDisclaimer}

--- a/frontend/benefit/common/src/emails/text-templates/received-message.template.txt
+++ b/frontend/benefit/common/src/emails/text-templates/received-message.template.txt
@@ -1,0 +1,14 @@
+${general.greeting}
+
+${receivedMessage.bodyText}
+
+${application.applicationDetails}
+${application.applicationNumber}: {{application.application_number}}
+${application.createdAt}: {{ application.created_at }}
+
+${receivedMessage.ctaButton}: https://helsinkilisa.hel.fi
+
+${general.bestRegards1}
+${general.bestRegards2}
+
+${general.automaticReplyDisclaimer}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1137,6 +1137,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.14.6":
+  version "7.23.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.5.tgz#11edb98f8aeec529b82b211028177679144242db"
+  integrity sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.6":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
@@ -2490,6 +2497,11 @@
   integrity sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
+
+"@one-ini/wasm@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@one-ini/wasm/-/wasm-0.1.1.tgz#6013659736c9dbfccc96e8a9c2b3de317df39323"
+  integrity sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==
 
 "@parcel/watcher@2.0.4":
   version "2.0.4"
@@ -3930,6 +3942,14 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+anymatch@~3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -4454,6 +4474,11 @@ bin-links@^4.0.1:
     read-cmd-shim "^4.0.0"
     write-file-atomic "^5.0.0"
 
+binary-extensions@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -4484,6 +4509,11 @@ body-parser@1.19.2:
     raw-body "2.4.3"
     type-is "~1.6.18"
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 bowser@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.0.tgz#37fc387b616cb6aef370dab4d6bd402b74c5c54d"
@@ -4509,7 +4539,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -4696,6 +4726,14 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camel-case@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  integrity sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
+
 camelcase-keys@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
@@ -4839,6 +4877,46 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
+cheerio-select@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz#4d8673286b8126ca2a8e42740d5e3c4884ae21b4"
+  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
+  dependencies:
+    boolbase "^1.0.0"
+    css-select "^5.1.0"
+    css-what "^6.1.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+
+cheerio@1.0.0-rc.12, cheerio@^1.0.0-rc.12:
+  version "1.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.12.tgz#788bf7466506b1c6bf5fae51d24a2c4d62e47683"
+  integrity sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    htmlparser2 "^8.0.1"
+    parse5 "^7.0.0"
+    parse5-htmlparser2-tree-adapter "^7.0.0"
+
+chokidar@^3.0.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chownr@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
@@ -4881,6 +4959,13 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
+
+clean-css@^4.2.1:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.4.tgz#733bf46eba4e607c6891ea57c24a989356831178"
+  integrity sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==
+  dependencies:
+    source-map "~0.6.0"
 
 clean-regexp@^1.0.0:
   version "1.0.0"
@@ -5103,6 +5188,11 @@ commander@2.11.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
   integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
 
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
 commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -5117,6 +5207,11 @@ commander@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
+commander@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commander@^8.3.0:
   version "8.3.0"
@@ -5173,7 +5268,7 @@ config-chain@1.1.12:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
-config-chain@^1.1.12:
+config-chain@^1.1.12, config-chain@^1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
   integrity sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==
@@ -5463,6 +5558,17 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
 css-to-react-native@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
@@ -5479,6 +5585,11 @@ css-tree@^1.1.2:
   dependencies:
     mdn-data "2.0.14"
     source-map "^0.6.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 css.escape@^1.5.1:
   version "1.5.1"
@@ -5804,6 +5915,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-node@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
+  integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+
 detect-node@^2.0.4, detect-node@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
@@ -5869,10 +5985,24 @@ dom-serializer@^1.0.1:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
 domelementtype@^2.0.1, domelementtype@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
   integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -5881,6 +6011,13 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
+domhandler@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.3.0.tgz#6db7ea46e4617eb15cf875df68b2b8524ce0037a"
+  integrity sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==
+  dependencies:
+    domelementtype "^2.0.1"
+
 domhandler@^4.2.0, domhandler@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
@@ -5888,7 +6025,14 @@ domhandler@^4.2.0, domhandler@^4.2.2:
   dependencies:
     domelementtype "^2.2.0"
 
-domutils@^2.8.0:
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^2.4.2, domutils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
   integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
@@ -5896,6 +6040,15 @@ domutils@^2.8.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
+
+domutils@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -5966,6 +6119,16 @@ editorconfig@^0.15.3:
     lru-cache "^4.1.5"
     semver "^5.6.0"
     sigmund "^1.0.1"
+
+editorconfig@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-1.0.4.tgz#040c9a8e9a6c5288388b87c2db07028aa89f53a3"
+  integrity sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==
+  dependencies:
+    "@one-ini/wasm" "0.1.1"
+    commander "^10.0.0"
+    minimatch "9.0.1"
+    semver "^7.5.3"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -6086,7 +6249,7 @@ entities@^3.0.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
-entities@^4.4.0:
+entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -6222,6 +6385,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-goat@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-3.0.0.tgz#e8b5fb658553fe8a3c4959c316c6ebb8c842b19c"
+  integrity sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -7636,7 +7804,7 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-glob-parent@5.1.2, glob-parent@^5.1.2:
+glob-parent@5.1.2, glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -7691,7 +7859,7 @@ glob@7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.2.2:
+glob@^10.2.2, glob@^10.3.3:
   version "10.3.10"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.10.tgz#0351ebb809fd187fe421ab96af83d3a70715df4b"
   integrity sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==
@@ -7967,6 +8135,11 @@ hds-react@^2.17.0:
     uuid "^9.0.0"
     yup "^1.0.2"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 highlight-es@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/highlight-es/-/highlight-es-1.0.3.tgz#12abc300a27e686f6f18010134e3a5c6d2fe6930"
@@ -8040,12 +8213,35 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+html-minifier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-4.0.0.tgz#cca9aad8bce1175e02e17a8c33e46d8988889f56"
+  integrity sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==
+  dependencies:
+    camel-case "^3.0.0"
+    clean-css "^4.2.1"
+    commander "^2.19.0"
+    he "^1.2.0"
+    param-case "^2.1.1"
+    relateurl "^0.2.7"
+    uglify-js "^3.5.1"
+
 html-parse-stringify@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
   integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
   dependencies:
     void-elements "3.1.0"
+
+htmlparser2@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-5.0.1.tgz#7daa6fc3e35d6107ac95a4fc08781f091664f6e7"
+  integrity sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.3.0"
+    domutils "^2.4.2"
+    entities "^2.0.0"
 
 htmlparser2@^7.1.2:
   version "7.2.0"
@@ -8056,6 +8252,16 @@ htmlparser2@^7.1.2:
     domhandler "^4.2.2"
     domutils "^2.8.0"
     entities "^3.0.1"
+
+htmlparser2@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
+  integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    entities "^4.4.0"
 
 http-cache-semantics@^4.1.0:
   version "4.1.0"
@@ -8467,6 +8673,13 @@ is-bigint@^1.0.1:
   dependencies:
     has-bigints "^1.0.1"
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-boolean-object@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
@@ -8609,7 +8822,7 @@ is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -9366,6 +9579,16 @@ js-beautify@^1.6.12:
     glob "^7.1.3"
     nopt "^5.0.0"
 
+js-beautify@^1.6.14:
+  version "1.14.11"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.14.11.tgz#57b17e009549ac845bdc58eddf8e1862e311314e"
+  integrity sha512-rPogWqAfoYh1Ryqqh2agUpVfbxAhbjuN1SmU86dskQUKouRiggUTCO4+2ym9UPXllc2WAp0J+T5qxn7Um3lCdw==
+  dependencies:
+    config-chain "^1.1.13"
+    editorconfig "^1.0.3"
+    glob "^10.3.3"
+    nopt "^7.2.0"
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
@@ -9562,6 +9785,17 @@ jsprim@^1.2.2:
   dependencies:
     array-includes "^3.1.4"
     object.assign "^4.1.2"
+
+juice@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/juice/-/juice-9.1.0.tgz#3ef8a12392d44c1cd996022aa977581049a65050"
+  integrity sha512-odblShmPrUoHUwRuC8EmLji5bPP2MLO1GL+gt4XU3tT2ECmbSrrMjtMQaqg3wgMFP2zvUzdPZGfxc5Trk3Z+fQ==
+  dependencies:
+    cheerio "^1.0.0-rc.12"
+    commander "^6.1.0"
+    mensch "^0.3.4"
+    slick "^1.12.2"
+    web-resource-inliner "^6.0.1"
 
 just-diff-apply@^5.2.0:
   version "5.5.0"
@@ -10036,6 +10270,11 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+  integrity sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==
+
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
@@ -10286,6 +10525,11 @@ memoize-one@5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
+mensch@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/mensch/-/mensch-0.3.4.tgz#770f91b46cb16ea5b204ee735768c3f0c491fecd"
+  integrity sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==
 
 meow@^8.0.0:
   version "8.1.2"
@@ -10588,6 +10832,11 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mime@^2.4.6:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
+
 mime@~1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
@@ -10624,6 +10873,13 @@ minimatch@3.0.5:
   integrity sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.1.tgz#8a555f541cf976c622daf078bb28f29fb927c253"
+  integrity sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
@@ -10768,6 +11024,338 @@ minizlib@^2.1.1, minizlib@^2.1.2:
   dependencies:
     minipass "^3.0.0"
     yallist "^4.0.0"
+
+mjml-accordion@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-accordion/-/mjml-accordion-4.14.1.tgz#39977d426ed4e828614245c8b2e8212085394d14"
+  integrity sha512-dpNXyjnhYwhM75JSjD4wFUa9JgHm86M2pa0CoTzdv1zOQz67ilc4BoK5mc2S0gOjJpjBShM5eOJuCyVIuAPC6w==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-body@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-body/-/mjml-body-4.14.1.tgz#31c79c25a74257ff042e287c09fb363a98e1209f"
+  integrity sha512-YpXcK3o2o1U+fhI8f60xahrhXuHmav6BZez9vIN3ZEJOxPFSr+qgr1cT2iyFz50L5+ZsLIVj2ZY+ALQjdsg8ig==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-button@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-button/-/mjml-button-4.14.1.tgz#a1779555ca4a479c5a52cc0025e8ca0f8e74dad8"
+  integrity sha512-V1Tl1vQ3lXYvvqHJHvGcc8URr7V1l/ZOsv7iLV4QRrh7kjKBXaRS7uUJtz6/PzEbNsGQCiNtXrODqcijLWlgaw==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-carousel@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-carousel/-/mjml-carousel-4.14.1.tgz#dc90116af6adab22bf2074e54165c3b5b7998328"
+  integrity sha512-Ku3MUWPk/TwHxVgKEUtzspy/ePaWtN/3z6/qvNik0KIn0ZUIZ4zvR2JtaVL5nd30LHSmUaNj30XMPkCjYiKkFA==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-cli@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-cli/-/mjml-cli-4.14.1.tgz#4f445e30a3573c9bd57ee6d5a2a6bf8d5b1a0b20"
+  integrity sha512-Gy6MnSygFXs0U1qOXTHqBg2vZX2VL/fAacgQzD4MHq4OuybWaTNSzXRwxBXYCxT3IJB874n2Q0Mxp+Xka+tnZg==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    chokidar "^3.0.0"
+    glob "^7.1.1"
+    html-minifier "^4.0.0"
+    js-beautify "^1.6.14"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+    mjml-migrate "4.14.1"
+    mjml-parser-xml "4.14.1"
+    mjml-validator "4.13.0"
+    yargs "^16.1.0"
+
+mjml-column@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-column/-/mjml-column-4.14.1.tgz#828cd4e5f82dcbc6d91bd2ac83d56e7b262becbe"
+  integrity sha512-iixVCIX1YJtpQuwG2WbDr7FqofQrlTtGQ4+YAZXGiLThs0En3xNIJFQX9xJ8sgLEGGltyooHiNICBRlzSp9fDg==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-core@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-core/-/mjml-core-4.14.1.tgz#f748a137c280b89a8d09fab1a988014c3fc8dcd2"
+  integrity sha512-di88rSfX+8r4r+cEqlQCO7CRM4mYZrfe2wSCu2je38i+ujjkLpF72cgLnjBlSG5aOUCZgYvlsZ85stqIz9LQfA==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    cheerio "1.0.0-rc.12"
+    detect-node "^2.0.4"
+    html-minifier "^4.0.0"
+    js-beautify "^1.6.14"
+    juice "^9.0.0"
+    lodash "^4.17.21"
+    mjml-migrate "4.14.1"
+    mjml-parser-xml "4.14.1"
+    mjml-validator "4.13.0"
+
+mjml-divider@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-divider/-/mjml-divider-4.14.1.tgz#c5f90bffc0cd1321b6a73342163311221dff1d26"
+  integrity sha512-agqWY0aW2xaMiUOhYKDvcAAfOLalpbbtjKZAl1vWmNkURaoK4L7MgDilKHSJDFUlHGm2ZOArTrq8i6K0iyThBQ==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-group@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-group/-/mjml-group-4.14.1.tgz#5c3f1a99f0f338241697c2971964a6f89a1fd2a7"
+  integrity sha512-dJt5batgEJ7wxlxzqOfHOI94ABX+8DZBvAlHuddYO4CsLFHYv6XRIArLAMMnAKU76r6p3X8JxYeOjKZXdv49kg==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-head-attributes@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-head-attributes/-/mjml-head-attributes-4.14.1.tgz#cd864f46e039823c4c0c1070745865dac83101d7"
+  integrity sha512-XdUNOp2csK28kBDSistInOyzWNwmu5HDNr4y1Z7vSQ1PfkmiuS6jWG7jHUjdoMhs27e6Leuyyc6a8gWSpqSWrg==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-head-breakpoint@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-head-breakpoint/-/mjml-head-breakpoint-4.14.1.tgz#60900466174b0e9dc1d763a4836917351a3cc074"
+  integrity sha512-Qw9l/W/I5Z9p7I4ShgnEpAL9if4472ejcznbBnp+4Gq+sZoPa7iYoEPsa9UCGutlaCh3N3tIi2qKhl9qD8DFxA==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-head-font@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-head-font/-/mjml-head-font-4.14.1.tgz#b642dff1f0542df701ececb80f8ca625d9efb48e"
+  integrity sha512-oBYm1gaOdEMjE5BoZouRRD4lCNZ1jcpz92NR/F7xDyMaKCGN6T/+r4S5dq1gOLm9zWqClRHaECdFJNEmrDpZqA==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-head-html-attributes@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-head-html-attributes/-/mjml-head-html-attributes-4.14.1.tgz#c9fddb0e8cb813a7f929c17ee8ae2dfdc397611e"
+  integrity sha512-vlJsJc1Sm4Ml2XvLmp01zsdmWmzm6+jNCO7X3eYi9ngEh8LjMCLIQOncnOgjqm9uGpQu2EgUhwvYFZP2luJOVg==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-head-preview@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-head-preview/-/mjml-head-preview-4.14.1.tgz#b7db35020229aadec857f292f9725cd81014c51f"
+  integrity sha512-89gQtt3fhl2dkYpHLF5HDQXz/RLpzecU6wmAIT7Dz6etjLGE1dgq2Ay6Bu/OeHjDcT1gbM131zvBwuXw8OydNw==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-head-style@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-head-style/-/mjml-head-style-4.14.1.tgz#6bec3b30fd0ac6ca3ee9806d8721c9e32b0968b6"
+  integrity sha512-XryOuf32EDuUCBT2k99C1+H87IOM919oY6IqxKFJCDkmsbywKIum7ibhweJdcxiYGONKTC6xjuibGD3fQTTYNQ==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-head-title@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-head-title/-/mjml-head-title-4.14.1.tgz#ff1af20467e8ea7f65a29bbc0c58e05d98cb45a6"
+  integrity sha512-aIfpmlQdf1eJZSSrFodmlC4g5GudBti2eMyG42M7/3NeLM6anEWoe+UkF/6OG4Zy0tCQ40BDJ5iBZlMsjQICzw==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-head@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-head/-/mjml-head-4.14.1.tgz#27ae83d9023b6b2126cd4dd105685b0b08a8baa3"
+  integrity sha512-KoCbtSeTAhx05Ugn9TB2UYt5sQinSCb7RGRer5iPQ3CrXj8hT5B5Svn6qvf/GACPkWl4auExHQh+XgLB+r3OEA==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-hero@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-hero/-/mjml-hero-4.14.1.tgz#6e969e24ae1eacff037c3170849f1eb51cda1253"
+  integrity sha512-TQJ3yfjrKYGkdEWjHLHhL99u/meKFYgnfJvlo9xeBvRjSM696jIjdqaPHaunfw4CP6d2OpCIMuacgOsvqQMWOA==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-image@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-image/-/mjml-image-4.14.1.tgz#825566ce9d79692b3c841f85597e533217a0a960"
+  integrity sha512-jfKLPHXuFq83okwlNM1Um/AEWeVDgs2JXIOsWp2TtvXosnRvGGMzA5stKLYdy1x6UfKF4c1ovpMS162aYGp+xQ==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-migrate@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-migrate/-/mjml-migrate-4.14.1.tgz#e3e1402f9310c1fed8a0a1c800fab316fbc56d12"
+  integrity sha512-d+9HKQOhZi3ZFAaFSDdjzJX9eDQGjMf3BArLWNm2okC4ZgfJSpOc77kgCyFV8ugvwc8fFegPnSV60Jl4xtvK2A==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    js-beautify "^1.6.14"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+    mjml-parser-xml "4.14.1"
+    yargs "^16.1.0"
+
+mjml-navbar@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-navbar/-/mjml-navbar-4.14.1.tgz#7979049759a7850f239fd2ee63bc47cc02c5c2e9"
+  integrity sha512-rNy1Kw8CR3WQ+M55PFBAUDz2VEOjz+sk06OFnsnmNjoMVCjo1EV7OFLDAkmxAwqkC8h4zQWEOFY0MBqqoAg7+A==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-parser-xml@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-parser-xml/-/mjml-parser-xml-4.14.1.tgz#bf20f06614569a2adf017698bb411e16dcd831c2"
+  integrity sha512-9WQVeukbXfq9DUcZ8wOsHC6BTdhaVwTAJDYMIQglXLwKwN7I4pTCguDDHy5d0kbbzK5OCVxCdZe+bfVI6XANOQ==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    detect-node "2.0.4"
+    htmlparser2 "^8.0.1"
+    lodash "^4.17.15"
+
+mjml-preset-core@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-preset-core/-/mjml-preset-core-4.14.1.tgz#9b465f4d1227c928497973b34c5d0903f04dc649"
+  integrity sha512-uUCqK9Z9d39rwB/+JDV2KWSZGB46W7rPQpc9Xnw1DRP7wD7qAfJwK6AZFCwfTgWdSxw0PwquVNcrUS9yBa9uhw==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    mjml-accordion "4.14.1"
+    mjml-body "4.14.1"
+    mjml-button "4.14.1"
+    mjml-carousel "4.14.1"
+    mjml-column "4.14.1"
+    mjml-divider "4.14.1"
+    mjml-group "4.14.1"
+    mjml-head "4.14.1"
+    mjml-head-attributes "4.14.1"
+    mjml-head-breakpoint "4.14.1"
+    mjml-head-font "4.14.1"
+    mjml-head-html-attributes "4.14.1"
+    mjml-head-preview "4.14.1"
+    mjml-head-style "4.14.1"
+    mjml-head-title "4.14.1"
+    mjml-hero "4.14.1"
+    mjml-image "4.14.1"
+    mjml-navbar "4.14.1"
+    mjml-raw "4.14.1"
+    mjml-section "4.14.1"
+    mjml-social "4.14.1"
+    mjml-spacer "4.14.1"
+    mjml-table "4.14.1"
+    mjml-text "4.14.1"
+    mjml-wrapper "4.14.1"
+
+mjml-raw@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-raw/-/mjml-raw-4.14.1.tgz#d543e40f7e1c3468593d6783e7e4ce10bfd9b2d8"
+  integrity sha512-9+4wzoXnCtfV6QPmjfJkZ50hxFB4Z8QZnl2Ac0D1Cn3dUF46UkmO5NLMu7UDIlm5DdFyycZrMOwvZS4wv9ksPw==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-section@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-section/-/mjml-section-4.14.1.tgz#3309aae46aca1b33f034c5f3b9dad883c52f2267"
+  integrity sha512-Ik5pTUhpT3DOfB3hEmAWp8rZ0ilWtIivnL8XdUJRfgYE9D+MCRn+reIO+DAoJHxiQoI6gyeKkIP4B9OrQ7cHQw==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-social@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-social/-/mjml-social-4.14.1.tgz#7fe45c7c8c328142d2514e5c61d8c3939ee97e3f"
+  integrity sha512-G44aOZXgZHukirjkeQWTTV36UywtE2YvSwWGNfo/8d+k5JdJJhCIrlwaahyKEAyH63G1B0Zt8b2lEWx0jigYUw==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-spacer@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-spacer/-/mjml-spacer-4.14.1.tgz#24fa57fb5e7781825ab3f03c1bec108afd0e97da"
+  integrity sha512-5SfQCXTd3JBgRH1pUy6NVZ0lXBiRqFJPVHBdtC3OFvUS3q1w16eaAXlIUWMKTfy8CKhQrCiE6m65kc662ZpYxA==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-table@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-table/-/mjml-table-4.14.1.tgz#f22ff9ec9b74cd4c3d677866b68e740b07fdf700"
+  integrity sha512-aVBdX3WpyKVGh/PZNn2KgRem+PQhWlvnD00DKxDejRBsBSKYSwZ0t3EfFvZOoJ9DzfHsN0dHuwd6Z18Ps44NFQ==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-text@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-text/-/mjml-text-4.14.1.tgz#09ba10828976fc7e2493ac3187f6a6e5e5b50442"
+  integrity sha512-yZuvf5z6qUxEo5CqOhCUltJlR6oySKVcQNHwoV5sneMaKdmBiaU4VDnlYFera9gMD9o3KBHIX6kUg7EHnCwBRQ==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+
+mjml-validator@4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/mjml-validator/-/mjml-validator-4.13.0.tgz#a05bac51535cb8073a253304105ffbaf88f85d26"
+  integrity sha512-uURYfyQYtHJ6Qz/1A7/+E9ezfcoISoLZhYK3olsxKRViwaA2Mm8gy/J3yggZXnsUXWUns7Qymycm5LglLEIiQg==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+
+mjml-wrapper@4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml-wrapper/-/mjml-wrapper-4.14.1.tgz#d52478d0529584343aa7924a012e26c084673ae0"
+  integrity sha512-aA5Xlq6d0hZ5LY+RvSaBqmVcLkvPvdhyAv3vQf3G41Gfhel4oIPmkLnVpHselWhV14A0KwIOIAKVxHtSAxyOTQ==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    lodash "^4.17.21"
+    mjml-core "4.14.1"
+    mjml-section "4.14.1"
+
+mjml@^4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/mjml/-/mjml-4.14.1.tgz#4c9ca49bb6a4df51c204d2448e3385d5e166ec00"
+  integrity sha512-f/wnWWIVbeb/ge3ff7c/KYYizI13QbGIp03odwwkCThsJsacw4gpZZAU7V4gXY3HxSXP2/q3jxOfaHVbkfNpOQ==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    mjml-cli "4.14.1"
+    mjml-core "4.14.1"
+    mjml-migrate "4.14.1"
+    mjml-preset-core "4.14.1"
+    mjml-validator "4.13.0"
 
 mkdir@0.0.2:
   version "0.0.2"
@@ -10981,6 +11569,13 @@ next@14.0.3:
     "@next/swc-win32-ia32-msvc" "14.0.3"
     "@next/swc-win32-x64-msvc" "14.0.3"
 
+no-case@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
+  integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
+  dependencies:
+    lower-case "^1.1.1"
+
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
@@ -11008,6 +11603,13 @@ node-fetch@2.6.7, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -11057,7 +11659,7 @@ nopt@^6.0.0:
   dependencies:
     abbrev "^1.0.0"
 
-nopt@^7.0.0:
+nopt@^7.0.0, nopt@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.0.tgz#067378c68116f602f552876194fd11f1292503d7"
   integrity sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==
@@ -11104,7 +11706,7 @@ normalize-package-data@^5.0.0:
     semver "^7.3.5"
     validate-npm-package-license "^3.0.4"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -11293,6 +11895,13 @@ npmlog@^7.0.1:
     console-control-strings "^1.1.0"
     gauge "^5.0.0"
     set-blocking "^2.0.0"
+
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -11749,6 +12358,13 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
+param-case@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  integrity sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==
+  dependencies:
+    no-case "^2.2.0"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -11814,6 +12430,14 @@ parse-url@^8.1.0:
   dependencies:
     parse-path "^7.0.0"
 
+parse5-htmlparser2-tree-adapter@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz#23c2cc233bcf09bb7beba8b8a69d46b08c62c2f1"
+  integrity sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==
+  dependencies:
+    domhandler "^5.0.2"
+    parse5 "^7.0.0"
+
 parse5@2.2.3, parse5@^2.1.5:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-2.2.3.tgz#0c4fc41c1000c5e6b93d48b03f8083837834e9f6"
@@ -11829,7 +12453,7 @@ parse5@^1.5.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
   integrity sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=
 
-parse5@^7.1.2:
+parse5@^7.0.0, parse5@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
   integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
@@ -11933,7 +12557,7 @@ picocolors@1.0.0, picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -12680,6 +13304,13 @@ readable-stream@^4.1.0:
     process "^0.11.10"
     string_decoder "^1.3.0"
 
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
+
 readline-transform@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/readline-transform/-/readline-transform-1.0.0.tgz#3157f97428acaec0f05a5c1ff2c3120f4e6d904b"
@@ -12772,6 +13403,11 @@ regjsparser@^0.8.2:
   integrity sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==
   dependencies:
     jsesc "~0.5.0"
+
+relateurl@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
+  integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
 
 remark-parse@^10.0.0:
   version "10.0.2"
@@ -13391,6 +14027,11 @@ slice-ansi@^5.0.0:
     ansi-styles "^6.0.0"
     is-fullwidth-code-point "^4.0.0"
 
+slick@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/slick/-/slick-1.12.2.tgz#bd048ddb74de7d1ca6915faa4a57570b3550c2d7"
+  integrity sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A==
+
 smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
@@ -13491,7 +14132,7 @@ source-map@^0.5.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -14712,6 +15353,11 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.3.tgz#9aa82ca22419ba4c0137642ba0df800cb06e0471"
   integrity sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==
 
+uglify-js@^3.5.1:
+  version "3.17.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
+  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
+
 unbox-primitive@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
@@ -14917,6 +15563,11 @@ upath@2.0.1, upath@^2.0.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
   integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
 
+upper-case@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
+  integrity sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -15005,6 +15656,11 @@ v8-to-istanbul@^8.1.0:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
+
+valid-data-url@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/valid-data-url/-/valid-data-url-3.0.1.tgz#826c1744e71b5632e847dd15dbd45b9fb38aa34f"
+  integrity sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==
 
 validate-npm-package-license@3.0.4, validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
@@ -15159,6 +15815,18 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-resource-inliner@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/web-resource-inliner/-/web-resource-inliner-6.0.1.tgz#df0822f0a12028805fe80719ed52ab6526886e02"
+  integrity sha512-kfqDxt5dTB1JhqsCUQVFDj0rmY+4HLwGQIsLPbyrsN9y9WV/1oFDSx3BQ4GfCv9X+jVeQ7rouTqwK53rA/7t8A==
+  dependencies:
+    ansi-colors "^4.1.1"
+    escape-goat "^3.0.0"
+    htmlparser2 "^5.0.0"
+    mime "^2.4.6"
+    node-fetch "^2.6.0"
+    valid-data-url "^3.0.0"
 
 web-streams-polyfill@^3.2.1:
   version "3.2.1"
@@ -15462,7 +16130,7 @@ yargs-parser@^21.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
-yargs@16.2.0, yargs@^16.2.0:
+yargs@16.2.0, yargs@^16.1.0, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==


### PR DESCRIPTION
## Description :sparkles:

Heavily influenced and loaned from https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/482

- MJML templating framework to produce HTML and TXT emails
  - [MJML does all the compability heavy lifting](https://documentation.mjml.io/) for email clients such as: Outlook 2016, Outlook 2019, Outlook 2021 and so forth
  - After compilation, these HTML/TXT templates are fed to django to "fill in the blanks" using django's template render
  - Would have used django-mjml but turns out it's just a wrapper for the node library
- Rework some internal send_mail functions and calls
- Fix tests

## Testing

Set `NEXT_PUBLIC_MOCK_FLAG=0` on backend and recreate. 

Then, 

* send message as handler from the sidebar
* open any from the sidebar to modification to the applicant
* run `python manage.py check_drafts_to_delete` in backend container