### PR TITLE
fix: start_date can now be in the future

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/__tests__/dates.test.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/__tests__/dates.test.ts
@@ -1,6 +1,7 @@
 import {
   getMaxEndDate,
   getMinEndDate,
+  validateDateWithinFourMonths,
 } from '@frontend/benefit-shared/src/utils/dates';
 import { BENEFIT_TYPES } from 'benefit-shared/constants';
 
@@ -61,6 +62,37 @@ describe('dates', () => {
 
       expect(maxEndDate1).toBeUndefined();
       expect(maxEndDate2).toBeUndefined();
+    });
+  });
+
+  describe('validateDateWithinFourMonths', () => {
+    it('should return true when date is exactly four months ago', () => {
+      const fourMonthsAgo = new Date();
+      fourMonthsAgo.setMonth(fourMonthsAgo.getMonth() - 4);
+
+      expect(validateDateWithinFourMonths(fourMonthsAgo)).toBe(true);
+    });
+
+    it('should return true when date is within four months', () => {
+      const twoMonthsAgo = new Date();
+      twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2);
+
+      expect(validateDateWithinFourMonths(twoMonthsAgo)).toBe(true);
+    });
+
+    it('should return true when date is two months in the future', () => {
+      const twoMonthsInTheFuture = new Date();
+      twoMonthsInTheFuture.setMonth(twoMonthsInTheFuture.getMonth() + 2);
+
+      expect(validateDateWithinFourMonths(twoMonthsInTheFuture)).toBe(true);
+    });
+
+
+    it('should return false when date is more than four months in the past', () => {
+      const fiveMonthsAgo = new Date();
+      fiveMonthsAgo.setMonth(fiveMonthsAgo.getMonth() - 5);
+
+      expect(validateDateWithinFourMonths(fiveMonthsAgo)).toBe(false);
     });
   });
 });

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
@@ -11,7 +11,7 @@ import {
   PAY_SUBSIDY_GRANTED,
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
-import { validateIsTodayOrPastDate } from 'benefit-shared/utils/dates';
+import { validateDateWithinFourMonths } from 'benefit-shared/utils/dates';
 import subMonths from 'date-fns/subMonths';
 import { FinnishSSN } from 'finnish-ssn';
 import { TFunction } from 'next-i18next';
@@ -47,7 +47,7 @@ export const getValidationSchema = (
         message: t(VALIDATION_MESSAGE_KEYS.DATE_MIN, {
           min: convertToUIDateFormat(subMonths(new Date(), 4)),
         }),
-        test: (value = '') => validateIsTodayOrPastDate(value),
+        test: (value = '') => validateDateWithinFourMonths(value),
       }),
     [APPLICATION_FIELDS_STEP2_KEYS.END_DATE]: Yup.string().required(
       t(VALIDATION_MESSAGE_KEYS.REQUIRED)

--- a/frontend/benefit/shared/src/utils/dates.ts
+++ b/frontend/benefit/shared/src/utils/dates.ts
@@ -2,9 +2,7 @@ import {
   APPLICATION_START_DATE,
   BENEFIT_TYPES,
 } from 'benefit-shared/constants';
-import { isFuture, parse, startOfYear } from 'date-fns';
-import addMonths from 'date-fns/addMonths';
-import subDays from 'date-fns/subDays';
+import { addMonths, isAfter, isEqual, isFuture, parse, startOfDay, startOfYear, subDays, subMonths } from 'date-fns';
 import { parseDate } from 'shared/utils/date.utils';
 
 export const getMinEndDate = (
@@ -73,3 +71,17 @@ export const validateIsTodayOrPastDate = (value: string): boolean => {
   }
   return true;
 };
+
+export const validateDateWithinFourMonths = (value: string): boolean => {
+  const isFinnishDate = validateFinnishDatePattern(value);
+  const date = isFinnishDate
+    ? parse(value, 'd.M.yyyy', new Date())
+    : parseDate(value);
+
+  if (!date || !date?.toJSON()) {
+    return false;
+  }
+  const startOfDayDate = startOfDay(date);
+  const fourMonthsAgo = startOfDay(subMonths(new Date(), 4));
+  return isEqual(startOfDayDate, fourMonthsAgo) || isAfter(startOfDayDate, fourMonthsAgo);
+}


### PR DESCRIPTION
## Description :sparkles:
Frontend validation did not allow for a start date in the future.
## Issues :bug:

## Testing :alembic:
As an applicant, create an application and in step 2, set start date to 4 months in the past, current date or any date in the future,
also 
`yarn test`
## Screenshots :camera_flash:
<img width="1000" alt="Screenshot 2024-01-03 at 14 45 13" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/f14b79d8-a37a-4d89-943a-20744661cc51">


## Additional notes :spiral_notepad:
