### PR TITLE
feat: adjust benefit applicant front page appearance (HL-1108)

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -19,11 +19,15 @@
         "applicationNumber": "Application number",
         "status": "Status",
         "check": "Review",
-        "editEndDate": "Edit by",
+        "validUntil": "The last benefit day",
         "newMessages_one": "{{count}} new",
         "newMessages_other": "{{count}} new",
-        "sortOrder": "Order applications by"
-      }
+        "sortOrder": "Order applications by",
+        "expand": "Show more",
+        "contract": "Show less"
+      },
+      "noApplications": "No submitted Helsinki benefit applications",
+      "navigateToDecisions": "See all applications with decisions"
     },
     "pageHeaders": {
       "created": "Created",
@@ -39,7 +43,7 @@
     },
     "statuses": {
       "draft": "Draft",
-      "additionalInformationNeeded": "Additional information is needed",
+      "additionalInformationNeeded": "Edit by {{date}}",
       "received": "Received",
       "accepted": "Accepted",
       "rejected": "Rejected",

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -19,11 +19,15 @@
         "applicationNumber": "Hakemusnumero",
         "status": "Tila",
         "check": "Tarkastele",
-        "editEndDate": "Muokkaa viimeistään",
+        "validUntil": "Tukiaika päättyy",
         "newMessages_one": "{{count}} uusi",
         "newMessages_other": "{{count}} uutta",
-        "sortOrder": "Järjestä hakemukset"
-      }
+        "sortOrder": "Järjestä hakemukset",
+        "expand": "Näytä lisää",
+        "contract": "Näytä vähemmän"
+      },
+      "noApplications": "Ei avoimia Helsinki-lisä -hakemuksia",
+      "navigateToDecisions": "Katso kaikki päätökset"
     },
     "pageHeaders": {
       "created": "Luotu",
@@ -39,7 +43,7 @@
     },
     "statuses": {
       "draft": "Luonnos",
-      "additionalInformationNeeded": "Lisätietoja tarvitaan",
+      "additionalInformationNeeded": "Muokkaa {{date}} mennessä",
       "received": "Vastaanotettu",
       "accepted": "Hyväksytty",
       "rejected": "Hylätty",

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -19,11 +19,15 @@
         "applicationNumber": "Ansökningsnummer",
         "status": "Status",
         "check": "Recensioner",
-        "editEndDate": "Redigera senast",
+        "validUntil": "Sista stöddagen",
         "newMessages_one": "{{count}} ny",
         "newMessages_other": "{{count}} nya",
-        "sortOrder": "Sortera ansökningar"
-      }
+        "sortOrder": "Sortera ansökningar",
+        "expand": "Visa fler",
+        "contract": "Visa mindre"
+      },
+      "noApplications": "Inga öppna ansökningar om Helsingforstillägget",
+      "navigateToDecisions": "Se alla ansökningar med beslut"
     },
     "pageHeaders": {
       "created": "Skapats",
@@ -39,7 +43,7 @@
     },
     "statuses": {
       "draft": "Utkast",
-      "additionalInformationNeeded": "Ytterligare uppgifter behövs",
+      "additionalInformationNeeded": "Redigera senast innan {{date}}",
       "received": "Mottagen",
       "accepted": "Godkänd",
       "rejected": "Avvisad",

--- a/frontend/benefit/applicant/src/components/applications/Applications.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/Applications.sc.ts
@@ -81,3 +81,11 @@ export const $AskemItem = styled.div`
     }
   }
 `;
+
+export const $NoApplicationsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${(props) => props.theme.spacing.xs};
+  margin: ${(props) => props.theme.spacingLayout.xl} 0;
+`;

--- a/frontend/benefit/applicant/src/components/applications/NoApplications.tsx
+++ b/frontend/benefit/applicant/src/components/applications/NoApplications.tsx
@@ -1,0 +1,27 @@
+import { $NoApplicationsContainer } from 'benefit/applicant/components/applications/Applications.sc';
+import { ROUTES } from 'benefit/applicant/constants';
+import { Button, IconDocument, IconPlus } from 'hds-react';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+
+const NoApplications = (): JSX.Element => {
+  const router = useRouter();
+  const { t } = useTranslation();
+
+  return (
+    <$NoApplicationsContainer>
+      <IconDocument size="xl" />
+      <h2>{t('common:applications.list.noApplications')}</h2>
+      <Button
+        onClick={() => router.push(ROUTES.APPLICATION_FORM)}
+        iconLeft={<IconPlus />}
+        theme="coat"
+      >
+        {t('common:mainIngress.frontPage.newApplicationBtnText')}
+      </Button>
+    </$NoApplicationsContainer>
+  );
+};
+
+export default NoApplications;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.sc.ts
@@ -38,3 +38,9 @@ export const $ListWrapper = styled.ul`
 export const $PaginationContainer = styled.div`
   margin-top: ${(props) => props.theme.spacing.xl2};
 `;
+
+export const $ListActionButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: ${(props) => props.theme.spacing.xs};
+`;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.tsx
@@ -1,17 +1,7 @@
-import { Pagination, Select } from 'hds-react';
-import React from 'react';
-import LoadingSkeleton from 'react-loading-skeleton';
-import Container from 'shared/components/container/Container';
-import theme from 'shared/styles/theme';
+import ListContents from 'benefit/applicant/components/applications/applicationList/listItem/ListContents';
+import React, { PropsWithChildren } from 'react';
 import { OptionType } from 'shared/types/common';
 
-import {
-  $Heading,
-  $HeadingContainer,
-  $ListWrapper,
-  $OrderByContainer,
-  $PaginationContainer,
-} from './ApplicationList.sc';
 import ListItem from './listItem/ListItem';
 import useApplicationList from './useApplicationList';
 
@@ -19,108 +9,59 @@ export interface ApplicationListProps {
   heading: ((count: number) => React.ReactNode) | React.ReactNode;
   status: string[];
   isArchived?: boolean;
-  clientPaginated?: boolean;
-  itemsPerPage?: number;
-  initialPage?: number;
-  pageHref?: (index: number) => string;
   orderByOptions?: OptionType[];
   noItemsText?: React.ReactNode;
+  onListLengthChanged?: (isLoading: boolean, length: number) => void;
 }
 
-const ApplicationsList: React.FC<ApplicationListProps> = ({
+const ApplicationList: React.FC<PropsWithChildren<ApplicationListProps>> = ({
   heading,
   status,
   isArchived,
-  clientPaginated = false,
-  itemsPerPage = 25,
-  initialPage,
   orderByOptions,
-  noItemsText = '',
+  noItemsText,
+  children,
+  onListLengthChanged,
 }) => {
   const {
     list,
     shouldShowSkeleton,
     shouldHideList,
-    currentPage,
-    setPage,
     t,
     orderBy,
     setOrderBy,
-    language,
+    hasItems,
   } = useApplicationList({
     status,
     isArchived,
-    initialPage: clientPaginated ? initialPage : null,
     orderByOptions,
   });
 
-  if (shouldHideList && !noItemsText) return null;
-
-  const hasItems = list?.length > 0;
-  let items =
+  const items =
     list?.map((props) => <ListItem key={props.id} {...props} />) || [];
-  if (clientPaginated && !shouldShowSkeleton) {
-    items = items.slice(
-      currentPage * itemsPerPage,
-      (currentPage + 1) * itemsPerPage
-    );
-  }
 
   const headingText =
     heading instanceof Function ? heading(list.length) : heading;
 
   return (
-    <Container backgroundColor={theme.colors.silverLight}>
-      {shouldShowSkeleton && (
-        <>
-          <$HeadingContainer>
-            <LoadingSkeleton width="20%" />
-          </$HeadingContainer>
-          <$ListWrapper>
-            <ListItem isLoading />
-          </$ListWrapper>
-        </>
-      )}
-      {!shouldShowSkeleton && (
-        <>
-          <$HeadingContainer>
-            <$Heading>{headingText}</$Heading>
-            <$OrderByContainer>
-              {orderByOptions?.length > 1 && (
-                <Select<OptionType>
-                  id={`application-list-'${status.join('-')}-order-by`}
-                  options={orderByOptions}
-                  defaultValue={orderBy}
-                  onChange={setOrderBy}
-                  label={t('common:applications.list.common.sortOrder')}
-                  disabled={!hasItems}
-                />
-              )}
-            </$OrderByContainer>
-          </$HeadingContainer>
-          <$ListWrapper>
-            {items}
-            {!hasItems && noItemsText}
-          </$ListWrapper>
-          {hasItems && clientPaginated && (
-            <$PaginationContainer>
-              <Pagination
-                pageHref={() => '#'}
-                pageIndex={currentPage}
-                pageCount={Math.ceil(list.length / Math.max(1, itemsPerPage))}
-                paginationAriaLabel={t('common:utility.pagination')}
-                onChange={(e, index) => {
-                  e.preventDefault();
-                  setPage(index);
-                }}
-                language={language}
-              />
-            </$PaginationContainer>
-          )}
-        </>
-      )}
-    </Container>
+    <ListContents
+      list={list}
+      shouldShowSkeleton={shouldShowSkeleton}
+      shouldHideList={shouldHideList}
+      t={t}
+      orderBy={orderBy}
+      setOrderBy={setOrderBy}
+      orderByOptions={orderByOptions}
+      hasItems={hasItems}
+      headingText={headingText}
+      status={status}
+      items={items}
+      noItemsText={noItemsText}
+      onListLengthChanged={onListLengthChanged}
+    >
+      {children}
+    </ListContents>
   );
 };
 
-export default ApplicationsList;
+export default ApplicationList;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/ExpandableApplicationList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/ExpandableApplicationList.tsx
@@ -1,0 +1,90 @@
+import { ApplicationListProps } from 'benefit/applicant/components/applications/applicationList/ApplicationList';
+import ListContents from 'benefit/applicant/components/applications/applicationList/listItem/ListContents';
+import { Button } from 'hds-react';
+import React, { PropsWithChildren, useState } from 'react';
+
+import { $ListActionButtonContainer } from './ApplicationList.sc';
+import ListItem from './listItem/ListItem';
+import useApplicationList from './useApplicationList';
+
+export interface PaginatedApplicationListProps {
+  initialItems: number;
+}
+
+type Props = PropsWithChildren<
+  ApplicationListProps & PaginatedApplicationListProps
+>;
+
+const ExpandableApplicationList: React.FC<Props> = ({
+  heading,
+  status,
+  isArchived,
+  initialItems,
+  orderByOptions,
+  noItemsText,
+  children,
+  onListLengthChanged,
+}) => {
+  const {
+    list,
+    shouldShowSkeleton,
+    shouldHideList,
+    t,
+    orderBy,
+    setOrderBy,
+    hasItems,
+  } = useApplicationList({
+    status,
+    isArchived,
+    orderByOptions,
+  });
+
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+  const showExpand = list.length > initialItems;
+
+  let items =
+    list?.map((props) => <ListItem key={props.id} {...props} />) || [];
+  if (showExpand && !isExpanded) {
+    items = items.slice(0, initialItems);
+  }
+
+  const headingText =
+    heading instanceof Function ? heading(list.length) : heading;
+
+  return (
+    <ListContents
+      list={list}
+      shouldShowSkeleton={shouldShowSkeleton}
+      shouldHideList={shouldHideList}
+      t={t}
+      orderBy={orderBy}
+      setOrderBy={setOrderBy}
+      orderByOptions={orderByOptions}
+      hasItems={hasItems}
+      headingText={headingText}
+      status={status}
+      items={items}
+      noItemsText={noItemsText}
+      onListLengthChanged={onListLengthChanged}
+    >
+      {hasItems && showExpand && (
+        <$ListActionButtonContainer>
+          <Button
+            onClick={() => setIsExpanded(!isExpanded)}
+            variant="secondary"
+            theme="black"
+          >
+            {t(
+              isExpanded
+                ? 'common:applications.list.common.contract'
+                : 'common:applications.list.common.expand'
+            )}
+          </Button>
+        </$ListActionButtonContainer>
+      )}
+      {children}
+    </ListContents>
+  );
+};
+
+export default ExpandableApplicationList;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/PaginatedApplicationList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/PaginatedApplicationList.tsx
@@ -1,0 +1,95 @@
+import { ApplicationListProps } from 'benefit/applicant/components/applications/applicationList/ApplicationList';
+import ListContents from 'benefit/applicant/components/applications/applicationList/listItem/ListContents';
+import { Pagination } from 'hds-react';
+import React, { PropsWithChildren, useState } from 'react';
+
+import { $PaginationContainer } from './ApplicationList.sc';
+import ListItem from './listItem/ListItem';
+import useApplicationList from './useApplicationList';
+
+export interface PaginatedApplicationListProps {
+  itemsPerPage?: number;
+  initialPage?: number;
+  pageHref?: (index: number) => string;
+}
+
+type Props = PropsWithChildren<
+  ApplicationListProps & PaginatedApplicationListProps
+>;
+
+const PaginatedApplicationList: React.FC<Props> = ({
+  heading,
+  status,
+  isArchived,
+  itemsPerPage = 25,
+  initialPage,
+  orderByOptions,
+  noItemsText,
+  children,
+  onListLengthChanged,
+}) => {
+  const {
+    list,
+    shouldShowSkeleton,
+    shouldHideList,
+    t,
+    orderBy,
+    setOrderBy,
+    language,
+    hasItems,
+  } = useApplicationList({
+    status,
+    isArchived,
+    orderByOptions,
+  });
+  const [currentPage, setPage] = useState<number | null>(initialPage ?? null);
+
+  let items =
+    list?.map((props) => <ListItem key={props.id} {...props} />) || [];
+  if (!shouldShowSkeleton) {
+    items = items.slice(
+      currentPage * itemsPerPage,
+      (currentPage + 1) * itemsPerPage
+    );
+  }
+
+  const headingText =
+    heading instanceof Function ? heading(list.length) : heading;
+
+  return (
+    <ListContents
+      list={list}
+      shouldShowSkeleton={shouldShowSkeleton}
+      shouldHideList={shouldHideList}
+      t={t}
+      orderBy={orderBy}
+      setOrderBy={setOrderBy}
+      orderByOptions={orderByOptions}
+      hasItems={hasItems}
+      headingText={headingText}
+      status={status}
+      items={items}
+      noItemsText={noItemsText}
+      onListLengthChanged={onListLengthChanged}
+    >
+      {hasItems && (
+        <$PaginationContainer>
+          <Pagination
+            pageHref={() => '#'}
+            pageIndex={currentPage}
+            pageCount={Math.ceil(list.length / Math.max(1, itemsPerPage))}
+            paginationAriaLabel={t('common:utility.pagination')}
+            onChange={(e, index) => {
+              e.preventDefault();
+              setPage(index);
+            }}
+            language={language}
+          />
+        </$PaginationContainer>
+      )}
+      {children}
+    </ListContents>
+  );
+};
+
+export default PaginatedApplicationList;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListContents.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListContents.tsx
@@ -1,0 +1,91 @@
+import {
+  $Heading,
+  $HeadingContainer,
+  $ListWrapper,
+  $OrderByContainer,
+} from 'benefit/applicant/components/applications/applicationList/ApplicationList.sc';
+import ListItem from 'benefit/applicant/components/applications/applicationList/listItem/ListItem';
+import { ApplicationListProps } from 'benefit/applicant/components/applications/applicationList/useApplicationList';
+import { Select } from 'hds-react';
+import React, { PropsWithChildren, useEffect } from 'react';
+import LoadingSkeleton from 'react-loading-skeleton';
+import Container from 'shared/components/container/Container';
+import theme from 'shared/styles/theme';
+import { OptionType } from 'shared/types/common';
+
+interface ListContentProps {
+  headingText: React.ReactNode;
+  orderByOptions?: OptionType[];
+  status: string[];
+  items: JSX.Element[];
+  noItemsText?: React.ReactNode;
+  onListLengthChanged?: (isLoading: boolean, length: number) => void;
+}
+
+type Props = PropsWithChildren<
+  Omit<ApplicationListProps, 'language'> & ListContentProps
+>;
+
+const ListContents = ({
+  shouldShowSkeleton,
+  shouldHideList,
+  headingText,
+  orderByOptions,
+  orderBy,
+  setOrderBy,
+  t,
+  status,
+  noItemsText,
+  items,
+  hasItems,
+  list,
+  onListLengthChanged,
+  children,
+}: Props): JSX.Element => {
+  useEffect(() => {
+    onListLengthChanged?.(shouldShowSkeleton, list.length);
+  }, [shouldShowSkeleton, list.length, onListLengthChanged]);
+
+  if (shouldHideList && !noItemsText) return null;
+
+  return (
+    <Container backgroundColor={theme.colors.silverLight}>
+      {shouldShowSkeleton && (
+        <>
+          <$HeadingContainer>
+            <LoadingSkeleton width="20%" />
+          </$HeadingContainer>
+          <$ListWrapper>
+            <ListItem isLoading />
+          </$ListWrapper>
+        </>
+      )}
+      {!shouldShowSkeleton && (
+        <>
+          <$HeadingContainer>
+            <$Heading>{headingText}</$Heading>
+            <$OrderByContainer>
+              {orderByOptions?.length > 1 && (
+                <Select<OptionType>
+                  id={`application-list-'${status.join('-')}-order-by`}
+                  options={orderByOptions}
+                  defaultValue={orderBy}
+                  onChange={setOrderBy}
+                  label={t('common:applications.list.common.sortOrder')}
+                  disabled={!hasItems}
+                />
+              )}
+            </$OrderByContainer>
+          </$HeadingContainer>
+          <$ListWrapper>
+            {items}
+            {!hasItems && noItemsText}
+          </$ListWrapper>
+          {children}
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default ListContents;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
@@ -1,3 +1,4 @@
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { respondAbove } from 'shared/styles/mediaQueries';
 import styled, { DefaultTheme } from 'styled-components';
 
@@ -71,7 +72,43 @@ export const $DataHeader = styled.div`
 
 export const $DataValue = styled.div`
   display: flex;
-  font-weight: 600;
+  font-weight: 500;
+`;
+
+export const $StatusDataColumn = styled($DataColumn)`
+  &.list-item-status--${APPLICATION_STATUSES.INFO_REQUIRED} {
+    ${respondAbove('sm')`
+      grid-column: span 2;
+    `};
+  }
+`;
+
+export const $StatusDataValue = styled($DataValue)`
+  align-items: center;
+  gap: ${(props) => props.theme.spacing.xs3};
+
+  .list-item-status--${APPLICATION_STATUSES.HANDLING} & {
+    svg {
+      color: ${(props) => props.theme.colors.info};
+    }
+  }
+
+  .list-item-status--${APPLICATION_STATUSES.ACCEPTED} & {
+    svg {
+      color: ${(props) => props.theme.colors.success};
+    }
+  }
+
+  .list-item-status--${APPLICATION_STATUSES.REJECTED} &,
+  .list-item-status--${APPLICATION_STATUSES.CANCELLED} & {
+    svg {
+      color: ${(props) => props.theme.colors.error};
+    }
+  }
+
+  .list-item-status--${APPLICATION_STATUSES.INFO_REQUIRED} & {
+    color: ${(props) => props.theme.colors.alertDark};
+  }
 `;
 
 export const $ItemActions = styled.div`

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.tsx
@@ -2,12 +2,10 @@ import { useTranslation } from 'benefit/applicant/i18n';
 import { Loading } from 'benefit/applicant/types/common';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { ApplicationListItemData } from 'benefit-shared/types/application';
-import { Button, IconSpeechbubbleText, StatusLabel } from 'hds-react';
+import { Button, IconSpeechbubbleText } from 'hds-react';
 import React from 'react';
 import LoadingSkeleton from 'react-loading-skeleton';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
-import { respondAbove } from 'shared/styles/mediaQueries';
-import styled from 'styled-components';
 
 import {
   $Avatar,
@@ -21,20 +19,11 @@ import {
   $ListInfoText,
   $ListItem,
   $ListItemWrapper,
+  $StatusDataColumn,
+  $StatusDataValue,
 } from './ListItem.sc';
 
 export type ListItemProps = ApplicationListItemData | Loading;
-
-const $StatusLabel = styled(StatusLabel)`
-  font-weight: 600;
-  text-align: center;
-  box-sizing: border-box;
-  max-width: 160px;
-  margin-right: var(--spacing-s);
-  ${respondAbove('sm')`
-    max-width: none;
-  `}
-`;
 
 const ListItem: React.FC<ListItemProps> = (props) => {
   const { t } = useTranslation();
@@ -59,15 +48,17 @@ const ListItem: React.FC<ListItemProps> = (props) => {
 
   const {
     name,
+    contactPersonName,
     avatar,
     statusText,
     modifiedAt,
     submittedAt,
     applicationNum,
     allowedAction,
-    editEndDate,
+    statusIcon: StatusIcon,
     status,
     unreadMessagesCount,
+    validUntil,
   } = props;
 
   const ActionIcon = allowedAction.Icon;
@@ -76,7 +67,9 @@ const ListItem: React.FC<ListItemProps> = (props) => {
     <$ListItemWrapper>
       <$ListItem>
         <$ItemContent>
-          <$Avatar $backgroundColor={avatar.color}>{avatar.initials}</$Avatar>
+          <$Avatar $backgroundColor={avatar.color} title={contactPersonName}>
+            {avatar.initials}
+          </$Avatar>
           <$DataColumn>
             <$DataHeader>{t(`${translationBase}.common.employee`)}</$DataHeader>
             <$DataValue>{name}</$DataValue>
@@ -102,17 +95,20 @@ const ListItem: React.FC<ListItemProps> = (props) => {
             </$DataColumn>
           )}
           {statusText && (
-            <$DataColumn>
+            <$StatusDataColumn className={`list-item-status--${status}`}>
               <$DataHeader>{t(`${translationBase}.common.status`)}</$DataHeader>
-              <$DataValue>{statusText}</$DataValue>
-            </$DataColumn>
+              <$StatusDataValue>
+                <StatusIcon />
+                <span>{statusText}</span>
+              </$StatusDataValue>
+            </$StatusDataColumn>
           )}
-          {editEndDate && (
+          {validUntil && (
             <$DataColumn>
               <$DataHeader>
-                {t(`${translationBase}.common.editEndDate`)}
+                {t(`${translationBase}.common.validUntil`)}
               </$DataHeader>
-              <$StatusLabel type="alert">{editEndDate}</$StatusLabel>
+              <$DataValue>{validUntil}</$DataValue>
             </$DataColumn>
           )}
         </$ItemContent>

--- a/frontend/benefit/applicant/src/components/decisions/DecisionsApplicationList.tsx
+++ b/frontend/benefit/applicant/src/components/decisions/DecisionsApplicationList.tsx
@@ -1,4 +1,4 @@
-import ApplicationsList from 'benefit/applicant/components/applications/applicationList/ApplicationList';
+import PaginatedApplicationList from 'benefit/applicant/components/applications/applicationList/PaginatedApplicationList';
 import {
   $ButtonContainer,
   $NoDecisionsText,
@@ -14,7 +14,7 @@ const DecisionsApplicationList = (): JSX.Element => {
   const router = useRouter();
 
   return (
-    <ApplicationsList
+    <PaginatedApplicationList
       heading={(count) => (
         <Trans
           i18nKey="common:decisions.heading"
@@ -26,7 +26,6 @@ const DecisionsApplicationList = (): JSX.Element => {
       )}
       status={SUBMITTED_STATUSES}
       isArchived
-      clientPaginated
       orderByOptions={[
         {
           label: t('common:sortOrder.submittedAt.desc'),

--- a/frontend/benefit/applicant/src/pages/index.tsx
+++ b/frontend/benefit/applicant/src/pages/index.tsx
@@ -1,20 +1,26 @@
-import ApplicationsList from 'benefit/applicant/components/applications/applicationList/ApplicationList';
+import ApplicationList from 'benefit/applicant/components/applications/applicationList/ApplicationList';
+import { $ListActionButtonContainer } from 'benefit/applicant/components/applications/applicationList/ApplicationList.sc';
+import ExpandableApplicationList from 'benefit/applicant/components/applications/applicationList/ExpandableApplicationList';
+import NoApplications from 'benefit/applicant/components/applications/NoApplications';
 import FrontPageMainIngress from 'benefit/applicant/components/mainIngress/frontPage/FrontPageMainIngress';
 import PrerequisiteReminder from 'benefit/applicant/components/prerequisiteReminder/PrerequisiteReminder';
 import AppContext from 'benefit/applicant/context/AppContext';
 import { useTranslation } from 'benefit/applicant/i18n';
+import { Button, IconArrowRight } from 'hds-react';
 import { GetStaticProps, NextPage } from 'next';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import * as React from 'react';
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import withAuth from 'shared/components/hocs/withAuth';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
 
-import { SUBMITTED_STATUSES } from '../constants';
+import { ROUTES, SUBMITTED_STATUSES } from '../constants';
 import FrontPageProvider from '../context/FrontPageProvider';
 
 const ApplicantIndex: NextPage = () => {
   const { t } = useTranslation();
+  const router = useRouter();
   const { setIsNavigationVisible } = React.useContext(AppContext);
 
   useEffect(() => {
@@ -25,6 +31,30 @@ const ApplicantIndex: NextPage = () => {
     };
   }, [setIsNavigationVisible]);
 
+  const [infoNeededCount, setInfoNeededCount] = useState<number | null>(null);
+  const [draftCount, setDraftCount] = useState<number | null>(null);
+  const [submittedCount, setSubmittedCount] = useState<number | null>(null);
+
+  const onInfoNeededChange = useCallback(
+    (isLoading: boolean, count: number) =>
+      setInfoNeededCount(isLoading ? null : count),
+    []
+  );
+  const onDraftChange = useCallback(
+    (isLoading: boolean, count: number) =>
+      setDraftCount(isLoading ? null : count),
+    []
+  );
+  const onSubmittedChange = useCallback(
+    (isLoading: boolean, count: number) =>
+      setSubmittedCount(isLoading ? null : count),
+    []
+  );
+
+  const noApplications = [infoNeededCount, draftCount, submittedCount].every(
+    (item) => item === 0
+  );
+
   return (
     <>
       <Head>
@@ -32,25 +62,47 @@ const ApplicantIndex: NextPage = () => {
       </Head>
       <FrontPageProvider>
         <FrontPageMainIngress />
-        <ApplicationsList
-          heading={t('common:applications.list.moreInfo.heading')}
-          status={['additional_information_needed']}
-        />
-        <ApplicationsList
-          heading={t('common:applications.list.drafts.heading')}
-          status={['draft']}
-          orderByOptions={[
-            {
-              label: t('common:sortOrder.modifiedAt.desc'),
-              value: '-modified_at',
-            },
-          ]}
-        />
-        <ApplicationsList
-          heading={t('common:applications.list.submitted.heading')}
-          status={SUBMITTED_STATUSES}
-          isArchived={false}
-        />
+        {noApplications ? (
+          <NoApplications />
+        ) : (
+          <>
+            <ExpandableApplicationList
+              heading={t('common:applications.list.moreInfo.heading')}
+              status={['additional_information_needed']}
+              initialItems={4}
+              onListLengthChanged={onInfoNeededChange}
+            />
+            <ExpandableApplicationList
+              heading={t('common:applications.list.drafts.heading')}
+              status={['draft']}
+              orderByOptions={[
+                {
+                  label: t('common:sortOrder.modifiedAt.desc'),
+                  value: '-modified_at',
+                },
+              ]}
+              initialItems={4}
+              onListLengthChanged={onDraftChange}
+            />
+            <ApplicationList
+              heading={t('common:applications.list.submitted.heading')}
+              status={SUBMITTED_STATUSES}
+              isArchived={false}
+              onListLengthChanged={onSubmittedChange}
+            >
+              <$ListActionButtonContainer>
+                <Button
+                  onClick={() => router.push(ROUTES.DECISIONS)}
+                  variant="secondary"
+                  theme="black"
+                  iconRight={<IconArrowRight />}
+                >
+                  {t('common:applications.list.navigateToDecisions')}
+                </Button>
+              </$ListActionButtonContainer>
+            </ApplicationList>
+          </>
+        )}
         <PrerequisiteReminder />
       </FrontPageProvider>
     </>

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -6,6 +6,7 @@ import {
   PROPOSALS_FOR_DECISION,
   TALPA_STATUSES,
 } from 'benefit-shared/constants';
+import React from 'react';
 import { Language } from 'shared/i18n/i18n';
 import { BenefitAttachment } from 'shared/types/attachment';
 import { DefaultTheme } from 'styled-components';
@@ -412,6 +413,8 @@ export type ApplicationData = {
   application_origin?: APPLICATION_ORIGINS;
   paper_application_date?: string;
   action?: APPLICATION_ACTIONS;
+  company_contact_person_first_name: string;
+  company_contact_person_last_name: string;
 };
 
 export type EmployeeData = {
@@ -486,11 +489,11 @@ export type ApplicationListItemData = {
   };
   status?: APPLICATION_STATUSES;
   statusText?: string;
+  statusIcon?: React.FC;
   companyName?: string;
   companyId?: string;
   createdAt?: string;
   modifiedAt?: string;
-  editEndDate?: string;
   submittedAt?: string;
   handledAt?: string;
   applicationNum?: number;
@@ -502,6 +505,8 @@ export type ApplicationListItemData = {
   unreadMessagesCount?: number;
   batch?: BatchData | string;
   applicationOrigin?: APPLICATION_ORIGINS;
+  validUntil?: string;
+  contactPersonName?: string;
 };
 
 export type TextProp = 'textFi' | 'textEn' | 'textSv';

--- a/frontend/shared/src/utils/__tests__/string.utils.test.ts
+++ b/frontend/shared/src/utils/__tests__/string.utils.test.ts
@@ -1,0 +1,21 @@
+import { getInitials } from 'shared/utils/string.utils';
+
+describe('string utils', () => {
+  describe('getInitials', () => {
+    it('should get proper initials for a Latin-1 name', () => {
+      expect(getInitials('Olli Testaaja')).toBe('OT');
+    });
+
+    it('should get proper initials for a name with Finnish or Swedish accented initials', () => {
+      expect(getInitials('Åke Lindqvist')).toBe('ÅL');
+      expect(getInitials('Jaakko Österlund')).toBe('JÖ');
+      expect(getInitials('Åke Österlund')).toBe('ÅÖ');
+    });
+
+    it('should get proper initials for name containing accented Finnish and Swedish letters outside the initials', () => {
+      expect(getInitials('Minna Hämäläinen')).toBe('MH');
+      expect(getInitials('Gösta Andersson')).toBe('GA');
+      expect(getInitials('Gösta Hämäläinen')).toBe('GH');
+    });
+  });
+});

--- a/frontend/shared/src/utils/string.utils.ts
+++ b/frontend/shared/src/utils/string.utils.ts
@@ -5,11 +5,10 @@ import { isString } from 'shared/utils/type-guards';
 
 export const getInitials = (name: string): string =>
   name
-    // eslint-disable-next-line security/detect-unsafe-regex
-    .match(/(^\S\S?|\b\S)?/g)
-    ?.join('')
-    .match(/(^\S|\S$)?/g)
-    ?.join('') ?? '';
+    .match(/(?<=^|\s)(\p{L})/gu)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
 
 export const capitalize = (s: string): string =>
   (s && s[0].toUpperCase() + s.slice(1)) || '';


### PR DESCRIPTION
## Description :sparkles:
- Update status styling
- Hide redundant date columns
- Make info needed and draft lists truncated by default and expandable
- Add link to archive page after the submitted applications list
- Update initials to represent the contact person
- Add handling for when there are no applications to show