### PR TITLE
YJDH-689 | feat: don't autocomplete youth/employee's personally identifiable fields

### DIFF
--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -68,7 +68,8 @@
       "remove_employment": "Delete the information",
       "fetch_employment": "Load information",
       "fetch_employment_error_title": "Error occured!",
-      "fetch_employment_error_message": "Could not fetch the info of the employee."
+      "fetch_employment_error_message": "Could not fetch the info of the employee.",
+      "fetch_employment_not_found_error_message": "Employee's information was not found."
     },
     "step3": {
       "name": "Send",

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -68,7 +68,8 @@
       "remove_employment": "Poista tiedot",
       "fetch_employment": "Hae tiedot",
       "fetch_employment_error_title": "Sattui virhe!",
-      "fetch_employment_error_message": "Ei hakenut työntekijän tietoja."
+      "fetch_employment_error_message": "Ei pystytty hakemaan työntekijän tietoja.",
+      "fetch_employment_not_found_error_message": "Työntekijän tietoja ei löytynyt."
     },
     "step3": {
       "name": "Lähetä",

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -68,7 +68,8 @@
       "remove_employment": "Ta bort uppgifterna",
       "fetch_employment": "Hämta uppgifter",
       "fetch_employment_error_title": "Fel uppstod!",
-      "fetch_employment_error_message": "Kunde inte hämta arbetstagarens uppgifter."
+      "fetch_employment_error_message": "Kunde inte hämta arbetstagarens uppgifter.",
+      "fetch_employment_not_found_error_message": "Arbetstagarens information hittades inte."
     },
     "step3": {
       "name": "Skicka",

--- a/frontend/kesaseteli/employer/src/components/application/form/TextInput.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/TextInput.tsx
@@ -16,6 +16,7 @@ export type TextInputProps = {
   placeholder?: string;
   helperFormat?: string;
   onChange?: (value: string) => void;
+  autoComplete?: string;
 } & GridCellProps;
 
 const TextInput: React.FC<TextInputProps> = ({
@@ -25,6 +26,7 @@ const TextInput: React.FC<TextInputProps> = ({
   helperFormat,
   placeholder,
   onChange,
+  autoComplete,
   ...$gridCellProps
 }) => {
   const { t } = useTranslation();
@@ -57,6 +59,7 @@ const TextInput: React.FC<TextInputProps> = ({
       errorText={errorText()}
       label={t(`common:application.form.inputs.${fieldName}`)}
       onChange={onChange}
+      autoComplete={autoComplete}
       {...$gridCellProps}
     />
   );

--- a/frontend/kesaseteli/employer/src/components/application/steps/step2/accordions/EmploymentAccordion.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step2/accordions/EmploymentAccordion.tsx
@@ -117,11 +117,13 @@ const EmploymentAccordion: React.FC<Props> = ({ index }: Props) => {
           id={getId('employee_name')}
           validation={{ required: true, maxLength: 256 }}
           onChange={enableFetchEmployeeDataButton}
+          autoComplete="off"
         />
         <TextInput
           id={getId('summer_voucher_serial_number')}
           validation={{ required: true, maxLength: 64 }}
           onChange={enableFetchEmployeeDataButton}
+          autoComplete="off"
         />
         <TextInput
           id={getId('employee_ssn')}
@@ -129,6 +131,7 @@ const EmploymentAccordion: React.FC<Props> = ({ index }: Props) => {
             required: true,
             maxLength: 32,
           }}
+          autoComplete="off"
         />
         <SelectionGroup
           id={getId('target_group')}
@@ -151,10 +154,12 @@ const EmploymentAccordion: React.FC<Props> = ({ index }: Props) => {
             pattern: POSTAL_CODE_REGEX,
             maxLength: 256,
           }}
+          autoComplete="off"
         />
         <TextInput
           id={getId('employee_phone_number')}
           validation={{ required: true, maxLength: 64 }}
+          autoComplete="off"
         />
         <TextInput
           id={getId('employment_postcode')}
@@ -213,6 +218,7 @@ const EmploymentAccordion: React.FC<Props> = ({ index }: Props) => {
           placeholder={t(
             'common:application.step2.employment_description_placeholder'
           )}
+          autoComplete="off"
         />
         <TextInput
           id={getId('employment_salary_paid')}

--- a/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
@@ -142,7 +142,7 @@ const useApplicationApi = <T = Application>(
       },
       {
         onSuccess: (data) => {
-          const { employer_summer_voucher_id, ...updatedData } = data;
+          const {employer_summer_voucher_id, ...updatedData} = data;
           updateEmployment(
             draftApplication,
             employmentIndex,
@@ -150,11 +150,21 @@ const useApplicationApi = <T = Application>(
             onSuccess
           );
         },
-        onError: () =>
-          showErrorToast(
-            t('common:application.step2.fetch_employment_error_title'),
-            t('common:application.step2.fetch_employment_error_message')
-          ),
+        onError: (error: unknown) => {
+          if (Axios.isAxiosError(error) && error.response.status === 404) {
+            // Not found error
+            showErrorToast(
+              t('common:application.step2.fetch_employment_error_title'),
+              t('common:application.step2.fetch_employment_not_found_error_message')
+            )
+          } else {
+            // General error
+            showErrorToast(
+              t('common:application.step2.fetch_employment_error_title'),
+              t('common:application.step2.fetch_employment_error_message')
+            )
+          }
+        }
       }
     );
   };

--- a/frontend/kesaseteli/youth/src/components/additional-info-form/AdditionalInfoForm.tsx
+++ b/frontend/kesaseteli/youth/src/components/additional-info-form/AdditionalInfoForm.tsx
@@ -63,6 +63,7 @@ const AdditionalInfoForm: React.FC<Props> = ({ applicationId }) => {
               required: true,
               maxLength: 4096,
             })}
+            autoComplete="off"
           />
           <$GridCell>
             <SaveFormButton

--- a/frontend/kesaseteli/youth/src/components/youth-form/YouthForm.tsx
+++ b/frontend/kesaseteli/youth/src/components/youth-form/YouthForm.tsx
@@ -21,7 +21,7 @@ const YouthForm: React.FC = () => {
   return (
     <>
       <Heading header={t('common:youthApplication.form.title')} />
-      <form data-testid="youth-form">
+      <form data-testid="youth-form" autoComplete="off">
         <FormSection columns={2}>
           <$GridCell $colSpan={2}>
             {submitError ? (

--- a/frontend/kesaseteli/youth/src/components/youth-form/YouthFormFields.tsx
+++ b/frontend/kesaseteli/youth/src/components/youth-form/YouthFormFields.tsx
@@ -27,6 +27,7 @@ const YouthFormFields: React.FC = () => {
           pattern: NAMES_REGEX,
           maxLength: 128,
         })}
+        autoComplete="off"
       />
       <TextInput<YouthFormData>
         {...register('last_name', {
@@ -34,11 +35,13 @@ const YouthFormFields: React.FC = () => {
           pattern: NAMES_REGEX,
           maxLength: 128,
         })}
+        autoComplete="off"
       />
       <SocialSecurityNumberInput<YouthFormData>
         {...register('social_security_number', {
           required: true,
         })}
+        autoComplete="off"
       />
       <TextInput<YouthFormData>
         {...register('postcode', {
@@ -47,6 +50,7 @@ const YouthFormFields: React.FC = () => {
           minLength: 5,
           maxLength: 5,
         })}
+        autoComplete="off"
       />
       <SchoolSelection />
       <TextInput<YouthFormData>
@@ -55,6 +59,7 @@ const YouthFormFields: React.FC = () => {
           maxLength: 64,
           pattern: PHONE_NUMBER_REGEX,
         })}
+        autoComplete="off"
       />
       <TextInput<YouthFormData>
         {...register('email', {
@@ -62,6 +67,7 @@ const YouthFormFields: React.FC = () => {
           maxLength: 254,
           pattern: EMAIL_REGEX,
         })}
+        autoComplete="off"
       />
       <$GridCell $colSpan={2}>
         <Checkbox<YouthFormData>

--- a/frontend/shared/src/components/forms/inputs/SocialSecurityNumberInput.tsx
+++ b/frontend/shared/src/components/forms/inputs/SocialSecurityNumberInput.tsx
@@ -79,6 +79,7 @@ const SocialSecurityNumberInput = <T,>({
         invalid={Boolean(errorText)}
         {...(process.env.NODE_ENV !== 'test' && { onChange: handleChange })}
         aria-invalid={Boolean(errorText)}
+        autoComplete="off"
       />
     </$GridCell>
   );

--- a/frontend/shared/src/components/forms/inputs/TextInput.tsx
+++ b/frontend/shared/src/components/forms/inputs/TextInput.tsx
@@ -44,6 +44,7 @@ const TextInput = <T,>({
   errorText,
   registerOptions = {},
   onChange,
+  autoComplete,
   ...rest
 }: TextInputProps<T>): React.ReactElement<T> => {
   const { $colSpan, $rowSpan, $colStart, alignSelf, justifySelf } = rest;
@@ -100,6 +101,7 @@ const TextInput = <T,>({
         label={label}
         invalid={Boolean(errorText)}
         aria-invalid={Boolean(errorText)}
+        autoComplete={autoComplete}
       />
     </$GridCell>
   );

--- a/frontend/shared/src/types/input-props.d.ts
+++ b/frontend/shared/src/types/input-props.d.ts
@@ -10,6 +10,7 @@ type InputProps<T, V = string> = {
   errorText?: string;
   placeholder?: string;
   disabled?: boolean;
+  autoComplete?: string;
 };
 
 export default InputProps;


### PR DESCRIPTION
## Description :sparkles:

### feat: don't autocomplete youth/employee's personally identifiable fields

Shared frontend code:
 - TextInput component
   - add autoComplete as input property and use it
 - SocialSecurityNumberInput component
   - force autoComplete="off" for this input as social security numbers
	 should not be auto-completed for security reasons

Kesäseteli frontend code:
 - turn off autocomplete for the following fields:
   - employer UI > employment accordion:
	 - employee_name
	 - summer_voucher_serial_number
	 - employee_ssn (i.e. employee's social security number)
	 - employee_postcode
	 - employee_phone_number
	 - employment_description
   - youth UI > application form:
	 - first_name
	 - last_name
	 - social_security_number
	 - postcode
	 - phone_number
	 - email
   - youth UI > additional info form:
	 - additional_info_description

refs YJDH-689

### feat(fetch_employee_data): add specific "Not found" error message

also make the generic error message clearer in Finnish

refs YJDH-689 (noticed the error message was generic)

## Issues :bug:

[YJDH-689](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-689)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-689]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ