### PR TITLE
fix: cast open case json reference field to string

### DIFF
--- a/backend/benefit/applications/services/ahjo_payload.py
+++ b/backend/benefit/applications/services/ahjo_payload.py
@@ -37,7 +37,7 @@ työnantaja {application.company_name}"
             {"Subject": "työllisyydenhoito"},
         ],
         "PersonalData": "Sisältää erityisiä henkilötietoja",
-        "Reference": application.application_number,
+        "Reference": f"{application.application_number}",
         "Records": case_records,
         "Agents": [
             {

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -329,7 +329,7 @@ työnantaja {application.company_name}"
             {"Subject": "työllisyydenhoito"},
         ],
         "PersonalData": "Sisältää erityisiä henkilötietoja",
-        "Reference": application.application_number,
+        "Reference": f"{application.application_number}",
         "Records": [],
         "Agents": [
             {


### PR DESCRIPTION
## Description :sparkles:
The reference attribute of the open case JSON needs to be string, not int.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
