### PR TITLE
Hl 1067 ahjo update

### DIFF
--- a/backend/benefit/applications/enums.py
+++ b/backend/benefit/applications/enums.py
@@ -187,3 +187,4 @@ class AhjoCallBackStatus(models.TextChoices):
 class AhjoRequestType(models.TextChoices):
     OPEN_CASE = "open_case", _("Open case in Ahjo")
     DELETE_APPLICATION = "delete_application", _("Delete application in Ahjo")
+    UPDATE_APPLICATION = "update_application", _("Update application in Ahjo")

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -274,19 +274,16 @@ def set_debug_to_false(settings):
 
 
 @pytest.fixture()
-def ahjo_payload_record(decided_application):
+def ahjo_record(decided_application):
     application = decided_application
-
-    record_title = "Hakemus"
-    record_type = "hakemus"
     acquired = application.created_at.isoformat()
     documents = []
     agent = application.calculation.handler
     publicity_class = "Salassa pidettävä"
 
     return {
-        "Title": record_title,
-        "Type": record_type,
+        "Title": "",
+        "Type": "",
         "Acquired": acquired,
         "PublicityClass": publicity_class,
         "SecurityReasons": ["JulkL (621/1999) 24.1 § 25 k"],
@@ -302,6 +299,25 @@ def ahjo_payload_record(decided_application):
             }
         ],
     }
+
+
+@pytest.fixture()
+def ahjo_payload_record_for_application(ahjo_record):
+    record = ahjo_record
+    record["Title"] = "Hakemus"
+    record["Type"] = "hakemus"
+
+    return record
+
+
+@pytest.fixture()
+def ahjo_payload_record_for_attachment(ahjo_record):
+    record = ahjo_record
+    record["Title"] = "Liite"
+    record["Type"] = "liite"
+    record.pop("MannerOfReceipt", None)
+
+    return record
 
 
 @pytest.fixture()

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -274,11 +274,23 @@ def set_debug_to_false(settings):
 
 
 @pytest.fixture()
-def ahjo_record(decided_application):
+def ahjo_payload_agents(decided_application):
+    application = decided_application
+    agent = application.calculation.handler
+    return [
+        {
+            "Role": "mainCreator",
+            "Name": f"{agent.last_name}, {agent.first_name}",
+            "ID": agent.ad_username,
+        }
+    ]
+
+
+@pytest.fixture()
+def ahjo_record(decided_application, ahjo_payload_agents):
     application = decided_application
     acquired = application.created_at.isoformat()
     documents = []
-    agent = application.calculation.handler
     publicity_class = "Salassa pidettävä"
 
     return {
@@ -291,31 +303,45 @@ def ahjo_record(decided_application):
         "PersonalData": "Sisältää erityisiä henkilötietoja",
         "MannerOfReceipt": "sähköinen asiointi",
         "Documents": documents,
-        "Agents": [
-            {
-                "Role": "mainCreator",
-                "Name": f"{agent.last_name}, {agent.first_name}",
-                "ID": agent.ad_username,
-            }
-        ],
+        "Agents": ahjo_payload_agents,
     }
 
 
 @pytest.fixture()
 def ahjo_payload_record_for_application(ahjo_record):
-    record = ahjo_record
-    record["Title"] = "Hakemus"
-    record["Type"] = "hakemus"
-
+    record = {**ahjo_record, "Title": "Hakemus", "Type": "hakemus"}
     return record
 
 
 @pytest.fixture()
 def ahjo_payload_record_for_attachment(ahjo_record):
-    record = ahjo_record
-    record["Title"] = "Liite"
-    record["Type"] = "liite"
+    record = {**ahjo_record, "Title": "Liite", "Type": "liite"}
     record.pop("MannerOfReceipt", None)
+    return record
+
+
+@pytest.fixture()
+def dummy_version_series_id():
+    return "{12345678910}"
+
+
+@pytest.fixture()
+def ahjo_payload_record_for_attachment_update(
+    ahjo_record, dummy_version_series_id, ahjo_payload_agents
+):
+    record = ahjo_record
+    record.pop("MannerOfReceipt", None)
+    record.pop("Documents", None)
+    record.pop("Agents", None)
+
+    record = {
+        **record,
+        "Title": "Liite",
+        "Type": "liite",
+        "VersionSeriesId": dummy_version_series_id,
+        "Documents": [],
+        "Agents": ahjo_payload_agents,
+    }
 
     return record
 

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -44,6 +44,25 @@ def test_prepare_attachment_record(
     assert ahjo_payload_record_for_attachment == record
 
 
+def test_prepare_attachment_update_record(
+    decided_application,
+    ahjo_payload_record_for_attachment_update,
+    dummy_version_series_id,
+):
+    application = decided_application
+
+    record = _prepare_record(
+        ahjo_payload_record_for_attachment_update["Title"],
+        ahjo_payload_record_for_attachment_update["Type"],
+        application.created_at.isoformat(),
+        [],
+        application.calculation.handler,
+        ahjo_version_series_id=dummy_version_series_id,
+    )
+
+    assert ahjo_payload_record_for_attachment_update == record
+
+
 def test_prepare_record_document_dict(decided_application, settings):
     settings.DEBUG = True
     settings.API_BASE_URL = "http://test.com"

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -12,18 +12,36 @@ from applications.services.ahjo_payload import (
 from common.utils import hash_file
 
 
-def test_prepare_record(decided_application, ahjo_payload_record):
+def test_prepare_application_record(
+    decided_application, ahjo_payload_record_for_application
+):
     application = decided_application
 
     record = _prepare_record(
-        ahjo_payload_record["Title"],
-        ahjo_payload_record["Type"],
+        ahjo_payload_record_for_application["Title"],
+        ahjo_payload_record_for_application["Type"],
         application.created_at.isoformat(),
         [],
         application.calculation.handler,
     )
 
-    assert ahjo_payload_record == record
+    assert ahjo_payload_record_for_application == record
+
+
+def test_prepare_attachment_record(
+    decided_application, ahjo_payload_record_for_attachment
+):
+    application = decided_application
+
+    record = _prepare_record(
+        ahjo_payload_record_for_attachment["Title"],
+        ahjo_payload_record_for_attachment["Type"],
+        application.created_at.isoformat(),
+        [],
+        application.calculation.handler,
+    )
+
+    assert ahjo_payload_record_for_attachment == record
 
 
 def test_prepare_record_document_dict(decided_application, settings):


### PR DESCRIPTION
## Description :sparkles:
Adds a method for updating an applications files ("records" in AHJO) by sending a PUT request to AHJO Rest API.
Payload is constructed the same way as in open case request  but now  only the "Records"-dict is send and it has a "VersionSeriesId" key/value pair and does not have the "MannerOfReceipt" key/value pair, if the record is for the application itself (the pdf-summary of the application). Example of the payload:
```
{
  "records": [
    {
      "Title": "Hakemuksen liite",
      "Type": "hakemuksen liite",
      "Acquired": "2023-12-14T10:00:00+02:00",
      "PublicityClass": "Salassa pidettävä",
      "SecurityReasons": [
        "JulkL (621/1999) 24.1 § 25 k"
      ],
      "Language": "fi",
      "PersonalData": "Sisältää erityisiä henkilötietoja",
      "VersionSeriesId": "{05DC00DB-892E-CC56-A9AF-5B47E8300004}",
      "Documents": [
        {
          "FileName": "liite.pdf",
          "FormatName": "application/pdf",
          "HashAlgorithm": "sha256",
          "HashValue": "b8dd...",
          "FileURI": "https://hel.fi/helsinkilisa/liite.pdf"
        }
      ],
      "Agents": [
        {
          "Role": "mainCreator",
          "Name": "Valmistelija, Venla",
          "ID": "venlav"
        }
      ]
    }
  ]
}
```
## Issues :bug:
 Requires [HL-1132](https://github.com/City-of-Helsinki/yjdh/pull/2789) to be merged first as that adds the `ahjo_version_series_id `attribute for Attachment.
## Testing :alembic:
`pytest applications/tests/test_ahjo_payload.py`
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1132]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ