### PR TITLE
fix: more liberal regex on gdpr ssn mask; to support 2024 ssn

### DIFF
--- a/frontend/shared/src/utils/mask-gdpr-data.ts
+++ b/frontend/shared/src/utils/mask-gdpr-data.ts
@@ -6,9 +6,7 @@ import { isString } from 'shared/utils/type-guards';
  */
 
 const maskFinnishSsn = (text: unknown): unknown =>
-  isString(text)
-    ? text.replace(/\d{6}[+Aa-]\d{3}[\dA-z]/g, '*'.repeat(11))
-    : text;
+  isString(text) ? text.replace(/\d{6}.\d{3}[\dA-z]/g, '*'.repeat(11)) : text;
 
 /* Gets the length of the given variable */
 const getLengthOfAttribute = (attrValue: unknown): number =>


### PR DESCRIPTION
## Description :sparkles:

Shared libraries' gdpr test has been failing since @mjturt  ssn upgrades. Loosen regex to support 2024 style on masking ssn.