### PR TITLE
fix: make caseId and caseGuid optional

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/ahjo_callback.py
+++ b/backend/benefit/applications/api/v1/serializers/ahjo_callback.py
@@ -4,8 +4,8 @@ from rest_framework import serializers
 class AhjoCallbackSerializer(serializers.Serializer):
     message = serializers.CharField()
     requestId = serializers.UUIDField(format="hex_verbose")
-    caseId = serializers.CharField()
-    caseGuid = serializers.UUIDField(format="hex_verbose")
+    caseId = serializers.CharField(required=False)
+    caseGuid = serializers.UUIDField(format="hex_verbose", required=False)
     records = serializers.ListField()
 
     # You can add additional validation here if needed

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -453,6 +453,8 @@ def test_ahjo_open_case_callback_failure(
     settings,
     ahjo_callback_payload,
 ):
+    ahjo_callback_payload.pop("caseId", None)
+    ahjo_callback_payload.pop("caseGuid", None)
     ahjo_callback_payload["message"] = AhjoCallBackStatus.FAILURE
 
     url = reverse(


### PR DESCRIPTION
## Description :sparkles:
In case of a failed open case request, the callback message does not have caseGuid and caseId fields, but they were required by the serializer anyways. This PR makes them optional so that the callback is not considered invalid in those cases.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
