### PR TITLE
fix: Records in update dict to lowercase

### DIFF
--- a/backend/benefit/applications/services/ahjo_payload.py
+++ b/backend/benefit/applications/services/ahjo_payload.py
@@ -173,7 +173,7 @@ def prepare_update_application_payload(
 ) -> dict:
     """Prepare the payload that is sent to Ahjo when an application is updated, \
           in this case it only contains a Records dict"""
-    return {"Records": _prepare_case_records(application, pdf_summary, is_update=True)}
+    return {"records": _prepare_case_records(application, pdf_summary, is_update=True)}
 
 
 def prepare_decision_proposal_payload(


### PR DESCRIPTION
## Description :sparkles:
Records key should be "records" in lowercase for AHJO.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
