### PR TITLE
feat: return 404 instead of 400 when no applications for talpa robot

### DIFF
--- a/backend/benefit/applications/api/v1/application_batch_views.py
+++ b/backend/benefit/applications/api/v1/application_batch_views.py
@@ -178,7 +178,7 @@ class ApplicationBatchViewSet(AuditLoggingModelViewSet):
                         " later"
                     )
                 },
-                status=status.HTTP_400_BAD_REQUEST,
+                status=status.HTTP_404_NOT_FOUND,
             )
         applications = Application.objects.filter(batch__in=approved_batches).order_by(
             "company__name", "application_number"

--- a/backend/benefit/applications/tests/test_application_batch_api.py
+++ b/backend/benefit/applications/tests/test_application_batch_api.py
@@ -819,7 +819,7 @@ def test_application_batches_talpa_export(anonymous_client, application_batch):
     application_batch.status = ApplicationBatchStatus.DECIDED_REJECTED
     fill_as_valid_batch_completion_and_save(application_batch)
     response = anonymous_client.get(reverse("v1:applicationbatch-talpa-export-batch"))
-    assert response.status_code == 400
+    assert response.status_code == 404
     assert "There is no available application to export" in response.data["detail"]
 
     application_batch.status = ApplicationBatchStatus.DECIDED_ACCEPTED


### PR DESCRIPTION
## Description :sparkles:
Return a more descripting error status when no applications are found for export.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
