### PR TITLE
fix: import date-fns properly

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/utils/validation.ts
@@ -9,7 +9,7 @@ import {
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
 import { DeMinimisAid } from 'benefit-shared/types/application';
-import { isBefore } from 'date-fns';
+import isBefore from 'date-fns/isBefore';
 import { TFunction } from 'next-i18next';
 import { convertToUIDateFormat, parseDate } from 'shared/utils/date.utils';
 import { getNumberValue } from 'shared/utils/string.utils';

--- a/frontend/benefit/handler/browser-tests/pages/1-new-application.testcafe.ts
+++ b/frontend/benefit/handler/browser-tests/pages/1-new-application.testcafe.ts
@@ -1,6 +1,6 @@
 import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
 import { DATE_FORMATS } from '@frontend/shared/src/utils/date.utils';
-import { format } from 'date-fns';
+import format from 'date-fns/format';
 import { Selector } from 'testcafe';
 
 import fi from '../../public/locales/fi/common.json';

--- a/frontend/benefit/handler/browser-tests/pages/2-edit-application.testcafe.ts
+++ b/frontend/benefit/handler/browser-tests/pages/2-edit-application.testcafe.ts
@@ -1,6 +1,6 @@
 import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
 import { DATE_FORMATS } from '@frontend/shared/src/utils/date.utils';
-import { format } from 'date-fns';
+import format from 'date-fns/format';
 import { Selector } from 'testcafe';
 
 import fi from '../../public/locales/fi/common.json';

--- a/frontend/benefit/shared/src/utils/dates.ts
+++ b/frontend/benefit/shared/src/utils/dates.ts
@@ -2,17 +2,15 @@ import {
   APPLICATION_START_DATE,
   BENEFIT_TYPES,
 } from 'benefit-shared/constants';
-import {
-  addMonths,
-  isAfter,
-  isEqual,
-  isFuture,
-  parse,
-  startOfDay,
-  startOfYear,
-  subDays,
-  subMonths,
-} from 'date-fns';
+import addMonths from 'date-fns/addMonths';
+import isAfter from 'date-fns/isAfter';
+import isEqual from 'date-fns/isEqual';
+import isFuture from 'date-fns/isFuture';
+import parse from 'date-fns/parse';
+import startOfDay from 'date-fns/startOfDay';
+import startOfYear from 'date-fns/startOfYear';
+import subDays from 'date-fns/subDays';
+import subMonths from 'date-fns/subMonths';
 import { parseDate } from 'shared/utils/date.utils';
 
 export const getMinEndDate = (

--- a/frontend/shared/src/utils/date.utils.ts
+++ b/frontend/shared/src/utils/date.utils.ts
@@ -1,4 +1,3 @@
-import { startOfYear } from 'date-fns';
 import formatDateStr from 'date-fns/format';
 import isBefore from 'date-fns/isBefore';
 import isFutureFn from 'date-fns/isFuture';
@@ -7,6 +6,7 @@ import isValid from 'date-fns/isValid';
 import { enGB as en, fi, sv } from 'date-fns/locale';
 import parse from 'date-fns/parse';
 import parseISO from 'date-fns/parseISO';
+import startOfYear from 'date-fns/startOfYear';
 
 import {
   DATE_BACKEND_REGEX,

--- a/frontend/shared/src/utils/file.utils.ts
+++ b/frontend/shared/src/utils/file.utils.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import format from 'date-fns/format';
 import fileDownload from 'js-file-download';
 import ExportFileType from 'shared/types/export-file-type';
 
@@ -11,7 +11,12 @@ export const downloadFile = (data: string, type: ExportFileType): void => {
 
   if (type === 'csv') {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
-    fileDownload(data, `hl ${dateString}.csv`, 'text/csv;charset=utf-8-sig', '\uFEFF');
+    fileDownload(
+      data,
+      `hl ${dateString}.csv`,
+      'text/csv;charset=utf-8-sig',
+      '\uFEFF'
+    );
   } else {
     fileDownload(data, `hl ${dateString}.zip`);
   }


### PR DESCRIPTION
## Description :sparkles:

Just noticed some bad import practice with date-fns and thought I'd make a change. There's still date-fns dependency in HDS that imports the whole lib, thus having two versions of date-fns in the bundle.