### PR TITLE
fix: app crash on empty calculations (HL-1041)

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/validation.ts
@@ -1,12 +1,13 @@
+import { validateNumberField } from '@frontend/benefit-shared/src/utils/validation';
 import {
   EMPLOYEE_MAX_WORKING_HOURS,
   EMPLOYEE_MIN_WORKING_HOURS,
-  MAX_MONTHLY_PAY,
   MAX_SHORT_STRING_LENGTH,
 } from 'benefit/applicant/constants';
 import {
   APPLICATION_FIELDS_STEP2_KEYS,
   EMPLOYEE_KEYS,
+  MAX_MONTHLY_PAY,
   ORGANIZATION_TYPES,
   PAY_SUBSIDY_GRANTED,
   VALIDATION_MESSAGE_KEYS,
@@ -17,7 +18,6 @@ import { FinnishSSN } from 'finnish-ssn';
 import { TFunction } from 'next-i18next';
 import { NAMES_REGEX } from 'shared/constants';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
-import { getNumberValue } from 'shared/utils/string.utils';
 import * as Yup from 'yup';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -89,63 +89,26 @@ export const getValidationSchema = (
       [EMPLOYEE_KEYS.JOB_TITLE]: Yup.string()
         .nullable()
         .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
-      [EMPLOYEE_KEYS.WORKING_HOURS]: Yup.number()
-        .transform((_value, originalValue) =>
-          Number(getNumberValue(originalValue))
-        )
-        .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
-        .nullable()
-        .min(EMPLOYEE_MIN_WORKING_HOURS, (param) => ({
-          min: param.min,
-          key: VALIDATION_MESSAGE_KEYS.NUMBER_MIN,
-        }))
-        .max(EMPLOYEE_MAX_WORKING_HOURS, (param) => ({
-          max: param.max,
-          key: VALIDATION_MESSAGE_KEYS.NUMBER_MAX,
-        }))
-        .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
-      [EMPLOYEE_KEYS.VACATION_MONEY]: Yup.number()
-        .min(0, (param) => ({
-          min: param.min,
-          key: VALIDATION_MESSAGE_KEYS.NUMBER_MIN,
-        }))
-        .max(MAX_MONTHLY_PAY, (param) => ({
-          max: param.max,
-          key: VALIDATION_MESSAGE_KEYS.NUMBER_MAX,
-        }))
-        .transform((_value, originalValue) =>
-          originalValue ? getNumberValue(originalValue) : null
-        )
-        .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
-        .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
-      [EMPLOYEE_KEYS.MONTHLY_PAY]: Yup.number()
-        .min(0, (param) => ({
-          min: param.min,
-          key: VALIDATION_MESSAGE_KEYS.NUMBER_MIN,
-        }))
-        .max(MAX_MONTHLY_PAY, (param) => ({
-          max: param.max,
-          key: VALIDATION_MESSAGE_KEYS.NUMBER_MAX,
-        }))
-        .transform((_value, originalValue) =>
-          originalValue ? getNumberValue(originalValue) : null
-        )
-        .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
-        .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
-      [EMPLOYEE_KEYS.OTHER_EXPENSES]: Yup.number()
-        .min(0, (param) => ({
-          min: param.min,
-          key: VALIDATION_MESSAGE_KEYS.NUMBER_MIN,
-        }))
-        .max(MAX_MONTHLY_PAY, (param) => ({
-          max: param.max,
-          key: VALIDATION_MESSAGE_KEYS.NUMBER_MAX,
-        }))
-        .transform((_value, originalValue) =>
-          originalValue ? getNumberValue(originalValue) : null
-        )
-        .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
-        .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
+      [EMPLOYEE_KEYS.WORKING_HOURS]: validateNumberField(
+        EMPLOYEE_MIN_WORKING_HOURS,
+        EMPLOYEE_MAX_WORKING_HOURS,
+        {
+          required: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+          typeError: t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID),
+        }
+      ),
+      [EMPLOYEE_KEYS.VACATION_MONEY]: validateNumberField(0, MAX_MONTHLY_PAY, {
+        required: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+        typeError: t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID),
+      }),
+      [EMPLOYEE_KEYS.MONTHLY_PAY]: validateNumberField(0, MAX_MONTHLY_PAY, {
+        required: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+        typeError: t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID),
+      }),
+      [EMPLOYEE_KEYS.OTHER_EXPENSES]: validateNumberField(0, MAX_MONTHLY_PAY, {
+        required: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+        typeError: t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID),
+      }),
       [EMPLOYEE_KEYS.COLLECTIVE_BARGAINING_AGREEMENT]: Yup.string().required(
         t(VALIDATION_MESSAGE_KEYS.REQUIRED)
       ),

--- a/frontend/benefit/applicant/src/constants.ts
+++ b/frontend/benefit/applicant/src/constants.ts
@@ -17,7 +17,6 @@ export enum ROUTES {
 }
 
 export const MAX_DEMINIMIS_AID_TOTAL_AMOUNT = 200_000;
-export const MAX_MONTHLY_PAY = 99_999;
 
 export enum SUPPORTED_LANGUAGES {
   FI = 'fi',

--- a/frontend/benefit/handler/src/components/applicationReview/handledView/HandledView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/handledView/HandledView.tsx
@@ -90,7 +90,12 @@ const HandledView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
               $colSpan={2}
             >
               <$ViewFieldBold large>
-                {formatFloatToCurrency(totalRow.amount, 'EUR', 'fi-FI', 0)}
+                {formatFloatToCurrency(
+                  totalRow?.amount || 0,
+                  'EUR',
+                  'fi-FI',
+                  0
+                )}
               </$ViewFieldBold>
             </$GridCell>
           </$HandledRow>

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -66,6 +66,7 @@ const SalaryBenefitCalculatorView: React.FC<
     handleSubmit,
     handleClear,
     isRecalculationRequired,
+    setIsRecalculationRequired,
   } = useCalculatorData(CALCULATION_TYPES.SALARY, formik);
 
   const eurosPerMonth = 'common:utility.eurosPerMonth';
@@ -78,13 +79,17 @@ const SalaryBenefitCalculatorView: React.FC<
       <$GridCell $colStart={1} $colSpan={11}>
         <$TabButton
           active={!isManualCalculator}
-          onClick={() => isManualCalculator && changeCalculatorMode()}
+          onClick={() =>
+            changeCalculatorMode('auto') && setIsRecalculationRequired(true)
+          }
         >
           {t(`${translationsBase}.calculator`)}
         </$TabButton>
         <$TabButton
           active={isManualCalculator}
-          onClick={() => !isManualCalculator && changeCalculatorMode()}
+          onClick={() =>
+            changeCalculatorMode('manual') && setIsRecalculationRequired(true)
+          }
         >
           {t(`${translationsBase}.calculateManually`)}
         </$TabButton>
@@ -610,7 +615,8 @@ const SalaryBenefitCalculatorView: React.FC<
           {t(`${translationsBase}.calculate`)}
         </Button>
         <Button onClick={handleClear} theme="coat" variant="secondary">
-          {t(`${translationsBase}.clear`)}
+          {isManualCalculator && t(`${translationsBase}.clear`)}
+          {!isManualCalculator && t(`${translationsBase}.reset`)}
         </Button>
       </$GridCell>
 
@@ -628,7 +634,11 @@ const SalaryBenefitCalculatorView: React.FC<
           </$Notification>
         </$GridCell>
       )}
-      <SalaryCalculatorResults data={data} />
+      <SalaryCalculatorResults
+        data={data}
+        isManualCalculator={isManualCalculator}
+        isRecalculationRequired={isRecalculationRequired}
+      />
     </ReviewSection>
   );
 };

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryCalculatorResults/SalaryCalculatorResults.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryCalculatorResults/SalaryCalculatorResults.tsx
@@ -21,97 +21,109 @@ import {
 
 const SalaryCalculatorResults: React.FC<ApplicationReviewViewProps> = ({
   data,
+  isManualCalculator,
+  isRecalculationRequired,
 }) => {
   const theme = useTheme();
   const translationsBase = 'common:calculators.result';
   const { t } = useTranslation();
   const { rowsWithoutTotal, totalRow, totalRowDescription } =
     extractCalculatorRows(data?.calculation?.rows);
-  if (rowsWithoutTotal.length > 0) {
-    return (
-      <$GridCell
-        $colSpan={11}
-        style={{
-          backgroundColor: 'white',
-          margin: `0 ${theme.spacing.xl4}`,
-          padding: `${theme.spacing.l} ${theme.spacing.xl4}`,
-        }}
-      >
-        {totalRow && totalRowDescription && (
-          <>
-            <$CalculatorTableHeader>
-              {t(`${translationsBase}.header`)}
-            </$CalculatorTableHeader>
-            <$Highlight>
-              <div style={{ fontSize: theme.fontSize.body.xl }}>
-                {totalRowDescription.descriptionFi}
-              </div>
-              <div style={{ fontSize: theme.fontSize.heading.xl }}>
-                {formatFloatToCurrency(totalRow.amount, 'EUR', 'fi-FI', 0)}
-              </div>
-            </$Highlight>
-            <hr style={{ margin: theme.spacing.s }} />
-          </>
-        )}
-        <$CalculatorTableHeader style={{ paddingBottom: theme.spacing.m }}>
-          {t(`${translationsBase}.header2`)}
-        </$CalculatorTableHeader>
-        {rowsWithoutTotal.map((row) => {
-          const isDateRange =
-            CALCULATION_ROW_DESCRIPTION_TYPES.DATE === row.descriptionType;
-          const isDescriptionRowType =
-            CALCULATION_ROW_TYPES.DESCRIPTION === row.rowType;
-          const isPerMonth = CALCULATION_PER_MONTH_ROW_TYPES.includes(
-            row.rowType
-          );
-          return (
-            <div key={row.id}>
-              {CALCULATION_ROW_TYPES.HELSINKI_BENEFIT_MONTHLY_EUR ===
-                row.rowType && (
-                <$CalculatorTableRow>
-                  <$ViewField isBold>
-                    {t(`${translationsBase}.acceptedBenefit`)}
-                  </$ViewField>
-                </$CalculatorTableRow>
-              )}
-              <$CalculatorTableRow
-                isNewSection={isDateRange}
-                style={{
-                  backgroundColor: !isDescriptionRowType
-                    ? theme.colors.silverMediumLight
-                    : 'transparent',
-                  marginBottom: '7px',
-                }}
-              >
-                <$ViewField
-                  isBold={isDateRange || isDescriptionRowType}
-                  isBig={isDateRange}
-                >
-                  {row.descriptionFi}
-                </$ViewField>
-                {!isDescriptionRowType && (
-                  <$ViewField isBold style={{ marginRight: theme.spacing.xl4 }}>
-                    {formatFloatToCurrency(row.amount)}
-                    {isPerMonth && t('common:utility.perMonth')}
-                  </$ViewField>
-                )}
-              </$CalculatorTableRow>
-            </div>
-          );
-        })}
-        <Koros
-          dense
-          type="pulse"
-          style={{
-            fill: theme.colors.coatOfArmsLight,
-            margin: `${theme.spacing.l} 0 -65px -65px`,
-            width: 'calc(100% + 130px)',
-          }}
-        />
-      </$GridCell>
-    );
+
+  if (isRecalculationRequired) {
+    return null;
   }
-  return null;
+  return (
+    <$GridCell
+      $colSpan={11}
+      style={{
+        backgroundColor: 'white',
+        margin: `0 ${theme.spacing.xl4}`,
+        padding: `${theme.spacing.l} ${theme.spacing.xl4}`,
+      }}
+    >
+      {totalRow && (
+        <>
+          <$CalculatorTableHeader>
+            {t(`${translationsBase}.header`)}
+          </$CalculatorTableHeader>
+          <$Highlight>
+            <div style={{ fontSize: theme.fontSize.body.xl }}>
+              {totalRowDescription
+                ? totalRowDescription.descriptionFi
+                : totalRow?.descriptionFi}
+            </div>
+            <div style={{ fontSize: theme.fontSize.heading.xl }}>
+              {formatFloatToCurrency(totalRow.amount, 'EUR', 'fi-FI', 0)}
+            </div>
+          </$Highlight>
+          <hr style={{ margin: theme.spacing.s }} />
+        </>
+      )}
+      {!isManualCalculator && (
+        <>
+          <$CalculatorTableHeader style={{ paddingBottom: theme.spacing.m }}>
+            {t(`${translationsBase}.header2`)}
+          </$CalculatorTableHeader>
+          {rowsWithoutTotal.map((row) => {
+            const isDateRange =
+              CALCULATION_ROW_DESCRIPTION_TYPES.DATE === row.descriptionType;
+            const isDescriptionRowType =
+              CALCULATION_ROW_TYPES.DESCRIPTION === row.rowType;
+            const isPerMonth = CALCULATION_PER_MONTH_ROW_TYPES.includes(
+              row.rowType
+            );
+            return (
+              <div key={row.id}>
+                {CALCULATION_ROW_TYPES.HELSINKI_BENEFIT_MONTHLY_EUR ===
+                  row.rowType && (
+                  <$CalculatorTableRow>
+                    <$ViewField isBold>
+                      {t(`${translationsBase}.acceptedBenefit`)}
+                    </$ViewField>
+                  </$CalculatorTableRow>
+                )}
+                <$CalculatorTableRow
+                  isNewSection={isDateRange}
+                  style={{
+                    backgroundColor: !isDescriptionRowType
+                      ? theme.colors.silverMediumLight
+                      : 'transparent',
+                    marginBottom: '7px',
+                  }}
+                >
+                  <$ViewField
+                    isBold={isDateRange || isDescriptionRowType}
+                    isBig={isDateRange}
+                  >
+                    {row.descriptionFi}
+                  </$ViewField>
+                  {!isDescriptionRowType && (
+                    <$ViewField
+                      isBold
+                      style={{ marginRight: theme.spacing.xl4 }}
+                    >
+                      {formatFloatToCurrency(row.amount)}
+                      {isPerMonth && t('common:utility.perMonth')}
+                    </$ViewField>
+                  )}
+                </$CalculatorTableRow>
+              </div>
+            );
+          })}
+        </>
+      )}
+      <Koros
+        dense
+        type="pulse"
+        style={{
+          fill: theme.colors.coatOfArmsLight,
+          margin: `${theme.spacing.l} 0 -35px -65px`,
+          width: 'calc(100% + 130px)',
+        }}
+      />
+    </$GridCell>
+  );
 };
 
 export default SalaryCalculatorResults;

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
@@ -101,7 +101,7 @@ const useSalaryBenefitCalculatorData = (
           ? application?.trainingCompensations
           : [],
     },
-    validationSchema: getValidationSchema(),
+    validationSchema: getValidationSchema(t),
     validateOnChange: true,
     validateOnBlur: true,
     enableReinitialize: true,

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
@@ -15,7 +15,6 @@ import fromPairs from 'lodash/fromPairs';
 import { useTranslation } from 'next-i18next';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Field } from 'shared/components/forms/fields/types';
-import useToggle from 'shared/hooks/useToggle';
 import { OptionType } from 'shared/types/common';
 import {
   convertToUIDateFormat,
@@ -37,7 +36,7 @@ type ExtendedComponentProps = {
   getStateAidMaxPercentageSelectValue: () => OptionType | undefined;
   paySubsidyPercentageOptions: OptionType[];
   isManualCalculator: boolean;
-  changeCalculatorMode: () => void;
+  changeCalculatorMode: (mode: 'auto' | 'manual') => true;
   getPaySubsidyPercentageSelectValue: (
     percent: number
   ) => OptionType | undefined;
@@ -53,7 +52,7 @@ const useSalaryBenefitCalculatorData = (
 ): ExtendedComponentProps => {
   const { t } = useTranslation();
 
-  const [isManualCalculator, toggleManualCalculator] = useToggle(
+  const [isManualCalculator, setIsManualCalculator] = useState(
     !!application.calculation?.overrideMonthlyBenefitAmount
   );
 
@@ -149,12 +148,13 @@ const useSalaryBenefitCalculatorData = (
     );
   };
 
-  const changeCalculatorMode = (): void => {
+  const changeCalculatorMode = (mode: 'auto' | 'manual'): true => {
     // Backend detects manual mode if overrideMonthlyBenefitAmount is not null
     // so to switch to auto mode, we set empty value here
     if (isManualCalculator)
       void formik.setFieldValue(fields.overrideMonthlyBenefitAmount.name, null);
-    toggleManualCalculator();
+    setIsManualCalculator(mode === 'manual');
+    return true;
   };
 
   const stateAidMaxPercentageOptions = React.useMemo(

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/utils/validation.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/utils/validation.ts
@@ -1,11 +1,17 @@
+import { validateNumberField } from '@frontend/benefit-shared/src/utils/validation';
 import {
   CALCULATION_EMPLOYMENT_KEYS,
+  EMPLOYEE_KEYS,
+  MAX_MONTHLY_PAY,
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
 import { CalculationCommon } from 'benefit-shared/types/application';
+import { TFunction } from 'next-i18next';
 import * as Yup from 'yup';
 
-export const getValidationSchema = (): Yup.SchemaOf<CalculationCommon> =>
+export const getValidationSchema = (
+  t: TFunction
+): Yup.SchemaOf<CalculationCommon> =>
   Yup.object().shape({
     [CALCULATION_EMPLOYMENT_KEYS.START_DATE]: Yup.string()
       .typeError(VALIDATION_MESSAGE_KEYS.DATE_FORMAT)
@@ -13,4 +19,16 @@ export const getValidationSchema = (): Yup.SchemaOf<CalculationCommon> =>
     [CALCULATION_EMPLOYMENT_KEYS.END_DATE]: Yup.string()
       .typeError(VALIDATION_MESSAGE_KEYS.DATE_FORMAT)
       .required(VALIDATION_MESSAGE_KEYS.REQUIRED),
+    [EMPLOYEE_KEYS.VACATION_MONEY]: validateNumberField(0, MAX_MONTHLY_PAY, {
+      required: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+      typeError: t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID),
+    }),
+    [EMPLOYEE_KEYS.MONTHLY_PAY]: validateNumberField(0, MAX_MONTHLY_PAY, {
+      required: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+      typeError: t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID),
+    }),
+    [EMPLOYEE_KEYS.OTHER_EXPENSES]: validateNumberField(0, MAX_MONTHLY_PAY, {
+      required: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+      typeError: t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID),
+    }),
   });

--- a/frontend/benefit/handler/src/components/newApplication/utils/validation.ts
+++ b/frontend/benefit/handler/src/components/newApplication/utils/validation.ts
@@ -10,10 +10,12 @@ import {
 } from 'benefit/handler/constants';
 import {
   EMPLOYEE_KEYS,
+  MAX_MONTHLY_PAY,
   ORGANIZATION_TYPES,
   PAY_SUBSIDY_GRANTED,
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
+import { validateNumberField } from 'benefit-shared/utils/validation';
 import startOfYear from 'date-fns/startOfYear';
 import { FinnishSSN } from 'finnish-ssn';
 import { TFunction } from 'next-i18next';
@@ -29,10 +31,7 @@ import {
   convertToUIDateFormat,
   validateDateIsFromCurrentYearOnwards,
 } from 'shared/utils/date.utils';
-import {
-  getNumberValue,
-  getNumberValueOrNull,
-} from 'shared/utils/string.utils';
+import { getNumberValueOrNull } from 'shared/utils/string.utils';
 import * as Yup from 'yup';
 
 import { getValidationSchema as getDeminimisValidationSchema } from '../formContent/companySection/deMinimisAid/utils/validation';
@@ -246,7 +245,7 @@ export const getValidationSchema = (
             value ? /^\d+.?\d{1,2}$/.test(String(value)) : false
         )
         .transform((_value, originalValue) =>
-          Number(getNumberValue(originalValue))
+          Number(getNumberValueOrNull(originalValue))
         )
         .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
         .nullable()
@@ -259,24 +258,18 @@ export const getValidationSchema = (
           key: VALIDATION_MESSAGE_KEYS.NUMBER_MAX,
         }))
         .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
-      [EMPLOYEE_KEYS.MONTHLY_PAY]: Yup.number()
-        .transform((_value, originalValue) =>
-          getNumberValueOrNull(originalValue)
-        )
-        .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
-        .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
-      [EMPLOYEE_KEYS.VACATION_MONEY]: Yup.number()
-        .transform((_value, originalValue) =>
-          getNumberValueOrNull(originalValue)
-        )
-        .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
-        .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
-      [EMPLOYEE_KEYS.OTHER_EXPENSES]: Yup.number()
-        .transform((_value, originalValue) =>
-          getNumberValueOrNull(originalValue)
-        )
-        .typeError(t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
-        .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
+      [EMPLOYEE_KEYS.MONTHLY_PAY]: validateNumberField(0, MAX_MONTHLY_PAY, {
+        required: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+        typeError: t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID),
+      }),
+      [EMPLOYEE_KEYS.VACATION_MONEY]: validateNumberField(0, MAX_MONTHLY_PAY, {
+        required: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+        typeError: t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID),
+      }),
+      [EMPLOYEE_KEYS.OTHER_EXPENSES]: validateNumberField(0, MAX_MONTHLY_PAY, {
+        required: t(VALIDATION_MESSAGE_KEYS.REQUIRED),
+        typeError: t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID),
+      }),
       [EMPLOYEE_KEYS.COLLECTIVE_BARGAINING_AGREEMENT]: Yup.string().required(
         t(VALIDATION_MESSAGE_KEYS.REQUIRED)
       ),

--- a/frontend/benefit/handler/src/hooks/useCalculatorData.ts
+++ b/frontend/benefit/handler/src/hooks/useCalculatorData.ts
@@ -18,6 +18,7 @@ type ExtendedComponentProps = {
   handleClear: () => void;
   getErrorMessage: (fieldName: string) => string | undefined;
   isRecalculationRequired: boolean;
+  setIsRecalculationRequired: (value: boolean) => void;
 };
 
 const useCalculatorData = (
@@ -67,6 +68,7 @@ const useCalculatorData = (
     handleSubmit,
     handleClear,
     isRecalculationRequired,
+    setIsRecalculationRequired,
   };
 };
 

--- a/frontend/benefit/handler/src/types/application.d.ts
+++ b/frontend/benefit/handler/src/types/application.d.ts
@@ -70,6 +70,8 @@ export type SubmittedApplication = {
 
 export interface ApplicationReviewViewProps {
   data: Application;
+  isManualCalculator?: boolean;
+  isRecalculationRequired?: boolean;
   isUploading?: boolean;
   handleUpload?: (attachment: FormData) => void;
 }

--- a/frontend/benefit/shared/package.json
+++ b/frontend/benefit/shared/package.json
@@ -20,7 +20,8 @@
     "ibantools": "^4.1.5",
     "next": "14.0.3",
     "react": "^18.2.0",
-    "styled-components": "^5.3.11"
+    "styled-components": "^5.3.11",
+    "yup": "^0.32.9"
   },
   "devDependencies": {
     "eslint-config-adjunct": "^4.11.1",

--- a/frontend/benefit/shared/src/constants.ts
+++ b/frontend/benefit/shared/src/constants.ts
@@ -53,6 +53,8 @@ export enum EMPLOYEE_KEYS {
   EMPLOYEE_COMMISSION_AMOUNT = 'commissionAmount',
 }
 
+export const MAX_MONTHLY_PAY = 99_999;
+
 export enum APPLICATION_FIELDS_STEP1_KEYS {
   USE_ALTERNATIVE_ADDRESS = 'useAlternativeAddress',
   ALTERNATIVE_COMPANY_STREET_ADDRESS = 'alternativeCompanyStreetAddress',
@@ -199,4 +201,4 @@ export enum CALCULATION_ROW_DESCRIPTION_TYPES {
   DEDUCTION = 'deduction',
 }
 
-export const HELSINKI_CONSENT_COOKIE_NAME = 'city-of-helsinki-cookie-consents'
+export const HELSINKI_CONSENT_COOKIE_NAME = 'city-of-helsinki-cookie-consents';

--- a/frontend/benefit/shared/src/utils/validation.ts
+++ b/frontend/benefit/shared/src/utils/validation.ts
@@ -1,0 +1,27 @@
+import { VALIDATION_MESSAGE_KEYS } from 'benefit-shared/constants';
+import { getNumberValueOrNull } from 'shared/utils/string.utils';
+import * as Yup from 'yup';
+import { RequiredNumberSchema } from 'yup/lib/number';
+import { AnyObject } from 'yup/lib/types';
+
+export const validateNumberField = (
+  min: number,
+  max: number,
+  texts: {
+    typeError: string;
+    required: string;
+  }
+): RequiredNumberSchema<number, AnyObject> =>
+  Yup.number()
+    .transform((_value, originalValue) => getNumberValueOrNull(originalValue))
+    .typeError(texts.typeError)
+    .nullable()
+    .min(min, (param) => ({
+      min: param.min,
+      key: VALIDATION_MESSAGE_KEYS.NUMBER_MIN,
+    }))
+    .max(max, (param) => ({
+      max: param.max,
+      key: VALIDATION_MESSAGE_KEYS.NUMBER_MAX,
+    }))
+    .required(texts.required);


### PR DESCRIPTION
## Description :sparkles:

Fix no.1

* Fix app crash when application is approved / rejected but no calculation has been done
* Add new validation requirements for required salary fields
* Refactor salary-related fields to use generic number validation function

Fix no.2

* Add calculation results for manual calculation
* Hide calculation results if recalculation is needed