### PR TITLE
feat: rip helsinkitest/python:3.9-slim to run backend on arm

### DIFF
--- a/backend/docker/arm/scripts/base_setup.sh
+++ b/backend/docker/arm/scripts/base_setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+scripts/setup_bash.sh
+scripts/setup_apt_packages.sh
+scripts/setup_user.sh
+scripts/setup_app_folder.sh

--- a/backend/docker/arm/scripts/setup_app_folder.sh
+++ b/backend/docker/arm/scripts/setup_app_folder.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+mkdir /app
+chown -R appuser:appuser /app

--- a/backend/docker/arm/scripts/setup_apt_packages.sh
+++ b/backend/docker/arm/scripts/setup_apt_packages.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get upgrade -y
+# Install convenience packages
+/tools/apt-install.sh \
+ git \
+ curl
+/tools/apt-cleanup.sh

--- a/backend/docker/arm/scripts/setup_bash.sh
+++ b/backend/docker/arm/scripts/setup_bash.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Make bash the only shell
+# The reason for this is that commands are still run
+# with sh even if shell is set for the user.
+# TODO: Find a way to not have to remove /bin/sh
+rm /bin/sh && ln -s /bin/bash /bin/sh
+
+
+
+

--- a/backend/docker/arm/scripts/setup_user.sh
+++ b/backend/docker/arm/scripts/setup_user.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+existing_group=$(getent group 1000 | cut -d: -f1)
+if [[ -z "${existing_group}" ]]; then
+    # Create appuser group
+   groupadd --gid 1000 appuser
+elif [[ "${existing_group}" != "appuser" ]]; then
+   # Change group name to appuser
+   groupmod -n appuser "${existing_group}"
+fi
+
+
+existing_user=$(id -nu 1000 2>/dev/null)
+if [[ -z "${existing_user}" ]]; then
+    # Add an application user
+    useradd --uid 1000 --gid appuser --create-home --shell /bin/bash appuser
+else
+    # Change user name to appuser
+    usermod -l appuser "${existing_user}"
+
+    # Add user to appuser group
+    gpasswd -a appuser appuser
+fi

--- a/backend/docker/arm/tools/apt-cleanup.sh
+++ b/backend/docker/arm/tools/apt-cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [[ ! -z "$@" ]]; then
+    apt-get remove -y "$@"
+fi
+
+apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+rm -rf /var/lib/apt/lists/*
+rm -rf /var/cache/apt/archives

--- a/backend/docker/arm/tools/apt-install.sh
+++ b/backend/docker/arm/tools/apt-install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install -y --no-install-recommends "$@"

--- a/backend/docker/arm/tools/pip-install.sh
+++ b/backend/docker/arm/tools/pip-install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+
+function usage {
+    echo "Usage: $0 [-p <path>] [-u <user>] -a <command>"
+    echo "  -a      argument for 'pip install'"
+    echo "  -p      path to run in"
+    echo "  -u      user to run as (forces pip --user flag)"
+    exit 1;
+}
+
+while getopts ":p::a:u::" o; do
+    case "${o}" in
+        p)
+            p=${OPTARG}
+            ;;
+        a)
+            a=${OPTARG}
+            ;;
+        u)
+            u=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [ -z "${a}" ]; then
+    usage
+fi
+
+path_command=""
+if [ ! -z "${p}" ]; then
+    path_command="cd ${p} &&"
+fi
+
+
+if [ ! -z "${u}" ]; then
+    echo "Running with user"
+    su - appuser -c "${path_command} pip install --user --no-cache-dir ${a}"
+else
+    echo "Running without user"
+    bash -c "${path_command} pip install --no-cache-dir ${a}"
+fi

--- a/backend/docker/arm/tools/wait-for-it.sh
+++ b/backend/docker/arm/tools/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/backend/docker/benefit-arm.Dockerfile
+++ b/backend/docker/benefit-arm.Dockerfile
@@ -1,0 +1,82 @@
+# ==============================
+FROM python:3.9-slim AS appbase
+# ==============================
+
+WORKDIR /
+# From helsinkitest/python:3.9-slim
+COPY docker/arm/tools/ /tools
+COPY docker/arm/scripts /scripts
+
+ENV PATH=/tools:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH=/scripts:/tools:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN /bin/sh -c /scripts/base_setup.sh #
+RUN /bin/sh -c apt-install.sh
+
+WORKDIR /app
+ENV PATH=/home/appuser/.local/bin:/scripts:/tools:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# END helsinkitest/python:3.9-slim
+
+ARG SENTRY_RELEASE
+
+RUN mkdir /entrypoint
+
+COPY --chown=appuser:appuser benefit/requirements.txt /app/requirements.txt
+COPY --chown=appuser:appuser benefit/requirements-prod.txt /app/requirements-prod.txt
+COPY --chown=appuser:appuser benefit/.prod/escape_json.c /app/.prod/escape_json.c
+COPY --chown=appuser:appuser shared /shared/
+
+RUN apt-install.sh \
+        git \
+        netcat-traditional \
+        libpq-dev \
+        build-essential \
+        wkhtmltopdf \
+        gettext \
+    && pip install -U pip \
+    && pip install --no-cache-dir -r /app/requirements.txt \
+    && pip install --no-cache-dir  -r /app/requirements-prod.txt \
+    && uwsgi --build-plugin /app/.prod/escape_json.c \
+    && mv /app/escape_json_plugin.so /app/.prod/escape_json_plugin.so \
+    && apt-cleanup.sh build-essential
+
+COPY --chown=appuser:appuser benefit/docker-entrypoint.sh /entrypoint/docker-entrypoint.sh
+ENTRYPOINT ["/entrypoint/docker-entrypoint.sh"]
+COPY --chown=appuser:appuser benefit /app/
+
+# ==============================
+FROM appbase AS development
+# ==============================
+
+COPY --chown=appuser:appuser benefit/requirements-dev.txt /app/requirements-dev.txt
+RUN apt-install.sh \
+        build-essential \
+    && pip install --no-cache-dir -r /app/requirements-dev.txt \
+    && apt-cleanup.sh build-essential
+
+ENV DEV_SERVER=1
+
+
+USER appuser
+
+# Compile messages as a part of Docker image build so it doesn't have to be done during
+# container startup. This removes the need for writeable localization directories.
+RUN django-admin compilemessages
+
+EXPOSE 8000/tcp
+
+# ==============================
+FROM appbase AS production
+# ==============================
+ARG SENTRY_RELEASE
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
+
+RUN SECRET_KEY="only-used-for-collectstatic" python manage.py collectstatic
+
+USER appuser
+
+# Compile messages as a part of Docker image build so it doesn't have to be done during
+# container startup. This removes the need for writeable localization directories.
+RUN django-admin compilemessages
+
+EXPOSE 8000/tcp

--- a/compose.benefit-backend.yml
+++ b/compose.benefit-backend.yml
@@ -21,7 +21,7 @@ services:
   backend:
     build:
       context: ./backend
-      dockerfile: ./docker/benefit.Dockerfile
+      dockerfile: ./docker/benefit-arm.Dockerfile
       target: development
     env_file:
       - .env.benefit-backend


### PR DESCRIPTION
## Description :sparkles:

### ⚠️ Considerably faster backend runtimes ahead ⚠️ 

Currently, MacOS use `amd64` emulation on running backend.

Copy whatever helsinkitest/python:3.9-slim is doing but mount everything on `bookworm`'s `arm` build.

https://hub.docker.com/layers/helsinkitest/python/3.9-slim/images/sha256-2a4ff79cfef2d0681699b53e3780b4cf5b192d66a99f485e29b387e250abb58c?context=explore

![test times](https://github.com/City-of-Helsinki/yjdh/assets/5328394/0ff1a59e-1b93-49f1-b75a-bf8fac66768b)

Usage:

`docker compose -f compose.benefit-backend.yml up --build`