### PR TITLE
fix: attachment type in ahjo payload

### DIFF
--- a/backend/benefit/applications/services/ahjo_payload.py
+++ b/backend/benefit/applications/services/ahjo_payload.py
@@ -144,7 +144,7 @@ def _prepare_case_records(
 
         document_record = _prepare_record(
             "Hakemuksen Liite",
-            "liite",
+            "hakemuksen liite",
             attachment.created_at.isoformat(),
             [_prepare_record_document_dict(attachment)],
             handler,

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -347,7 +347,7 @@ def ahjo_payload_record_for_attachment_update(
     record = {
         **record,
         "Title": "Liite",
-        "Type": "liite",
+        "Type": "hakemuksen liite",
         "VersionSeriesId": dummy_version_series_id,
         "Documents": [],
         "Agents": ahjo_payload_agents,

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -126,7 +126,7 @@ def test_prepare_case_records(decided_application, settings):
     ):
         document_record = _prepare_record(
             "Hakemuksen Liite",
-            "liite",
+            "hakemuksen liite",
             attachment.created_at.isoformat(),
             [_prepare_record_document_dict(attachment)],
             handler,


### PR DESCRIPTION
## Description :sparkles:
Change the attachment type from "liite" to "hakemuksen liite" in the payload generated for Ahjo api call.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
