### PR TITLE
fix: handler review section bugs (HL-1119)

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
@@ -49,9 +49,7 @@ const EmployeeView: React.FC<ApplicationReviewViewProps> = ({
         </$ViewFieldBold>
         <$ViewField>
           {t(
-            `common:utility.${
-              data.associationImmediateManagerCheck ? 'yes' : 'no'
-            }`
+            `common:utility.${data.employee?.isLivingInHelsinki ? 'yes' : 'no'}`
           )}
         </$ViewField>
       </$GridCell>

--- a/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
@@ -48,7 +48,7 @@ const EmploymentView: React.FC<ApplicationReviewViewProps> = ({
         </$ViewFieldBold>
         <$ViewField>
           {parseFloat(data.employee?.workingHours).toLocaleString('fi-FI')}{' '}
-          {t(`${translationsBase}.fields.workingHours`)}
+          {t(`${translationsBase}.fields.workingHoursText`)}
         </$ViewField>
       </$GridCell>
       <$GridCell $colSpan={6} $colStart={1}>


### PR DESCRIPTION
## Description :sparkles:

Fix two small bugs that cause confusion for the handler.

### Working hours

Working hours was displayed as:

```
Työaika
37,5 Työaika # should be "hours per week"
```


### Lives in Helsinki

`isLivingInHelsinki` used `associationImmediateManagerCheck` field in condition for yes/no thus only showing up for associations as yes (associationImmediateManagerCheck=true is a requirement).