### PR TITLE
feat: list old processed applications on the archive page (HL-1011)

### DIFF
--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -80,6 +80,15 @@ class ApplicationManager(models.Manager):
         ApplicationStatus.CANCELLED,
     ]
 
+    COMPLETED_BATCH_STATUSES = [
+        ApplicationBatchStatus.DECIDED_ACCEPTED,
+        ApplicationBatchStatus.DECIDED_REJECTED,
+        ApplicationBatchStatus.SENT_TO_TALPA,
+        ApplicationBatchStatus.COMPLETED,
+    ]
+
+    ARCHIVE_THRESHOLD = relativedelta(days=-14)
+
     def _annotate_with_log_timestamp(self, qs, field_name, to_statuses):
         subquery = (
             ApplicationLogEntry.objects.filter(

--- a/backend/benefit/applications/services/change_history.py
+++ b/backend/benefit/applications/services/change_history.py
@@ -57,6 +57,8 @@ def _get_application_change_history_between_timestamps(
         hist_employee_when_stop_editing = employee.history.as_of(ts_end)._history
     except Employee.DoesNotExist:
         return []
+    except Application.DoesNotExist:
+        return []
 
     new_or_edited_attachments = Attachment.objects.filter(
         Q(created_at__gte=ts_start) | Q(modified_at=ts_start),

--- a/backend/benefit/locale/en/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-01 10:42+0200\n"
+"POT-Creation-Date: 2024-01-25 18:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,50 +35,6 @@ msgstr ""
 msgid "TALPA export {date}"
 msgstr ""
 
-#, python-brace-format
-msgid "Upload file size cannot be greater than {size} bytes"
-msgstr ""
-
-msgid "Too many attachments"
-msgstr ""
-
-msgid "Not a valid pdf file"
-msgstr ""
-
-msgid "Not a valid image file"
-msgstr ""
-
-msgid "Grant date too much in past"
-msgstr ""
-
-msgid "Grant date can not be in the future"
-msgstr ""
-
-msgid "Social security number invalid"
-msgstr ""
-
-msgid "Social security number checksum invalid"
-msgstr ""
-
-#, python-brace-format
-msgid "Working hour must be greater than {min_hour} per week"
-msgstr ""
-
-msgid "Monthly pay must be greater than 0"
-msgstr ""
-
-msgid "Vacation money must be a positive number"
-msgstr ""
-
-msgid "Other expenses must be a positive number"
-msgstr ""
-
-msgid "Applications in a batch can not be changed when batch is in this status"
-msgstr ""
-
-msgid "This application has invalid status and can not be added to this batch"
-msgstr ""
-
 msgid "This should be unreachable"
 msgstr ""
 
@@ -101,13 +57,7 @@ msgstr ""
 msgid "Total amount of de minimis aid too large"
 msgstr ""
 
-msgid "start_date must not be in a past year"
-msgstr ""
-
 msgid "start_date must not be more than 4 months in the past"
-msgstr ""
-
-msgid "end_date must not be in a past year"
 msgstr ""
 
 msgid "application end_date can not be less than start_date"
@@ -121,9 +71,6 @@ msgstr ""
 
 msgid ""
 "This application can not have a description for co-operation negotiations"
-msgstr ""
-
-msgid "Pay subsidy percent required"
 msgstr ""
 
 #, python-brace-format
@@ -140,6 +87,14 @@ msgid "This field can be set for associations only"
 msgstr ""
 
 msgid "This benefit type can not be selected"
+msgstr ""
+
+msgid ""
+"Apprenticeship program can not be selected if there is no granted pay subsidy"
+msgstr ""
+
+msgid ""
+"Apprenticeship program has to be yes or no if there is a granted pay subsidy"
 msgstr ""
 
 msgid "Application does not have the employee consent attachment"
@@ -167,6 +122,10 @@ msgstr ""
 msgid "create_application_for_company missing from request"
 msgstr ""
 
+#, python-brace-format
+msgid "company with id {company_id} not found"
+msgstr ""
+
 msgid "The calculation should be created when the application is submitted"
 msgstr ""
 
@@ -178,11 +137,55 @@ msgid "Reading {localized_model_name} data failed: {errors}"
 msgstr ""
 
 #, python-brace-format
+msgid "Upload file size cannot be greater than {size} bytes"
+msgstr ""
+
+msgid "Too many attachments"
+msgstr ""
+
+msgid "Not a valid pdf file"
+msgstr ""
+
+msgid "Not a valid image file"
+msgstr ""
+
+msgid "Applications in a batch can not be changed when batch is in this status"
+msgstr ""
+
+msgid "This application has invalid status and can not be added to this batch"
+msgstr ""
+
+msgid "Grant date too much in past"
+msgstr ""
+
+msgid "Grant date can not be in the future"
+msgstr ""
+
+msgid "Social security number invalid"
+msgstr ""
+
+#, python-brace-format
+msgid "Working hour must be greater than {min_hour} per week"
+msgstr ""
+
+msgid "Monthly pay must be greater than 0"
+msgstr ""
+
+msgid "Vacation money must be a positive number"
+msgstr ""
+
+msgid "Other expenses must be a positive number"
+msgstr ""
+
+#, python-brace-format
 msgid "State transition not allowed: {status} to {value}"
 msgstr ""
 
 #, python-brace-format
 msgid "Initial status must be {initial_status}"
+msgstr ""
+
+msgid "Displayed in the archive in the applicant view"
 msgstr ""
 
 msgid "Operation not allowed for this application status."
@@ -192,7 +195,7 @@ msgid "File not found."
 msgstr ""
 
 #, python-brace-format
-msgid "Helsinki-lisän hakemukset viety {date}"
+msgid "Helsinki-lisan hakemukset viety {date}"
 msgstr ""
 
 msgid "Benefit can not be granted before 24-month waiting period expires"
@@ -276,6 +279,20 @@ msgstr ""
 msgid "helsinki benefit voucher"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
+msgid "employee consent"
+msgstr "Employee's consent for processing personal data"
+
+msgid "full application"
+msgstr ""
+
+msgid "other attachment"
+msgstr ""
+
+msgid "pdf summary"
+msgstr ""
+
 msgid "attachment is required"
 msgstr ""
 
@@ -303,10 +320,95 @@ msgstr ""
 msgid "Processing is completed"
 msgstr ""
 
+msgid "Rejected by Talpa"
+msgstr ""
+
+msgid "Not sent to Talpa"
+msgstr ""
+
+msgid "Successfully sent to Talpa"
+msgstr ""
+
+msgid "Handler"
+msgstr ""
+
+msgid "Applicant"
+msgstr ""
+
+msgid "Pay subsidy granted (default)"
+msgstr ""
+
+msgid "Pay subsidy granted (aged)"
+msgstr ""
+
+msgid "No granted pay subsidy"
+msgstr ""
+
+msgid "Submitted but not sent to AHJO"
+msgstr ""
+
+msgid "Request to open the case sent to AHJO"
+msgstr ""
+
+msgid "Case opened in AHJO"
+msgstr ""
+
+msgid "Update request sent"
+msgstr ""
+
+msgid "Update request received"
+msgstr ""
+
+msgid "Decision proposal sent"
+msgstr ""
+
+msgid "Decision proposal accepted"
+msgstr ""
+
+msgid "Decision proposal rejected"
+msgstr ""
+
+msgid "Delete request sent"
+msgstr ""
+
+msgid "Delete request received"
+msgstr ""
+
+msgid "Allow/disallow applicant's modifications"
+msgstr ""
+
+msgid "Success"
+msgstr ""
+
+msgid "Failure"
+msgstr ""
+
+msgid "Open case in Ahjo"
+msgstr ""
+
+msgid "Delete application in Ahjo"
+msgstr ""
+
+#, python-brace-format
+msgid ""
+"Your application {id} will be deleted soon. If you want to continue the "
+"application process, please do so by {application_deletion_date}, otherwise "
+"the application will deleted permanently."
+msgstr ""
+
+msgid "Your Helsinki benefit draft application will expire"
+msgstr ""
+
 msgid "company"
 msgstr ""
 
 msgid "status"
+msgstr ""
+
+msgid "talpa_status"
+msgstr ""
+
+msgid "application origin"
 msgstr ""
 
 msgid "application number"
@@ -363,6 +465,9 @@ msgstr ""
 msgid "benefit end date"
 msgstr ""
 
+msgid "paper application date"
+msgstr ""
+
 msgid "ahjo batch"
 msgstr ""
 
@@ -411,10 +516,22 @@ msgstr ""
 msgid "date of the decision in Ahjo"
 msgstr ""
 
+msgid "P2P inspector's name"
+msgstr ""
+
+msgid "P2P inspector's email address"
+msgstr ""
+
+msgid "P2P acceptor's title"
+msgstr ""
+
 msgid "Expert inspector's name"
 msgstr ""
 
 msgid "Expert inspector's email address"
+msgstr ""
+
+msgid "Expert inspector's title"
 msgstr ""
 
 msgid "application batch"
@@ -486,6 +603,199 @@ msgstr ""
 msgid "attachments"
 msgstr ""
 
+msgid "paper"
+msgstr ""
+
+msgid "company contact person"
+msgstr ""
+
+msgid "co-operation negotiations"
+msgstr ""
+
+msgid "pay subsidy"
+msgstr ""
+
+msgid "benefit"
+msgstr ""
+
+#, fuzzy
+#| msgid "employee_consent"
+msgid "employment"
+msgstr "Employee's consent for processing personal data"
+
+msgid "approval"
+msgstr ""
+
+msgid "ahjo status"
+msgstr ""
+
+msgid "ahjo statuses"
+msgstr ""
+
+msgid "Not found"
+msgstr ""
+
+msgid "Employer information"
+msgstr ""
+
+msgid "Name of the employer"
+msgstr ""
+
+msgid "Business ID"
+msgstr ""
+
+msgid "Street address"
+msgstr ""
+
+msgid "Delivery address"
+msgstr ""
+
+msgid "Bank account number"
+msgstr ""
+
+msgid "Does the employer engage in economic activity?"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Contact person for the employer"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Telephone"
+msgstr ""
+
+msgid "Email address"
+msgstr ""
+
+msgid "Preferred language of communication"
+msgstr ""
+
+msgid "De minimis aid received by the employer"
+msgstr ""
+
+#, fuzzy
+#| msgid "granted"
+msgid "Granter"
+msgstr "Pay subsidy"
+
+msgid "Amount"
+msgstr ""
+
+msgid "Date"
+msgstr ""
+
+msgid "Total"
+msgstr ""
+
+msgid "No, the applicant has not listed any previous de minimis aids."
+msgstr ""
+
+msgid "Change negotiations or co-determination negotiations"
+msgstr ""
+
+msgid ""
+"Yes, the organization has ongoing or completed change negotiations within "
+"the previous 12 months."
+msgstr ""
+
+msgid ""
+"No, the organization does not have change negotiations in progress or that "
+"have ended in the previous 12 months."
+msgstr ""
+
+msgid "Describe the situation"
+msgstr ""
+
+msgid "Person to be hired"
+msgstr ""
+
+msgid "First name"
+msgstr ""
+
+msgid "Last name"
+msgstr ""
+
+msgid "Personal identity code"
+msgstr ""
+
+msgid "The subsidised employee’s municipality of residence is Helsinki"
+msgstr ""
+
+msgid "Has the person who is being employed been assigned a job supervisor?"
+msgstr ""
+
+msgid "Employment relationship"
+msgstr ""
+
+msgid "Job title"
+msgstr ""
+
+msgid "Working hours per week"
+msgstr ""
+
+msgid "Gross salary per month"
+msgstr ""
+
+msgid "Holiday pay per month"
+msgstr ""
+
+msgid "Indirect labour costs per month"
+msgstr ""
+
+msgid "Applicable collective agreement"
+msgstr ""
+
+msgid "Yhdistyksellä on yritystoimintaa"
+msgstr ""
+
+msgid "Is this an apprenticeship?"
+msgstr ""
+
+msgid "Received aid"
+msgstr ""
+
+msgid "Benefit is applied for the period"
+msgstr ""
+
+msgid "Applying for dates"
+msgstr ""
+
+msgid "Attachments"
+msgstr ""
+
+msgid "granted_aged"
+msgstr "Employment aid for people aged 55 and above"
+
+msgid "Printed at"
+msgstr ""
+
+msgid "City of Helsinki"
+msgstr ""
+
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
+msgid "Helsinki-benefit online service"
+msgstr "The Helsinki Benefit card"
+
+msgid "Helsinki-benefit application"
+msgstr ""
+
+msgid "Employee"
+msgstr ""
+
+msgid "Application received"
+msgstr ""
+
+msgid "Application number"
+msgstr ""
+
 msgid "Date range too large"
 msgstr ""
 
@@ -507,6 +817,9 @@ msgstr ""
 msgid "End date cannot be empty"
 msgstr ""
 
+msgid "State aid maximum percentage cannot be empty"
+msgstr ""
+
 msgid "Description row, amount ignored"
 msgstr ""
 
@@ -514,9 +827,6 @@ msgid "Salary costs"
 msgstr ""
 
 msgid "State aid maximum %"
-msgstr ""
-
-msgid "State aid maximum percentage cannot be empty"
 msgstr ""
 
 msgid "Pay subsidy/month"
@@ -535,6 +845,15 @@ msgid "Training compensation amount monthly"
 msgstr ""
 
 msgid "Total amount of deductions monthly"
+msgstr ""
+
+msgid "Basic date range description"
+msgstr ""
+
+msgid "Date range description for total row"
+msgstr ""
+
+msgid "Deduction description"
 msgstr ""
 
 msgid "Calculation already exists"
@@ -569,9 +888,6 @@ msgid "Pay subsidy end date"
 msgstr ""
 
 msgid "Work time percent"
-msgstr ""
-
-msgid "pay subsidy"
 msgstr ""
 
 msgid "pay subsidies"
@@ -628,6 +944,9 @@ msgstr ""
 msgid "Company information is not available"
 msgstr ""
 
+msgid "Your IP address is not on the safe list."
+msgstr ""
+
 msgid "bank account number"
 msgstr ""
 
@@ -643,9 +962,6 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-msgid "Application number"
-msgstr ""
-
 #, python-brace-format
 msgid ""
 "Your application has been opened for editing. Please make the corrections by "
@@ -653,7 +969,11 @@ msgid ""
 "processed."
 msgstr ""
 
-msgid "You have received a new message regarding your Helsinki benefit application"
+msgid ""
+"You have received a new message regarding your Helsinki benefit application"
+msgstr ""
+
+msgid "Your Helsinki benefit application requires additional information"
 msgstr ""
 
 #, python-format
@@ -727,7 +1047,20 @@ msgstr ""
 msgid "Terms of application - show at application submit"
 msgstr ""
 
+msgid ""
+"Terms of application for handler - show at application submit for handler"
+msgstr ""
+
 msgid "type of terms"
+msgstr ""
+
+msgid "Finnish terms (md)"
+msgstr ""
+
+msgid "English terms (md)"
+msgstr ""
+
+msgid "Swedish terms (md)"
 msgstr ""
 
 msgid "first day these terms are in effect"
@@ -740,6 +1073,9 @@ msgid "english terms (pdf file)"
 msgstr ""
 
 msgid "swedish terms (pdf file)"
+msgstr ""
+
+msgid "PDF or MD fields are missing for FI/EN/SV! Fill in either or"
 msgstr ""
 
 msgid "terms"
@@ -784,44 +1120,29 @@ msgstr ""
 msgid "terms of service approvals"
 msgstr ""
 
-msgid "fi"
-msgstr "Finnish"
+#~ msgid "fi"
+#~ msgstr "Finnish"
 
-msgid "sv"
-msgstr "Swedish"
+#~ msgid "sv"
+#~ msgstr "Swedish"
 
-msgid "en"
-msgstr "English"
+#~ msgid "en"
+#~ msgstr "English"
 
-msgid "granted"
-msgstr "Pay subsidy"
+#~ msgid "not_granted"
+#~ msgstr "None"
 
-msgid "granted_aged"
-msgstr "Employment aid for people aged 55 and above"
+#~ msgid "Processing of the personal data of the person to be employed"
+#~ msgstr "Behandlingen av personuppgifterna av personen som ska sysselsättas"
 
-msgid "not_granted"
-msgstr "None"
+#~ msgid "Agreement for employee's personal data processing"
+#~ msgstr "Avtal för anställds personuppgiftsbehandling"
 
-msgid "Processing of the personal data of the person to be employed"
-msgstr "Behandlingen av personuppgifterna av personen som ska sysselsättas"
+#~ msgid "employment_contract"
+#~ msgstr "Employment contract"
 
-msgid "Agreement for employee's personal data processing"
-msgstr "Avtal för anställds personuppgiftsbehandling"
+#~ msgid "pay_subsidy_decision"
+#~ msgstr "Pay subsidy decision"
 
-msgid "employment_contract"
-msgstr "Employment contract"
-
-msgid "pay_subsidy_decision"
-msgstr "Pay subsidy decision"
-
-msgid "education_contract"
-msgstr "Agreement on providing apprenticeship training"
-
-msgid "helsinki_benefit_voucher"
-msgstr "The Helsinki Benefit card"
-
-msgid "employee_consent"
-msgstr "Employee's consent for processing personal data"
-
-msgid "Your Helsinki benefit application requires additional information"
-msgstr ""
+#~ msgid "education_contract"
+#~ msgstr "Agreement on providing apprenticeship training"

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-01 10:42+0200\n"
+"POT-Creation-Date: 2024-01-25 18:30+0200\n"
 "PO-Revision-Date: 2022-11-01 10:45+0200\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
@@ -35,51 +35,6 @@ msgstr "Ei vietävää hakemusta, yritä myöhemmin uudelleen"
 msgid "TALPA export {date}"
 msgstr "TALPA-vienti {date}"
 
-#, python-brace-format
-msgid "Upload file size cannot be greater than {size} bytes"
-msgstr "Ladattavan tiedoston koko ei voi ylittää {size} tavua"
-
-msgid "Too many attachments"
-msgstr "Liian monta liitettä"
-
-msgid "Not a valid pdf file"
-msgstr "Epäkelpo PDF-tiedosto"
-
-msgid "Not a valid image file"
-msgstr "Epäkelpo kuvatiedosto"
-
-msgid "Grant date too much in past"
-msgstr "Myöntämispäivä liian kaukana menneisyydessä"
-
-msgid "Grant date can not be in the future"
-msgstr "Myöntämispäivä ei voi olla tulevaisuudessa"
-
-msgid "Social security number invalid"
-msgstr "Epäkelpo henkilötunnus"
-
-msgid "Social security number checksum invalid"
-msgstr "Epäkelpo henkilötunnuksen tarkistussumma"
-
-#, python-brace-format
-msgid "Working hour must be greater than {min_hour} per week"
-msgstr "Työajan on oltava suurempi kuin {min_hour} viikossa"
-
-msgid "Monthly pay must be greater than 0"
-msgstr "Kuukausipalkan on oltava suurempi kuin 0"
-
-msgid "Vacation money must be a positive number"
-msgstr "Lomarahojen täytyy olla positiivinen luku"
-
-msgid "Other expenses must be a positive number"
-msgstr "Muiden kulujen täytyy olla positiivinen luku"
-
-msgid "Applications in a batch can not be changed when batch is in this status"
-msgstr "Erän hakemuksia ei voida muuttaa erän ollessa tässä tilassa"
-
-msgid "This application has invalid status and can not be added to this batch"
-msgstr ""
-"Tämän hakemuksen tila on virheellinen, eikä sitä voi lisätä tähän erään"
-
 msgid "This should be unreachable"
 msgstr "Tämän pitäisi olla tavoittamattomissa"
 
@@ -88,8 +43,8 @@ msgstr "Työnjohdollinen esihenkilö on pakollinen valinta"
 
 msgid "for companies, association_immediate_manager_check must always be null"
 msgstr ""
-"yrityksen ollessa kyseessä kohteen Työnjohdollinen esihenkilö (association_immediate_manager_check) on "
-"aina oltava tyhjä"
+"yrityksen ollessa kyseessä kohteen Työnjohdollinen esihenkilö "
+"(association_immediate_manager_check) on aina oltava tyhjä"
 
 msgid ""
 "This application has non-null de_minimis_aid but is applied by an association"
@@ -98,7 +53,8 @@ msgstr ""
 "joka ei harjoita liiketoimintaa"
 
 msgid "This application has de_minimis_aid set but does not define any"
-msgstr "Tässä hakemuksessa on valittu de minimis tuki, mutta sitä ei ole annettu"
+msgstr ""
+"Tässä hakemuksessa on valittu de minimis tuki, mutta sitä ei ole annettu"
 
 msgid "This application can not have de minimis aid"
 msgstr "Tässä hakemuksessa ei voi olla de minimis -tukea"
@@ -106,14 +62,8 @@ msgstr "Tässä hakemuksessa ei voi olla de minimis -tukea"
 msgid "Total amount of de minimis aid too large"
 msgstr "De minimis -tuen kokonaismäärä liian suuri"
 
-msgid "start_date must not be in a past year"
-msgstr "Aloituspäivä ei saa olla menneessä vuodessa"
-
 msgid "start_date must not be more than 4 months in the past"
 msgstr "Aloituspäivä voi olla enintään 4 kuukautta menneisyydessä"
-
-msgid "end_date must not be in a past year"
-msgstr "Päättymispäivä ei saa olla menneessä vuodessa"
 
 msgid "application end_date can not be less than start_date"
 msgstr "hakemuksen päättymispäivä ei voi olla aiemmin kuin aloituspäivä"
@@ -128,15 +78,13 @@ msgid ""
 "This application can not have a description for co-operation negotiations"
 msgstr "Tässä hakemuksessa ei voi olla kuvausta yhteistoimintaneuvotteluista"
 
-msgid "Pay subsidy percent required"
-msgstr "Palkkatukiprosentti on pakollinen"
-
 #, python-brace-format
 msgid "This application can not have {key}"
 msgstr "Tässä hakemuksessa ei voi olla kohdetta {key}"
 
 msgid "This application can not have additional_pay_subsidy_percent"
-msgstr "Tässä hakemuksessa ei voi olla kohdetta toinen tuki prosentti "
+msgstr ""
+"Tässä hakemuksessa ei voi olla kohdetta toinen tuki prosentti "
 "additional_pay_subsidy_percent"
 
 msgid "This field is required before submitting the application"
@@ -147,6 +95,14 @@ msgstr "Tämä kenttä voidaan valita vain yhteisöille"
 
 msgid "This benefit type can not be selected"
 msgstr "Tätä avustustyyppiä ei voida valita"
+
+msgid ""
+"Apprenticeship program can not be selected if there is no granted pay subsidy"
+msgstr ""
+
+msgid ""
+"Apprenticeship program has to be yes or no if there is a granted pay subsidy"
+msgstr ""
 
 msgid "Application does not have the employee consent attachment"
 msgstr "Hakemuksessa ei ole liitteenä työntekijän suostumusta"
@@ -173,6 +129,10 @@ msgstr "Hakemusta ei voida muuttaa tässä tilassa"
 msgid "create_application_for_company missing from request"
 msgstr "create_application_for_company puuttuu pyynnöstä"
 
+#, python-brace-format
+msgid "company with id {company_id} not found"
+msgstr ""
+
 msgid "The calculation should be created when the application is submitted"
 msgstr "Laskelma on luotava, kun hakemus lähetetään"
 
@@ -184,12 +144,57 @@ msgid "Reading {localized_model_name} data failed: {errors}"
 msgstr "{localized_model_name} -tietojen lukeminen epäonnistui: {errors}"
 
 #, python-brace-format
+msgid "Upload file size cannot be greater than {size} bytes"
+msgstr "Ladattavan tiedoston koko ei voi ylittää {size} tavua"
+
+msgid "Too many attachments"
+msgstr "Liian monta liitettä"
+
+msgid "Not a valid pdf file"
+msgstr "Epäkelpo PDF-tiedosto"
+
+msgid "Not a valid image file"
+msgstr "Epäkelpo kuvatiedosto"
+
+msgid "Applications in a batch can not be changed when batch is in this status"
+msgstr "Erän hakemuksia ei voida muuttaa erän ollessa tässä tilassa"
+
+msgid "This application has invalid status and can not be added to this batch"
+msgstr ""
+"Tämän hakemuksen tila on virheellinen, eikä sitä voi lisätä tähän erään"
+
+msgid "Grant date too much in past"
+msgstr "Myöntämispäivä liian kaukana menneisyydessä"
+
+msgid "Grant date can not be in the future"
+msgstr "Myöntämispäivä ei voi olla tulevaisuudessa"
+
+msgid "Social security number invalid"
+msgstr "Epäkelpo henkilötunnus"
+
+#, python-brace-format
+msgid "Working hour must be greater than {min_hour} per week"
+msgstr "Työajan on oltava suurempi kuin {min_hour} viikossa"
+
+msgid "Monthly pay must be greater than 0"
+msgstr "Kuukausipalkan on oltava suurempi kuin 0"
+
+msgid "Vacation money must be a positive number"
+msgstr "Lomarahojen täytyy olla positiivinen luku"
+
+msgid "Other expenses must be a positive number"
+msgstr "Muiden kulujen täytyy olla positiivinen luku"
+
+#, python-brace-format
 msgid "State transition not allowed: {status} to {value}"
 msgstr "Tilan siirto ei ole sallittu: {status} arvoon {value}"
 
 #, python-brace-format
 msgid "Initial status must be {initial_status}"
 msgstr "Alkutilan on oltava {initial_status}"
+
+msgid "Displayed in the archive in the applicant view"
+msgstr ""
 
 msgid "Operation not allowed for this application status."
 msgstr "Toiminto ei ole sallittu tässä hakemuksen tilassa."
@@ -198,7 +203,7 @@ msgid "File not found."
 msgstr "Tiedostoa ei löydy."
 
 #, python-brace-format
-msgid "Helsinki-lisän hakemukset viety {date}"
+msgid "Helsinki-lisan hakemukset viety {date}"
 msgstr ""
 
 msgid "Benefit can not be granted before 24-month waiting period expires"
@@ -283,6 +288,26 @@ msgstr "oppisopimustoimiston koulutussopimus"
 msgid "helsinki benefit voucher"
 msgstr "Helsinki-lisä-seteli"
 
+#, fuzzy
+#| msgid "employee_consent"
+msgid "employee consent"
+msgstr "Suostumus työntekijän henkilötietojen käsittelyyn"
+
+#, fuzzy
+#| msgid "application"
+msgid "full application"
+msgstr "hakemus"
+
+#, fuzzy
+#| msgid "attachment"
+msgid "other attachment"
+msgstr "liite"
+
+#, fuzzy
+#| msgid "Step 4 - summary"
+msgid "pdf summary"
+msgstr "Vaihe 4 – yhteenveto"
+
 msgid "attachment is required"
 msgstr "liite on pakollinen"
 
@@ -310,11 +335,124 @@ msgstr "Lähetetty Talpaan"
 msgid "Processing is completed"
 msgstr "Käsittely on valmis"
 
+#, fuzzy
+#| msgid "Rejected"
+msgid "Rejected by Talpa"
+msgstr "Hylätty"
+
+#, fuzzy
+#| msgid "Sent to Talpa"
+msgid "Not sent to Talpa"
+msgstr "Lähetetty Talpaan"
+
+#, fuzzy
+#| msgid "Sent to Talpa"
+msgid "Successfully sent to Talpa"
+msgstr "Lähetetty Talpaan"
+
+msgid "Handler"
+msgstr "Käsittelijä"
+
+#, fuzzy
+#| msgid "application"
+msgid "Applicant"
+msgstr "hakemus"
+
+#, fuzzy
+#| msgid "Pay subsidy end date"
+msgid "Pay subsidy granted (default)"
+msgstr "Palkkatuen päättymispäivä"
+
+#, fuzzy
+#| msgid "Pay subsidy end date"
+msgid "Pay subsidy granted (aged)"
+msgstr "Palkkatuen päättymispäivä"
+
+#, fuzzy
+#| msgid "pay subsidy"
+msgid "No granted pay subsidy"
+msgstr "palkkatuki"
+
+msgid "Submitted but not sent to AHJO"
+msgstr ""
+
+msgid "Request to open the case sent to AHJO"
+msgstr ""
+
+msgid "Case opened in AHJO"
+msgstr ""
+
+msgid "Update request sent"
+msgstr ""
+
+msgid "Update request received"
+msgstr ""
+
+#, fuzzy
+#| msgid "Decision date"
+msgid "Decision proposal sent"
+msgstr "Päätöksen päivämäärä"
+
+#, fuzzy
+#| msgid "Decision date"
+msgid "Decision proposal accepted"
+msgstr "Päätöksen päivämäärä"
+
+#, fuzzy
+#| msgid "Decision date"
+msgid "Decision proposal rejected"
+msgstr "Päätöksen päivämäärä"
+
+msgid "Delete request sent"
+msgstr ""
+
+msgid "Delete request received"
+msgstr ""
+
+msgid "Allow/disallow applicant's modifications"
+msgstr ""
+
+msgid "Success"
+msgstr ""
+
+msgid "Failure"
+msgstr ""
+
+#, fuzzy
+#| msgid "Rejected in Ahjo"
+msgid "Open case in Ahjo"
+msgstr "Hylätty Ahjossa"
+
+#, fuzzy
+#| msgid "Incomplete application"
+msgid "Delete application in Ahjo"
+msgstr "Puutteellinen hakemus"
+
+#, python-brace-format
+msgid ""
+"Your application {id} will be deleted soon. If you want to continue the "
+"application process, please do so by {application_deletion_date}, otherwise "
+"the application will deleted permanently."
+msgstr ""
+
+msgid "Your Helsinki benefit draft application will expire"
+msgstr "Helsinki-lisä -hakemuksesi luonnos vanhenee"
+
 msgid "company"
 msgstr "yritys"
 
 msgid "status"
 msgstr "tila"
+
+#, fuzzy
+#| msgid "status"
+msgid "talpa_status"
+msgstr "tila"
+
+#, fuzzy
+#| msgid "application log entry"
+msgid "application origin"
+msgstr "hakemuksen lokimerkintä"
 
 msgid "application number"
 msgstr "hakemuksen numero"
@@ -370,6 +508,11 @@ msgstr "avustuksen alkamispäivä"
 msgid "benefit end date"
 msgstr "avustuksen päättymispäivä"
 
+#, fuzzy
+#| msgid "application batches"
+msgid "paper application date"
+msgstr "hakemuserät"
+
 msgid "ahjo batch"
 msgstr "Ahjo-erä"
 
@@ -418,11 +561,29 @@ msgstr "Ahjo-päätöksen lakipykälä"
 msgid "date of the decision in Ahjo"
 msgstr "päätöksen päivämäärä Ahjossa"
 
+#, fuzzy
+#| msgid "Expert inspector's name"
+msgid "P2P inspector's name"
+msgstr "Asiantuntijatarkastajan nimi"
+
+#, fuzzy
+#| msgid "Expert inspector's email address"
+msgid "P2P inspector's email address"
+msgstr "Asiantuntijatarkastajan sähköpostiosoite"
+
+msgid "P2P acceptor's title"
+msgstr ""
+
 msgid "Expert inspector's name"
 msgstr "Asiantuntijatarkastajan nimi"
 
 msgid "Expert inspector's email address"
 msgstr "Asiantuntijatarkastajan sähköpostiosoite"
+
+#, fuzzy
+#| msgid "Expert inspector's name"
+msgid "Expert inspector's title"
+msgstr "Asiantuntijatarkastajan nimi"
 
 msgid "application batch"
 msgstr "hakemuserä"
@@ -493,6 +654,214 @@ msgstr "liite"
 msgid "attachments"
 msgstr "liitteet"
 
+msgid "paper"
+msgstr ""
+
+#, fuzzy
+#| msgid "company contact person's email"
+msgid "company contact person"
+msgstr "yrityksen yhteyshenkilön sähköpostiosoite"
+
+msgid "co-operation negotiations"
+msgstr ""
+
+msgid "pay subsidy"
+msgstr "palkkatuki"
+
+#, fuzzy
+#| msgid "benefit end date"
+msgid "benefit"
+msgstr "avustuksen päättymispäivä"
+
+#, fuzzy
+#| msgid "employee"
+msgid "employment"
+msgstr "työntekijä"
+
+msgid "approval"
+msgstr ""
+
+#, fuzzy
+#| msgid "status"
+msgid "ahjo status"
+msgstr "tila"
+
+#, fuzzy
+#| msgid "status"
+msgid "ahjo statuses"
+msgstr "tila"
+
+#, fuzzy
+#| msgid "File not found."
+msgid "Not found"
+msgstr "Tiedostoa ei löydy."
+
+msgid "Employer information"
+msgstr "Työnantajan tiedot"
+
+msgid "Name of the employer"
+msgstr "Yrityksen nimi"
+
+msgid "Business ID"
+msgstr "Y-tunnus"
+
+msgid "Street address"
+msgstr "Katuosoite"
+
+msgid "Delivery address"
+msgstr "Postiosoite päätöstä varten"
+
+msgid "Bank account number"
+msgstr "Tilinumero"
+
+msgid "Does the employer engage in economic activity?"
+msgstr "Harjoittaako työnantaja taloudellista liiketoimintaa?"
+
+msgid "Yes"
+msgstr ""
+
+#, fuzzy
+#| msgid "Note"
+msgid "No"
+msgstr "Huomautus"
+
+msgid "Contact person for the employer"
+msgstr "Työnantajan yhteyshenkilö"
+
+msgid "Name"
+msgstr "Nimi"
+
+msgid "Telephone"
+msgstr "Puhelin"
+
+msgid "Email address"
+msgstr "Sähköposti"
+
+msgid "Preferred language of communication"
+msgstr "Asiointikieli"
+
+msgid "De minimis aid received by the employer"
+msgstr "Työnantajalle myönnetyt de minimis -tuet"
+
+msgid "Granter"
+msgstr "Myöntäjä"
+
+msgid "Amount"
+msgstr "Määrä"
+
+msgid "Date"
+msgstr "Pvm"
+
+msgid "Total"
+msgstr "Yhteensä"
+
+msgid "No, the applicant has not listed any previous de minimis aids."
+msgstr ""
+"Ei, työnantajalle ei ole myönnetty de minimis -tukia kuluvan vuoden ja "
+"kahden edellisen verovuoden aikana."
+
+msgid "Change negotiations or co-determination negotiations"
+msgstr "Muutosneuvottelut tai YT-tilanne"
+
+msgid ""
+"Yes, the organization has ongoing or completed change negotiations within "
+"the previous 12 months."
+msgstr ""
+"Kyllä, organisaatiolla on käynnissä olevat, tai päättyneet muutosneuvottelut "
+"edeltävän 12 kuukauden aikana."
+
+msgid ""
+"No, the organization does not have change negotiations in progress or that "
+"have ended in the previous 12 months."
+msgstr ""
+"Ei, organisaatiolla ei ole käynnissä tai edeltävän 12 kuukauden aikana "
+"päättyneitä muutosneuvotteluja"
+
+msgid "Describe the situation"
+msgstr "Kuvaus tilanteesta"
+
+msgid "Person to be hired"
+msgstr "Työllistettävän henkilön tiedot"
+
+msgid "First name"
+msgstr "Etunimi"
+
+msgid "Last name"
+msgstr "Sukunimi"
+
+msgid "Personal identity code"
+msgstr "Henkilötunnus"
+
+msgid "The subsidised employee’s municipality of residence is Helsinki"
+msgstr "Työllistetyn kotikunta Helsinki työsuhteen alkaessa"
+
+msgid "Has the person who is being employed been assigned a job supervisor?"
+msgstr "Onko työllistetylle osoitettu työnjohdollinen esihenkilö?"
+
+msgid "Employment relationship"
+msgstr "Työsuhde"
+
+msgid "Job title"
+msgstr "Tehtävänimike"
+
+msgid "Working hours per week"
+msgstr "Työtunnit / viikko"
+
+msgid "Gross salary per month"
+msgstr "Bruttopalkka / kuukausi"
+
+msgid "Holiday pay per month"
+msgstr "Lomaraha / kuukausi"
+
+msgid "Indirect labour costs per month"
+msgstr "Sivukulut / kuukausi"
+
+msgid "Applicable collective agreement"
+msgstr "Työehtosopimus"
+
+msgid "Yhdistyksellä on yritystoimintaa"
+msgstr ""
+
+msgid "Is this an apprenticeship?"
+msgstr "Onko kyseessä oppisopimus?"
+
+msgid "Received aid"
+msgstr "Myönnetty tuki"
+
+msgid "Benefit is applied for the period"
+msgstr "Haettu ajankohta"
+
+msgid "Applying for dates"
+msgstr "Ajalle"
+
+msgid "Attachments"
+msgstr "Liitteet"
+
+msgid "granted_aged"
+msgstr "55 vuotta täyttäneiden työllistämistuki"
+
+msgid "Printed at"
+msgstr "Tulostettu"
+
+# Application printout
+msgid "City of Helsinki"
+msgstr "Helsingin kaupunki"
+
+msgid "Helsinki-benefit online service"
+msgstr "Helsinki-lisän asiointipalvelu"
+
+msgid "Helsinki-benefit application"
+msgstr "Helsinki-lisä hakemus"
+
+msgid "Employee"
+msgstr "Työllistettävä"
+
+msgid "Application received"
+msgstr "Hakemus saapunut"
+
+msgid "Application number"
+msgstr "Hakemusnumero"
+
 msgid "Date range too large"
 msgstr "Päivämääräalue liian suuri"
 
@@ -502,8 +871,7 @@ msgstr ""
 "override_monthly_benefit_amount_comment"
 
 msgid "This calculation needs override_monthly_benefit_amount_comment"
-msgstr ""
-"Tässä laskelmassa on oltava manuaalisen laskelman perustelu"
+msgstr "Tässä laskelmassa on oltava manuaalisen laskelman perustelu"
 
 msgid "Handler can not be unassigned in this status"
 msgstr "Käsittelijää ei voida muuttaa tässä tilassa"
@@ -518,7 +886,9 @@ msgid "End date cannot be empty"
 msgstr "Päättymispäivä ei voi olla tyhjä"
 
 msgid "State aid maximum percentage cannot be empty"
-msgstr "Valtiontuen maksimimäärä ei voi olla tyhjä ja sen täytyy olla yksi alasvetovalikon arvoista"
+msgstr ""
+"Valtiontuen maksimimäärä ei voi olla tyhjä ja sen täytyy olla yksi "
+"alasvetovalikon arvoista"
 
 msgid "Description row, amount ignored"
 msgstr "Kuvausrivi, rahamäärä ohitettu"
@@ -546,6 +916,17 @@ msgstr "Koulutuskorvauksen määrä kuukaudelta"
 
 msgid "Total amount of deductions monthly"
 msgstr "Vähennysten kokonaismäärä kuukaudelta"
+
+msgid "Basic date range description"
+msgstr ""
+
+#, fuzzy
+#| msgid "Date range too large"
+msgid "Date range description for total row"
+msgstr "Päivämääräalue liian suuri"
+
+msgid "Deduction description"
+msgstr ""
 
 msgid "Calculation already exists"
 msgstr "Laskelma on jo olemassa"
@@ -580,9 +961,6 @@ msgstr "Palkkatuen päättymispäivä"
 
 msgid "Work time percent"
 msgstr "Työaikaprosentti"
-
-msgid "pay subsidy"
-msgstr "palkkatuki"
 
 msgid "pay subsidies"
 msgstr "palkkatuet"
@@ -638,6 +1016,9 @@ msgstr "Sinun on hyväksyttävä palveluehdot ennen mitään toimenpiteitä"
 msgid "Company information is not available"
 msgstr "Yrityksen tietoja ei ole saatavilla"
 
+msgid "Your IP address is not on the safe list."
+msgstr ""
+
 msgid "bank account number"
 msgstr "tilinumero"
 
@@ -663,8 +1044,12 @@ msgstr ""
 "{additional_information_needed_by} mennessä, muuten hakemusta ei voida "
 "käsitellä."
 
-msgid "You have received a new message regarding your Helsinki benefit application"
+msgid ""
+"You have received a new message regarding your Helsinki benefit application"
 msgstr "Olet saanut uuden viestin Helsinki-lisä -hakemukseen littyen"
+
+msgid "Your Helsinki benefit application requires additional information"
+msgstr "Helsinki-lisä -hakemus tarvitsee lisätietoja"
 
 #, python-format
 msgid ""
@@ -742,8 +1127,29 @@ msgstr "Palveluehdot – näytetään sisäänkirjautumisen yhteydessä"
 msgid "Terms of application - show at application submit"
 msgstr "Hakuehdot – näytä hakemuksen lähettämisen yhteydessä"
 
+#, fuzzy
+#| msgid "Terms of application - show at application submit"
+msgid ""
+"Terms of application for handler - show at application submit for handler"
+msgstr "Hakuehdot – näytä hakemuksen lähettämisen yhteydessä"
+
 msgid "type of terms"
 msgstr "ehtojen tyyppi"
+
+#, fuzzy
+#| msgid "finnish terms (pdf file)"
+msgid "Finnish terms (md)"
+msgstr "suomenkieliset ehdot (PDF-tiedosto)"
+
+#, fuzzy
+#| msgid "english terms (pdf file)"
+msgid "English terms (md)"
+msgstr "englanninkieliset ehdot (PDF-tiedosto)"
+
+#, fuzzy
+#| msgid "swedish terms (pdf file)"
+msgid "Swedish terms (md)"
+msgstr "ruotsinkieliset ehdot (PDF-tiedosto)"
 
 msgid "first day these terms are in effect"
 msgstr "näiden ehtojen ensimmäinen voimassaolopäivä"
@@ -756,6 +1162,9 @@ msgstr "englanninkieliset ehdot (PDF-tiedosto)"
 
 msgid "swedish terms (pdf file)"
 msgstr "ruotsinkieliset ehdot (PDF-tiedosto)"
+
+msgid "PDF or MD fields are missing for FI/EN/SV! Fill in either or"
+msgstr ""
 
 msgid "terms"
 msgstr "ehdot"
@@ -799,202 +1208,53 @@ msgstr "palveluehtojen hyväksyntä"
 msgid "terms of service approvals"
 msgstr "palveluehtojen hyväksynnät"
 
-# Application printout
+#~ msgid "Social security number checksum invalid"
+#~ msgstr "Epäkelpo henkilötunnuksen tarkistussumma"
 
-msgid "City of Helsinki"
-msgstr "Helsingin kaupunki"
+#~ msgid "start_date must not be in a past year"
+#~ msgstr "Aloituspäivä ei saa olla menneessä vuodessa"
 
-msgid "Helsinki-benefit online service"
-msgstr "Helsinki-lisän asiointipalvelu"
+#~ msgid "end_date must not be in a past year"
+#~ msgstr "Päättymispäivä ei saa olla menneessä vuodessa"
 
-msgid "Helsinki-benefit application"
-msgstr "Helsinki-lisä hakemus"
+#~ msgid "Pay subsidy percent required"
+#~ msgstr "Palkkatukiprosentti on pakollinen"
 
-msgid "Employee"
-msgstr "Työllistettävä"
+#~ msgid "Helsinki benefit is granted"
+#~ msgstr "Helsinki-lisää myönnetään"
 
-msgid "Application received"
-msgstr "Hakemus saapunut"
+#~ msgid "Helsinki benefit is not granted"
+#~ msgstr "Helsinki-lisää ei myönnetä"
 
-msgid "Application number"
-msgstr "Hakemusnumero"
+#~ msgid "Granted as de minimis aid"
+#~ msgstr "Myönnetään de minimis -tukena"
 
-msgid "Employer information"
-msgstr "Työnantajan tiedot"
- 
-msgid "Name of the employer"
-msgstr "Yrityksen nimi"
- 
-msgid "Business ID"
-msgstr "Y-tunnus"
- 
-msgid "Street address"
-msgstr "Katuosoite"
- 
-msgid "Bank account number"
-msgstr "Tilinumero"
- 
-msgid "Does the employer engage in economic activity?"
-msgstr "Harjoittaako työnantaja taloudellista liiketoimintaa?"
- 
-msgid "Delivery address"
-msgstr "Postiosoite päätöstä varten"
- 
-msgid "Contact person for the employer"
-msgstr "Työnantajan yhteyshenkilö"
- 
-msgid "Name"
-msgstr "Nimi"
- 
-msgid "Telephone"
-msgstr "Puhelin"
- 
-msgid "Email address"
-msgstr "Sähköposti"
- 
-msgid "Preferred language of communication"
-msgstr "Asiointikieli"
- 
-msgid "De minimis aid received by the employer"
-msgstr "Työnantajalle myönnetyt de minimis -tuet"
- 
-msgid "Granter"
-msgstr "Myöntäjä"
- 
-msgid "Amount"
-msgstr "Määrä"
- 
-msgid "Date"
-msgstr "Pvm"
- 
-msgid "Total"
-msgstr "Yhteensä"
- 
-msgid "No, the applicant has not listed any previous de minimis aids."
-msgstr "Ei, työnantajalle ei ole myönnetty de minimis -tukia kuluvan vuoden ja kahden edellisen verovuoden aikana."
- 
-msgid "Change negotiations or co-determination negotiations"
-msgstr "Muutosneuvottelut tai YT-tilanne"
- 
-msgid "Yes, the organization has ongoing or completed change negotiations within the previous 12 months."
-msgstr "Kyllä, organisaatiolla on käynnissä olevat, tai päättyneet muutosneuvottelut edeltävän 12 kuukauden aikana."
- 
-msgid "No, the organization does not have change negotiations in progress or that have ended in the previous 12 months."
-msgstr "Ei, organisaatiolla ei ole käynnissä tai edeltävän 12 kuukauden aikana päättyneitä muutosneuvotteluja"
- 
-msgid "Describe the situation"
-msgstr "Kuvaus tilanteesta"
- 
-msgid "Person to be hired"
-msgstr "Työllistettävän henkilön tiedot"
- 
-msgid "First name"
-msgstr "Etunimi"
- 
-msgid "Last name"
-msgstr "Sukunimi"
- 
-msgid "Personal identity code"
-msgstr "Henkilötunnus"
- 
-msgid "The subsidised employee’s municipality of residence is Helsinki"
-msgstr "Työllistetyn kotikunta Helsinki työsuhteen alkaessa"
- 
-msgid "Has the person who is being employed been assigned a job supervisor?"
-msgstr "Onko työllistetylle osoitettu työnjohdollinen esihenkilö?"
- 
-msgid "Employment relationship"
-msgstr "Työsuhde"
- 
-msgid "Job title"
-msgstr "Tehtävänimike"
- 
-msgid "Working hours per week"
-msgstr "Työtunnit / viikko"
- 
-msgid "Gross salary per month"
-msgstr "Bruttopalkka / kuukausi"
- 
-msgid "Indirect labour costs per month"
-msgstr "Sivukulut / kuukausi"
- 
-msgid "Holiday pay per month"
-msgstr "Lomaraha / kuukausi"
- 
-msgid "Applicable collective agreement"
-msgstr "Työehtosopimus"
- 
-msgid "Is this an apprenticeship?"
-msgstr "Onko kyseessä oppisopimus?"
- 
-msgid "Received aid"
-msgstr "Myönnetty tuki"
- 
-msgid "Benefit is applied for the period"
-msgstr "Haettu ajankohta"
- 
-msgid "Helsinki benefit is granted"
-msgstr "Helsinki-lisää myönnetään"
- 
-msgid "Helsinki benefit is not granted"
-msgstr "Helsinki-lisää ei myönnetä"
- 
-msgid "Applying for dates"
-msgstr "Ajalle"
- 
-msgid "Decision date"
-msgstr "Päätöksen päivämäärä"
- 
-msgid "Handler"
-msgstr "Käsittelijä"
- 
-msgid "Granted as de minimis aid"
-msgstr "Myönnetään de minimis -tukena"
- 
-msgid "Attachments"
-msgstr "Liitteet"
- 
-msgid "Processing of the personal data of the person to be employed"
-msgstr "Työllistettävän henkilötietojen käsittely"
+#~ msgid "Processing of the personal data of the person to be employed"
+#~ msgstr "Työllistettävän henkilötietojen käsittely"
 
-msgid "employee_consent"
-msgstr "Suostumus työntekijän henkilötietojen käsittelyyn"
+#~ msgid "employment_contract"
+#~ msgstr "Työsopimus"
 
-msgid "employment_contract"
-msgstr "Työsopimus"
+#~ msgid "pay_subsidy_decision"
+#~ msgstr "Palkkatukipäätös"
 
-msgid "pay_subsidy_decision"
-msgstr "Palkkatukipäätös"
+#~ msgid "education_contract"
+#~ msgstr "Sopimus oppisopimuskoulutuksen järjestämisestä"
 
-msgid "education_contract"
-msgstr "Sopimus oppisopimuskoulutuksen järjestämisestä"
+#~ msgid "helsinki_benefit_voucher"
+#~ msgstr "Helsinki-lisä -kortti"
 
-msgid "helsinki_benefit_voucher"
-msgstr "Helsinki-lisä -kortti"
+#~ msgid "fi"
+#~ msgstr "Suomi"
 
-msgid "fi"
-msgstr "Suomi"
+#~ msgid "sv"
+#~ msgstr "Ruotsi"
 
-msgid "sv"
-msgstr "Ruotsi"
+#~ msgid "en"
+#~ msgstr "Englanti"
 
-msgid "en"
-msgstr "Englanti"
+#~ msgid "granted"
+#~ msgstr "Palkkatuki"
 
-msgid "granted"
-msgstr "Palkkatuki"
-
-msgid "granted_aged"
-msgstr "55 vuotta täyttäneiden työllistämistuki"
-
-msgid "not_granted"
-msgstr "Ei myönnetty"
-
-msgid "Printed at"
-msgstr "Tulostettu"
-
-msgid "Your Helsinki benefit draft application will expire"
-msgstr "Helsinki-lisä -hakemuksesi luonnos vanhenee"
-
-msgid "Your Helsinki benefit application requires additional information"
-msgstr "Helsinki-lisä -hakemus tarvitsee lisätietoja"
+#~ msgid "not_granted"
+#~ msgstr "Ei myönnetty"

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-01 10:42+0200\n"
+"POT-Creation-Date: 2024-01-25 18:30+0200\n"
 "PO-Revision-Date: 2022-11-01 10:47+0200\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
@@ -36,50 +36,6 @@ msgstr ""
 msgid "TALPA export {date}"
 msgstr "TALPA-export {date}"
 
-#, python-brace-format
-msgid "Upload file size cannot be greater than {size} bytes"
-msgstr "Den fil som laddas upp kan inte vara större än {size} byte"
-
-msgid "Too many attachments"
-msgstr "För många bilagor"
-
-msgid "Not a valid pdf file"
-msgstr "Ingen giltig PDF-fil"
-
-msgid "Not a valid image file"
-msgstr "Ingen giltig bildfil"
-
-msgid "Grant date too much in past"
-msgstr "Beviljandedatum för tidigt"
-
-msgid "Grant date can not be in the future"
-msgstr "Beviljandedatum kan inte vara i framtiden"
-
-msgid "Social security number invalid"
-msgstr "Personbeteckning felaktig"
-
-msgid "Social security number checksum invalid"
-msgstr "Personbeteckning kontrollsumma felaktig"
-
-#, python-brace-format
-msgid "Working hour must be greater than {min_hour} per week"
-msgstr "Antalet arbetstimmar måste vara högre än {min_hour} per vecka"
-
-msgid "Monthly pay must be greater than 0"
-msgstr "Månatlig lön måste vara större än 0"
-
-msgid "Vacation money must be a positive number"
-msgstr "Semesterpenning måste vara ett positivt tal"
-
-msgid "Other expenses must be a positive number"
-msgstr "Andra kostnader måste vara ett positivt tal"
-
-msgid "Applications in a batch can not be changed when batch is in this status"
-msgstr "Ansökningar i en sats kan inte ändras när satsen har denna status"
-
-msgid "This application has invalid status and can not be added to this batch"
-msgstr "Denna ansökan har felaktig status och kan inte läggas till denna sats"
-
 msgid "This should be unreachable"
 msgstr "Detta bör vara onåbart"
 
@@ -104,14 +60,8 @@ msgstr "Denna ansökan kan inte ha de minimis-stöd"
 msgid "Total amount of de minimis aid too large"
 msgstr "Totalt belopp av de minimis-stöd är för stort"
 
-msgid "start_date must not be in a past year"
-msgstr "Startdatum får inte vara under föregående år"
-
 msgid "start_date must not be more than 4 months in the past"
 msgstr "Startdatumet får inte ligga mer än fyra månader bakåt i tiden"
-
-msgid "end_date must not be in a past year"
-msgstr "Slutdatum får inte vara under föregående år"
 
 msgid "application end_date can not be less than start_date"
 msgstr "end_date för ansökan kan inte vara tidigare än start_date"
@@ -125,9 +75,6 @@ msgstr "längsta varaktighet för understödet är en månad"
 msgid ""
 "This application can not have a description for co-operation negotiations"
 msgstr "Denna ansökan kan inte ha en beskrivning för samarbetsförhandlingar"
-
-msgid "Pay subsidy percent required"
-msgstr "Lönesubventionsprocent krävs"
 
 #, python-brace-format
 msgid "This application can not have {key}"
@@ -144,6 +91,14 @@ msgstr "Detta fält är tillgängligt endast för sammanslutningar"
 
 msgid "This benefit type can not be selected"
 msgstr "Denna understödstyp kan inte väljas"
+
+msgid ""
+"Apprenticeship program can not be selected if there is no granted pay subsidy"
+msgstr ""
+
+msgid ""
+"Apprenticeship program has to be yes or no if there is a granted pay subsidy"
+msgstr ""
 
 msgid "Application does not have the employee consent attachment"
 msgstr "Den anställdas samtycke har inte bifogats ansökan"
@@ -170,6 +125,10 @@ msgstr "Ansökan kan inte ändras i denna status"
 msgid "create_application_for_company missing from request"
 msgstr "create_application_for_company saknas från begäran"
 
+#, python-brace-format
+msgid "company with id {company_id} not found"
+msgstr ""
+
 msgid "The calculation should be created when the application is submitted"
 msgstr "Beräkningen bör skapas när ansökan skickas"
 
@@ -181,12 +140,56 @@ msgid "Reading {localized_model_name} data failed: {errors}"
 msgstr "Data {localized_model_name} kan inte läsas: {errors}"
 
 #, python-brace-format
+msgid "Upload file size cannot be greater than {size} bytes"
+msgstr "Den fil som laddas upp kan inte vara större än {size} byte"
+
+msgid "Too many attachments"
+msgstr "För många bilagor"
+
+msgid "Not a valid pdf file"
+msgstr "Ingen giltig PDF-fil"
+
+msgid "Not a valid image file"
+msgstr "Ingen giltig bildfil"
+
+msgid "Applications in a batch can not be changed when batch is in this status"
+msgstr "Ansökningar i en sats kan inte ändras när satsen har denna status"
+
+msgid "This application has invalid status and can not be added to this batch"
+msgstr "Denna ansökan har felaktig status och kan inte läggas till denna sats"
+
+msgid "Grant date too much in past"
+msgstr "Beviljandedatum för tidigt"
+
+msgid "Grant date can not be in the future"
+msgstr "Beviljandedatum kan inte vara i framtiden"
+
+msgid "Social security number invalid"
+msgstr "Personbeteckning felaktig"
+
+#, python-brace-format
+msgid "Working hour must be greater than {min_hour} per week"
+msgstr "Antalet arbetstimmar måste vara högre än {min_hour} per vecka"
+
+msgid "Monthly pay must be greater than 0"
+msgstr "Månatlig lön måste vara större än 0"
+
+msgid "Vacation money must be a positive number"
+msgstr "Semesterpenning måste vara ett positivt tal"
+
+msgid "Other expenses must be a positive number"
+msgstr "Andra kostnader måste vara ett positivt tal"
+
+#, python-brace-format
 msgid "State transition not allowed: {status} to {value}"
 msgstr "Tillståndsövergång tillåts inte: {status} till {value}"
 
 #, python-brace-format
 msgid "Initial status must be {initial_status}"
 msgstr "Initialstatus måste vara {initial_status}"
+
+msgid "Displayed in the archive in the applicant view"
+msgstr ""
 
 msgid "Operation not allowed for this application status."
 msgstr "Åtgärd tillåts inte för denna ansökningsstatus"
@@ -195,7 +198,7 @@ msgid "File not found."
 msgstr "Fil hittades inte."
 
 #, python-brace-format
-msgid "Helsinki-lisän hakemukset viety {date}"
+msgid "Helsinki-lisan hakemukset viety {date}"
 msgstr ""
 
 msgid "Benefit can not be granted before 24-month waiting period expires"
@@ -281,6 +284,26 @@ msgstr "läroavtal"
 msgid "helsinki benefit voucher"
 msgstr "sedel för Helsingforstillägg"
 
+#, fuzzy
+#| msgid "employee_consent"
+msgid "employee consent"
+msgstr "Behandlingen av personuppgifterna av personen som ska sysselsättas"
+
+#, fuzzy
+#| msgid "application"
+msgid "full application"
+msgstr "Ansökan"
+
+#, fuzzy
+#| msgid "attachment"
+msgid "other attachment"
+msgstr "bilaga"
+
+#, fuzzy
+#| msgid "Step 4 - summary"
+msgid "pdf summary"
+msgstr "Steg 4 – sammanfattning"
+
 msgid "attachment is required"
 msgstr "bilaga är obligatorisk"
 
@@ -308,11 +331,124 @@ msgstr "Skickad till Talpa"
 msgid "Processing is completed"
 msgstr "Processen är slutförd"
 
+#, fuzzy
+#| msgid "Rejected"
+msgid "Rejected by Talpa"
+msgstr "Avvisad"
+
+#, fuzzy
+#| msgid "Sent to Talpa"
+msgid "Not sent to Talpa"
+msgstr "Skickad till Talpa"
+
+#, fuzzy
+#| msgid "Sent to Talpa"
+msgid "Successfully sent to Talpa"
+msgstr "Skickad till Talpa"
+
+msgid "Handler"
+msgstr "Handläggare"
+
+#, fuzzy
+#| msgid "application"
+msgid "Applicant"
+msgstr "Ansökan"
+
+#, fuzzy
+#| msgid "Pay subsidy end date"
+msgid "Pay subsidy granted (default)"
+msgstr "Slutdatum för lönesubvention"
+
+#, fuzzy
+#| msgid "Pay subsidy end date"
+msgid "Pay subsidy granted (aged)"
+msgstr "Slutdatum för lönesubvention"
+
+#, fuzzy
+#| msgid "pay subsidy"
+msgid "No granted pay subsidy"
+msgstr "lönesubvention"
+
+msgid "Submitted but not sent to AHJO"
+msgstr ""
+
+msgid "Request to open the case sent to AHJO"
+msgstr ""
+
+msgid "Case opened in AHJO"
+msgstr ""
+
+msgid "Update request sent"
+msgstr ""
+
+msgid "Update request received"
+msgstr ""
+
+#, fuzzy
+#| msgid "Decision date"
+msgid "Decision proposal sent"
+msgstr "Beslutsdatum"
+
+#, fuzzy
+#| msgid "Decision date"
+msgid "Decision proposal accepted"
+msgstr "Beslutsdatum"
+
+#, fuzzy
+#| msgid "Decision date"
+msgid "Decision proposal rejected"
+msgstr "Beslutsdatum"
+
+msgid "Delete request sent"
+msgstr ""
+
+msgid "Delete request received"
+msgstr ""
+
+msgid "Allow/disallow applicant's modifications"
+msgstr ""
+
+msgid "Success"
+msgstr ""
+
+msgid "Failure"
+msgstr ""
+
+#, fuzzy
+#| msgid "Rejected in Ahjo"
+msgid "Open case in Ahjo"
+msgstr "Avvisad i Ahjo"
+
+#, fuzzy
+#| msgid "Incomplete application"
+msgid "Delete application in Ahjo"
+msgstr "Ofullständig ansökan"
+
+#, python-brace-format
+msgid ""
+"Your application {id} will be deleted soon. If you want to continue the "
+"application process, please do so by {application_deletion_date}, otherwise "
+"the application will deleted permanently."
+msgstr ""
+
+msgid "Your Helsinki benefit draft application will expire"
+msgstr "Ditt utkast för ansökan går ut"
+
 msgid "company"
 msgstr "företag"
 
 msgid "status"
 msgstr "status"
+
+#, fuzzy
+#| msgid "status"
+msgid "talpa_status"
+msgstr "status"
+
+#, fuzzy
+#| msgid "application log entry"
+msgid "application origin"
+msgstr "registrering i ansökningslogg"
 
 msgid "application number"
 msgstr "ansökningsnummer"
@@ -368,6 +504,11 @@ msgstr "startdatum för understöd"
 msgid "benefit end date"
 msgstr "slutdatum för understöd"
 
+#, fuzzy
+#| msgid "application batches"
+msgid "paper application date"
+msgstr "ansökningssatser"
+
 msgid "ahjo batch"
 msgstr "ahjo-sats"
 
@@ -416,11 +557,29 @@ msgstr "lag som tillämpas i Ahjos beslut"
 msgid "date of the decision in Ahjo"
 msgstr "datum då beslut fattas vid Ahjo"
 
+#, fuzzy
+#| msgid "Expert inspector's name"
+msgid "P2P inspector's name"
+msgstr "Namn på sakkunnig inspektör"
+
+#, fuzzy
+#| msgid "Expert inspector's email address"
+msgid "P2P inspector's email address"
+msgstr "E-postadress till sakkunnig inspektör"
+
+msgid "P2P acceptor's title"
+msgstr ""
+
 msgid "Expert inspector's name"
 msgstr "Namn på sakkunnig inspektör"
 
 msgid "Expert inspector's email address"
 msgstr "E-postadress till sakkunnig inspektör"
+
+#, fuzzy
+#| msgid "Expert inspector's name"
+msgid "Expert inspector's title"
+msgstr "Namn på sakkunnig inspektör"
 
 msgid "application batch"
 msgstr "ansökningssats"
@@ -491,6 +650,212 @@ msgstr "bilaga"
 msgid "attachments"
 msgstr "bilagor"
 
+msgid "paper"
+msgstr ""
+
+#, fuzzy
+#| msgid "company contact person's email"
+msgid "company contact person"
+msgstr "kontaktpersonens e-postadress"
+
+msgid "co-operation negotiations"
+msgstr ""
+
+msgid "pay subsidy"
+msgstr "lönesubvention"
+
+#, fuzzy
+#| msgid "benefit end date"
+msgid "benefit"
+msgstr "slutdatum för understöd"
+
+#, fuzzy
+#| msgid "employee"
+msgid "employment"
+msgstr "anställd"
+
+msgid "approval"
+msgstr ""
+
+#, fuzzy
+#| msgid "status"
+msgid "ahjo status"
+msgstr "status"
+
+#, fuzzy
+#| msgid "status"
+msgid "ahjo statuses"
+msgstr "status"
+
+#, fuzzy
+#| msgid "File not found."
+msgid "Not found"
+msgstr "Fil hittades inte."
+
+msgid "Employer information"
+msgstr "Arbetsgivarinformation"
+
+msgid "Name of the employer"
+msgstr "Arbetsgivarens namn"
+
+msgid "Business ID"
+msgstr "FO-nummer"
+
+msgid "Street address"
+msgstr "Adress"
+
+msgid "Delivery address"
+msgstr "Leveransadress"
+
+msgid "Bank account number"
+msgstr "Kontonummer"
+
+msgid "Does the employer engage in economic activity?"
+msgstr "Har arbetsgivaren ekonomisk verksamhet?"
+
+msgid "Yes"
+msgstr ""
+
+#, fuzzy
+#| msgid "Note"
+msgid "No"
+msgstr "Anteckning"
+
+msgid "Contact person for the employer"
+msgstr "Arbetsgivarens kontaktperson"
+
+msgid "Name"
+msgstr "Namn"
+
+msgid "Telephone"
+msgstr "Telefon"
+
+msgid "Email address"
+msgstr "E-postadress"
+
+msgid "Preferred language of communication"
+msgstr "Affärsspråk"
+
+msgid "De minimis aid received by the employer"
+msgstr "De minimis-stöden som arbetsgivaren fått"
+
+msgid "Granter"
+msgstr "Beviljare av stödet"
+
+msgid "Amount"
+msgstr "Stödbeloppet"
+
+msgid "Date"
+msgstr "Datum"
+
+msgid "Total"
+msgstr "Sammanlagt"
+
+msgid "No, the applicant has not listed any previous de minimis aids."
+msgstr "Nej, arbetsgivaren har inte angett några tidigare de minimis-stöd."
+
+msgid "Change negotiations or co-determination negotiations"
+msgstr "Samarbetsförhandlingar eller samarbetsförfarande"
+
+msgid ""
+"Yes, the organization has ongoing or completed change negotiations within "
+"the previous 12 months."
+msgstr ""
+"Ja, organisationen har pågående eller avslutade samarbetsförhandlingar under "
+"de föregående 12 månaderna."
+
+msgid ""
+"No, the organization does not have change negotiations in progress or that "
+"have ended in the previous 12 months."
+msgstr ""
+"Nej, organisationen har inga samarbetsförhandlingar på gång eller som har "
+"avslutats under de senaste 12 månaderna."
+
+msgid "Describe the situation"
+msgstr "Beskrivning av situationen"
+
+msgid "Person to be hired"
+msgstr "Personen som ska sysselsättas"
+
+msgid "First name"
+msgstr "Förnamn"
+
+msgid "Last name"
+msgstr "Efternamn"
+
+msgid "Personal identity code"
+msgstr "Personbeteckning"
+
+msgid "The subsidised employee’s municipality of residence is Helsinki"
+msgstr "Personen som anställs bor i Helsingfors"
+
+msgid "Has the person who is being employed been assigned a job supervisor?"
+msgstr "Har personen som ska sysselsättas utsetts en arbetsledande chef?"
+
+msgid "Employment relationship"
+msgstr "Anställningsförhållande"
+
+msgid "Job title"
+msgstr "Titel"
+
+msgid "Working hours per week"
+msgstr "Arbetstid per vecka"
+
+msgid "Gross salary per month"
+msgstr "Bruttolön per månad"
+
+msgid "Holiday pay per month"
+msgstr "Semesterpenning per månad"
+
+msgid "Indirect labour costs per month"
+msgstr "Bikostnader per månad"
+
+msgid "Applicable collective agreement"
+msgstr "Kollektivavtal som tillämpas"
+
+msgid "Yhdistyksellä on yritystoimintaa"
+msgstr ""
+
+msgid "Is this an apprenticeship?"
+msgstr "Handlar det om ett läroavtal?"
+
+msgid "Received aid"
+msgstr "Beviljat stöd"
+
+msgid "Benefit is applied for the period"
+msgstr "Stillägg tillämpas för perioden"
+
+msgid "Applying for dates"
+msgstr "Ansöker om datum"
+
+msgid "Attachments"
+msgstr "Bilagor"
+
+msgid "granted_aged"
+msgstr "Sysselsättningsstöd för personer som fyllt 55 år"
+
+msgid "Printed at"
+msgstr "Tryckt"
+
+# Application printout
+msgid "City of Helsinki"
+msgstr "Helsingfors stad"
+
+msgid "Helsinki-benefit online service"
+msgstr "Helsingforstillägg e-tjänst"
+
+msgid "Helsinki-benefit application"
+msgstr "Helsingforstillägg ansökning"
+
+msgid "Employee"
+msgstr "Anställd"
+
+msgid "Application received"
+msgstr "Ansökning mottagen"
+
+msgid "Application number"
+msgstr "Ansökningsnummer"
+
 msgid "Date range too large"
 msgstr "Tidsperiod för lång"
 
@@ -512,6 +877,9 @@ msgstr "Startdatum kan inte vara tomt"
 msgid "End date cannot be empty"
 msgstr "Slutdatum kan inte vara tomt"
 
+msgid "State aid maximum percentage cannot be empty"
+msgstr "Maximalt statsunderstöd får inte vara tom"
+
 msgid "Description row, amount ignored"
 msgstr "Beskrivningsrad, belopp ignorerat"
 
@@ -520,9 +888,6 @@ msgstr "Lönekostnader"
 
 msgid "State aid maximum %"
 msgstr "Maximalt statsunderstöd %"
-
-msgid "State aid maximum percentage cannot be empty"
-msgstr "Maximalt statsunderstöd får inte vara tom"
 
 msgid "Pay subsidy/month"
 msgstr "Lönesubvention/månad"
@@ -541,6 +906,17 @@ msgstr "Utbildningsersättningens belopp per månad"
 
 msgid "Total amount of deductions monthly"
 msgstr "Totalbelopp av avdrag per månad"
+
+msgid "Basic date range description"
+msgstr ""
+
+#, fuzzy
+#| msgid "Date range too large"
+msgid "Date range description for total row"
+msgstr "Tidsperiod för lång"
+
+msgid "Deduction description"
+msgstr ""
 
 msgid "Calculation already exists"
 msgstr "Beräkning finns redan"
@@ -575,9 +951,6 @@ msgstr "Slutdatum för lönesubvention"
 
 msgid "Work time percent"
 msgstr "Arbetstidsprocent"
-
-msgid "pay subsidy"
-msgstr "lönesubvention"
 
 msgid "pay subsidies"
 msgstr "lönesubventioner"
@@ -628,10 +1001,14 @@ msgid "Invalid IBAN"
 msgstr "Felaktigt IBAN-kontonummer"
 
 msgid "You have to accept Terms of Service before doing any action"
-msgstr "Du måste godkänna användarvillkoren för tjänsten innan du kan göra något"
+msgstr ""
+"Du måste godkänna användarvillkoren för tjänsten innan du kan göra något"
 
 msgid "Company information is not available"
 msgstr "Företagets uppgifter är inte tillgängliga"
+
+msgid "Your IP address is not on the safe list."
+msgstr ""
 
 msgid "bank account number"
 msgstr "bankkontonummer"
@@ -648,9 +1025,6 @@ msgstr "Engelska"
 msgid "Swedish"
 msgstr "Svenska"
 
-msgid "Application number"
-msgstr "Ansökningsnummer"
-
 #, python-brace-format
 msgid ""
 "Your application has been opened for editing. Please make the corrections by "
@@ -660,8 +1034,12 @@ msgstr ""
 "Din ansökan har öppnats för redigering. Gör ändringarna senast "
 "{additional_information_needed_by}, annars kan ansökan inte behandlas."
 
-msgid "You have received a new message regarding your Helsinki benefit application"
+msgid ""
+"You have received a new message regarding your Helsinki benefit application"
 msgstr "Du har fått ett nytt meddelande om ansökningen om Helsingforstillägget"
+
+msgid "Your Helsinki benefit application requires additional information"
+msgstr "Ansökan om Helsingforstillägget behöver ytterligare information"
 
 #, python-format
 msgid ""
@@ -740,8 +1118,29 @@ msgstr "Villkor för tjänsten – visas vid inloggning"
 msgid "Terms of application - show at application submit"
 msgstr "Ansökningsvillkor – visas vid inlämning av ansökan"
 
+#, fuzzy
+#| msgid "Terms of application - show at application submit"
+msgid ""
+"Terms of application for handler - show at application submit for handler"
+msgstr "Ansökningsvillkor – visas vid inlämning av ansökan"
+
 msgid "type of terms"
 msgstr "typ av villkor"
+
+#, fuzzy
+#| msgid "finnish terms (pdf file)"
+msgid "Finnish terms (md)"
+msgstr "villkoren på finska (PDF-fil)"
+
+#, fuzzy
+#| msgid "english terms (pdf file)"
+msgid "English terms (md)"
+msgstr "villkoren på engelska (PDF-fil)"
+
+#, fuzzy
+#| msgid "swedish terms (pdf file)"
+msgid "Swedish terms (md)"
+msgstr "villkoren på svenska (PDF-fil)"
 
 msgid "first day these terms are in effect"
 msgstr "första datum då dessa villkor gäller"
@@ -754,6 +1153,9 @@ msgstr "villkoren på engelska (PDF-fil)"
 
 msgid "swedish terms (pdf file)"
 msgstr "villkoren på svenska (PDF-fil)"
+
+msgid "PDF or MD fields are missing for FI/EN/SV! Fill in either or"
+msgstr ""
 
 msgid "terms"
 msgstr "villkor"
@@ -797,196 +1199,50 @@ msgstr "godkännande av villkoren för tjänsten"
 msgid "terms of service approvals"
 msgstr "godkännanden av villkoren för tjänsten"
 
-# Application printout
+#~ msgid "Social security number checksum invalid"
+#~ msgstr "Personbeteckning kontrollsumma felaktig"
 
-msgid "City of Helsinki"
-msgstr "Helsingfors stad"
+#~ msgid "start_date must not be in a past year"
+#~ msgstr "Startdatum får inte vara under föregående år"
 
-msgid "Helsinki-benefit online service"
-msgstr "Helsingforstillägg e-tjänst"
+#~ msgid "end_date must not be in a past year"
+#~ msgstr "Slutdatum får inte vara under föregående år"
 
-msgid "Helsinki-benefit application"
-msgstr "Helsingforstillägg ansökning"
+#~ msgid "Pay subsidy percent required"
+#~ msgstr "Lönesubventionsprocent krävs"
 
-msgid "Employee"
-msgstr "Anställd"
+#~ msgid "Helsinki benefit is granted"
+#~ msgstr "Helsingforstillägg beviljas"
 
-msgid "Application received"
-msgstr "Ansökning mottagen"
+#~ msgid "Helsinki benefit is not granted"
+#~ msgstr "Helsingforstillägg beviljas inte"
 
-msgid "Employer information"
-msgstr "Arbetsgivarinformation"
- 
-msgid "Name of the employer"
-msgstr "Arbetsgivarens namn"
- 
-msgid "Business ID"
-msgstr "FO-nummer"
- 
-msgid "Street address"
-msgstr "Adress"
- 
-msgid "Bank account number"
-msgstr "Kontonummer"
- 
-msgid "Does the employer engage in economic activity?"
-msgstr "Har arbetsgivaren ekonomisk verksamhet?"
- 
-msgid "Delivery address"
-msgstr "Leveransadress"
- 
-msgid "Contact person for the employer"
-msgstr "Arbetsgivarens kontaktperson"
- 
-msgid "Name"
-msgstr "Namn"
- 
-msgid "Telephone"
-msgstr "Telefon"
- 
-msgid "Email address"
-msgstr "E-postadress"
- 
-msgid "Preferred language of communication"
-msgstr "Affärsspråk"
- 
-msgid "De minimis aid received by the employer"
-msgstr "De minimis-stöden som arbetsgivaren fått"
- 
-msgid "Granter"
-msgstr "Beviljare av stödet"
- 
-msgid "Amount"
-msgstr "Stödbeloppet"
- 
-msgid "Date"
-msgstr "Datum"
- 
-msgid "Total"
-msgstr "Sammanlagt"
- 
-msgid "No, the applicant has not listed any previous de minimis aids."
-msgstr "Nej, arbetsgivaren har inte angett några tidigare de minimis-stöd."
- 
-msgid "Change negotiations or co-determination negotiations"
-msgstr "Samarbetsförhandlingar eller samarbetsförfarande"
- 
-msgid "Yes, the organization has ongoing or completed change negotiations within the previous 12 months."
-msgstr "Ja, organisationen har pågående eller avslutade samarbetsförhandlingar under de föregående 12 månaderna."
- 
-msgid "No, the organization does not have change negotiations in progress or that have ended in the previous 12 months."
-msgstr "Nej, organisationen har inga samarbetsförhandlingar på gång eller som har avslutats under de senaste 12 månaderna."
- 
-msgid "Describe the situation"
-msgstr "Beskrivning av situationen"
- 
-msgid "Person to be hired"
-msgstr "Personen som ska sysselsättas"
- 
-msgid "First name"
-msgstr "Förnamn"
- 
-msgid "Last name"
-msgstr "Efternamn"
- 
-msgid "Personal identity code"
-msgstr "Personbeteckning"
- 
-msgid "The subsidised employee’s municipality of residence is Helsinki"
-msgstr "Personen som anställs bor i Helsingfors"
- 
-msgid "Has the person who is being employed been assigned a job supervisor?"
-msgstr "Har personen som ska sysselsättas utsetts en arbetsledande chef?"
+#~ msgid "Granted as de minimis aid"
+#~ msgstr "Beviljas som stöd av de minimis stöd"
 
-msgid "Employment relationship"
-msgstr "Anställningsförhållande"
- 
-msgid "Job title"
-msgstr "Titel"
- 
-msgid "Working hours per week"
-msgstr "Arbetstid per vecka"
- 
-msgid "Gross salary per month"
-msgstr "Bruttolön per månad"
- 
-msgid "Indirect labour costs per month"
-msgstr "Bikostnader per månad"
- 
-msgid "Holiday pay per month"
-msgstr "Semesterpenning per månad"
- 
-msgid "Applicable collective agreement"
-msgstr "Kollektivavtal som tillämpas"
- 
-msgid "Is this an apprenticeship?"
-msgstr "Handlar det om ett läroavtal?"
- 
-msgid "Received aid"
-msgstr "Beviljat stöd"
- 
-msgid "Benefit is applied for the period"
-msgstr "Stillägg tillämpas för perioden"
- 
-msgid "Helsinki benefit is granted"
-msgstr "Helsingforstillägg beviljas"
- 
-msgid "Helsinki benefit is not granted"
-msgstr "Helsingforstillägg beviljas inte"
- 
-msgid "Applying for dates"
-msgstr "Ansöker om datum"
- 
-msgid "Decision date"
-msgstr "Beslutsdatum"
- 
-msgid "Handler"
-msgstr "Handläggare"
- 
-msgid "Granted as de minimis aid"
-msgstr "Beviljas som stöd av de minimis stöd"
- 
-msgid "Attachments"
-msgstr "Bilagor"
- 
-msgid "employee_consent"
-msgstr "Behandlingen av personuppgifterna av personen som ska sysselsättas"
+#~ msgid "employment_contract"
+#~ msgstr "Arbetsavtal"
 
-msgid "employment_contract"
-msgstr "Arbetsavtal"
+#~ msgid "pay_subsidy_decision"
+#~ msgstr "Beslut om lönesubvention"
 
-msgid "pay_subsidy_decision"
-msgstr "Beslut om lönesubvention"
+#~ msgid "education_contract"
+#~ msgstr "Avtal om ordnandet av läroavtalsutbildning"
 
-msgid "education_contract"
-msgstr "Avtal om ordnandet av läroavtalsutbildning"
+#~ msgid "helsinki_benefit_voucher"
+#~ msgstr "Helsingforstilläggskortet"
 
-msgid "helsinki_benefit_voucher"
-msgstr "Helsingforstilläggskortet"
+#~ msgid "fi"
+#~ msgstr "Finska"
 
-msgid "fi"
-msgstr "Finska"
+#~ msgid "sv"
+#~ msgstr "Svenska"
 
-msgid "sv"
-msgstr "Svenska"
+#~ msgid "en"
+#~ msgstr "Engelska"
 
-msgid "en"
-msgstr "Engelska"
+#~ msgid "granted"
+#~ msgstr "Lönesubvention"
 
-msgid "granted"
-msgstr "Lönesubvention"
-
-msgid "granted_aged"
-msgstr "Sysselsättningsstöd för personer som fyllt 55 år"
-
-msgid "not_granted"
-msgstr "Inget stöd"
-
-msgid "Printed at"
-msgstr "Tryckt"
-
-msgid "Your Helsinki benefit draft application will expire"
-msgstr "Ditt utkast för ansökan går ut"
-
-msgid "Your Helsinki benefit application requires additional information"
-msgstr "Ansökan om Helsingforstillägget behöver ytterligare information"
+#~ msgid "not_granted"
+#~ msgstr "Inget stöd"

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -21,7 +21,8 @@
         "check": "Review",
         "editEndDate": "Edit by",
         "newMessages_one": "{{count}} new",
-        "newMessages_other": "{{count}} new"
+        "newMessages_other": "{{count}} new",
+        "sortOrder": "Order applications by"
       }
     },
     "pageHeaders": {
@@ -40,7 +41,7 @@
       "draft": "Draft",
       "additionalInformationNeeded": "Additional information is needed",
       "received": "Received",
-      "approved": "Accepted",
+      "accepted": "Accepted",
       "rejected": "Rejected",
       "handling": "Handling",
       "cancelled": "Cancelled"
@@ -604,7 +605,9 @@
     "yes": "Yes",
     "no": "No",
     "close": "Close",
-    "home": "Return to the front page"
+    "home": "Return to the front page",
+    "pagination": "Pagination",
+    "back": "Back"
   },
   "messenger": {
     "messages": "Application’s messages",
@@ -745,6 +748,18 @@
     "button": "Muokkaa evästeasetuksia"
   },
   "decisions": {
-    "heading": "Archive"
+    "heading_one": "<strong>{{count}}</strong> application for which a decision has been made",
+    "heading_other": "<strong>{{count}}</strong> applications for which decisions have been made",
+    "noDecisions": "No decisions have been made for any Helsinki Benefit applications yet."
+  },
+  "sortOrder": {
+    "label": "Order by",
+    "submittedAt": {
+      "asc": "Oldest first",
+      "desc": "Newest first"
+    },
+    "name": {
+      "asc": "Alphabetically"
+    }
   }
 }

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -21,7 +21,8 @@
         "check": "Tarkastele",
         "editEndDate": "Muokkaa viimeistään",
         "newMessages_one": "{{count}} uusi",
-        "newMessages_other": "{{count}} uutta"
+        "newMessages_other": "{{count}} uutta",
+        "sortOrder": "Järjestä hakemukset"
       }
     },
     "pageHeaders": {
@@ -40,7 +41,7 @@
       "draft": "Luonnos",
       "additionalInformationNeeded": "Lisätietoja tarvitaan",
       "received": "Vastaanotettu",
-      "approved": "Hyväksytty",
+      "accepted": "Hyväksytty",
       "rejected": "Hylätty",
       "handling": "Käsittelyssä",
       "cancelled": "Peruttu"
@@ -604,7 +605,9 @@
     "yes": "Kyllä",
     "no": "Ei",
     "close": "Sulje",
-    "home": "Palaa etusivulle"
+    "home": "Palaa etusivulle",
+    "pagination": "Sivut",
+    "back": "Takaisin"
   },
   "messenger": {
     "messages": "Hakemuksen viestit",
@@ -745,6 +748,18 @@
     "button": "Muokkaa evästeasetuksia"
   },
   "decisions": {
-    "heading": "Arkisto"
+    "heading_one": "<strong>{{count}}</strong> hakemus, jolle on tehty päätös",
+    "heading_other": "<strong>{{count}}</strong> hakemusta, joille on tehty päätös",
+    "noDecisions": "Ei vielä yhtään Helsinki-lisä -hakemusta, joille on tehty päätös."
+  },
+  "sortOrder": {
+    "label": "Järjestä",
+    "submittedAt": {
+      "asc": "Vanhin ensin",
+      "desc": "Uusin ensin"
+    },
+    "name": {
+      "asc": "Aakkosjärjestyksessä"
+    }
   }
 }

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -21,7 +21,8 @@
         "check": "Recensioner",
         "editEndDate": "Redigera senast",
         "newMessages_one": "{{count}} ny",
-        "newMessages_other": "{{count}} nya"
+        "newMessages_other": "{{count}} nya",
+        "sortOrder": "Sortera ansökningar"
       }
     },
     "pageHeaders": {
@@ -40,7 +41,7 @@
       "draft": "Utkast",
       "additionalInformationNeeded": "Ytterligare uppgifter behövs",
       "received": "Mottagen",
-      "approved": "Godkänd",
+      "accepted": "Godkänd",
       "rejected": "Avvisad",
       "handling": "Behandling",
       "cancelled": "Peruttu"
@@ -604,7 +605,9 @@
     "yes": "Ja",
     "no": "Nej",
     "close": "Stäng",
-    "home": "Gå tillbaka till ingångssidan"
+    "home": "Gå tillbaka till ingångssidan",
+    "pagination": "Sidor",
+    "back": "Tillbaka"
   },
   "messenger": {
     "messages": "Meddelanden om ansökan",
@@ -745,6 +748,18 @@
     "button": "Muokkaa evästeasetuksia"
   },
   "decisions": {
-    "heading": "Arkiv"
+    "heading_one": "<strong>{{count}}</strong> ansökan, för vilken beslut har fattats.",
+    "heading_other": "<strong>{{count}}</strong> ansökningar, för vilka beslut har fattats.",
+    "noDecisions": "Inga beslut har fattats för några ansökningar om Helsingforstillägget ännu."
+  },
+  "sortOrder": {
+    "label": "Sortera",
+    "submittedAt": {
+      "asc": "Äldsta först",
+      "desc": "Senaste först"
+    },
+    "name": {
+      "asc": "I bokstavsording"
+    }
   }
 }

--- a/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.sc.ts
@@ -1,8 +1,29 @@
+import { respondAbove } from 'shared/styles/mediaQueries';
 import styled from 'styled-components';
+
+export const $HeadingContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+
+  ${respondAbove('sm')`
+    flex-direction: row;
+    align-items: center;
+  `}
+`;
 
 export const $Heading = styled.h2`
   font-size: ${(props) => props.theme.fontSize.heading.m};
   font-weight: 500;
+  flex: 1 1 100%;
+`;
+
+export const $OrderByContainer = styled.div`
+  flex: 0;
+  margin-bottom: ${(props) => props.theme.spacing.xs};
+  ${respondAbove('sm')`
+    flex: 1 0 300px;
+  `}
 `;
 
 export const $ListWrapper = styled.ul`
@@ -12,4 +33,8 @@ export const $ListWrapper = styled.ul`
   list-style: none;
   padding: 0;
   margin: 0;
+`;
+
+export const $PaginationContainer = styled.div`
+  margin-top: ${(props) => props.theme.spacing.xl2};
 `;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.tsx
@@ -1,38 +1,124 @@
+import { Pagination, Select } from 'hds-react';
 import React from 'react';
 import LoadingSkeleton from 'react-loading-skeleton';
 import Container from 'shared/components/container/Container';
 import theme from 'shared/styles/theme';
+import { OptionType } from 'shared/types/common';
 
-import { $Heading, $ListWrapper } from './ApplicationList.sc';
+import {
+  $Heading,
+  $HeadingContainer,
+  $ListWrapper,
+  $OrderByContainer,
+  $PaginationContainer,
+} from './ApplicationList.sc';
 import ListItem from './listItem/ListItem';
 import useApplicationList from './useApplicationList';
 
 export interface ApplicationListProps {
-  heading: string;
+  heading: ((count: number) => React.ReactNode) | React.ReactNode;
   status: string[];
+  isArchived?: boolean;
+  clientPaginated?: boolean;
+  itemsPerPage?: number;
+  initialPage?: number;
+  pageHref?: (index: number) => string;
+  orderByOptions?: OptionType[];
+  noItemsText?: React.ReactNode;
 }
 
 const ApplicationsList: React.FC<ApplicationListProps> = ({
   heading,
   status,
+  isArchived,
+  clientPaginated = false,
+  itemsPerPage = 25,
+  initialPage,
+  orderByOptions,
+  noItemsText = '',
 }) => {
-  const { list, shouldShowSkeleton, shouldHideList } =
-    useApplicationList(status);
+  const {
+    list,
+    shouldShowSkeleton,
+    shouldHideList,
+    currentPage,
+    setPage,
+    t,
+    orderBy,
+    setOrderBy,
+    language,
+  } = useApplicationList({
+    status,
+    isArchived,
+    initialPage: clientPaginated ? initialPage : null,
+    orderByOptions,
+  });
 
-  const items = shouldShowSkeleton ? (
-    <ListItem isLoading />
-  ) : (
-    list?.map((props) => <ListItem key={props.id} {...props} />)
-  );
+  if (shouldHideList && !noItemsText) return null;
 
-  if (shouldHideList) return null;
+  const hasItems = list?.length > 0;
+  let items =
+    list?.map((props) => <ListItem key={props.id} {...props} />) || [];
+  if (clientPaginated && !shouldShowSkeleton) {
+    items = items.slice(
+      currentPage * itemsPerPage,
+      (currentPage + 1) * itemsPerPage
+    );
+  }
+
+  const headingText =
+    heading instanceof Function ? heading(list.length) : heading;
 
   return (
     <Container backgroundColor={theme.colors.silverLight}>
-      <$Heading>
-        {shouldShowSkeleton ? <LoadingSkeleton width="20%" /> : heading}
-      </$Heading>
-      <$ListWrapper>{items}</$ListWrapper>
+      {shouldShowSkeleton && (
+        <>
+          <$HeadingContainer>
+            <LoadingSkeleton width="20%" />
+          </$HeadingContainer>
+          <$ListWrapper>
+            <ListItem isLoading />
+          </$ListWrapper>
+        </>
+      )}
+      {!shouldShowSkeleton && (
+        <>
+          <$HeadingContainer>
+            <$Heading>{headingText}</$Heading>
+            <$OrderByContainer>
+              {orderByOptions?.length > 1 && (
+                <Select<OptionType>
+                  id={`application-list-'${status.join('-')}-order-by`}
+                  options={orderByOptions}
+                  defaultValue={orderBy}
+                  onChange={setOrderBy}
+                  label={t('common:applications.list.common.sortOrder')}
+                  disabled={!hasItems}
+                />
+              )}
+            </$OrderByContainer>
+          </$HeadingContainer>
+          <$ListWrapper>
+            {items}
+            {!hasItems && noItemsText}
+          </$ListWrapper>
+          {hasItems && clientPaginated && (
+            <$PaginationContainer>
+              <Pagination
+                pageHref={() => '#'}
+                pageIndex={currentPage}
+                pageCount={Math.ceil(list.length / Math.max(1, itemsPerPage))}
+                paginationAriaLabel={t('common:utility.pagination')}
+                onChange={(e, index) => {
+                  e.preventDefault();
+                  setPage(index);
+                }}
+                language={language}
+              />
+            </$PaginationContainer>
+          )}
+        </>
+      )}
     </Container>
   );
 };

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
@@ -122,7 +122,11 @@ const useApplicationFormStep5 = (
     updateApplicationStep5(currentApplicationData);
   };
   const handleClose = (): void => {
-    void router.push(ROUTES.HOME);
+    if (application.archivedForApplicant) {
+      void router.push(ROUTES.DECISIONS);
+    } else {
+      void router.push(ROUTES.HOME);
+    }
   };
 
   return {

--- a/frontend/benefit/applicant/src/components/decisions/DecisionsApplicationList.sc.ts
+++ b/frontend/benefit/applicant/src/components/decisions/DecisionsApplicationList.sc.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const $NoDecisionsText = styled.p`
+  font-size: ${(props) => props.theme.fontSize.heading.l};
+`;
+
+export const $ButtonContainer = styled.div`
+  margin-top: ${(props) => props.theme.spacing.s};
+  margin-bottom: ${(props) => props.theme.spacing.xl2};
+`;

--- a/frontend/benefit/applicant/src/components/decisions/DecisionsApplicationList.tsx
+++ b/frontend/benefit/applicant/src/components/decisions/DecisionsApplicationList.tsx
@@ -1,0 +1,59 @@
+import ApplicationsList from 'benefit/applicant/components/applications/applicationList/ApplicationList';
+import {
+  $ButtonContainer,
+  $NoDecisionsText,
+} from 'benefit/applicant/components/decisions/DecisionsApplicationList.sc';
+import { ROUTES, SUBMITTED_STATUSES } from 'benefit/applicant/constants';
+import { Trans, useTranslation } from 'benefit/applicant/i18n';
+import { Button, IconArrowLeft } from 'hds-react';
+import { useRouter } from 'next/router';
+import React from 'react';
+
+const DecisionsApplicationList = (): JSX.Element => {
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  return (
+    <ApplicationsList
+      heading={(count) => (
+        <Trans
+          i18nKey="common:decisions.heading"
+          values={{ count }}
+          components={{
+            strong: <strong />,
+          }}
+        />
+      )}
+      status={SUBMITTED_STATUSES}
+      isArchived
+      clientPaginated
+      orderByOptions={[
+        {
+          label: t('common:sortOrder.submittedAt.desc'),
+          value: '-submitted_at',
+        },
+        { label: t('common:sortOrder.submittedAt.asc'), value: 'submitted_at' },
+        { label: t('common:sortOrder.name.asc'), value: 'employee_name' },
+      ]}
+      noItemsText={
+        <div>
+          <$NoDecisionsText>
+            {t('common:decisions.noDecisions')}
+          </$NoDecisionsText>
+          <$ButtonContainer>
+            <Button
+              variant="secondary"
+              onClick={() => router.push(ROUTES.HOME)}
+              theme="black"
+              iconLeft={<IconArrowLeft />}
+            >
+              {t('common:utility.back')}
+            </Button>
+          </$ButtonContainer>
+        </div>
+      }
+    />
+  );
+};
+
+export default DecisionsApplicationList;

--- a/frontend/benefit/applicant/src/components/layout/Layout.tsx
+++ b/frontend/benefit/applicant/src/components/layout/Layout.tsx
@@ -27,6 +27,9 @@ const selectBgColor = (pathname: string): keyof DefaultTheme['colors'] => {
     case ROUTES.HOME:
       return theme.colors.silverLight as keyof DefaultTheme['colors'];
 
+    case ROUTES.DECISIONS:
+      return theme.colors.silverLight as keyof DefaultTheme['colors'];
+
     default:
       return theme.colors.white as keyof DefaultTheme['colors'];
   }

--- a/frontend/benefit/applicant/src/hooks/useApplicationsQuery.ts
+++ b/frontend/benefit/applicant/src/hooks/useApplicationsQuery.ts
@@ -3,20 +3,26 @@ import { ApplicationData } from 'benefit-shared/types/application';
 import { useQuery, UseQueryResult } from 'react-query';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 
-const useApplicationsQuery = (
-  status: string[],
-  orderBy = 'id'
-): UseQueryResult<ApplicationData[], Error> => {
+const useApplicationsQuery = ({
+  status,
+  isArchived,
+  orderBy = 'id',
+}: {
+  status: string[];
+  isArchived?: boolean;
+  orderBy?: string;
+}): UseQueryResult<ApplicationData[], Error> => {
   const { axios, handleResponse } = useBackendAPI();
 
   return useQuery<ApplicationData[], Error>(
-    ['applicationsList', ...status],
+    ['applicationsList', ...status, orderBy],
     async () => {
       const res = axios.get<ApplicationData[]>(
         `${BackendEndpoint.APPLICATIONS_SIMPLIFIED}`,
         {
           params: {
             status: status.join(','),
+            archived_for_applicant: isArchived ?? undefined,
             order_by: orderBy,
           },
         }

--- a/frontend/benefit/applicant/src/i18n.ts
+++ b/frontend/benefit/applicant/src/i18n.ts
@@ -1,3 +1,3 @@
-import { appWithTranslation, i18n, useTranslation } from 'next-i18next';
+import { appWithTranslation, i18n, Trans, useTranslation } from 'next-i18next';
 
-export { appWithTranslation, i18n, useTranslation };
+export { appWithTranslation, i18n, Trans, useTranslation };

--- a/frontend/benefit/applicant/src/pages/decisions.tsx
+++ b/frontend/benefit/applicant/src/pages/decisions.tsx
@@ -1,3 +1,4 @@
+import DecisionsApplicationList from 'benefit/applicant/components/decisions/DecisionsApplicationList';
 import DecisionsMainIngress from 'benefit/applicant/components/mainIngress/decisions/DecisionsMainIngress';
 import AppContext from 'benefit/applicant/context/AppContext';
 import { useTranslation } from 'benefit/applicant/i18n';
@@ -28,7 +29,7 @@ const ApplicantDecisions: NextPage = () => {
       </Head>
       <DecisionsMainIngress />
       <Container>
-        <h2>{t('common:decisions.heading')} (0)</h2>
+        <DecisionsApplicationList />
       </Container>
     </>
   );

--- a/frontend/benefit/applicant/src/pages/index.tsx
+++ b/frontend/benefit/applicant/src/pages/index.tsx
@@ -39,10 +39,17 @@ const ApplicantIndex: NextPage = () => {
         <ApplicationsList
           heading={t('common:applications.list.drafts.heading')}
           status={['draft']}
+          orderByOptions={[
+            {
+              label: t('common:sortOrder.modifiedAt.desc'),
+              value: '-modified_at',
+            },
+          ]}
         />
         <ApplicationsList
           heading={t('common:applications.list.submitted.heading')}
           status={SUBMITTED_STATUSES}
+          isArchived={false}
         />
         <PrerequisiteReminder />
       </FrontPageProvider>

--- a/frontend/benefit/shared/src/constants.ts
+++ b/frontend/benefit/shared/src/constants.ts
@@ -145,7 +145,6 @@ export enum APPLICATION_STATUSES {
   INFO_REQUIRED = 'additional_information_needed',
   RECEIVED = 'received',
   ACCEPTED = 'accepted',
-  APPROVED = 'approved',
   REJECTED = 'rejected',
   CANCELLED = 'cancelled',
   HANDLING = 'handling',

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -264,6 +264,7 @@ export type Application = {
   unreadMessagesCount?: number;
   organizationType?: ORGANIZATION_TYPES;
   associationImmediateManagerCheck?: boolean;
+  archivedForApplicant?: boolean;
 } & Step1 &
   Step2;
 


### PR DESCRIPTION
## Description :sparkles:
Implements the data retrieval for archived applications in the benefit applicant frontend as well as the related filter and serializer changes in the backend.

## Additional notes :spiral_notepad:
Due to the odd issues with the annotation approach that couldn't be solved for now, the logic for determining whether an application is archived is implemented in two different locations instead.