### PR TITLE
fix: calculation and pay subsidies would not reset if changed on edit (hl-1110, hl-1127, hl-1130) 

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1295,7 +1295,7 @@
       "phoneNumber": {
         "label": "Puhelin"
       },
-      "coOperationNegotiations":{
+      "coOperationNegotiations": {
         "label": "Muutosneuvottelut"
       },
       "coOperationNegotiationsDescription": {
@@ -1321,6 +1321,12 @@
       },
       "endDate": {
         "label": "Työsuhde päättyy"
+      },
+      "paySubsidyGranted": {
+        "label": "Palkkatuki"
+      },
+      "apprenticeshipProgram": {
+        "label": "Oppisopimus"
       }
     }
   }

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1304,7 +1304,7 @@
       "alternativeCompanyStreetAddress": {
         "label": "Osoite"
       },
-      "coOperationNegotiations":{
+      "coOperationNegotiations": {
         "label": "Muutosneuvottelut"
       },
       "coOperationNegotiationsDescription": {
@@ -1321,6 +1321,12 @@
       },
       "endDate": {
         "label": "Työsuhde päättyy"
+      },
+      "paySubsidyGranted": {
+        "label": "Palkkatuki"
+      },
+      "apprenticeshipProgram": {
+        "label": "Oppisopimus"
       }
     }
   }

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1295,7 +1295,7 @@
       "phoneNumber": {
         "label": "Puhelin"
       },
-      "coOperationNegotiations":{
+      "coOperationNegotiations": {
         "label": "Muutosneuvottelut"
       },
       "coOperationNegotiationsDescription": {
@@ -1321,6 +1321,12 @@
       },
       "endDate": {
         "label": "Työsuhde päättyy"
+      },
+      "paySubsidyGranted": {
+        "label": "Palkkatuki"
+      },
+      "apprenticeshipProgram": {
+        "label": "Oppisopimus"
       }
     }
   }

--- a/frontend/benefit/handler/src/components/applicationForm/companySearch/useCompanySearch.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/companySearch/useCompanySearch.ts
@@ -38,7 +38,7 @@ const useCompanySearch = (): ExtendedComponentProps => {
   const [companies, setCompanies] = useState<CompanySearchResult[]>([]);
   const [selectedCompany, setSelectedCompany] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const { onCompanySelected } = useFormActions({});
+  const { onCompanySelected } = useFormActions({}, {});
 
   const onCompanyChange = (businessId: string): void => {
     setSelectedCompany(businessId);

--- a/frontend/benefit/handler/src/components/applicationForm/useApplicationForm.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/useApplicationForm.ts
@@ -100,8 +100,10 @@ export const useApplicationForm = (): ExtendedComponentProps => {
   const [initialApplication, setInitialApplication] =
     React.useState<Application>(null);
 
-  const { onSave, onQuietSave, onSubmit, onNext, onDelete } =
-    useFormActions(application);
+  const { onSave, onQuietSave, onSubmit, onNext, onDelete } = useFormActions(
+    application,
+    initialApplication
+  );
 
   React.useEffect(() => {
     if (id) {

--- a/frontend/benefit/handler/src/constants.ts
+++ b/frontend/benefit/handler/src/constants.ts
@@ -4,6 +4,7 @@ import {
   BENEFIT_TYPES,
   CALCULATION_ROW_TYPES,
   EMPLOYEE_KEYS,
+  PAY_SUBSIDY_OPTIONS,
 } from 'benefit-shared/constants';
 
 export enum ROUTES {
@@ -204,3 +205,12 @@ export enum LOCAL_STORAGE_KEYS {
 export enum APPLICATION_ACTIONS {
   HANDLER_ALLOW_APPLICATION_EDIT = 'HANDLER_ALLOW_APPLICATION_EDIT',
 }
+
+export const PAY_SUBSIDIES_OVERRIDE = {
+  startDate: null,
+  endDate: null,
+  paySubsidyPercent: PAY_SUBSIDY_OPTIONS[0],
+  workTimePercent: 100,
+  disabilityOrIllness: false,
+  durationInMonthsRounded: '',
+};


### PR DESCRIPTION
## Description :sparkles:

Fix an issue with calculation and pay subsidies showing wrong if any of these change:

* Pay subsidy type
* Apprenticeship yes/no

Also sets new expense information (salary, vacation expenses, other expenses) as calculation defaults.