### PR TITLE
fix: show rejected in archive (HL-1039)

### DIFF
--- a/backend/benefit/applications/api/v1/application_batch_views.py
+++ b/backend/benefit/applications/api/v1/application_batch_views.py
@@ -319,6 +319,7 @@ class ApplicationBatchViewSet(AuditLoggingModelViewSet):
 
         if new_status in [
             ApplicationBatchStatus.SENT_TO_TALPA,
+            ApplicationBatchStatus.DECIDED_REJECTED,
         ]:
             # Archive all applications if this batch will be completed
             Application.objects.filter(batch=batch).update(archived=True)


### PR DESCRIPTION
## Description :sparkles:

Rejected are not sent to Talpa, so the status for them isn't `SENT_TO_TALPA` and so the `archived` is staying `false`. Now also set `archived=true` for rejected. Haven't worked with Talpa stuff before, can this interfere with something?