### PR TITLE
fix: defer accepted/rejected status until the decision has been accepted in Ahjo (HL-1241)

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1402,11 +1402,23 @@ class ApplicantApplicationStatusChoiceField(serializers.ChoiceField):
         ApplicationStatus.RECEIVED: ApplicationStatus.HANDLING,
     }
 
-    def to_representation(self, value):
+    def get_attribute(self, obj):
+        return obj
+
+    def to_representation(self, application):
         """
         Transform the *outgoing* native value into primitive data.
         """
+
+        value = getattr(application, self.field_name)
         value_shown_to_applicant = self.STATUS_OVERRIDES.get(value, value)
+
+        if (
+            value in [ApplicationStatus.REJECTED, ApplicationStatus.ACCEPTED]
+            and not application.is_accepted_in_ahjo
+        ):
+            value_shown_to_applicant = ApplicationStatus.HANDLING
+
         return super().to_representation(value_shown_to_applicant)
 
 

--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -447,6 +447,18 @@ class Application(UUIDModel, TimeStampedModel, DurationMixin):
         else:
             return None
 
+    @property
+    def is_accepted_in_ahjo(self):
+        if self.batch is not None:
+            return self.batch.status in [
+                ApplicationBatchStatus.DECIDED_ACCEPTED,
+                ApplicationBatchStatus.DECIDED_REJECTED,
+                ApplicationBatchStatus.SENT_TO_TALPA,
+                ApplicationBatchStatus.COMPLETED,
+            ]
+        else:
+            return False
+
     def __str__(self):
         return "{}: {} {} {}-{}".format(
             self.pk, self.company_name, self.status, self.start_date, self.end_date


### PR DESCRIPTION
## Additional notes :spiral_notepad:
Only includes the old batch based solution as discussed. Checks for both this and for applicant-side archive status according to the new Ahjo integration will be implemented later.