### PR TITLE
fix: redo various issues with typos and text flow (#2622)

### DIFF
--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_en.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_en.html
@@ -244,7 +244,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
-      >Your Helsinki benefit application requires additional information</div>
+      ><h1 style="font-size: 34px; line-height: 125%;">Your Helsinki benefit application requires additional information</h1></div>
     
                 </td>
               </tr>
@@ -285,7 +285,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
-      >The Helsinki benefit application you submitted is missing required information. Log in to the Helsinki benefit service and fill in the missing information by {{ additional_information_deadline_time }} on {{ additional_information_deadline_date }}.</div>
+      ><p>The Helsinki benefit application you submitted is missing required information. Log in to the Helsinki benefit service and fill in the missing information by {{ additional_information_deadline_time }} on {{ additional_information_deadline_date }}.</p></div>
     
                 </td>
               </tr>

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_fi.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_fi.html
@@ -244,7 +244,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
-      >Helsinki-lisä -hakemus tarvitsee lisätietoja</div>
+      ><h1 style="font-size: 34px; line-height: 125%;">Helsinki-lisä -hakemus tarvitsee lisätietoja</h1></div>
     
                 </td>
               </tr>
@@ -285,7 +285,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
-      >Lähettämästäsi Helsinki-lisä-hakemuksesta puuttuu tarvittavia tietoja. Kirjaudu Helsinki-lisän asiointipalveluun ja täytä puttuvat tiedot {{ additional_information_deadline_date }} klo {{ additional_information_deadline_time }} mennessä.</div>
+      ><p>Lähettämästäsi Helsinki-lisä-hakemuksesta puuttuu tarvittavia tietoja. Kirjaudu Helsinki-lisän asiointipalveluun ja täytä puuttuvat tiedot {{ additional_information_deadline_date }} klo {{ additional_information_deadline_time }} mennessä.</p></div>
     
                 </td>
               </tr>

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_sv.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/additional-information-required_sv.html
@@ -244,7 +244,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
-      >Ansökan om Helsingforstillägget behöver ytterligare information</div>
+      ><h1 style="font-size: 34px; line-height: 125%;">Ansökan om Helsingforstillägget behöver ytterligare information</h1></div>
     
                 </td>
               </tr>
@@ -285,7 +285,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
-      >Den ansökan om Helsingforstillägget du skickade saknar nödvändiga uppgifter. Logg in på e-tjänst för sysselsättning Helsingforstillägg och fyll in de saknande uppgifterna senast {{ additional_information_deadline_date }} kl. {{ additional_information_deadline_time }}.</div>
+      ><p>Den ansökan om Helsingforstillägget du skickade saknar nödvändiga uppgifter. Logg in på e-tjänst för sysselsättning Helsingforstillägg och fyll in de saknande uppgifterna senast {{ additional_information_deadline_date }} kl. {{ additional_information_deadline_time }}.</p></div>
     
                 </td>
               </tr>

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_en.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_en.html
@@ -244,7 +244,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
-      >Your draft application will expire on {{ application_deletion_date }}</div>
+      ><h1 style="font-size: 34px; line-height: 125%;">Your draft application will expire on {{ application_deletion_date }}</h1></div>
     
                 </td>
               </tr>
@@ -285,7 +285,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
-      >Your Helsinki benefit draft application {{application.application_number}} will expire in two weeks on {{ application_deletion_date }}. You can update the information in your Helsinki benefit application or delete your application by logging in to the Helsinki benefit e-service and opening your application.</div>
+      ><p>Your Helsinki benefit draft application {{application.application_number}} will expire in two weeks on {{ application_deletion_date }}. You can update the information in your Helsinki benefit application or delete your application by logging in to the Helsinki benefit e-service and opening your application.</p></div>
     
                 </td>
               </tr>

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_fi.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_fi.html
@@ -244,7 +244,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
-      >Helsinki-lisä -hakemuksesi luonnos vanhenee {{ application_deletion_date }}</div>
+      ><h1 style="font-size: 34px; line-height: 125%;">Helsinki-lisä -hakemuksesi luonnos vanhenee {{ application_deletion_date }}</h1></div>
     
                 </td>
               </tr>
@@ -285,7 +285,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
-      >Helsinki-lisä -hakemuksesi {{application.application_number}} luonnos vanhentuu kahden viikon kuluttua {{ application_deletion_date }}. Voit päivittää Helsinki-lisä-hakemuksesi tietoja tai poistaa hakemuksen kirjautumalla Helsinki-lisä palveluun ja avaamalla hakemuksesi.</div>
+      ><p>Helsinki-lisä -hakemuksesi {{application.application_number}} luonnos vanhentuu kahden viikon kuluttua {{ application_deletion_date }}. Voit päivittää Helsinki-lisä-hakemuksesi tietoja tai poistaa hakemuksen kirjautumalla Helsinki-lisä palveluun ja avaamalla hakemuksesi.</p></div>
     
                 </td>
               </tr>
@@ -423,7 +423,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
-      ><a href="https://www.hel.fi/fi/yritykset-ja-tyo/tyonantajat/taloudelliset-tuet/helsinki-lisa-tyonantajille">Lue lisãä Helsinki-lisän hakemisesta</a></div>
+      ><a href="https://www.hel.fi/fi/yritykset-ja-tyo/tyonantajat/taloudelliset-tuet/helsinki-lisa-tyonantajille">Lue lisää Helsinki-lisän hakemisesta</a></div>
     
                 </td>
               </tr>

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_sv.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/draft-notice_sv.html
@@ -244,7 +244,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
-      >Ditt utkast för ansökan on Helsingforstillägget går ut {{application_deletion_date}}</div>
+      ><h1 style="font-size: 34px; line-height: 125%;">Ditt utkast för ansökan on Helsingforstillägget går ut {{application_deletion_date}}</h1></div>
     
                 </td>
               </tr>
@@ -285,7 +285,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
-      >Ditt utkast för ansökan om Helsingforstillägget {{application.application_number}} går ut om två veckor {{ application_deletion_date }}. Du kan uppdatera uppgifterna för din ansökan om Helsingforstillägget eller avlägsna ansökan genom att logga in på tjänsten för Helsingforstillägget och öppna din ansökan.</div>
+      ><p>Ditt utkast för ansökan om Helsingforstillägget {{application.application_number}} går ut om två veckor {{ application_deletion_date }}. Du kan uppdatera uppgifterna för din ansökan om Helsingforstillägget eller avlägsna ansökan genom att logga in på tjänsten för Helsingforstillägget och öppna din ansökan.</p></div>
     
                 </td>
               </tr>

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_en.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_en.html
@@ -244,7 +244,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
-      >You have received a new message regarding your Helsinki benefit application</div>
+      ><h1 style="font-size: 34px; line-height: 150%;">You have received a new message regarding your Helsinki benefit application</h1></div>
     
                 </td>
               </tr>
@@ -285,7 +285,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
-      >You have received a new message regarding your Helsinki benefit application. You can read the message in the Helsinki benefit service.</div>
+      ><p>You have received a new message regarding your Helsinki benefit application. You can read the message in the Helsinki benefit service.</p></div>
     
                 </td>
               </tr>

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_fi.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_fi.html
@@ -244,7 +244,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
-      >Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen</div>
+      ><h1 style="font-size: 34px; line-height: 150%;">Olet saanut uuden viestin Helsinki-lisä -hakemukseen liittyen</h1></div>
     
                 </td>
               </tr>
@@ -285,7 +285,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
-      >Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen. Voit lukea viestin Helsinki-lisän asiointipalvelussa.</div>
+      ><p>Olet saanut uuden viestin Helsinki-lisä -hakemukseen liittyen. Voit lukea viestin Helsinki-lisän asiointipalvelussa.</p></div>
     
                 </td>
               </tr>

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_sv.html
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/html/received-message_sv.html
@@ -244,7 +244,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:34px;font-weight:600;line-height:150%;text-align:left;color:#222222;"
-      >Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget</div>
+      ><h1 style="font-size: 34px; line-height: 150%;">Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget</h1></div>
     
                 </td>
               </tr>
@@ -285,7 +285,7 @@ p {
                   
       <div
          style="font-family:HelsinkiGrotesk,system-ui,sans-serif;font-size:16px;font-weight:400;line-height:150%;text-align:left;color:#222222;"
-      >Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget. Du kan läsa meddelandet i e-tjänst för sysselsättning Helsingforstillägg.</div>
+      ><p>Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget. Du kan läsa meddelandet i e-tjänst för sysselsättning Helsingforstillägg.</p></div>
     
                 </td>
               </tr>

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/additional-information-required_fi.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/additional-information-required_fi.txt
@@ -1,6 +1,6 @@
 {% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hei!
 
-Lähettämästäsi Helsinki-lisä-hakemuksesta puuttuu tarvittavia tietoja. Kirjaudu Helsinki-lisän asiointipalveluun ja täytä puttuvat tiedot {{ additional_information_deadline_date }} klo {{ additional_information_deadline_time }} mennessä.
+Lähettämästäsi Helsinki-lisä-hakemuksesta puuttuu tarvittavia tietoja. Kirjaudu Helsinki-lisän asiointipalveluun ja täytä puuttuvat tiedot {{ additional_information_deadline_date }} klo {{ additional_information_deadline_time }} mennessä.
 Mikäli sinulla herää kysyttävää, lähetä meille viesti Helsinki-lisän asiointipalvelun kautta.
 
 Hakemuksen tiedot

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/draft-notice_fi.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/draft-notice_fi.txt
@@ -6,7 +6,7 @@ Jatka Helsinki-lisä -hakemuksen täyttöä: https://helsinkilisa.hel.fi/
 
 Ohjeet ja lisätietoa hakulomakkeen täyttämiseen löydät Helsingin kaupungin sivuilta.
 
-Lue lisãä Helsinki-lisän hakemisesta: https://www.hel.fi/fi/yritykset-ja-tyo/tyonantajat/taloudelliset-tuet/helsinki-lisa-tyonantajille 
+Lue lisää Helsinki-lisän hakemisesta: https://www.hel.fi/fi/yritykset-ja-tyo/tyonantajat/taloudelliset-tuet/helsinki-lisa-tyonantajille 
 
 Ystävällisin terveisin,
 Helsinki-lisän tiimi

--- a/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/received-message_fi.txt
+++ b/backend/benefit/helsinkibenefit/templates/emails/mjml-generated/txt/received-message_fi.txt
@@ -1,6 +1,6 @@
 {% comment %} NEVER MAKE MODIFICATIONS TO THIS GENERATED FILE DIRECTLY, ALL MODIFICATIONS SHOULD BE DONE TO MJML TEMPLATE FILES! {% endcomment %}Hei!
 
-Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen. Voit lukea viestin Helsinki-lisän asiointipalvelussa.
+Olet saanut uuden viestin Helsinki-lisä -hakemukseen liittyen. Voit lukea viestin Helsinki-lisän asiointipalvelussa.
 
 Hakemuksen tiedot
 Hakemusnumero: {{application.application_number}}

--- a/backend/benefit/messages/tests/test_api.py
+++ b/backend/benefit/messages/tests/test_api.py
@@ -333,8 +333,9 @@ def test_create_message(
                 email_parts = email.message_from_string(mailoutbox[0].body)
                 for part in email_parts.walk():
                     if part.get_content_type() == "text/plain":
+                        print(part.get_payload())
                         assert (
-                            "Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen. Voit lukea viestin"
+                            "Olet saanut uuden viestin Helsinki-lisä -hakemukseen liittyen. Voit lukea viestin"
                             in part.get_payload()
                         )
 

--- a/frontend/benefit/common/src/emails/i18n/fi.json
+++ b/frontend/benefit/common/src/emails/i18n/fi.json
@@ -21,8 +21,8 @@
   },
   "receivedMessage": {
     "headerText": "Olet saanut uuden viestin",
-    "heading": "Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen",
-    "bodyText": "Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen. Voit lukea viestin Helsinki-lisän asiointipalvelussa.",
+    "heading": "Olet saanut uuden viestin Helsinki-lisä -hakemukseen liittyen",
+    "bodyText": "Olet saanut uuden viestin Helsinki-lisä -hakemukseen liittyen. Voit lukea viestin Helsinki-lisän asiointipalvelussa.",
     "ctaButton": "Kirjaudu palveluun ja lue viesti"
   },
   "draftExpiring": {
@@ -33,7 +33,7 @@
     "helper": {
       "text": "Ohjeet ja lisätietoa hakulomakkeen täyttämiseen löydät Helsingin kaupungin sivuilta.",
       "link": {
-        "title": "Lue lisãä Helsinki-lisän hakemisesta",
+        "title": "Lue lisää Helsinki-lisän hakemisesta",
         "url": "https://www.hel.fi/fi/yritykset-ja-tyo/tyonantajat/taloudelliset-tuet/helsinki-lisa-tyonantajille"
       }
     }
@@ -41,7 +41,7 @@
   "additionalInformationRequired": {
     "headerText": "Hakemuksesi tarvitsee lisätietoja",
     "heading": "Helsinki-lisä -hakemus tarvitsee lisätietoja",
-    "bodyText": "Lähettämästäsi Helsinki-lisä-hakemuksesta puuttuu tarvittavia tietoja. Kirjaudu Helsinki-lisän asiointipalveluun ja täytä puttuvat tiedot {{ additional_information_deadline_date }} klo {{ additional_information_deadline_time }} mennessä.",
+    "bodyText": "Lähettämästäsi Helsinki-lisä-hakemuksesta puuttuu tarvittavia tietoja. Kirjaudu Helsinki-lisän asiointipalveluun ja täytä puuttuvat tiedot {{ additional_information_deadline_date }} klo {{ additional_information_deadline_time }} mennessä.",
     "ctaButton": "Kirjaudu palveluun ja täydennä hakemusta",
     "helper": {
       "text": "Mikäli sinulla herää kysyttävää, lähetä meille viesti Helsinki-lisän asiointipalvelun kautta."

--- a/frontend/benefit/common/src/emails/templates/additional-information-required.template.mjml
+++ b/frontend/benefit/common/src/emails/templates/additional-information-required.template.mjml
@@ -15,10 +15,10 @@
 
     <mj-section background-color="#fff" padding-bottom="0px">
       <mj-column>
-        <mj-text font-weight="600" font-size="34px">${additionalInformationRequired.heading}</mj-text>
+        <mj-text font-weight="600" font-size="34px"><h1 style="font-size: 34px; line-height: 125%;">${additionalInformationRequired.heading}</h1></mj-text>
         <mj-divider border-color="#0072c6" />
         <mj-text padding-bottom="20px" padding-top="10px">${general.greeting}</mj-text>
-        <mj-text>${additionalInformationRequired.bodyText}</mj-text>
+        <mj-text><p>${additionalInformationRequired.bodyText}</p></mj-text>
       </mj-column>
     </mj-section>
 

--- a/frontend/benefit/common/src/emails/templates/draft-notice.template.mjml
+++ b/frontend/benefit/common/src/emails/templates/draft-notice.template.mjml
@@ -15,10 +15,10 @@
 
     <mj-section background-color="#fff" padding-bottom="0px">
       <mj-column>
-        <mj-text font-weight="600" font-size="34px">${draftExpiring.heading}</mj-text>
+        <mj-text font-weight="600" font-size="34px"><h1 style="font-size: 34px; line-height: 125%;">${draftExpiring.heading}</h1></mj-text>
         <mj-divider border-color="#0072c6" />
         <mj-text padding-bottom="20px" padding-top="10px">${general.greeting}</mj-text>
-        <mj-text>${draftExpiring.bodyText}</mj-text>
+        <mj-text><p>${draftExpiring.bodyText}</p></mj-text>
       </mj-column>
     </mj-section>
 

--- a/frontend/benefit/common/src/emails/templates/received-message.template.mjml
+++ b/frontend/benefit/common/src/emails/templates/received-message.template.mjml
@@ -15,10 +15,12 @@
 
     <mj-section background-color="#fff" padding-bottom="0px">
       <mj-column>
-        <mj-text font-weight="600" font-size="34px">${receivedMessage.heading}</mj-text>
+        <mj-text font-weight="600" font-size="34px"
+          ><h1 style="font-size: 34px; line-height: 150%;">${receivedMessage.heading}</h1></mj-text
+        >
         <mj-divider border-color="#0072c6" />
         <mj-text padding-bottom="20px" padding-top="10px">${general.greeting}</mj-text>
-        <mj-text>${receivedMessage.bodyText}</mj-text>
+        <mj-text><p>${receivedMessage.bodyText}</p></mj-text>
       </mj-column>
     </mj-section>
     <mj-section padding-bottom="0px">


### PR DESCRIPTION
Fix broken builds caused by failing pytest.

This reverts and adds to commit c870fcb932b2eff85e3c03339a9fd859877ba274 which is a revert of a previous PR ♻️ .

## Description :sparkles:

Fix issue in test. Test would assert **littyen** but it should've been **liittyen** ofc 🤷 .