### PR TITLE
feat: remove "Palkan" from salary benefit locale

### DIFF
--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -281,7 +281,7 @@ msgid "Employment Benefit"
 msgstr "Työllistämisen Helsinki-lisä"
 
 msgid "Salary Benefit"
-msgstr "Palkan Helsinki-lisä"
+msgstr "Helsinki-lisä"
 
 msgid "Commission Benefit"
 msgstr "Toimeksiannon Helsinki-lisä"


### PR DESCRIPTION
## Description :sparkles:
Shorten the salary benefit finnish translation from "Palkan Helsinki-lisä" to "Helsinki-Lisä".
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
