### PR TITLE
feat: query for rejected_by_talpa batches and show talpa_status icon for each app

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/batch.py
+++ b/backend/benefit/applications/api/v1/serializers/batch.py
@@ -205,4 +205,5 @@ class BatchApplicationSerializer(ReadOnlySerializer):
             "handled_at",
             "employee",
             "calculation",
+            "talpa_status",
         ]

--- a/backend/benefit/applications/api/v1/status_transition_validator.py
+++ b/backend/benefit/applications/api/v1/status_transition_validator.py
@@ -106,9 +106,13 @@ class ApplicationBatchStatusValidator(StatusTransitionValidator):
         ),
         ApplicationBatchStatus.DECIDED_ACCEPTED: (
             ApplicationBatchStatus.SENT_TO_TALPA,
+            ApplicationBatchStatus.REJECTED_BY_TALPA,
         ),
         ApplicationBatchStatus.RETURNED: (ApplicationBatchStatus.DRAFT,),
         ApplicationBatchStatus.DECIDED_REJECTED: (),
+        ApplicationBatchStatus.REJECTED_BY_TALPA: (
+            ApplicationBatchStatus.SENT_TO_TALPA,
+        ),
         ApplicationBatchStatus.SENT_TO_TALPA: (ApplicationBatchStatus.COMPLETED,),
         ApplicationBatchStatus.COMPLETED: (),
     }

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1069,7 +1069,8 @@
           "accepted": "Myönteiset",
           "rejected": "Kielteiset",
           "inPayment": "Maksussa",
-          "waitingForPayment": "Menossa maksuun"
+          "waitingForPayment": "Menossa maksuun",
+          "issueInTalpa": "Yksi tai useampi virhe"
         },
         "handler": "Käsittelijä"
       },

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1069,7 +1069,8 @@
           "accepted": "Myönteiset",
           "rejected": "Kielteiset",
           "inPayment": "Maksussa",
-          "waitingForPayment": "Menossa maksuun"
+          "waitingForPayment": "Menossa maksuun",
+          "issueInTalpa": "Yksi tai useampi virhe"
         },
         "handler": "Käsittelijä"
       },

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1069,7 +1069,8 @@
           "accepted": "Myönteiset",
           "rejected": "Kielteiset",
           "inPayment": "Maksussa",
-          "waitingForPayment": "Menossa maksuun"
+          "waitingForPayment": "Menossa maksuun",
+          "issueInTalpa": "Yksi tai useampi virhe"
         },
         "handler": "Käsittelijä"
       },

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
@@ -1,8 +1,13 @@
 import { ROUTES } from 'benefit/handler/constants';
 import useRemoveAppFromBatch from 'benefit/handler/hooks/useRemoveAppFromBatch';
 import {
+  BatchTableColumns,
+  BatchTableTransforms,
+} from 'benefit/handler/types/batchList';
+import {
   BATCH_STATUSES,
   PROPOSALS_FOR_DECISION,
+  TALPA_STATUSES,
 } from 'benefit-shared/constants';
 import {
   ApplicationInBatch,
@@ -10,9 +15,11 @@ import {
 } from 'benefit-shared/types/application';
 import {
   Button,
+  IconAlertCircle,
   IconAngleDown,
   IconAngleUp,
   IconArrowUndo,
+  IconCheck,
   IconCheckCircle,
   IconCheckCircleFill,
   IconClock,
@@ -159,6 +166,25 @@ const BatchApplicationList: React.FC<BatchProps> = ({ batch }: BatchProps) => {
         ) : null,
     });
   }
+  if (status === BATCH_STATUSES.REJECTED_BY_TALPA) {
+    cols.push({
+      headerName: '',
+      key: 'talpa_status',
+      transform: ({ talpa_status }: BatchTableTransforms) => (
+        <>
+          {talpa_status === TALPA_STATUSES.NOT_SENT_TO_TALPA && (
+            <IconClock color="var(--color-metro)" />
+          )}
+          {talpa_status === TALPA_STATUSES.REJECTED_BY_TALPA && (
+            <IconAlertCircle color="var(--color-alert-dark)" />
+          )}
+          {talpa_status === TALPA_STATUSES.SUCCESFULLY_SENT_TO_TALPA && (
+            <IconCheck color="var(--color-tram)" />
+          )}
+        </>
+      ),
+    });
+  }
 
   const proposalForDecisionHeader = (): JSX.Element => {
     if (proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED) {
@@ -236,21 +262,27 @@ const BatchApplicationList: React.FC<BatchProps> = ({ batch }: BatchProps) => {
           {[
             BATCH_STATUSES.SENT_TO_TALPA,
             BATCH_STATUSES.DECIDED_ACCEPTED,
+            BATCH_STATUSES.REJECTED_BY_TALPA,
           ].includes(status) && (
             <div>
               <dt>{t('common:batches.list.columns.status')}</dt>
               <dd>
-                {status === BATCH_STATUSES.SENT_TO_TALPA ? (
+                {status === BATCH_STATUSES.DECIDED_ACCEPTED && (
+                  <IconClock color="var(--color-info)" />
+                )}
+                {status === BATCH_STATUSES.SENT_TO_TALPA && (
                   <IconCheckCircle color="var(--color-tram)" />
-                ) : (
-                  <IconClock color="var(--color-metro)" />
+                )}
+                {status === BATCH_STATUSES.REJECTED_BY_TALPA && (
+                  <IconAlertCircle color="var(--color-alert-dark)" />
                 )}
                 <$BatchStatusValue>
-                  {status === BATCH_STATUSES.SENT_TO_TALPA
-                    ? t('common:batches.list.columns.statuses.inPayment')
-                    : t(
-                        'common:batches.list.columns.statuses.waitingForPayment'
-                      )}
+                  {status === BATCH_STATUSES.DECIDED_ACCEPTED &&
+                    t('common:batches.list.columns.statuses.waitingForPayment')}
+                  {status === BATCH_STATUSES.REJECTED_BY_TALPA &&
+                    t('common:batches.list.columns.statuses.issueInTalpa')}
+                  {status === BATCH_STATUSES.SENT_TO_TALPA &&
+                    t('common:batches.list.columns.statuses.inPayment')}
                 </$BatchStatusValue>
               </dd>
             </div>
@@ -303,6 +335,7 @@ const BatchApplicationList: React.FC<BatchProps> = ({ batch }: BatchProps) => {
               {[
                 BATCH_STATUSES.DECIDED_ACCEPTED,
                 BATCH_STATUSES.SENT_TO_TALPA,
+                BATCH_STATUSES.REJECTED_BY_TALPA,
               ].includes(status) && (
                 <BatchFooterCompletion
                   batch={batch}

--- a/frontend/benefit/handler/src/components/batchProcessing/batchFooter/BatchFooterCompletion.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/batchFooter/BatchFooterCompletion.tsx
@@ -50,14 +50,14 @@ const BatchFooterCompletion: React.FC<BatchProps> = ({
   } = useDownloadP2PFile();
 
   const { mutate: changeBatchStatus } = useBatchStatus(setBatchCloseAnimation);
-  const [isModalBatchToCompletion, setModalBatchToCompletion] =
+  const [isModalBatchToCompletion, setIsModalBatchToCompletion] =
     React.useState(false);
-  const [isModalBatchToInspection, setModalBatchToInspection] =
+  const [isModalBatchToInspection, setIsModalBatchToInspection] =
     React.useState(false);
 
   const handleModalClose = (): void => {
-    setModalBatchToCompletion(false);
-    setModalBatchToInspection(false);
+    setIsModalBatchToCompletion(false);
+    setIsModalBatchToInspection(false);
   };
 
   const handleBatchStatusChange = (status: BATCH_STATUSES): void => {
@@ -251,7 +251,7 @@ const BatchFooterCompletion: React.FC<BatchProps> = ({
             iconLeft={<IconArrowUndo />}
             isLoading={isDownloadingAttachments}
             disabled={isDownloadingAttachments}
-            onClick={() => setModalBatchToInspection(true)}
+            onClick={() => setIsModalBatchToInspection(true)}
           >
             {t('common:batches.actions.returnToInspection')}
           </Button>
@@ -262,7 +262,7 @@ const BatchFooterCompletion: React.FC<BatchProps> = ({
             theme="coat"
             variant="primary"
             disabled={isDownloadingAttachments}
-            onClick={() => setModalBatchToCompletion(true)}
+            onClick={() => setIsModalBatchToCompletion(true)}
           >
             {t('common:batches.actions.markToArchive')}
           </Button>

--- a/frontend/benefit/handler/src/components/batchProcessing/useBatches.ts
+++ b/frontend/benefit/handler/src/components/batchProcessing/useBatches.ts
@@ -21,13 +21,14 @@ const translationsBase = 'common:applications.list';
 
 const useBatchProposal = (filterByStatus: BATCH_STATUSES[]): BatchListProps => {
   const { t } = useTranslation();
-  const orderBy = filterByStatus.filter(
+  const orderBy = filterByStatus.some(
     (status: BATCH_STATUSES) =>
       status === BATCH_STATUSES.DECIDED_ACCEPTED ||
       status === BATCH_STATUSES.SENT_TO_TALPA
   )
     ? '-modified_at'
     : undefined;
+
   const query = useBatchQuery(filterByStatus, orderBy);
 
   let batches: BatchProposal[] = [];
@@ -42,6 +43,7 @@ const useBatchProposal = (filterByStatus: BATCH_STATUSES[]): BatchListProps => {
             application_number,
             employee,
             handled_at,
+            talpa_status,
             calculation,
           } = app;
 
@@ -49,6 +51,7 @@ const useBatchProposal = (filterByStatus: BATCH_STATUSES[]): BatchListProps => {
 
           return {
             id,
+            talpa_status,
             company_name: company?.name || '',
             application_number,
             employee_name:

--- a/frontend/benefit/handler/src/pages/batches/index.tsx
+++ b/frontend/benefit/handler/src/pages/batches/index.tsx
@@ -81,6 +81,7 @@ const BatchIndex: NextPage = () => {
               status={[
                 BATCH_STATUSES.DECIDED_ACCEPTED,
                 BATCH_STATUSES.SENT_TO_TALPA,
+                BATCH_STATUSES.REJECTED_BY_TALPA,
               ]}
             />
           </Tabs.TabPanel>

--- a/frontend/benefit/handler/src/types/batchList.d.ts
+++ b/frontend/benefit/handler/src/types/batchList.d.ts
@@ -1,6 +1,9 @@
+import { TALPA_STATUSES } from 'benefit-shared/constants';
+
 type BatchTableTransforms = {
   id?: string;
   company_name?: string;
+  talpa_status?: TALPA_STATUSES;
 };
 
 type BatchTableColumns = {

--- a/frontend/benefit/shared/src/constants.ts
+++ b/frontend/benefit/shared/src/constants.ts
@@ -151,6 +151,12 @@ export enum APPLICATION_STATUSES {
   HANDLING = 'handling',
 }
 
+export enum TALPA_STATUSES {
+  NOT_SENT_TO_TALPA = 'not_sent_to_talpa',
+  REJECTED_BY_TALPA = 'rejected_by_talpa',
+  SUCCESFULLY_SENT_TO_TALPA = 'succesfully_sent_to_talpa',
+}
+
 export enum APPLICATION_ORIGINS {
   APPLICANT = 'applicant',
   HANDLER = 'handler',
@@ -162,6 +168,7 @@ export enum BATCH_STATUSES {
   AHJO_REPORT_CREATED = 'exported_ahjo_report',
   DECIDED_ACCEPTED = 'accepted',
   DECIDED_REJECTED = 'rejected',
+  REJECTED_BY_TALPA = 'rejected_by_talpa',
   SENT_TO_TALPA = 'sent_to_talpa',
   COMPLETED = 'completed',
 }

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -3,6 +3,7 @@ import {
   CALCULATION_ROW_TYPES,
   PAY_SUBSIDY_GRANTED,
   PROPOSALS_FOR_DECISION,
+  TALPA_STATUSES,
 } from 'benefit-shared/constants';
 import { Language } from 'shared/i18n/i18n';
 import { BenefitAttachment } from 'shared/types/attachment';
@@ -76,6 +77,7 @@ export type ApplicationInBatch = {
   business_id: string;
   calculation?: CalculationData;
   benefitAmount: number | string;
+  talpa_status: TALPA_STATUSES;
 };
 
 interface ApplicationAllowedAction {


### PR DESCRIPTION
## Description :sparkles:

Use new status field to display changes for rejected Talpa batch / applications.

* Adjust colors for batch that is waiting for payment (metro -> info)
* Display new status icon for  batch that is `rejected_by_talpa` in the information header
* Use `talpa_status` to display success or alert icon on each application if the batch is `rejected_by_talpa`

UI changes already seen and accepted by Susanna.

See new functionality on the last batch of the screenshot:

![screencapture-localhost-3100-batches-2024-01-17-16_47_52](https://github.com/City-of-Helsinki/yjdh/assets/5328394/4a68ffc5-9b66-47f3-98fc-4f9fce3a3740)
