### PR TITLE
fix: various calculator fixes and tweaks

### DIFF
--- a/backend/benefit/calculator/rules.py
+++ b/backend/benefit/calculator/rules.py
@@ -106,8 +106,13 @@ class HelsinkiBenefitCalculator:
                     training_compensation,
                 )
             )
-        assert ranges[0].start_date == self.calculation.start_date
-        assert ranges[-1].end_date == self.calculation.end_date
+
+        if (
+            ranges[-1].end_date != self.calculation.end_date
+            or ranges[0].start_date != self.calculation.start_date
+        ):
+            raise ValueError("Error in range of calculation.start_date / end_date")
+
         return ranges
 
     def get_amount(self, row_type: RowType, default=None):

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -924,6 +924,11 @@
       "header": "Myönnettävä Helsinki-lisä",
       "header2": "Arvio koostuu seuraavista tiedoista:",
       "acceptedBenefit": "Myönnettävä Helsinki-lisä"
+    },
+    "errors": {
+      "trainingCompensation": {
+        "invalid": "Koulutuskorvausrivin syöttö on vielä kesken. Lisää rivi laskelmaan."
+      }
     }
   },
   "organizationTypes": {

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -862,6 +862,10 @@
       "monthlyAmount": {
         "label": "Koulutuskorvaus",
         "placeholder": "Koulutuskorvaus € / kk"
+      },
+      "unknownField": {
+        "label": "Tunnistamaton kenttä",
+        "placeholder": ""
       }
     },
     "notifications": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -924,6 +924,11 @@
       "header": "Myönnettävä Helsinki-lisä",
       "header2": "Arvio koostuu seuraavista tiedoista:",
       "acceptedBenefit": "Myönnettävä Helsinki-lisä"
+    },
+    "errors": {
+      "trainingCompensation": {
+        "invalid": "Koulutuskorvausrivin syöttö on vielä kesken. Lisää rivi laskelmaan."
+      }
     }
   },
   "organizationTypes": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -862,6 +862,10 @@
       "monthlyAmount": {
         "label": "Koulutuskorvaus",
         "placeholder": "Koulutuskorvaus € / kk"
+      },
+      "unknownField": {
+        "label": "Tunnistamaton kenttä",
+        "placeholder": ""
       }
     },
     "notifications": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -924,6 +924,11 @@
       "header": "Myönnettävä Helsinki-lisä",
       "header2": "Arvio koostuu seuraavista tiedoista:",
       "acceptedBenefit": "Myönnettävä Helsinki-lisä"
+    },
+    "errors": {
+      "trainingCompensation": {
+        "invalid": "Koulutuskorvausrivin syöttö on vielä kesken. Lisää rivi laskelmaan."
+      }
     }
   },
   "organizationTypes": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -862,6 +862,10 @@
       "monthlyAmount": {
         "label": "Koulutuskorvaus",
         "placeholder": "Koulutuskorvaus € / kk"
+      },
+      "unknownField": {
+        "label": "Tunnistamaton kenttä",
+        "placeholder": ""
       }
     },
     "notifications": {

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -615,6 +615,15 @@ const SalaryBenefitCalculatorView: React.FC<
         $colSpan={11}
         style={{ marginTop: 'var(--spacing-xs)' }}
       >
+        <$ViewField
+          css={`
+            color: ${theme.colors.brick};
+          `}
+        >
+          {isDisabledAddTrainingCompensationButton === false &&
+            t('common:calculators.errors.trainingCompensation.invalid')}
+        </$ViewField>
+
         <Button
           onClick={handleSubmit}
           theme="coat"

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -2,6 +2,7 @@ import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSectio
 import { CALCULATION_TYPES } from 'benefit/handler/constants';
 import { useCalculatorData } from 'benefit/handler/hooks/useCalculatorData';
 import { SalaryBenefitCalculatorViewProps } from 'benefit/handler/types/application';
+import { PAY_SUBSIDY_GRANTED } from 'benefit-shared/constants';
 import { PaySubsidy } from 'benefit-shared/types/application';
 import {
   Button,
@@ -179,16 +180,23 @@ const SalaryBenefitCalculatorView: React.FC<
             />
           </$GridCell>
 
-          <$GridCell $colStart={1} $colSpan={11}>
-            <$CalculatorHeader>
-              {t(`${translationsBase}.subsidies`)}
-            </$CalculatorHeader>
-          </$GridCell>
-          {formik.values.paySubsidies && (
+          {formik.values.paySubsidies?.length > 0 && (
             <$GridCell $colStart={1} $colSpan={11}>
-              <h3 style={{ fontSize: theme.fontSize.heading.xs, margin: 0 }}>
-                {t(`${translationsBase}.paySubsidy`)}
-              </h3>
+              <$CalculatorHeader as="div">
+                <p style={{ marginBottom: '0.5em' }}>
+                  {t(`${translationsBase}.subsidies`)}
+                </p>
+                <$ViewField>
+                  <strong>
+                    {t(`${translationsBase}.paySubsidy`)}{' '}
+                    {data.paySubsidyGranted === PAY_SUBSIDY_GRANTED.GRANTED_AGED
+                      ? `(${t(
+                          'applications.sections.fields.paySubsidyGranted.grantedAged'
+                        )})`
+                      : null}
+                  </strong>
+                </$ViewField>
+              </$CalculatorHeader>
             </$GridCell>
           )}
           {formik.values.paySubsidies?.map(

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -634,11 +634,14 @@ const SalaryBenefitCalculatorView: React.FC<
           </$Notification>
         </$GridCell>
       )}
-      <SalaryCalculatorResults
-        data={data}
-        isManualCalculator={isManualCalculator}
-        isRecalculationRequired={isRecalculationRequired}
-      />
+
+      {!calculationsErrors && (
+        <SalaryCalculatorResults
+          data={data}
+          isManualCalculator={isManualCalculator}
+          isRecalculationRequired={isRecalculationRequired}
+        />
+      )}
     </ReviewSection>
   );
 };

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryCalculatorResults/SalaryCalculatorResults.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryCalculatorResults/SalaryCalculatorResults.tsx
@@ -33,6 +33,11 @@ const SalaryCalculatorResults: React.FC<ApplicationReviewViewProps> = ({
   if (isRecalculationRequired) {
     return null;
   }
+
+  if (rowsWithoutTotal.length === 0) {
+    return null;
+  }
+
   return (
     <$GridCell
       $colSpan={11}

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
@@ -11,6 +11,7 @@ import {
   TrainingCompensation,
 } from 'benefit-shared/types/application';
 import { FormikProps, useFormik } from 'formik';
+import clone from 'lodash/clone';
 import fromPairs from 'lodash/fromPairs';
 import { useTranslation } from 'next-i18next';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
@@ -47,6 +48,13 @@ type ExtendedComponentProps = {
   isDisabledAddTrainingCompensationButton: boolean;
 };
 
+const initialTrainingCompensationValues = {
+  id: '',
+  monthlyAmount: '',
+  startDate: '',
+  endDate: '',
+};
+
 const useSalaryBenefitCalculatorData = (
   application: Application
 ): ExtendedComponentProps => {
@@ -60,12 +68,7 @@ const useSalaryBenefitCalculatorData = (
     useHandlerReviewActions(application);
 
   const [newTrainingCompensation, setNewTrainingCompensation] =
-    useState<TrainingCompensation>({
-      id: '',
-      monthlyAmount: '',
-      startDate: '',
-      endDate: '',
-    });
+    useState<TrainingCompensation>(clone(initialTrainingCompensationValues));
 
   const [
     isDisabledAddTrainingCompensationButton,
@@ -136,6 +139,7 @@ const useSalaryBenefitCalculatorData = (
         id: uuidv4(),
       },
     ]);
+    setNewTrainingCompensation(clone(initialTrainingCompensationValues));
   };
 
   const removeTrainingCompensation = (id: string): void => {


### PR DESCRIPTION
## Description :sparkles:

I'm about to make big changes on how the application is handled when moving towards Ahjo. Handling to accepted or rejected state will have three steps instead of just one. The calculator has been buggy and I have to make sure that it's ok before moving further from step 1.

* Handle calculator error 500 instead of crashing the app
* Raise error instead of fatally assert crash in Django
* Do not show certain calculator elements if calculator state is not 💯  ✅ 