### PR TITLE
chore: update default outgoing email address (HL-1145)

### DIFF
--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -129,7 +129,7 @@ env = environ.Env(
     EMAIL_HOST_PASSWORD=(str, ""),
     EMAIL_PORT=(int, 25),
     EMAIL_TIMEOUT=(int, 15),
-    DEFAULT_FROM_EMAIL=(str, "Helsinki-lisä <helsinkilisa@hel.fi>"),
+    DEFAULT_FROM_EMAIL=(str, "Helsinki-lisä <noreply-helsinkilisa@hel.fi>"),
     WKHTMLTOPDF_BIN=(str, "/usr/bin/wkhtmltopdf"),
     DUMMY_COMPANY_FORM_CODE=(
         int,


### PR DESCRIPTION
## Description :sparkles:
The default outgoing email address was changed to the no-reply one.

## Additional notes :spiral_notepad:
The environment variable for the yjdh-helsinkilisa-api-testing pipeline has also been changed. Changes to the rest of the API pipelines are pending the approval of this change.