### PR TITLE
feat: add a command for opening cases in ahjo

### DIFF
--- a/backend/benefit/applications/management/commands/open_cases_in_ahjo.py
+++ b/backend/benefit/applications/management/commands/open_cases_in_ahjo.py
@@ -1,0 +1,105 @@
+import time
+from typing import List
+
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management.base import BaseCommand
+
+from applications.enums import AhjoStatus as AhjoStatusEnum
+from applications.models import Application
+from applications.services.ahjo_authentication import AhjoToken
+from applications.services.ahjo_integration import (
+    create_status_for_application,
+    get_applications_for_open_case,
+    get_token,
+    send_open_case_request_to_ahjo,
+)
+
+
+class Command(BaseCommand):
+    help = "Send a request to Ahjo to open cases for applications"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--number",
+            type=int,
+            default=50,
+            help="Number of applications to send open case requests for",
+        )
+
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Run the command without making actual changes",
+        )
+
+    def handle(self, *args, **options):
+        ahjo_auth_token = get_token()
+        if not ahjo_auth_token:
+            self.stdout.write("Failed to get auth token from Ahjo")
+            return
+
+        number_to_process = options["number"]
+        dry_run = options["dry_run"]
+
+        applications = get_applications_for_open_case()
+
+        if not applications:
+            self.stdout.write("No applications to process")
+            return
+
+        applications = applications[:number_to_process]
+
+        if dry_run:
+            self.stdout.write(
+                f"Would send open case requests for {len(applications)} applications to Ahjo"
+            )
+            return
+
+        self.run_requests(applications[:number_to_process], ahjo_auth_token)
+
+    def run_requests(self, applications: List[Application], ahjo_auth_token: AhjoToken):
+        start_time = time.time()
+        successful_applications = []
+
+        self.stdout.write(
+            f"Sending request to Ahjo to open cases for {len(applications)} applications"
+        )
+
+        for application in applications:
+            if not application.calculation.handler.ad_username:
+                raise ImproperlyConfigured(
+                    f"No ad_username set for the handler for Ahjo open case request for application {application.id}."
+                )
+            sent_application, response_text = send_open_case_request_to_ahjo(
+                application, ahjo_auth_token.access_token
+            )
+            if sent_application:
+                successful_applications.append(sent_application)
+                self._handle_succesfully_opened_application(
+                    sent_application, response_text
+                )
+
+        self.stdout.write(
+            f"Sent open case requests for {len(successful_applications)} applications to Ahjo"
+        )
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        self.stdout.write(
+            f"Submitting {len(successful_applications)} open case requests took {elapsed_time} seconds to run."
+        )
+
+    def _handle_succesfully_opened_application(
+        self, application: Application, response_text: str
+    ):
+        """Create Ahjo status for application and set Ahjo case guid"""
+        create_status_for_application(
+            application, AhjoStatusEnum.REQUEST_TO_OPEN_CASE_SENT
+        )
+        # The guid is returned in the response text in text format {guid}, so remove brackets here
+        response_text = response_text.replace("{", "").replace("}", "")
+        application.ahjo_case_guid = response_text
+        application.save()
+
+        self.stdout.write(
+            f"Successfully submitted open case request for application {application.id} to Ahjo, received GUID: {response_text}"
+        )

--- a/backend/benefit/applications/management/commands/open_cases_in_ahjo.py
+++ b/backend/benefit/applications/management/commands/open_cases_in_ahjo.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from typing import List
 
@@ -13,6 +14,8 @@ from applications.services.ahjo_integration import (
     get_token,
     send_open_case_request_to_ahjo,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -33,9 +36,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        ahjo_auth_token = get_token()
-        if not ahjo_auth_token:
-            self.stdout.write("Failed to get auth token from Ahjo")
+        try:
+            ahjo_auth_token = get_token()
+        except ImproperlyConfigured as e:
+            LOGGER.error(f"Failed to get auth token from Ahjo: {e}")
             return
 
         number_to_process = options["number"]
@@ -101,5 +105,6 @@ class Command(BaseCommand):
         application.save()
 
         self.stdout.write(
-            f"Successfully submitted open case request for application {application.id} to Ahjo, received GUID: {response_text}"
+            f"Successfully submitted open case request for application {application.id} to Ahjo, \
+            received GUID: {response_text}"
         )

--- a/backend/benefit/applications/services/ahjo_integration.py
+++ b/backend/benefit/applications/services/ahjo_integration.py
@@ -542,12 +542,18 @@ def delete_application_in_ahjo(application_id: uuid.UUID):
     try:
         application = get_application_for_ahjo(application_id)
         ahjo_token = get_token()
+        token = ahjo_token.access_token
+
         headers = prepare_headers(
-            ahjo_token.access_token, application.id, AhjoRequestType.DELETE_APPLICATION
+            token, application, AhjoRequestType.DELETE_APPLICATION
         )
-        application, response = send_request_to_ahjo(
+        application, _ = send_request_to_ahjo(
             AhjoRequestType.DELETE_APPLICATION, headers, application
         )
+        if application:
+            create_status_for_application(
+                application, AhjoStatusEnum.DELETE_REQUEST_SENT
+            )
     except ObjectDoesNotExist as e:
         LOGGER.error(f"Object not found: {e}")
     except ImproperlyConfigured as e:

--- a/backend/benefit/applications/services/ahjo_integration.py
+++ b/backend/benefit/applications/services/ahjo_integration.py
@@ -390,21 +390,15 @@ def get_token() -> Union[AhjoToken, None]:
     """Get the access token from Ahjo Service."""
     try:
         ahjo_auth_code = AhjoSetting.objects.get(name="ahjo_code").data
-        LOGGER.info(f"Retrieved auth code: {ahjo_auth_code}")
-        connector = AhjoConnector()
-
-        if not connector.is_configured():
-            LOGGER.error("AHJO connector is not configured")
-            return
-        return connector.get_access_token(ahjo_auth_code["code"])
-    except ObjectDoesNotExist:
-        LOGGER.error(
+    except AhjoSetting.DoesNotExist:
+        raise ImproperlyConfigured(
             "Error: Ahjo auth code not found in database. Please set the 'ahjo_code' setting."
         )
-        return None
-    except Exception as e:
-        LOGGER.error(f"Error retrieving Ahjo access token: {e}")
-        return None
+    connector = AhjoConnector()
+
+    if not connector.is_configured():
+        raise ImproperlyConfigured("AHJO connector is not configured")
+    return connector.get_access_token(ahjo_auth_code["code"])
 
 
 def prepare_headers(

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -64,6 +64,22 @@ def decided_application(mock_get_organisation_roles_and_create_company):
 
 
 @pytest.fixture
+def multiple_decided_applications(mock_get_organisation_roles_and_create_company):
+    with factory.Faker.override_default_locale("fi_FI"):
+        return DecidedApplicationFactory.create_batch(
+            5, company=mock_get_organisation_roles_and_create_company
+        )
+
+
+@pytest.fixture
+def multiple_handling_applications(mock_get_organisation_roles_and_create_company):
+    with factory.Faker.override_default_locale("fi_FI"):
+        return HandlingApplicationFactory.create_batch(
+            5, company=mock_get_organisation_roles_and_create_company
+        )
+
+
+@pytest.fixture
 def application_batch():
     with factory.Faker.override_default_locale("fi_FI"):
         return ApplicationBatchFactory()

--- a/backend/benefit/applications/tests/test_ahjo_requests.py
+++ b/backend/benefit/applications/tests/test_ahjo_requests.py
@@ -6,7 +6,7 @@ import requests_mock
 from django.conf import settings
 from django.urls import reverse
 
-from applications.enums import AhjoRequestType, AhjoStatus
+from applications.enums import AhjoRequestType
 from applications.services.ahjo_integration import prepare_headers, send_request_to_ahjo
 
 
@@ -45,24 +45,21 @@ def test_prepare_headers(settings, request_type, decided_application):
 
 
 @pytest.mark.parametrize(
-    "request_type, request_url, ahjo_status",
+    "request_type, request_url",
     [
         (
             AhjoRequestType.OPEN_CASE,
             f"{settings.AHJO_REST_API_URL}/cases",
-            AhjoStatus.REQUEST_TO_OPEN_CASE_SENT,
         ),
         (
             AhjoRequestType.DELETE_APPLICATION,
             f"{settings.AHJO_REST_API_URL}/cases/12345",
-            AhjoStatus.DELETE_REQUEST_SENT,
         ),
     ],
 )
 def test_send_request_to_ahjo(
     request_type,
     request_url,
-    ahjo_status,
     application_with_ahjo_case_id,
 ):
     headers = {"Authorization": "Bearer test"}
@@ -76,9 +73,6 @@ def test_send_request_to_ahjo(
             request_type, headers, application_with_ahjo_case_id, {"foo": "bar"}
         )
         assert m.called
-
-    application_with_ahjo_case_id.refresh_from_db()
-    assert application_with_ahjo_case_id.ahjo_status.latest().status == ahjo_status
 
 
 @patch("applications.services.ahjo_integration.LOGGER")

--- a/backend/benefit/applications/tests/test_application_tasks.py
+++ b/backend/benefit/applications/tests/test_application_tasks.py
@@ -2,6 +2,7 @@ import os
 import random
 from datetime import timedelta
 from io import StringIO
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.management import call_command
@@ -147,3 +148,72 @@ def test_user_is_notified_of_upcoming_application_deletion(drafts_about_to_be_de
         f"Notified users of {drafts_about_to_be_deleted.count()} applications about upcoming application deletion"
         in out.getvalue()
     )
+
+
+@pytest.mark.django_db
+def test_open_cases_in_ahjo_success(capfd, dummy_ahjo_token):
+    # Mock external services
+    with patch(
+        "applications.services.ahjo_integration.get_token"
+    ) as mock_get_token, patch(
+        "applications.services.ahjo_integration.get_applications_for_open_case"
+    ) as mock_get_applications, patch(
+        "applications.services.ahjo_integration.send_open_case_request_to_ahjo"
+    ) as mock_send_request, patch(
+        "applications.services.ahjo_integration.create_status_for_application"
+    ) as mock_create_status:
+        # Setup mock return values
+        mock_get_token.return_value = dummy_ahjo_token
+        mock_get_applications.return_value = [MagicMock(spec=Application)]
+        mock_send_request.return_value = (
+            MagicMock(spec=Application),
+            "{response_text}",
+        )
+
+        number_to_open = 1
+
+        # Call the command
+        call_command("open_cases_in_ahjo", number=number_to_open)
+
+        # Capture the output
+        out, _ = capfd.readouterr()
+
+        # Assertions
+        assert (
+            f"Sending request to Ahjo to open cases for {number_to_open} applications"
+            in out
+        )
+        assert "Successfully submitted open case request" in out
+        assert mock_send_request.called
+        assert mock_send_request.call_count == number_to_open
+        assert mock_create_status.called
+        assert mock_create_status.call_count == number_to_open
+
+        assert (
+            f"Sent open case requests for {number_to_open} applications to Ahjo" in out
+        )
+
+
+@pytest.mark.django_db
+def test_open_cases_in_ahjo_dryrun(capfd, dummy_ahjo_token):
+    with patch(
+        "applications.services.ahjo_integration.get_token"
+    ) as mock_get_token, patch(
+        "applications.services.ahjo_integration.get_applications_for_open_case"
+    ) as mock_get_applications:
+        number_to_open = 3
+        # Setup mock return values
+        mock_get_token.return_value = dummy_ahjo_token
+        mock_get_applications.return_value = [
+            MagicMock(spec=Application) for _ in range(number_to_open)
+        ]
+
+        # Call the command
+        call_command("open_cases_in_ahjo", dry_run=True, number=number_to_open)
+
+        # Capture the output
+        out, _ = capfd.readouterr()
+        assert (
+            f"Would send open case requests for {number_to_open} applications to Ahjo"
+            in out
+        )


### PR DESCRIPTION
## Description :sparkles:
Adds a Django command `open_cases_in_ahjo` which collects applications that are in handling and are not yet sent to Ahjo and sends a open case request for each of them into the AHJO rest api. Adds some suitable test applications into the seeder.
## Issues :bug:

## Testing :alembic:
Configure ahjo authentication as instructed [here](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/8392311697/Django+-+AHJO+Rest+API+autentikaation+kuvaus), 
run `python manage.py seed` and then `python manage.py open_cases_in_ahjo` or `python manage.py open_cases_in_ahjo --dry-run` (which does not send anything but shows how many  applications would be sent).
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
This command should be scheduled first in testing environment as a nightly cron job.
Performance needs to be tested in OpenShift environments, currently the command outputs the total time for sending the applications.