### PR TITLE
fix: training compensations removed from calculation (hl-1165)

### DIFF
--- a/frontend/benefit/handler/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/handler/src/hooks/useFormActions.tsx
@@ -272,6 +272,9 @@ const useFormActions = (
       deMinimisAidSet: deMinimisAids,
       action: APPLICATION_ACTIONS.HANDLER_ALLOW_APPLICATION_EDIT,
       benefitType: BENEFIT_TYPES.SALARY,
+      trainingCompensations: normalizedValues.trainingCompensations
+        ? []
+        : undefined,
       calculation: calculation
         ? getPayloadForCalculation(currentValues)
         : undefined,


### PR DESCRIPTION
## Description :sparkles:

Just reset all training compensations when submitting an application.