### PR TITLE
Hl 1069 ahjo cancel

### DIFF
--- a/backend/benefit/applications/api/v1/ahjo_integration_views.py
+++ b/backend/benefit/applications/api/v1/ahjo_integration_views.py
@@ -147,9 +147,6 @@ class AhjoCallbackView(APIView):
                 status=status.HTTP_200_OK,
             )
 
-    def _create_status(self, application: Application, status: AhjoStatusEnum):
-        return AhjoStatus.objects.create(application=application, status=status)
-
     def _handle_open_case_callback(self, application: Application, callback_data: dict):
         application.ahjo_case_guid = callback_data["caseGuid"]
         application.ahjo_case_id = callback_data["caseId"]

--- a/backend/benefit/applications/api/v1/ahjo_integration_views.py
+++ b/backend/benefit/applications/api/v1/ahjo_integration_views.py
@@ -11,7 +11,11 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from applications.api.v1.serializers.ahjo_callback import AhjoCallbackSerializer
-from applications.enums import AhjoCallBackStatus, AhjoStatus as AhjoStatusEnum
+from applications.enums import (
+    AhjoCallBackStatus,
+    AhjoRequestType,
+    AhjoStatus as AhjoStatusEnum,
+)
 from applications.models import AhjoStatus, Application, Attachment
 from common.permissions import SafeListPermission
 from shared.audit_log import audit_logging
@@ -76,7 +80,14 @@ class AhjoCallbackView(APIView):
                 required=True,
                 type=OpenApiTypes.UUID,
                 location=OpenApiParameter.PATH,
-            )
+            ),
+            OpenApiParameter(
+                name="request_id",
+                description="The type of request that Ahjo responded to",
+                required=True,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+            ),
         ],
         description="Callback endpoint for Ahjo to send updates to the application.",
         request=AhjoCallbackSerializer,
@@ -97,21 +108,28 @@ class AhjoCallbackView(APIView):
         if callback_data["message"] == AhjoCallBackStatus.SUCCESS:
             ahjo_request_id = callback_data["requestId"]
             application = get_object_or_404(Application, pk=application_id)
-            application.ahjo_case_guid = callback_data["caseGuid"]
-            application.ahjo_case_id = callback_data["caseId"]
-            application.save()
+            request_type = self.kwargs["request_type"]
 
-            AhjoStatus.objects.create(
-                application=application, status=AhjoStatusEnum.CASE_OPENED
-            )
+            if request_type == AhjoRequestType.OPEN_CASE:
+                application = self._handle_open_case_callback(
+                    application, callback_data
+                )
+                ahjo_status = AhjoStatusEnum.CASE_OPENED
+                info = f"""Application ahjo_case_guid and ahjo_case_id
+                were updated by Ahjo request id: {ahjo_request_id}"""
+            elif request_type == AhjoRequestType.DELETE_APPLICATION:
+                self._handle_delete_callback()
+                ahjo_status = AhjoStatusEnum.DELETE_REQUEST_RECEIVED
+                info = f"""Application was marked for cancellation in Ahjo with request id: {ahjo_request_id}"""
+
+            AhjoStatus.objects.create(application=application, status=ahjo_status)
 
             audit_logging.log(
                 request.user,
                 "",
                 Operation.UPDATE,
                 application,
-                additional_information=f"""Application ahjo_case_guid and ahjo_case_id were updated
-                by Ahjo request id: {ahjo_request_id}""",
+                additional_information=info,
             )
 
             return Response(
@@ -128,3 +146,16 @@ class AhjoCallbackView(APIView):
                 {"message": "Callback received but unsuccessful"},
                 status=status.HTTP_200_OK,
             )
+
+    def _create_status(self, application: Application, status: AhjoStatusEnum):
+        return AhjoStatus.objects.create(application=application, status=status)
+
+    def _handle_open_case_callback(self, application: Application, callback_data: dict):
+        application.ahjo_case_guid = callback_data["caseGuid"]
+        application.ahjo_case_id = callback_data["caseId"]
+        application.save()
+        return application
+
+    def _handle_delete_callback(self):
+        # do anything that needs to be done when Ahjo sends a delete callback
+        pass

--- a/backend/benefit/applications/enums.py
+++ b/backend/benefit/applications/enums.py
@@ -172,3 +172,8 @@ class ApplicationActions(models.TextChoices):
 class AhjoCallBackStatus(models.TextChoices):
     SUCCESS = "Success", _("Success")
     FAILURE = "Failure", _("Failure")
+
+
+class AhjoRequestType(models.TextChoices):
+    OPEN_CASE = "open_case", _("Open case in Ahjo")
+    DELETE_APPLICATION = "delete_application", _("Delete application in Ahjo")

--- a/backend/benefit/applications/tests/test_ahjo_requests.py
+++ b/backend/benefit/applications/tests/test_ahjo_requests.py
@@ -1,25 +1,40 @@
-import uuid
 from unittest.mock import patch
 
+import pytest
 import requests
 import requests_mock
+from django.conf import settings
 from django.urls import reverse
 
-from applications.enums import AhjoStatus
-from applications.services.ahjo_integration import (
-    do_ahjo_request_with_json_payload,
-    prepare_headers,
+from applications.enums import AhjoRequestType, AhjoStatus
+from applications.services.ahjo_integration import prepare_headers, send_request_to_ahjo
+
+
+@pytest.fixture
+def application_with_ahjo_case_id(decided_application):
+    decided_application.ahjo_case_id = "12345"
+    decided_application.save()
+    return decided_application
+
+
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        (AhjoRequestType.OPEN_CASE,),
+        (AhjoRequestType.DELETE_APPLICATION,),
+    ],
 )
-
-
-def test_prepare_headers(settings):
+def test_prepare_headers(settings, request_type, decided_application):
     settings.API_BASE_URL = "http://test.com"
     access_token = "test_token"
-    application_uuid = uuid.uuid4()
 
-    headers = prepare_headers(access_token, application_uuid)
+    url = reverse(
+        "ahjo_callback_url",
+        kwargs={"request_type": request_type, "uuid": decided_application.id},
+    )
 
-    url = reverse("ahjo_callback_url", kwargs={"uuid": str(application_uuid)})
+    headers = prepare_headers(access_token, decided_application, request_type)
+
     expected_headers = {
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/hal+json",
@@ -29,61 +44,109 @@ def test_prepare_headers(settings):
     assert headers == expected_headers
 
 
-def test_do_ahjo_request_with_json_payload_success(
-    decided_application, ahjo_open_case_payload
+@pytest.mark.parametrize(
+    "request_type, request_url, ahjo_status",
+    [
+        (
+            AhjoRequestType.OPEN_CASE,
+            f"{settings.AHJO_REST_API_URL}/cases",
+            AhjoStatus.REQUEST_TO_OPEN_CASE_SENT,
+        ),
+        (
+            AhjoRequestType.DELETE_APPLICATION,
+            f"{settings.AHJO_REST_API_URL}/cases/12345",
+            AhjoStatus.DELETE_REQUEST_SENT,
+        ),
+    ],
+)
+def test_send_request_to_ahjo(
+    request_type,
+    request_url,
+    ahjo_status,
+    application_with_ahjo_case_id,
+    ahjo_open_case_payload,
 ):
-    url = "http://test.com"
     headers = {"Authorization": "Bearer test"}
 
     with requests_mock.Mocker() as m:
-        m.post(f"{url}/cases", text="data")
-        do_ahjo_request_with_json_payload(
-            url, headers, ahjo_open_case_payload, decided_application
+        if request_type == AhjoRequestType.OPEN_CASE:
+            m.post(request_url, text="data")
+        elif request_type == AhjoRequestType.DELETE_APPLICATION:
+            m.delete(request_url)
+        send_request_to_ahjo(
+            request_type, headers, application_with_ahjo_case_id, ahjo_open_case_payload
         )
-    decided_application.refresh_from_db()
-    assert (
-        decided_application.ahjo_status.latest().status
-        == AhjoStatus.REQUEST_TO_OPEN_CASE_SENT
-    )
+        assert m.called
+
+    application_with_ahjo_case_id.refresh_from_db()
+    assert application_with_ahjo_case_id.ahjo_status.latest().status == ahjo_status
 
 
 @patch("applications.services.ahjo_integration.LOGGER")
-def test_http_error(mock_logger, decided_application, ahjo_open_case_payload):
-    url = "http://mockedurl.com"
+def test_http_error(mock_logger, application_with_ahjo_case_id):
     headers = {}
-    data = ahjo_open_case_payload
-    application = decided_application
 
-    with requests_mock.Mocker() as m:
-        m.post(f"{url}/cases", status_code=400)
-        do_ahjo_request_with_json_payload(url, headers, data, application)
+    with requests_mock.Mocker() as m, pytest.raises(requests.exceptions.HTTPError):
+        m.post(f"{settings.AHJO_REST_API_URL}/cases", status_code=400)
+        send_request_to_ahjo(
+            AhjoRequestType.OPEN_CASE, headers, application_with_ahjo_case_id
+        )
 
+        assert m.called
+        mock_logger.error.assert_called()
+
+    with requests_mock.Mocker() as m, pytest.raises(requests.exceptions.HTTPError):
+        m.delete(f"{settings.AHJO_REST_API_URL}/cases/12345", status_code=400)
+        send_request_to_ahjo(
+            AhjoRequestType.DELETE_APPLICATION, headers, application_with_ahjo_case_id
+        )
+
+        assert m.called
         mock_logger.error.assert_called()
 
 
 @patch("applications.services.ahjo_integration.LOGGER")
-def test_network_error(mock_logger, decided_application, ahjo_open_case_payload):
-    url = "http://mockedurl.com"
+def test_network_error(mock_logger, application_with_ahjo_case_id):
     headers = {}
-    data = ahjo_open_case_payload
-    application = decided_application
+    exception = requests.exceptions.ConnectionError
 
-    with requests_mock.Mocker() as m:
-        m.post(f"{url}/cases", exc=requests.exceptions.ConnectionError)
-        do_ahjo_request_with_json_payload(url, headers, data, application)
+    with requests_mock.Mocker() as m, pytest.raises(exception):
+        m.post(f"{settings.AHJO_REST_API_URL}/cases", exc=exception)
+        send_request_to_ahjo(
+            AhjoRequestType.OPEN_CASE, headers, application_with_ahjo_case_id
+        )
 
+        assert m.called
+        mock_logger.error.assert_called()
+
+    with requests_mock.Mocker() as m, pytest.raises(exception):
+        m.delete(f"{settings.AHJO_REST_API_URL}/cases/12345", exc=exception)
+        send_request_to_ahjo(
+            AhjoRequestType.DELETE_APPLICATION, headers, application_with_ahjo_case_id
+        )
+
+        assert m.called
         mock_logger.error.assert_called()
 
 
 @patch("applications.services.ahjo_integration.LOGGER")
-def test_other_exception(mock_logger, decided_application, ahjo_open_case_payload):
-    url = "http://mockedurl.com"
+def test_other_error(mock_logger, application_with_ahjo_case_id):
     headers = {}
-    data = ahjo_open_case_payload
-    application = decided_application
 
-    with requests_mock.Mocker() as m:
-        m.post(f"{url}/cases", exc=Exception("Some error"))
-        do_ahjo_request_with_json_payload(url, headers, data, application)
+    with requests_mock.Mocker() as m, pytest.raises(Exception):
+        m.post(f"{settings.AHJO_REST_API_URL}/cases", exc=Exception)
+        send_request_to_ahjo(
+            AhjoRequestType.OPEN_CASE, headers, application_with_ahjo_case_id
+        )
 
+        assert m.called
+        mock_logger.error.assert_called()
+
+    with requests_mock.Mocker() as m, pytest.raises(Exception):
+        m.delete(f"{settings.AHJO_REST_API_URL}/cases/12345", exc=Exception)
+        send_request_to_ahjo(
+            AhjoRequestType.DELETE_APPLICATION, headers, application_with_ahjo_case_id
+        )
+
+        assert m.called
         mock_logger.error.assert_called()

--- a/backend/benefit/helsinkibenefit/urls.py
+++ b/backend/benefit/helsinkibenefit/urls.py
@@ -66,7 +66,7 @@ router.register(r"previousbenefits", calculator_views.PreviousBenefitViewSet)
 urlpatterns = [
     path("admin/", admin.site.urls),
     path(
-        "v1/ahjo-integration/callback/<uuid:uuid>",
+        "v1/ahjo-integration/callback/<str:request_type>/<uuid:uuid>",
         AhjoCallbackView.as_view(),
         name="ahjo_callback_url",
     ),


### PR DESCRIPTION
## Description :sparkles:
Adjusts the callback view so that different kinds of callbacks can be received based on the AhjoRequestType enum.
Add a callback address for a DELETE request to Ahjo REST api.

Refactor the function `do_ahjo_request_with_json_payload` into `send_request_to_ahjo` that can do different types of requests.

## Issues :bug:

## Testing :alembic:
```
pytest applications/tests/test_ahjo_integration.py
pytest applications/tests/test_ahjo_requests.py

```
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
`ahjo_integration_views.py` has a function, `_handle_delete_callback()` which currently does nothing, as placeholder because it's not certain yet, what we should do to the application after it is deleted in Ahjo.
