### PR TITLE
fix: require confirmation on attachment removal and when cancelling edit

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -628,7 +628,8 @@
         },
         "attachmentsIngress": "Lisää hakemukselle seuraavat liitteet. Kaikki *-merkityt liitteet ovat pakollisia. Tiedostomuoto voi olla JPG, PNG tai PDF ja kooltaan maksimissaan 10 MB.",
         "add": "Liitä tiedosto",
-        "remove": "Poista liite"
+        "remove": "Poista liite",
+        "confirm": "Haluatko varmasti poistaa liitteen {{ name }}? Se poistuu heti eikä tiedostoa voida enää palauttaa."
       }
     },
     "summary": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -628,7 +628,8 @@
         },
         "attachmentsIngress": "Lisää hakemukselle seuraavat liitteet. Kaikki *-merkityt liitteet ovat pakollisia. Tiedostomuoto voi olla JPG, PNG tai PDF ja kooltaan maksimissaan 10 MB.",
         "add": "Liitä tiedosto",
-        "remove": "Poista liite"
+        "remove": "Poista liite",
+        "confirm": "Haluatko varmasti poistaa liitteen {{ name }}? Se poistuu heti eikä tiedostoa voida enää palauttaa."
       }
     },
     "summary": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -628,7 +628,8 @@
         },
         "attachmentsIngress": "Lisää hakemukselle seuraavat liitteet. Kaikki *-merkityt liitteet ovat pakollisia. Tiedostomuoto voi olla JPG, PNG tai PDF ja kooltaan maksimissaan 10 MB.",
         "add": "Liitä tiedosto",
-        "remove": "Poista liite"
+        "remove": "Poista liite",
+        "confirm": "Haluatko varmasti poistaa liitteen {{ name }}? Se poistuu heti eikä tiedostoa voida enää palauttaa."
       }
     },
     "summary": {

--- a/frontend/benefit/handler/src/components/applicationForm/actionBar/ActionBarEdit.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/actionBar/ActionBarEdit.tsx
@@ -80,8 +80,14 @@ const ActionBarEdit: React.FC<ActionBarProps> = ({
                 theme="black"
                 variant="secondary"
                 onClick={() => {
-                  // eslint-disable-next-line no-alert
-                  const alert = formik.dirty && !window.confirm();
+                  const alert =
+                    formik.dirty &&
+                    // eslint-disable-next-line no-alert
+                    !window.confirm(
+                      t(
+                        'common:applications.actions.backWithoutSavingDescription'
+                      )
+                    );
 
                   if (!alert) {
                     return void router.push(

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/attachmentsList/AttachmentsList.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/attachmentsList/AttachmentsList.tsx
@@ -32,7 +32,7 @@ const AttachmentsList: React.FC<AttachmentsListProps> = ({
     translationsBase,
     isRemoving,
     isUploading,
-  } = useAttachmentsList(handleQuietSave);
+  } = useAttachmentsList(handleQuietSave, attachments);
 
   return (
     <AttachmentsListBase

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/attachmentsList/useAttachmentsList.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/attachmentsList/useAttachmentsList.ts
@@ -20,7 +20,8 @@ type ExtendedComponentProps = {
 };
 
 const useAttachmentsList = (
-  handleQuietSave?: () => Promise<ApplicationData | void>
+  handleQuietSave?: () => Promise<ApplicationData | void>,
+  attachments?: BenefitAttachment[]
 ): ExtendedComponentProps => {
   const router = useRouter();
   const id = router?.query?.id;
@@ -59,7 +60,16 @@ const useAttachmentsList = (
 
   const handleRemove = async (attachmentId: string): Promise<void> => {
     const response = handleQuietSave ? await handleQuietSave() : true;
-    if (response) {
+    const attachment = attachments?.find((file) => file.id === attachmentId);
+    if (
+      response &&
+      // eslint-disable-next-line no-alert
+      window.confirm(
+        t('common:applications.sections.attachments.confirm', {
+          name: attachment?.attachmentFileName,
+        })
+      )
+    ) {
       removeAttachment({
         applicationId,
         attachmentId,

--- a/frontend/benefit/handler/src/components/applicationForm/useApplicationForm.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/useApplicationForm.ts
@@ -129,7 +129,7 @@ export const useApplicationForm = (): ExtendedComponentProps => {
       [APPLICATION_FIELDS.PAPER_APPLICATION_DATE]:
         application.paperApplicationDate
           ? formatDate(parseDate(application.paperApplicationDate))
-          : undefined,
+          : formatDate(new Date()),
     },
     validationSchema: getValidationSchema(organizationType, t),
     validateOnChange: true,

--- a/frontend/shared/src/components/attachments/AttachmentsList.tsx
+++ b/frontend/shared/src/components/attachments/AttachmentsList.tsx
@@ -22,7 +22,7 @@ type Props<T extends Attachment> = {
   errorMessage?: string | false;
   attachments?: T[];
   onUpload: (data: FormData) => void | Promise<void>;
-  onRemove: (fileId: string) => void | Promise<void>;
+  onRemove: (fileId: string, fileName?: string) => void | Promise<void>;
   onOpen: (attachment: T) => void | Promise<void>;
   isUploading: boolean;
   isRemoving: boolean;


### PR DESCRIPTION
## Description :sparkles:

Add a couple of missing nags with `window.confirm()`. It's lacking the cool HDS modal styles but at least it's working 😏  

Also set default paper application date if it's untouched.