### PR TITLE
chore: bump django-helusers to 0.11.0

### DIFF
--- a/backend/benefit/requirements.txt
+++ b/backend/benefit/requirements.txt
@@ -76,7 +76,7 @@ django-extensions==3.2.1
     #   yjdh-backend-shared
 django-filter==22.1
     # via -r requirements.in
-django-helusers==0.7.1
+django-helusers==0.11.0
     # via helsinki-profile-gdpr-api
 django-localflavor==3.1
     # via -r requirements.in


### PR DESCRIPTION
## Description :sparkles:

Prepare for new authorization tech by updating helusers library. I've tested this on localhost and authentication works just like before on both handler and applicant (with `NEXT_PUBLIC_MOCK_FLAG=0` ofc).