### PR TITLE
Hl 1093 y2k24 bug

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -703,13 +703,18 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
             )
 
     def _validate_date_range_on_submit(self, start_date, end_date):
-        if start_date < date(date.today().year, 1, 1):
+        four_months_ago = date.today() - relativedelta(months=4)
+        if start_date < four_months_ago:
             raise serializers.ValidationError(
-                {"start_date": _("start_date must not be in a past year")}
+                {
+                    "start_date": _(
+                        "start_date must not be more than 4 months in the past"
+                    )
+                }
             )
-        if end_date < date(date.today().year, 1, 1):
+        if end_date < start_date:
             raise serializers.ValidationError(
-                {"end_date": _("end_date must not be in a past year")}
+                {"end_date": _("application end_date can not be less than start_date")}
             )
 
     def _validate_date_range(self, start_date, end_date, benefit_type):

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -977,7 +977,7 @@ def test_application_date_range(
         (
             "2021-01-01",
             "2021-02-28",
-            200,
+            400,
         ),  # start_date in current year (relative to freeze_time date)
         (
             "2022-12-31",

--- a/backend/benefit/locale/en/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/en/LC_MESSAGES/django.po
@@ -104,6 +104,9 @@ msgstr ""
 msgid "start_date must not be in a past year"
 msgstr ""
 
+msgid "start_date must not be more than 4 months in the past"
+msgstr ""
+
 msgid "end_date must not be in a past year"
 msgstr ""
 

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -109,6 +109,9 @@ msgstr "De minimis -tuen kokonaismäärä liian suuri"
 msgid "start_date must not be in a past year"
 msgstr "Aloituspäivä ei saa olla menneessä vuodessa"
 
+msgid "start_date must not be more than 4 months in the past"
+msgstr "Aloituspäivä voi olla enintään 4 kuukautta menneisyydessä"
+
 msgid "end_date must not be in a past year"
 msgstr "Päättymispäivä ei saa olla menneessä vuodessa"
 

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -107,6 +107,9 @@ msgstr "Totalt belopp av de minimis-stöd är för stort"
 msgid "start_date must not be in a past year"
 msgstr "Startdatum får inte vara under föregående år"
 
+msgid "start_date must not be more than 4 months in the past"
+msgstr "Startdatumet får inte ligga mer än fyra månader bakåt i tiden"
+
 msgid "end_date must not be in a past year"
 msgstr "Slutdatum får inte vara under föregående år"
 

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
@@ -12,8 +12,7 @@ import {
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
 import { validateIsTodayOrPastDate } from 'benefit-shared/utils/dates';
-import  subMonths from 'date-fns/subMonths';
-
+import subMonths from 'date-fns/subMonths';
 import { FinnishSSN } from 'finnish-ssn';
 import { TFunction } from 'next-i18next';
 import { NAMES_REGEX } from 'shared/constants';

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
@@ -11,8 +11,9 @@ import {
   PAY_SUBSIDY_GRANTED,
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
-import { validateDateIsFromCurrentYearOnwards } from 'benefit-shared/utils/dates';
-import startOfYear from 'date-fns/startOfYear';
+import { validateIsTodayOrPastDate } from 'benefit-shared/utils/dates';
+import  subMonths from 'date-fns/subMonths';
+
 import { FinnishSSN } from 'finnish-ssn';
 import { TFunction } from 'next-i18next';
 import { NAMES_REGEX } from 'shared/constants';
@@ -45,9 +46,9 @@ export const getValidationSchema = (
       .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED))
       .test({
         message: t(VALIDATION_MESSAGE_KEYS.DATE_MIN, {
-          min: convertToUIDateFormat(startOfYear(new Date())),
+          min: convertToUIDateFormat(subMonths(new Date(), 4)),
         }),
-        test: (value = '') => validateDateIsFromCurrentYearOnwards(value),
+        test: (value = '') => validateIsTodayOrPastDate(value),
       }),
     [APPLICATION_FIELDS_STEP2_KEYS.END_DATE]: Yup.string().required(
       t(VALIDATION_MESSAGE_KEYS.REQUIRED)

--- a/frontend/benefit/applicant/src/constants.ts
+++ b/frontend/benefit/applicant/src/constants.ts
@@ -1,11 +1,10 @@
-import  subMonths from 'date-fns/subMonths';
-
 import {
   APPLICATION_FIELDS_STEP1_KEYS,
   APPLICATION_FIELDS_STEP2,
   APPLICATION_FIELDS_STEP2_KEYS,
   APPLICATION_STATUSES,
 } from 'benefit-shared/constants';
+import subMonths from 'date-fns/subMonths';
 
 export const IS_CLIENT = typeof window !== 'undefined';
 

--- a/frontend/benefit/applicant/src/constants.ts
+++ b/frontend/benefit/applicant/src/constants.ts
@@ -1,3 +1,5 @@
+import  subMonths from 'date-fns/subMonths';
+
 import {
   APPLICATION_FIELDS_STEP1_KEYS,
   APPLICATION_FIELDS_STEP2,
@@ -52,7 +54,7 @@ export const DE_MINIMIS_AID_GRANTED_AT_MIN_DATE = new Date(
   1
 );
 
-export const APPLICATION_START_DATE = new Date(new Date().getFullYear(), 0, 1);
+export const APPLICATION_START_DATE = subMonths(new Date(), 4);
 
 export const APPLICATION_INITIAL_VALUES = {
   status: APPLICATION_STATUSES.DRAFT,


### PR DESCRIPTION
## Description :sparkles:
Fix application start date validations that did not allow the start date to be in the past year.
Fix validations to allow a start date 4 months in the past.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
