### PR TITLE
fix: generate talpa export csv synchronously

### DIFF
--- a/backend/benefit/applications/tests/test_application_batch_api.py
+++ b/backend/benefit/applications/tests/test_application_batch_api.py
@@ -8,7 +8,7 @@ import pytest
 import pytz
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.http import StreamingHttpResponse
+from django.http import HttpResponse
 from rest_framework.reverse import reverse
 
 from applications.api.v1.serializers.application import ApplicationBatchSerializer
@@ -838,6 +838,6 @@ def test_application_batches_talpa_export(anonymous_client, application_batch):
     assert application_batch.status == ApplicationBatchStatus.SENT_TO_TALPA
     assert app_batch_2.status == ApplicationBatchStatus.SENT_TO_TALPA
 
-    assert isinstance(response, StreamingHttpResponse)
+    assert isinstance(response, HttpResponse)
     assert response.headers["Content-Type"] == "text/csv"
     assert response.status_code == 200


### PR DESCRIPTION
## Description :sparkles:
The generator code and StreamingHttpResponse made it difficult to update the application batch as sent_to_talpa after response was complete, which resulted in an empty csv file.

## Issues :bug:

## Testing :alembic:
Add a few applications to a batch and visit (credentials for talpa robot in .env or default ones in settings.py)
https://localhost:8000/v1/applicationbatches/talpa_export/
https://localhost:8000/v1/applicationbatches/talpa_export/?skip_update=0
now respond with a csv tha includes the applications from the batch afterwhich the batch is updated to sent_to_talpa-status
and visiting
https://localhost:8000/v1/applicationbatches/talpa_export/?skip_update=1
returns the csv but does not update the batch.
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
