### PR TITLE
refactor: move applicant consent to edit view (hl-1171)

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -667,7 +667,7 @@
   "review": {
     "actions": {
       "handle": "Ota käsittelyyn",
-      "edit": "Muokkaa hakemusta",
+      "edit": "Muokkaa",
       "close": "Sulje",
       "done": "Tee päätösehdotus",
       "saveAndContinue": "Tallenna ja sulje",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -667,7 +667,7 @@
   "review": {
     "actions": {
       "handle": "Ota käsittelyyn",
-      "edit": "Muokkaa hakemusta",
+      "edit": "Muokkaa",
       "close": "Sulje",
       "done": "Tee päätösehdotus",
       "saveAndContinue": "Tallenna ja sulje",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -667,7 +667,7 @@
   "review": {
     "actions": {
       "handle": "Ota käsittelyyn",
-      "edit": "Muokkaa hakemusta",
+      "edit": "Muokkaa",
       "close": "Sulje",
       "done": "Tee päätösehdotus",
       "saveAndContinue": "Tallenna ja sulje",

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/FormContent.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/FormContent.tsx
@@ -692,6 +692,16 @@ const FormContent: React.FC<Props> = ({
             />
           </$GridCell>
         )}
+        {application.applicationOrigin === APPLICATION_ORIGINS.APPLICANT && (
+          <$GridCell $colSpan={12}>
+            <AttachmentsList
+              attachments={attachments}
+              attachmentType={ATTACHMENT_TYPES.EMPLOYEE_CONSENT}
+              handleQuietSave={handleQuietSave}
+              required
+            />
+          </$GridCell>
+        )}
       </FormSection>
       <FormSection
         paddingBottom

--- a/frontend/benefit/handler/src/components/applicationForm/reviewChanges/ReviewEditChanges.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/reviewChanges/ReviewEditChanges.tsx
@@ -1,6 +1,7 @@
 import { APPLICATION_FIELD_KEYS } from 'benefit/handler/constants';
 import DeMinimisContext from 'benefit/handler/context/DeMinimisContext';
 import { Application } from 'benefit/handler/types/application';
+import { APPLICATION_ORIGINS } from 'benefit-shared/constants';
 import deepDiff from 'deep-diff';
 import { IconArrowRight } from 'hds-react';
 import { useTranslation } from 'next-i18next';
@@ -18,7 +19,6 @@ import {
   getDiffPrefilter,
   translateLabelFromPath,
 } from './utils';
-import { APPLICATION_ORIGINS } from 'benefit-shared/constants';
 
 export type ReviewEditChangesProps = {
   initialValues: Application;

--- a/frontend/benefit/handler/src/components/applicationForm/reviewChanges/ReviewEditChanges.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/reviewChanges/ReviewEditChanges.tsx
@@ -18,6 +18,7 @@ import {
   getDiffPrefilter,
   translateLabelFromPath,
 } from './utils';
+import { APPLICATION_ORIGINS } from 'benefit-shared/constants';
 
 export type ReviewEditChangesProps = {
   initialValues: Application;
@@ -63,7 +64,12 @@ const ReviewEditChanges: React.FC<ReviewEditChangesProps> = ({
     const diff: Difference[] =
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       deepDiff(initialValues, currentValues, (path: string[], key: string) =>
-        getDiffPrefilter(path, key, requiredKeys)
+        getDiffPrefilter(
+          path,
+          key,
+          requiredKeys,
+          currentValues.applicationOrigin === APPLICATION_ORIGINS.HANDLER
+        )
       ) || [];
     setChanges(diff);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/benefit/handler/src/components/applicationForm/reviewChanges/utils.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/reviewChanges/utils.ts
@@ -92,7 +92,8 @@ export const getDeMinimisChanged = (
 export const getDiffPrefilter = (
   path: string[],
   key: string,
-  requiredKeys: Set<APPLICATION_FIELD_KEYS>
+  requiredKeys: Set<APPLICATION_FIELD_KEYS>,
+  isOfHandlerOrigin: boolean
 ): boolean => {
   if (path.length > 0 && path.includes('employee')) return false;
   if (
@@ -102,6 +103,14 @@ export const getDiffPrefilter = (
     ].includes(key as APPLICATION_FIELD_KEYS)
   )
     return true;
+
+  if (
+    key === APPLICATION_FIELD_KEYS.PAPER_APPLICATION_DATE &&
+    !isOfHandlerOrigin
+  ) {
+    return true;
+  }
+
   const isRequiredKey = requiredKeys.has(key as APPLICATION_FIELD_KEYS);
   return !isRequiredKey;
 };

--- a/frontend/benefit/handler/src/components/applicationForm/utils/applicationForm.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/utils/applicationForm.ts
@@ -12,6 +12,7 @@ import {
   ApplicationFields,
 } from 'benefit/handler/types/application';
 import {
+  APPLICATION_ORIGINS,
   APPLICATION_STATUSES,
   ATTACHMENT_TYPES,
   EMPLOYEE_KEYS,
@@ -52,7 +53,9 @@ const getApplication = (
           ...applicationData,
           start_date: convertToUIDateFormat(applicationData.start_date),
           end_date: convertToUIDateFormat(applicationData.end_date),
-          paper_application_date: convertToUIDateFormat(applicationData.paper_application_date),
+          paper_application_date: convertToUIDateFormat(
+            applicationData.paper_application_date
+          ),
           calculation: applicationData.calculation
             ? {
                 ...applicationData.calculation,
@@ -222,11 +225,22 @@ const requiredAttachments = (
       )
     );
   }
+
+  let hasApplicantConsent = true;
+  if (values.applicationOrigin === APPLICATION_ORIGINS.APPLICANT) {
+    hasApplicantConsent = !isEmpty(
+      values?.attachments?.find(
+        (att: BenefitAttachment) =>
+          att.attachmentType === ATTACHMENT_TYPES.EMPLOYEE_CONSENT
+      )
+    );
+  }
   return (
     hasWorkContract &&
     hasFullApplication &&
     hasPaySubsidyDecision &&
-    hasApprenticeshipProgram
+    hasApprenticeshipProgram &&
+    hasApplicantConsent
   );
 };
 

--- a/frontend/benefit/handler/src/components/applicationReview/consentView/ConsentView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/consentView/ConsentView.tsx
@@ -15,13 +15,7 @@ import useLocale from 'shared/hooks/useLocale';
 import { capitalize } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
-import ConsentActions from './consentActions/ConsentActions';
-
-const ConsentView: React.FC<ApplicationReviewViewProps> = ({
-  data,
-  isUploading,
-  handleUpload,
-}) => {
+const ConsentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   const cbPrefix = 'application_consent';
@@ -30,16 +24,10 @@ const ConsentView: React.FC<ApplicationReviewViewProps> = ({
   const theme = useTheme();
   return (
     <ReviewSection
+      id={data.id}
       header={t(`${translationsBase}.headings.heading9`)}
       section="approval"
-      action={
-        !ACTIONLESS_STATUSES.includes(data.status) ? (
-          <ConsentActions
-            isUploading={isUploading}
-            handleUpload={handleUpload}
-          />
-        ) : null
-      }
+      action={!ACTIONLESS_STATUSES.includes(data.status) ? true : null}
     >
       {data.applicationOrigin === APPLICATION_ORIGINS.APPLICANT ? (
         <$GridCell $colSpan={12}>

--- a/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
@@ -12,13 +12,8 @@ import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { getFullName } from 'shared/utils/application.utils';
 
 import AttachmentsListView from '../../attachmentsListView/AttachmentsListView';
-import EmployeeActions from './EmployeeActions/EmployeeActions';
 
-const EmployeeView: React.FC<ApplicationReviewViewProps> = ({
-  data,
-  handleUpload,
-  isUploading,
-}) => {
+const EmployeeView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
@@ -26,14 +21,7 @@ const EmployeeView: React.FC<ApplicationReviewViewProps> = ({
       id={data.id}
       header={t(`${translationsBase}.headings.heading5`)}
       section="employee"
-      action={
-        !ACTIONLESS_STATUSES.includes(data.status) ? (
-          <EmployeeActions
-            handleUpload={handleUpload}
-            isUploading={isUploading}
-          />
-        ) : null
-      }
+      action={!ACTIONLESS_STATUSES.includes(data.status) ? true : null}
     >
       <$GridCell $colSpan={6}>
         <$ViewFieldBold large>

--- a/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
@@ -14,13 +14,8 @@ import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { formatFloatToCurrency } from 'shared/utils/string.utils';
 
 import AttachmentsListView from '../../attachmentsListView/AttachmentsListView';
-import EmploymentActions from './employmentActions/EmploymentActions';
 
-const EmploymentView: React.FC<ApplicationReviewViewProps> = ({
-  data,
-  isUploading,
-  handleUpload,
-}) => {
+const EmploymentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
   const { t } = useTranslation();
   return (
@@ -28,14 +23,7 @@ const EmploymentView: React.FC<ApplicationReviewViewProps> = ({
       id={data.id}
       header={t(`${translationsBase}.headings.heading8`)}
       section="employment"
-      action={
-        !ACTIONLESS_STATUSES.includes(data.status) ? (
-          <EmploymentActions
-            handleUpload={handleUpload}
-            isUploading={isUploading}
-          />
-        ) : null
-      }
+      action={!ACTIONLESS_STATUSES.includes(data.status) ? true : null}
     >
       <$GridCell $colSpan={6} $colStart={1}>
         <$ViewFieldBold>

--- a/frontend/benefit/handler/src/components/reviewSection/ReviewSection.sc.ts
+++ b/frontend/benefit/handler/src/components/reviewSection/ReviewSection.sc.ts
@@ -28,7 +28,7 @@ export const $CheckIconFill = styled(IconCheckCircleFill)`
 
 export const $EditButtonContainer = styled.div`
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 18px;
+  right: 18px;
   z-index: 99;
 `;


### PR DESCRIPTION
## Description :sparkles:

* Add / delete one or more applicant consents from handler edit view
* Do not display paper application date diff in _edit changes review_ if origin is `applicant`
* Includes some small fixes that were left from hl-1062