### PR TITLE
fix: some urls were missing from email templates

### DIFF
--- a/frontend/benefit/common/src/emails/i18n/en.json
+++ b/frontend/benefit/common/src/emails/i18n/en.json
@@ -3,11 +3,11 @@
     "links": {
       "aboutHelsinkiBenefit": {
         "title": "Information about the Helsinki benefit",
-        "url": "#"
+        "url": "https://www.hel.fi/en/business-and-work/employers/financial-support/helsinki-benefit-for-employers"
       },
       "customerService": {
         "title": "Customer service and contact details",
-        "url": "#"
+        "url": "https://www.hel.fi/en/business-and-work/employers/financial-support/helsinki-benefit-for-employers#contact-information"
       }
     }
   },
@@ -34,7 +34,7 @@
       "text": "Visit the City of Helsinki’s website for instructions and more information on completing the application form.",
       "link": {
         "title": "Read more about applying for the Helsinki benefit",
-        "url": "#"
+        "url": "https://www.hel.fi/en/business-and-work/employers/financial-support/helsinki-benefit-for-employers"
       }
     }
   },

--- a/frontend/benefit/common/src/emails/i18n/fi.json
+++ b/frontend/benefit/common/src/emails/i18n/fi.json
@@ -3,11 +3,11 @@
     "links": {
       "aboutHelsinkiBenefit": {
         "title": "Tietoa Helsinki-lisästä",
-        "url": "#"
+        "url": "https://www.hel.fi/fi/yritykset-ja-tyo/tyonantajat/taloudelliset-tuet/helsinki-lisa-tyonantajille"
       },
       "customerService": {
         "title": "Asiakaspalvelu ja yhteystiedot",
-        "url": "#"
+        "url": "https://www.hel.fi/fi/yritykset-ja-tyo/tyonantajat/taloudelliset-tuet/helsinki-lisa-tyonantajille#yhteystiedot"
       }
     }
   },
@@ -34,7 +34,7 @@
       "text": "Ohjeet ja lisätietoa hakulomakkeen täyttämiseen löydät Helsingin kaupungin sivuilta.",
       "link": {
         "title": "Lue lisãä Helsinki-lisän hakemisesta",
-        "url": "#"
+        "url": "https://www.hel.fi/fi/yritykset-ja-tyo/tyonantajat/taloudelliset-tuet/helsinki-lisa-tyonantajille"
       }
     }
   },

--- a/frontend/benefit/common/src/emails/i18n/sv.json
+++ b/frontend/benefit/common/src/emails/i18n/sv.json
@@ -3,11 +3,11 @@
     "links": {
       "aboutHelsinkiBenefit": {
         "title": "Information om Helsingforstillägget",
-        "url": "#"
+        "url": "https://www.hel.fi/sv/foretag-och-arbete/arbetsgivare/ekonomiska-stod/helsingforstillagget-for-arbetsgivare"
       },
       "customerService": {
         "title": "Kundtjänst och kontaktuppgifter",
-        "url": "#"
+        "url": "https://www.hel.fi/sv/foretag-och-arbete/arbetsgivare/ekonomiska-stod/helsingforstillagget-for-arbetsgivare#kontaktuppgifter"
       }
     }
   },
@@ -34,7 +34,7 @@
       "text": "Anvisningar och ytterligare information om hur du ska fylla in ansökan hittar du på Helsingfors stads webbplats.",
       "link": {
         "title": "Läs mer om att ansöka om Helsingforstillägget",
-        "url": "#"
+        "url": "https://www.hel.fi/sv/foretag-och-arbete/arbetsgivare/ekonomiska-stod/helsingforstillagget-for-arbetsgivare"
       }
     }
   },


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
