### PR TITLE
YJDH-661 | fix: make name regular expression more permissive

### DIFF
--- a/backend/kesaseteli/applications/tests/test_application_validation.py
+++ b/backend/kesaseteli/applications/tests/test_application_validation.py
@@ -9,10 +9,11 @@ from applications.api.v1.serializers import (
 from applications.enums import AttachmentType, EmployerApplicationStatus
 from applications.models import School, validate_name, YouthApplication
 from applications.tests.test_applications_api import get_detail_url
+from shared.common.tests.names import INVALID_NAMES, VALID_NAMES
 
 
 @pytest.mark.django_db
-def test_validate_name_with_all_listed_schools():
+def test_validate_name_with_all_listed_schools(school_list):
     for school in School.objects.all():
         validate_name(school.name)
 
@@ -20,9 +21,13 @@ def test_validate_name_with_all_listed_schools():
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "name",
-    [
+    VALID_NAMES
+    + [
         "Jokin muu koulu",
         "Testikoulu",
+        "Testikoulu 1",
+        "Testikoulu: Arabian yläaste",
+        "Yläaste (Arabia)",
     ],
 )
 def test_validate_name_with_valid_unlisted_school(name):
@@ -74,14 +79,7 @@ def test_validate_youth_application_vtj_data_fields(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "name",
-    [
-        "Testikoulu 1",  # Number is not allowed after the first character
-        "Testikoulu: Arabian yläaste",  # Colon is not allowed
-        "Yläaste (Arabia)",  # Parentheses are not allowed
-    ],
-)
+@pytest.mark.parametrize("name", INVALID_NAMES)
 def test_validate_name_with_invalid_unlisted_school(name):
     with pytest.raises(ValidationError):
         validate_name(name)

--- a/backend/shared/shared/common/tests/names.py
+++ b/backend/shared/shared/common/tests/names.py
@@ -1,0 +1,59 @@
+ARABIC_NAME = "حَسَّان"  # Ḥassān (benefactor) in Arabic
+CHINESE_NAME = "慧芬"  # Huì Fēn (wise scent) in Mandarin Chinese
+ESTONIAN_NAME = "Õras"
+FINNISH_NAME = "Matti Meikäläinen"
+GERMAN_NAME = "Strauß Jünemann"
+HEBREW_NAME = "אברהם"  # Abraham (father of many) in Hebrew
+ICELANDIC_FEMALE_NAME = "María Kristín Þorkelsdóttir"
+ICELANDIC_MALE_NAME = "Ingólfur Álfheiður"
+RUSSIAN_NAME = "Мельник"  # Melnik (miller) in Russian
+SHORT_CHINESE_NAME = "王"  # Wáng (king) in Mandarin Chinese
+SPANISH_NAME = "Peña"
+SWEDISH_NAME = "Åse-Marie Öllegård"
+THAI_NAME = "อาทิตย์"  # Arthit (sun) in Thai
+TURKISH_NAME = "Ümit"  # Ümit (hope) in Turkish
+
+VALID_NAMES = [
+    # should match Finnish first names, last names and full names
+    "Helinä",
+    "Aalto",
+    "Kalle Väyrynen",
+    "Janne Ö",
+    # should match Swedish first names, last names and full names
+    "Gun-Britt",
+    "Lindén",
+    "Ögge Ekström",
+    # should match English first names, last names and full names
+    "Eric",
+    "Bradtke",
+    "Daniela O'Brian",
+    # should match special characters
+    "!@#$%^&*()_+-=[]{}|;':\",./<>?",
+    # should match digits
+    "1234567890",
+    # should match more languages than just Finnish, Swedish, English
+    ARABIC_NAME,
+    CHINESE_NAME,
+    ESTONIAN_NAME,
+    FINNISH_NAME,
+    GERMAN_NAME,
+    HEBREW_NAME,
+    ICELANDIC_FEMALE_NAME,
+    ICELANDIC_MALE_NAME,
+    RUSSIAN_NAME,
+    SHORT_CHINESE_NAME,
+    SPANISH_NAME,
+    SWEDISH_NAME,
+    THAI_NAME,
+    TURKISH_NAME,
+]
+
+INVALID_NAMES = [
+    "",
+    " ",
+    "\t",
+    "\r",
+    "\n",
+    "\r\n",
+    " \t\r\n  ",
+]

--- a/backend/shared/shared/common/tests/test_validators.py
+++ b/backend/shared/shared/common/tests/test_validators.py
@@ -4,6 +4,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.db import models
 
+from shared.common.tests.names import INVALID_NAMES, VALID_NAMES
 from shared.common.validators import (
     validate_json,
     validate_name,
@@ -136,24 +137,7 @@ def test_validate_phone_number_with_invalid_input(value):
 
 
 # Based on frontend/shared/src/__tests__/constants.test.ts
-@pytest.mark.parametrize(
-    "value",
-    [
-        # should match Finnish first names, last names and full names
-        "Helinä",
-        "Aalto",
-        "Kalle Väyrynen",
-        "Janne Ö",
-        # should match Swedish first names, last names and full names
-        "Gun-Britt",
-        "Lindén",
-        "Ögge Ekström",
-        # should match English first names, last names and full names
-        "Eric",
-        "Bradtke",
-        "Daniela O'Brian",
-    ],
-)
+@pytest.mark.parametrize("value", VALID_NAMES)
 def test_validate_name_with_valid_input(value):
     validate_name(value)
 
@@ -161,12 +145,10 @@ def test_validate_name_with_valid_input(value):
 # Based on frontend/shared/src/__tests__/constants.test.ts
 @pytest.mark.parametrize(
     "value",
-    [
-        # should fail to match invalid characters
-        "!@#$%^&*()_+-=[]{}|;':\",./<>?",
-        # should fail to match digits
-        "1234567890",
-    ],
+    INVALID_NAMES
+    + [" " + name for name in VALID_NAMES]
+    + [name + " " for name in VALID_NAMES]
+    + [" " + name + " " for name in VALID_NAMES],
 )
 def test_validate_name_with_invalid_input(value):
     with pytest.raises(ValidationError):

--- a/backend/shared/shared/common/validators.py
+++ b/backend/shared/shared/common/validators.py
@@ -18,14 +18,10 @@ PHONE_NUMBER_REGEX = (
 # \d in Javascript matches [0-9] and has been replaced:
 POSTAL_CODE_REGEX = r"^[0-9]{5}$"
 
-# \w in Javascript matches [A-Za-z0-9_] and has been replaced:
-NAMES_REGEX = r"^[A-Za-z0-9_',.ÄÅÖäåö-][^\d!#$%&()*+/:;<=>?@[\\\]_{|}~¡¿÷ˆ]+$"
-
 # Please note that using a RegexValidator in a Django model field hardcodes the used
 # regular expression into the model and its migration but using a function does not.
 PHONE_NUMBER_REGEX_VALIDATOR = RegexValidator(PHONE_NUMBER_REGEX)
 POSTAL_CODE_REGEX_VALIDATOR = RegexValidator(POSTAL_CODE_REGEX)
-NAMES_REGEX_VALIDATOR = RegexValidator(NAMES_REGEX)
 
 
 def validate_phone_number(phone_number) -> None:
@@ -52,13 +48,15 @@ def validate_postcode(postcode) -> None:
 
 def validate_name(name) -> None:
     """
-    Function wrapper for NAMES_REGEX_VALIDATOR. If used as a validator in a
-    Django model's field this does not hardcode the underlying regular expression into
-    the migration nor into the model.
+    Validates name to be a non-empty string with no trailing or leading whitespace.
 
-    Raise ValidationError if the given value doesn't pass NAMES_REGEX_VALIDATOR.
+    Raise ValidationError if the given value is not a non-empty string with no trailing
+    or leading whitespace.
     """
-    NAMES_REGEX_VALIDATOR(name)
+    if not (isinstance(name, str) and name == name.strip() and name.strip()):
+        raise ValidationError(
+            "Name must be a non-empty string with no trailing or leading whitespace"
+        )
 
 
 def validate_json(value) -> None:

--- a/frontend/kesaseteli/youth/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/index.test.tsx
@@ -131,8 +131,8 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
       const indexPageApi = getIndexPageApi();
       await indexPageApi.expectations.pageIsLoaded();
 
-      await indexPageApi.actions.typeInput('first_name', '!#$%&()*+/:;<=>?@');
-      await indexPageApi.actions.typeInput('last_name', '~¡¿÷ˆ]+$');
+      await indexPageApi.actions.typeInput('first_name', ' leading whitespace');
+      await indexPageApi.actions.typeInput('last_name', '\tleading whitespace');
       // Note! 170915-915L is a fake ssn. See more info (in finnish only):
       // https://www.tuomas.salste.net/doc/tunnus/henkilotunnus.html#keinotunnus
       await indexPageApi.actions.typeInput(
@@ -184,10 +184,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
         'maxLength'
       );
 
-      await indexPageApi.actions.typeInput(
-        'unlistedSchool',
-        '!#$%&()*+/:;<=>?@'
-      );
+      await indexPageApi.actions.typeInput('unlistedSchool', ' ');
       await indexPageApi.expectations.textInputHasError(
         'unlistedSchool',
         'pattern'
@@ -306,7 +303,9 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
           ),
         });
         await waitFor(() =>
-          expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/${errorType}`)
+          expect(spyPush).toHaveBeenCalledWith(
+            `${DEFAULT_LANGUAGE}/${errorType}`
+          )
         );
       });
     }
@@ -442,7 +441,9 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
             ),
           });
           await waitFor(() =>
-            expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/${errorType}`)
+            expect(spyPush).toHaveBeenCalledWith(
+              `${DEFAULT_LANGUAGE}/${errorType}`
+            )
           );
         });
       }

--- a/frontend/shared/src/__tests__/constants.test.ts
+++ b/frontend/shared/src/__tests__/constants.test.ts
@@ -13,48 +13,49 @@ import {
 describe('constants', () => {
   describe('regex', () => {
     describe('NAMES_REGEX', () => {
-      it('should match Finnish first names, last names and full names', () => {
-        const firstName = 'Helinä';
-        const lastName = 'Aalto';
-        const fullName = 'Kalle Väyrynen';
-        const fullName2 = 'Janne Ö';
+      it('should match names in many different languages', () => {
+        const names = [
+          "Daniela O'Brian",
+          'Aalto',
+          'Bradtke',
+          'Eric',
+          'Gun-Britt',
+          'Helinä',
+          'Ingólfur Álfheiður',
+          'Janne Ö',
+          'Kalle Väyrynen',
+          'Lindén',
+          'María Kristín Þorkelsdóttir',
+          'Matti Meikäläinen',
+          'Peña',
+          'Strauß Jünemann',
+          'Åse-Marie Öllegård',
+          'Õras',
+          'Ögge Ekström',
+          'Ümit',
+          'Мельник',
+          'אברהם',
+          'حَسَّان',
+          'อาทิตย์',
+          '慧芬',
+          '王',
+        ];
 
-        expect(firstName).toMatch(NAMES_REGEX);
-        expect(lastName).toMatch(NAMES_REGEX);
-        expect(fullName).toMatch(NAMES_REGEX);
-        expect(fullName2).toMatch(NAMES_REGEX);
+        names.forEach((name) => {
+          expect(name).toMatch(NAMES_REGEX);
+        });
       });
 
-      it('should match Swedish first names, last names and full names', () => {
-        const firstName = 'Gun-Britt';
-        const lastName = 'Lindén';
-        const fullName = 'Ögge Ekström';
-
-        expect(firstName).toMatch(NAMES_REGEX);
-        expect(lastName).toMatch(NAMES_REGEX);
-        expect(fullName).toMatch(NAMES_REGEX);
-      });
-
-      it('should match English first names, last names and full names', () => {
-        const firstName = 'Eric';
-        const lastName = 'Bradtke';
-        const fullName = "Daniela O'Brian";
-
-        expect(firstName).toMatch(NAMES_REGEX);
-        expect(lastName).toMatch(NAMES_REGEX);
-        expect(fullName).toMatch(NAMES_REGEX);
-      });
-
-      it('should fail to match invalid characters', () => {
+      it('should match special characters', () => {
         const invalidCharacters = '!@#$%^&*()_+-=[]{}|;\':",./<>?';
 
-        expect(invalidCharacters).not.toMatch(NAMES_REGEX);
+        expect(invalidCharacters).toMatch(NAMES_REGEX);
       });
 
-      it('should fail to match digits', () => {
+      it('should match digits', () => {
         const digits = '1234567890';
 
-        expect(digits).not.toMatch(NAMES_REGEX);
+        expect(digits).toMatch(NAMES_REGEX);
       });
     });
 

--- a/frontend/shared/src/constants.ts
+++ b/frontend/shared/src/constants.ts
@@ -8,8 +8,7 @@ export const PHONE_NUMBER_REGEX =
   // eslint-disable-next-line security/detect-unsafe-regex
   /^((\+358[ -]*)+|(\\(\d{2,3}\\)[ -]*)|(\d{2,4})[ -]*)*?\d{3,4}?[ -]*\d{3,4}?$/;
 export const POSTAL_CODE_REGEX = /^\d{5}$/;
-export const NAMES_REGEX =
-  /^[\w',.ÄÅÖäåö-][^\d!#$%&()*+/:;<=>?@[\\\]_{|}~¡¿÷ˆ]+$/;
+export const NAMES_REGEX = /^\S.*$/;
 export const CITY_REGEX = /^[ A-Za-zÄÅÖäåö-]+$/;
 
 export const EMAIL_REGEX =


### PR DESCRIPTION
## Description :sparkles:

### feat: permit more names in YouthApplication (first|last)_name & school

these now accept any other strings except empty/whitespace only strings:
 - YouthApplication.first_name
 - YouthApplication.last_name
 - YouthApplication.school

refs YJDH-661

### feat: permit more names in frontend NAMES_REGEX, update tests

refs YJDH-661

## Issues :bug:

[YJDH-661](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-661)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-661]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ