### PR TITLE
fix: localization keys added to change messages hl-1213

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1342,6 +1342,21 @@
       "apprenticeshipProgram": {
         "label": "Oppisopimus"
       },
+      "commissionAmount": {
+        "label": "Toimeksiannon summa"
+      },
+      "companyDepartment": {
+        "label": "Toimipiste (valinnainen)"
+      },
+      "applicantLanguage": {
+        "label": "Asiointikieli"
+      },
+      "ahjoCaseGuid": {
+        "label": "Ahjo guid"
+      },
+      "ahjoCaseId": {
+        "label": "Diaarinro"
+      },
       "attachments": {
         "label": "Liite"
       }

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1342,6 +1342,21 @@
       "apprenticeshipProgram": {
         "label": "Oppisopimus"
       },
+      "commissionAmount": {
+        "label": "Toimeksiannon summa"
+      },
+      "companyDepartment": {
+        "label": "Toimipiste (valinnainen)"
+      },
+      "applicantLanguage": {
+        "label": "Asiointikieli"
+      },
+      "ahjoCaseGuid": {
+        "label": "Ahjo guid"
+      },
+      "ahjoCaseId": {
+        "label": "Diaarinro"
+      },
       "attachments": {
         "label": "Liite"
       }

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1342,6 +1342,21 @@
       "apprenticeshipProgram": {
         "label": "Oppisopimus"
       },
+      "commissionAmount": {
+        "label": "Toimeksiannon summa"
+      },
+      "companyDepartment": {
+        "label": "Toimipiste (valinnainen)"
+      },
+      "applicantLanguage": {
+        "label": "Asiointikieli"
+      },
+      "ahjoCaseGuid": {
+        "label": "Ahjo guid"
+      },
+      "ahjoCaseId": {
+        "label": "Diaarinro"
+      },
       "attachments": {
         "label": "Liite"
       }


### PR DESCRIPTION
## Description :sparkles:
Missing localizations added.

commissionAmount is not anymore in use, but it was seen in one test case showing
changes.fields.commissionAmount.label:
(tyhjä)->(tyhjä)

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
