### PR TITLE
Hl 1070 token refresh

### DIFF
--- a/backend/benefit/applications/jobs/hourly/hourly_ahjo_job.py
+++ b/backend/benefit/applications/jobs/hourly/hourly_ahjo_job.py
@@ -1,0 +1,13 @@
+from django.core.management import call_command
+from django_extensions.management.jobs import HourlyJob
+
+"""
+A hourly job to refresh the Ahjo access token via the refresh token saved in the Django database.
+"""
+
+
+class Job(HourlyJob):
+    help = "Hourly Ahjo refresh jobs are executed here."
+
+    def execute(self):
+        call_command("refresh_ahjo_token")

--- a/backend/benefit/applications/management/commands/refresh_ahjo_token.py
+++ b/backend/benefit/applications/management/commands/refresh_ahjo_token.py
@@ -26,6 +26,9 @@ class Command(BaseCommand):
             return
         try:
             token = ahjo_connector.refresh_token()
+            self.stdout.write(
+                f"Ahjo token refreshed, token valid until {token.expires_in}"
+            )
         except Exception as e:
             self.stdout.write(f"Failed to refresh Ahjo token: {e}")
-        self.stdout.write(f"Ahjo token refreshed, token valid until {token.expires_in}")
+            return

--- a/backend/benefit/applications/services/ahjo_authentication.py
+++ b/backend/benefit/applications/services/ahjo_authentication.py
@@ -84,9 +84,12 @@ class AhjoConnector:
 
     def do_token_request(self, payload: Dict[str, str]) -> AhjoToken:
         # Make the POST request
-        response = requests.post(
-            self.token_url, headers=self.headers, data=payload, timeout=self.timeout
-        )
+        try:
+            response = requests.post(
+                self.token_url, headers=self.headers, data=payload, timeout=self.timeout
+            )
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Failed to get or refresh token from Ahjo: {e}")
 
         # Check if the request was successful
         if response.status_code == 200:


### PR DESCRIPTION
## Description :sparkles:
Adds a command that can be schedule to refresh the Ahjo access token hourly.
See [here](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/8392311697/Django+-+AHJO+Rest+API+autentikaation+kuvaus) for details.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
