### PR TITLE
fix: nullish coalescing operator caused warning on page load

### DIFF
--- a/frontend/shared/src/components/app/BaseApp.tsx
+++ b/frontend/shared/src/components/app/BaseApp.tsx
@@ -55,7 +55,7 @@ const BaseApp: React.FC<Props> = ({
     <>
       <ThemeProvider theme={theme}>
         <Head>
-          <title>{title ?? t('common:appName')}</title>
+          <title>{title?.length > 0 ? title : t('common:appName')}</title>
         </Head>
         <GlobalStyling />
         <LayoutComponent>


### PR DESCRIPTION
## Description :sparkles:

Something has changed when next updated. Every page load causes a warning now, which is related to page's `<title>`. Fix behaviour so dev server no longer warns out.

```
Warning: A title element received a value that was not a string or number for children. In the browser title Elements can only have Text Nodes as children. If the children being rendered output more than a single text node in aggregate the browser will display markup and comments as text in the title and hydration will likely fail and fall back to client rendering
    at title
    at head
    at Head (webpack-internal:///../../node_modules/next/dist/pages/_document.js:258:1)
    at html
    at Html (webpack-internal:///../../node_modules/next/dist/pages/_document.js:676:132)
    at BenefitDocument (webpack-internal:///../shared/src/pages/BenefitDocument.tsx:21:1)
```