### PR TITLE
feat: secret xml attachment as per the  new design

### DIFF
--- a/backend/benefit/applications/services/ahjo_integration.py
+++ b/backend/benefit/applications/services/ahjo_integration.py
@@ -5,6 +5,7 @@ import uuid
 import zipfile
 from collections import defaultdict
 from dataclasses import dataclass
+from datetime import date
 from io import BytesIO
 from typing import List, Optional, Tuple, Union
 
@@ -43,6 +44,12 @@ from applications.services.generate_application_summary import (
     generate_application_summary_file,
 )
 from calculator.enums import RowType
+from calculator.models import (
+    Calculation,
+    SalaryBenefitMonthlyRow,
+    SalaryBenefitSubTotalRow,
+    SalaryBenefitTotalRow,
+)
 from companies.models import Company
 
 
@@ -390,11 +397,97 @@ PDF_CONTENT_TYPE = "application/pdf"
 XML_CONTENT_TYPE = "application/xml"
 
 
-def generate_secret_xml_string(application: Application) -> str:
-    calculation_rows = application.calculation.rows.all()
-    sub_total_rows = calculation_rows.filter(
-        row_type=RowType.HELSINKI_BENEFIT_SUB_TOTAL_EUR
+def get_period_rows_for_xml(
+    calculation: Calculation,
+) -> Tuple[
+    SalaryBenefitTotalRow,
+    List[Union[SalaryBenefitMonthlyRow, SalaryBenefitSubTotalRow]],
+]:
+    total_amount_row = calculation.rows.filter(
+        row_type=RowType.HELSINKI_BENEFIT_TOTAL_EUR
+    ).first()
+
+    row_types_to_list = [
+        RowType.HELSINKI_BENEFIT_MONTHLY_EUR,
+        RowType.HELSINKI_BENEFIT_SUB_TOTAL_EUR,
+    ]
+    calculation_rows = calculation.rows.filter(row_type__in=row_types_to_list)
+    return total_amount_row, calculation_rows
+
+
+@dataclass
+class BenefitPeriodRow:
+    start_date: date
+    end_date: date
+    amount_per_month: float
+    total_amount: float
+
+
+def _prepare_multiple_period_rows(
+    calculation_rows: List[Union[SalaryBenefitMonthlyRow, SalaryBenefitSubTotalRow]],
+) -> List[BenefitPeriodRow]:
+    """In the case  where there are multiple benefit periods,
+    there will be multiple pairs of sub total rows and a corresponding monthly eur rows.
+    Here we prepare the calculation rows per payment period by looping through the calculation rows
+    and parsing the data into a list of BenefitPeriodRows.
+    """
+    calculation_rows_for_xml = []
+
+    for idx, r in enumerate(calculation_rows):
+        # check that we do not go out of bounds
+        if 0 <= idx + 1 < len(calculation_rows):
+            # the dates are in the next row, which is always a sub total row
+            start_date = calculation_rows[idx + 1].start_date
+            end_date = calculation_rows[idx + 1].end_date
+            # get data only from rows that have start_date and end_date
+            if start_date and end_date:
+                calculation_rows_for_xml.append(
+                    BenefitPeriodRow(
+                        start_date=start_date,
+                        end_date=end_date,
+                        amount_per_month=r.amount,
+                        # the total amount is also in the next row
+                        total_amount=calculation_rows[idx + 1].amount,
+                    )
+                )
+
+    return calculation_rows_for_xml
+
+
+def _prepare_single_period_row(
+    calculation_row_per_month: SalaryBenefitMonthlyRow,
+    total_amount_row: SalaryBenefitTotalRow,
+) -> List[BenefitPeriodRow]:
+    """In the case where there is only one benefit period,
+    we combine the monthly eur row and the salary benefit total row into a single BenefitPeriodRow.
+    """
+    calculation_rows_for_xml = []
+    calculation_rows_for_xml.append(
+        BenefitPeriodRow(
+            start_date=total_amount_row.start_date,
+            end_date=total_amount_row.end_date,
+            amount_per_month=calculation_row_per_month.amount,
+            total_amount=total_amount_row.amount,
+        )
     )
+    return calculation_rows_for_xml
+
+
+def generate_secret_xml_string(application: Application) -> str:
+    """Generate the secret decision XML for the given application."""
+    total_amount_row, calculation_rows = get_period_rows_for_xml(
+        application.calculation
+    )
+    # If there is only one period, we can combine the monthly eur row and the total row into a single row
+    if (
+        len(calculation_rows) == 1
+        and calculation_rows[0].row_type == RowType.HELSINKI_BENEFIT_MONTHLY_EUR
+    ):
+        calculation_data_for_xml = _prepare_single_period_row(
+            calculation_rows[0], total_amount_row
+        )
+    else:
+        calculation_data_for_xml = _prepare_multiple_period_rows(calculation_rows)
 
     # Set the locale for this thread to the application's language
     translation.activate(application.applicant_language)
@@ -402,7 +495,8 @@ def generate_secret_xml_string(application: Application) -> str:
     context = {
         "application": application,
         "benefit_type": "Palkan Helsinki-lisä",
-        "calculation_rows": sub_total_rows,
+        "calculation_periods": calculation_data_for_xml,
+        "total_amount_row": total_amount_row,
         "language": application.applicant_language,
     }
     xml_content = render_to_string("secret_decision.xml", context)

--- a/backend/benefit/applications/services/ahjo_xml_builder.py
+++ b/backend/benefit/applications/services/ahjo_xml_builder.py
@@ -40,7 +40,8 @@ class AhjoPublicXMLBuilder(AhjoXMLBuilder):
         return f"{XML_VERSION}{self.ahjo_decision_text.decision_text}"
 
     def generate_xml_file_name(self) -> str:
-        return f"decision_text_{self.application.application_number}.xml"
+        date_str = self.application.created_at.strftime("%d.%m.%Y")
+        return f"Hakemus {date_str}, päätösteksti, {self.application.application_number}.xml"
 
 
 SECRET_ATTACHMENT_TEMPLATE = "secret_decision.xml"
@@ -156,4 +157,7 @@ class AhjoSecretXMLBuilder(AhjoXMLBuilder):
         }
 
     def generate_xml_file_name(self) -> str:
-        return f"decision_text_secret_{self.application.application_number}.xml"
+        date_str = self.application.created_at.strftime("%d.%m.%Y")
+        return (
+            f"Hakemus {date_str}, liite 1/1, {self.application.application_number}.xml"
+        )

--- a/backend/benefit/applications/services/ahjo_xml_builder.py
+++ b/backend/benefit/applications/services/ahjo_xml_builder.py
@@ -1,0 +1,159 @@
+from dataclasses import dataclass
+from datetime import date
+from typing import List, Tuple
+
+from django.template.loader import render_to_string
+from django.utils import translation
+from django.utils.translation import gettext_lazy as _
+
+from applications.models import AhjoDecisionText, Application
+from calculator.enums import RowType
+from calculator.models import Calculation, CalculationRow
+
+XML_VERSION = "<?xml version='1.0' encoding='UTF-8'?>"
+
+AhjoXMLString = str
+
+
+class AhjoXMLBuilder:
+    def __init__(self, application: Application) -> None:
+        self.application = application
+        self.content_type = "application/xml"
+
+    def generate_xml(self) -> AhjoXMLString:
+        raise NotImplementedError("Subclasses must implement generate_xml")
+
+    def generate_xml_file_name(self) -> str:
+        raise NotImplementedError("Subclasses must implement generate_xml_file_name")
+
+
+class AhjoPublicXMLBuilder(AhjoXMLBuilder):
+    """Generates the XML for the public decision."""
+
+    def __init__(
+        self, application: Application, ahjo_decision_text: AhjoDecisionText
+    ) -> None:
+        super().__init__(application)
+        self.ahjo_decision_text = ahjo_decision_text
+
+    def generate_xml(self) -> AhjoXMLString:
+        return f"{XML_VERSION}{self.ahjo_decision_text.decision_text}"
+
+    def generate_xml_file_name(self) -> str:
+        return f"decision_text_{self.application.application_number}.xml"
+
+
+SECRET_ATTACHMENT_TEMPLATE = "secret_decision.xml"
+
+
+@dataclass
+class BenefitPeriodRow:
+    start_date: date
+    end_date: date
+    amount_per_month: float
+    total_amount: float
+
+
+class AhjoSecretXMLBuilder(AhjoXMLBuilder):
+    def generate_xml(self) -> AhjoXMLString:
+        context = self.get_context_for_secret_xml()
+        # Set the locale for this thread to the application's language
+        translation.activate(self.application.applicant_language)
+
+        xml_content = render_to_string(SECRET_ATTACHMENT_TEMPLATE, context)
+
+        # Reset the locale to the default
+        translation.deactivate()
+        return xml_content
+
+    def _get_period_rows_for_xml(
+        self,
+        calculation: Calculation,
+    ) -> Tuple[CalculationRow, List[CalculationRow],]:
+        total_amount_row = calculation.rows.filter(
+            row_type=RowType.HELSINKI_BENEFIT_TOTAL_EUR
+        ).first()
+
+        row_types_to_list = [
+            RowType.HELSINKI_BENEFIT_MONTHLY_EUR,
+            RowType.HELSINKI_BENEFIT_SUB_TOTAL_EUR,
+        ]
+        calculation_rows = calculation.rows.filter(row_type__in=row_types_to_list)
+        return total_amount_row, calculation_rows
+
+    def _prepare_multiple_period_rows(
+        self,
+        calculation_rows: List[CalculationRow],
+    ) -> List[BenefitPeriodRow]:
+        """In the case  where there are multiple benefit periods,
+        there will be multiple pairs of sub total rows and a corresponding monthly eur rows.
+        Here we prepare the calculation rows per payment period by looping through the calculation rows
+        and parsing the data into a list of BenefitPeriodRows.
+        """
+        calculation_rows_for_xml = []
+
+        for idx, r in enumerate(calculation_rows):
+            # check that we do not go out of bounds
+            if 0 <= idx + 1 < len(calculation_rows):
+                # the dates are in the next row, which is always a sub total row
+                start_date = calculation_rows[idx + 1].start_date
+                end_date = calculation_rows[idx + 1].end_date
+                # get data only from rows that have start_date and end_date
+                if start_date and end_date:
+                    calculation_rows_for_xml.append(
+                        BenefitPeriodRow(
+                            start_date=start_date,
+                            end_date=end_date,
+                            amount_per_month=r.amount,
+                            # the total amount is also in the next row
+                            total_amount=calculation_rows[idx + 1].amount,
+                        )
+                    )
+
+        return calculation_rows_for_xml
+
+    def _prepare_single_period_row(
+        self,
+        calculation_row_per_month: CalculationRow,
+        total_amount_row: CalculationRow,
+    ) -> List[BenefitPeriodRow]:
+        """In the case where there is only one benefit period,
+        we combine the monthly eur row and the salary benefit total row into a single BenefitPeriodRow.
+        """
+        calculation_rows_for_xml = []
+        calculation_rows_for_xml.append(
+            BenefitPeriodRow(
+                start_date=total_amount_row.start_date,
+                end_date=total_amount_row.end_date,
+                amount_per_month=calculation_row_per_month.amount,
+                total_amount=total_amount_row.amount,
+            )
+        )
+        return calculation_rows_for_xml
+
+    def get_context_for_secret_xml(self) -> dict:
+        total_amount_row, calculation_rows = self._get_period_rows_for_xml(
+            self.application.calculation
+        )
+        # If there is only one period, we can combine the monthly eur row and the total row into a single row
+        if (
+            len(calculation_rows) == 1
+            and calculation_rows[0].row_type == RowType.HELSINKI_BENEFIT_MONTHLY_EUR
+        ):
+            calculation_data_for_xml = self._prepare_single_period_row(
+                calculation_rows[0], total_amount_row
+            )
+        else:
+            calculation_data_for_xml = self._prepare_multiple_period_rows(
+                calculation_rows
+            )
+        return {
+            "application": self.application,
+            "benefit_type": _("Salary Benefit"),
+            "calculation_periods": calculation_data_for_xml,
+            "total_amount_row": total_amount_row,
+            "language": self.application.applicant_language,
+        }
+
+    def generate_xml_file_name(self) -> str:
+        return f"decision_text_secret_{self.application.application_number}.xml"

--- a/backend/benefit/applications/templates/secret_decision.xml
+++ b/backend/benefit/applications/templates/secret_decision.xml
@@ -18,35 +18,47 @@
 					<td>{{ application.company.business_id }}</td>
 				</tr>
 				<tr>
-					<th scope="row">{{ _("Employee last name") }}</th>
-					<td>{{ application.employee.last_name }}</td>
-				</tr>
-				<tr>
-					<th scope="row">{{ _("Employee first name") }}</th>
-					<td>{{ application.employee.first_name }}</td>
+					<th scope="row">{{ _("Employee name") }}</th>
+					<td>{{ application.employee.first_name }} {{ application.employee.last_name }}</td>
 				</tr>
 				<tr>
 					<th scope="row">{{ _("Benefit type") }}</th>
 					<td>{{ benefit_type }}</td>
 				</tr>
+
+				<tr>
+					<th scope="row">{{ _("Applying for dates") }}</th>
+					<td>{{ total_amount_row.start_date | date:"d.m.Y" }} - {{ total_amount_row.end_date |date:"d.m.Y" }}</td>
+				</tr>
+				<tr>
+					<th>{{ _("Received aid") }}</th>
+					<td>{{ total_amount_row.amount }} €</td>
+				</tr>
+				{% if application.calculation.granted_as_de_minimis_aid %}
+				<tr>
+					<th>{{ _("Additional information") }}</th>
+					<td>{{ _("De Minimis description") }}</td>
+				</tr>
+				{% endif %}
 			</tbody>
 		</table>
-		<table>
+		<table class="rowbordersonly">
 			<thead>
 				<tr>
 					<th>{{ _("Applying for dates") }}</th>
 					<th>{{ _("Benefit per month") }}</th>
-					<th>{{ _("Total benefit") }}€</th>
+					<th>{{ _("Total benefit") }} </th>
 				</tr>
 			</thead>
 			<tbody>
-			{% for row in calculation_rows %}
+			{% for row in calculation_periods %}
 				<tr>
 					<td>{{ row.start_date|date:"d.m.Y" }} - {{ row.end_date|date:"d.m.Y" }}</td>
-					<td>{{ row.amount }}</td>
-					<th>{{ application.calculation.calculated_benefit_amount }}</th>
+					<td class="sum">{{ row.amount_per_month }} €/kk</td>
+					<td class="sum">{{ row.total_amount }} €</td>
 				</tr>
 			{% endfor %}
+			<tr><th>{{ _("Total for benefit time period") }}</th><td class="sum"><strong>{{ total_amount_row.amount }} €</strong></td></tr>
 			</tbody>
 		</table>
 	</main>

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -7,11 +7,15 @@ import pytest
 from django.conf import settings
 from django.utils import timezone
 
-from applications.enums import ApplicationStatus, BenefitType
+from applications.enums import ApplicationStatus, BenefitType, DecisionType
 from applications.models import Application
+from applications.services.ahjo_decision_service import (
+    replace_decision_template_placeholders,
+)
 from applications.services.applications_csv_report import ApplicationsCsvService
 from applications.tests.factories import (
     AcceptedDecisionProposalFactory,
+    AhjoDecisionTextFactory,
     ApplicationBatchFactory,
     ApplicationFactory,
     CancelledApplicationFactory,
@@ -408,6 +412,20 @@ def accepted_ahjo_decision_section():
 @pytest.fixture()
 def denied_ahjo_decision_section():
     return DeniedDecisionProposalFactory()
+
+
+@pytest.fixture()
+def accepted_ahjo_decision_text(decided_application):
+    template = AcceptedDecisionProposalFactory()
+    replaced_decision_text = replace_decision_template_placeholders(
+        template.template_text, decided_application
+    )
+    return AhjoDecisionTextFactory(
+        decision_type=DecisionType.ACCEPTED,
+        application=decided_application,
+        decision_text=replaced_decision_text,
+        language=decided_application.applicant_language,
+    )
 
 
 def split_lines_at_semicolon(csv_string):

--- a/backend/benefit/applications/tests/factories.py
+++ b/backend/benefit/applications/tests/factories.py
@@ -15,6 +15,7 @@ from applications.enums import (
 )
 from applications.models import (
     AhjoDecision,
+    AhjoDecisionText,
     Application,
     APPLICATION_LANGUAGE_CHOICES,
     ApplicationBasis,
@@ -30,6 +31,11 @@ from calculator.models import Calculation
 from companies.tests.factories import CompanyFactory
 from shared.service_bus.enums import YtjOrganizationCode
 from users.tests.factories import BFHandlerUserFactory
+
+
+class AhjoDecisionTextFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = AhjoDecisionText
 
 
 class AttachmentFactory(factory.django.DjangoModelFactory):

--- a/backend/benefit/applications/tests/test_ahjo_decisions.py
+++ b/backend/benefit/applications/tests/test_ahjo_decisions.py
@@ -8,9 +8,6 @@ from applications.models import AhjoDecisionText
 from applications.services.ahjo_decision_service import (
     replace_decision_template_placeholders,
 )
-from applications.services.ahjo_integration import generate_secret_xml_string
-from calculator.enums import RowType
-from calculator.tests.factories import CalculationRowFactory
 
 
 def test_replace_accepted_decision_template_placeholders(
@@ -85,33 +82,6 @@ def test_handler_gets_the_template_sections(
             == DecisionProposalTemplateSectionType.DECISION_SECTION
         ):
             assert decided_application.company.name in template.template_text
-
-
-def test_secret_xml_decision_string(decided_application):
-    calculation = decided_application.calculation
-    row = CalculationRowFactory(
-        calculation=calculation,
-        row_type=RowType.HELSINKI_BENEFIT_SUB_TOTAL_EUR,
-        ordering=4,
-    )
-
-    row.start_date = calculation.start_date
-    row.end_date = calculation.end_date
-    row.save()
-
-    xml_string = generate_secret_xml_string(decided_application)
-
-    wanted_replacements = [
-        str(decided_application.application_number),
-        decided_application.company.name,
-        decided_application.company.business_id,
-        decided_application.employee.last_name,
-        decided_application.employee.first_name,
-        f"{row.start_date.strftime('%d.%m.%Y')} - {row.end_date.strftime('%d.%m.%Y')}",
-        str(row.amount),
-        str(calculation.calculated_benefit_amount),
-    ]
-    assert all([replacement in xml_string for replacement in wanted_replacements])
 
 
 def get_decisions_list_url(application_id: uuid) -> str:

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -28,7 +28,6 @@ from applications.services.ahjo_integration import (
     ExportFileInfo,
     generate_application_attachment,
     generate_composed_files,
-    generate_secret_xml_string,
     generate_single_approved_file,
     generate_single_declined_file,
     get_application_for_ahjo,
@@ -658,17 +657,6 @@ def test_get_applications_for_open_case(
     # only handled_applications should be returned as their last  AhjoStatus is SUBMITTED_BUT_NOT_SENT_TO_AHJO
     # and their application status is HANDLING
     assert applications_for_open_case.count() == len(multiple_handling_applications)
-
-
-@pytest.mark.django_db
-def test_generate_secret_xml_string(decided_application):
-    application = decided_application
-    xml_content = generate_secret_xml_string(application)
-
-    wanted_language = application.applicant_language
-
-    # Check if the returned XML string contains the expected content
-    assert f'<main id="paatoksenliite" lang="{wanted_language}">' in xml_content
 
 
 @pytest.mark.django_db

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -599,10 +599,7 @@ def test_generate_ahjo_public_decision_text_xml(decided_application):
     assert attachment.application == decided_application
     assert attachment.content_type == "application/xml"
     assert attachment.attachment_type == AttachmentType.DECISION_TEXT_XML
-    assert (
-        attachment.attachment_file.name
-        == f"decision_text_{decided_application.application_number}.xml"
-    )
+
     assert attachment.attachment_file.size > 0
     assert os.path.exists(attachment.attachment_file.path)
     if os.path.exists(attachment.attachment_file.path):
@@ -619,10 +616,7 @@ def test_generate_ahjo_secret_decision_text_xml(decided_application):
     assert attachment.application == decided_application
     assert attachment.content_type == "application/xml"
     assert attachment.attachment_type == AttachmentType.DECISION_TEXT_SECRET_XML
-    assert (
-        attachment.attachment_file.name
-        == f"decision_text_secret_{decided_application.application_number}.xml"
-    )
+
     assert attachment.attachment_file.size > 0
     assert os.path.exists(attachment.attachment_file.path)
     if os.path.exists(attachment.attachment_file.path):

--- a/backend/benefit/applications/tests/test_ahjo_xml_builder.py
+++ b/backend/benefit/applications/tests/test_ahjo_xml_builder.py
@@ -1,0 +1,248 @@
+from datetime import timedelta
+
+import pytest
+
+from applications.services.ahjo_xml_builder import (
+    AhjoPublicXMLBuilder,
+    AhjoSecretXMLBuilder,
+    BenefitPeriodRow,
+)
+from calculator.enums import RowType
+from calculator.models import CalculationRow
+from calculator.tests.factories import CalculationRowFactory
+
+
+@pytest.fixture
+def calculation(decided_application):
+    calculation = decided_application.calculation
+    calculation.rows.all().delete()
+    return calculation
+
+
+@pytest.fixture
+def secret_xml_builder(decided_application):
+    return AhjoSecretXMLBuilder(decided_application)
+
+
+@pytest.fixture
+def public_xml_builder(decided_application, accepted_ahjo_decision_text):
+    return AhjoPublicXMLBuilder(decided_application, accepted_ahjo_decision_text)
+
+
+@pytest.fixture
+def monthly_row_1(calculation, ordering: int = 3):
+    return CalculationRowFactory(
+        calculation=calculation,
+        row_type=RowType.HELSINKI_BENEFIT_MONTHLY_EUR,
+        ordering=ordering,
+        start_date=None,
+        end_date=None,
+    )
+
+
+@pytest.fixture
+def sub_total_row_1(calculation, ordering: int = 4):
+    return CalculationRowFactory(
+        calculation=calculation,
+        row_type=RowType.HELSINKI_BENEFIT_SUB_TOTAL_EUR,
+        ordering=ordering,
+        start_date=calculation.start_date,
+        end_date=calculation.start_date + timedelta(days=30),
+    )
+
+
+@pytest.fixture
+def monthly_row_2(calculation, ordering: int = 5):
+    return CalculationRowFactory(
+        calculation=calculation,
+        row_type=RowType.HELSINKI_BENEFIT_MONTHLY_EUR,
+        ordering=ordering,
+        start_date=None,
+        end_date=None,
+    )
+
+
+@pytest.fixture
+def sub_total_row_2(calculation, ordering: int = 6):
+    return CalculationRowFactory(
+        calculation=calculation,
+        row_type=RowType.HELSINKI_BENEFIT_SUB_TOTAL_EUR,
+        ordering=ordering,
+        start_date=calculation.start_date + timedelta(days=31),
+        end_date=calculation.end_date,
+    )
+
+
+@pytest.fixture
+def total_eur_row(calculation, ordering: int = 8):
+    return CalculationRowFactory(
+        calculation=calculation,
+        row_type=RowType.HELSINKI_BENEFIT_TOTAL_EUR,
+        ordering=ordering,
+        start_date=calculation.start_date,
+        end_date=calculation.end_date,
+    )
+
+
+@pytest.mark.django_db
+def test_generate_secret_xml_string(decided_application, secret_xml_builder):
+    application = decided_application
+    xml_content = secret_xml_builder.generate_xml()
+
+    wanted_language = application.applicant_language
+
+    # Check if the returned XML string contains the expected content
+    assert f'<main id="paatoksenliite" lang="{wanted_language}">' in xml_content
+
+
+@pytest.mark.django_db
+def test_generate_public_xml_string(accepted_ahjo_decision_text, public_xml_builder):
+    xml_content = public_xml_builder.generate_xml()
+    wanted_decision_text = accepted_ahjo_decision_text.decision_text
+
+    # Check if the returned XML string contains the expected content
+    assert wanted_decision_text in xml_content
+
+
+def test_public_xml_file_name(decided_application, public_xml_builder):
+    application = decided_application
+    xml_file_name = public_xml_builder.generate_xml_file_name()
+
+    wanted_file_name = f"decision_text_{application.application_number}.xml"
+
+    assert xml_file_name == wanted_file_name
+
+
+def test_secret_xml_decision_string(decided_application, secret_xml_builder):
+    calculation = decided_application.calculation
+    row = CalculationRowFactory(
+        calculation=calculation,
+        row_type=RowType.HELSINKI_BENEFIT_SUB_TOTAL_EUR,
+        ordering=4,
+        start_date=calculation.start_date,
+        end_date=calculation.end_date,
+    )
+
+    xml_string = secret_xml_builder.generate_xml()
+
+    wanted_replacements = [
+        str(decided_application.application_number),
+        decided_application.company.name,
+        decided_application.company.business_id,
+        decided_application.employee.last_name,
+        decided_application.employee.first_name,
+        f"{row.start_date.strftime('%d.%m.%Y')} - {row.end_date.strftime('%d.%m.%Y')}",
+        str(row.amount),
+        str(calculation.calculated_benefit_amount),
+    ]
+    assert all([replacement in xml_string for replacement in wanted_replacements])
+
+
+def test_secret_xml_file_name(decided_application, secret_xml_builder):
+    application = decided_application
+    xml_file_name = secret_xml_builder.generate_xml_file_name()
+
+    wanted_file_name = f"decision_text_secret_{application.application_number}.xml"
+
+    assert xml_file_name == wanted_file_name
+
+
+@pytest.mark.django_db
+def test_get_period_rows_for_xml(
+    decided_application,
+    secret_xml_builder,
+    monthly_row_1,
+    sub_total_row_1,
+    total_eur_row,
+):
+    total_amount_row, calculation_rows = secret_xml_builder._get_period_rows_for_xml(
+        decided_application.calculation
+    )
+
+    assert total_eur_row == total_amount_row
+    assert len(calculation_rows) == 2
+    assert sub_total_row_1 in calculation_rows
+    assert monthly_row_1 in calculation_rows
+
+
+def test_prepare_multiple_period_rows(
+    secret_xml_builder, monthly_row_1, sub_total_row_1, monthly_row_2, sub_total_row_2
+):
+    calculation_rows = [monthly_row_1, sub_total_row_1, monthly_row_2, sub_total_row_2]
+
+    period_rows = secret_xml_builder._prepare_multiple_period_rows(calculation_rows)
+
+    assert len(period_rows) == 2
+    assert period_rows[0].start_date == sub_total_row_1.start_date
+    assert period_rows[0].end_date == sub_total_row_1.end_date
+    assert period_rows[0].amount_per_month == monthly_row_1.amount
+    assert period_rows[0].total_amount == sub_total_row_1.amount
+
+    assert period_rows[1].start_date == sub_total_row_2.start_date
+    assert period_rows[1].end_date == sub_total_row_2.end_date
+    assert period_rows[1].amount_per_month == monthly_row_2.amount
+    assert period_rows[1].total_amount == sub_total_row_2.amount
+
+
+def test_prepare_single_period_row(secret_xml_builder, monthly_row_1, total_eur_row):
+    period_rows = secret_xml_builder._prepare_single_period_row(
+        monthly_row_1, total_eur_row
+    )
+
+    assert len(period_rows) == 1
+    assert period_rows[0].start_date == total_eur_row.start_date
+    assert period_rows[0].end_date == total_eur_row.end_date
+    assert period_rows[0].amount_per_month == monthly_row_1.amount
+    assert period_rows[0].total_amount == total_eur_row.amount
+
+
+def test_get_context_for_secret_xml_with_single_period(
+    decided_application, monthly_row_1, total_eur_row, secret_xml_builder
+):
+    context = secret_xml_builder.get_context_for_secret_xml()
+
+    assert context["application"] == decided_application
+    assert len(context["calculation_periods"]) == 1
+    assert isinstance(context["calculation_periods"][0], BenefitPeriodRow)
+    assert context["calculation_periods"][0].start_date == total_eur_row.start_date
+    assert context["calculation_periods"][0].end_date == total_eur_row.end_date
+    assert context["calculation_periods"][0].amount_per_month == monthly_row_1.amount
+    assert context["calculation_periods"][0].total_amount == total_eur_row.amount
+    assert context["language"] == decided_application.applicant_language
+    assert isinstance(context["total_amount_row"], CalculationRow)
+    assert context["total_amount_row"] == total_eur_row
+
+
+def test_get_context_for_secret_xml_with_multiple_periods(
+    calculation, decided_application, monthly_row_1, sub_total_row_1, secret_xml_builder
+):
+    monthly_row_2 = CalculationRowFactory(
+        calculation=calculation,
+        row_type=RowType.HELSINKI_BENEFIT_MONTHLY_EUR,
+        ordering=6,
+        start_date=None,
+        end_date=None,
+    )
+
+    sub_total_row_2 = CalculationRowFactory(
+        calculation=calculation,
+        row_type=RowType.HELSINKI_BENEFIT_SUB_TOTAL_EUR,
+        ordering=7,
+        start_date=calculation.start_date + timedelta(days=31),
+        end_date=calculation.end_date,
+    )
+
+    context = secret_xml_builder.get_context_for_secret_xml()
+
+    assert context["application"] == decided_application
+    assert len(context["calculation_periods"]) == 2
+    assert isinstance(context["calculation_periods"][0], BenefitPeriodRow)
+    assert context["calculation_periods"][0].start_date == sub_total_row_1.start_date
+    assert context["calculation_periods"][0].end_date == sub_total_row_1.end_date
+    assert context["calculation_periods"][0].amount_per_month == monthly_row_1.amount
+    assert context["calculation_periods"][0].total_amount == sub_total_row_1.amount
+    assert isinstance(context["calculation_periods"][1], BenefitPeriodRow)
+    assert context["calculation_periods"][1].start_date == sub_total_row_2.start_date
+    assert context["calculation_periods"][1].end_date == sub_total_row_2.end_date
+    assert context["calculation_periods"][1].amount_per_month == monthly_row_2.amount
+    assert context["calculation_periods"][1].total_amount == sub_total_row_2.amount

--- a/backend/benefit/applications/tests/test_ahjo_xml_builder.py
+++ b/backend/benefit/applications/tests/test_ahjo_xml_builder.py
@@ -108,7 +108,8 @@ def test_public_xml_file_name(decided_application, public_xml_builder):
     application = decided_application
     xml_file_name = public_xml_builder.generate_xml_file_name()
 
-    wanted_file_name = f"decision_text_{application.application_number}.xml"
+    wanted_file_name = f"Hakemus {application.created_at.strftime('%d.%m.%Y')}, \
+päätösteksti, {application.application_number}.xml"
 
     assert xml_file_name == wanted_file_name
 
@@ -142,7 +143,8 @@ def test_secret_xml_file_name(decided_application, secret_xml_builder):
     application = decided_application
     xml_file_name = secret_xml_builder.generate_xml_file_name()
 
-    wanted_file_name = f"decision_text_secret_{application.application_number}.xml"
+    wanted_file_name = f"Hakemus {application.created_at.strftime('%d.%m.%Y')}, \
+liite 1/1, {application.application_number}.xml"
 
     assert xml_file_name == wanted_file_name
 

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -1382,11 +1382,17 @@ msgstr "tuki yhteensä"
 msgid "Benefit per month"
 msgstr "tuki/kk"
 
-msgid "Employee first name"
-msgstr "Työllistetyn etunimi"
+msgid "Employee name"
+msgstr "Työllistetyn nimi"
 
-msgid "Employee last name"
-msgstr "Työllistetyn sukunimi"
+msgid "Additional information"
+msgstr "Lisätietoja"
+
+msgid "De Minimis description"
+msgstr "Tuki myönnetään vähämerkityksisenä eli de minimis-tukena"
+
+msgid "Total for benefit time period"
+msgstr "Yhteensä koko tukiajalta"
 
 #~ msgid "applicant"
 #~ msgstr "hakija"

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -1394,16 +1394,22 @@ msgid "Benefit type"
 msgstr "Typ av förmån"
 
 msgid "Total benefit"
-msgstr "total förmån"
+msgstr "Total förmån"
 
 msgid "Benefit per month"
-msgstr "förmån per månad"
+msgstr "Förmån per månad"
 
-msgid "Employee first name"
-msgstr "anställdas förnamn"
+msgid "Employee name"
+msgstr "Den anställdes namn"
 
-msgid "Employee last name"
-msgstr "anställdas efternamn"
+msgid "Additional information"
+msgstr "Ytterligare information"
+
+msgid "De Minimis description"
+msgstr "Stödet beviljas som stöd av mindre betydelse"
+
+msgid "Total for benefit time period"
+msgstr "Totalt för hela perioden"
 
 #~ msgid "applicant"
 #~ msgstr "sökande"


### PR DESCRIPTION
## Description :sparkles:
[HL-1207](https://helsinkisolutionoffice.atlassian.net/browse/HL-1207?atlOrigin=eyJpIjoiYWZhYmYzNjIyYWUyNDk5MzhiYjU0ZmNlZTYxMDIxYTMiLCJwIjoiaiJ9) format the secret decision XML according to the new design (see screenshots).

Refactor the XML building to a class, as ahjo_integration.py is already doing way too much stuff.
Add more tests for the XML strings.

[HL-1242](https://helsinkisolutionoffice.atlassian.net/browse/HL-1242?atlOrigin=eyJpIjoiMmFkOGRlYmVjYWIyNGIwOTljNzExNDBkZTZlMTEzMjMiLCJwIjoiaiJ9) Rename the generated XML files to format requested by AHJO.

## Issues :bug:

## Testing :alembic
`pytest applications/tests/test_ahjo_xml_builder.py`
To manually check what kind of XML files are created run
`python manage.py shell_plus`
`from applications.services.ahjo_integration import generate_application_attachment`
`from applications.enums import AttachmentType`
`app = Application.objects.get(pk="some_accepted_application_id")`
`generate_application_attachment(app, AttachmentType.DECISION_TEXT_SECRET_XML)`
the xml file is then found at `/var/media `folder.
## Screenshots :camera_flash:
<img width="467" alt="Screenshot 2024-03-27 at 15 35 02" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/5c660bad-610c-4c34-9781-a1508be04974">
<img width="534" alt="Screenshot 2024-03-27 at 15 34 51" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/a49540b2-5845-47ea-ae09-a9aa93063087">

## Additional notes :spiral_notepad:


[HL-1207]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-1242]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ