### PR TITLE
fix: no apprenticeship information should be required for applicant without pay subsidy (HL-1257)

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -60,8 +60,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
 
   useDependentFieldsEffect(
     {
-      apprenticeshipProgram: formik.values.apprenticeshipProgram,
-      benefitType: formik.values.benefitType,
       paySubsidyGranted: formik.values.paySubsidyGranted,
       associationHasBusinessActivities:
         formik.values.associationHasBusinessActivities,

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
@@ -3,7 +3,10 @@ import useFormActions from 'benefit/applicant/hooks/useFormActions';
 import useUpdateApplicationQuery from 'benefit/applicant/hooks/useUpdateApplicationQuery';
 import { useTranslation } from 'benefit/applicant/i18n';
 import { getApplicationStepString } from 'benefit/applicant/utils/common';
-import { APPLICATION_STATUSES } from 'benefit-shared/constants';
+import {
+  APPLICATION_STATUSES,
+  PAY_SUBSIDY_GRANTED,
+} from 'benefit-shared/constants';
 import { Application, ApplicationData } from 'benefit-shared/types/application';
 import { useRouter } from 'next/router';
 import { TFunction } from 'next-i18next';
@@ -99,6 +102,10 @@ const useApplicationFormStep5 = (
       {
         ...application,
         ...submitFields,
+        apprenticeshipProgram:
+          application?.paySubsidyGranted === PAY_SUBSIDY_GRANTED.NOT_GRANTED
+            ? null
+            : application?.apprenticeshipProgram,
         calculation: application.calculation
           ? {
               ...application.calculation,

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step6/useApplicationFormStep6.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step6/useApplicationFormStep6.ts
@@ -4,6 +4,7 @@ import useUpdateApplicationQuery from 'benefit/applicant/hooks/useUpdateApplicat
 import { useTranslation } from 'benefit/applicant/i18n';
 import {
   APPLICATION_STATUSES,
+  PAY_SUBSIDY_GRANTED,
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
 import {
@@ -92,6 +93,10 @@ const useApplicationFormStep6 = (
                 (consent) => consent.id
               ),
           },
+          apprenticeshipProgram:
+            application?.paySubsidyGranted === PAY_SUBSIDY_GRANTED.NOT_GRANTED
+              ? null
+              : application?.apprenticeshipProgram,
           status:
             application.status === APPLICATION_STATUSES.DRAFT
               ? APPLICATION_STATUSES.RECEIVED

--- a/frontend/benefit/applicant/src/hooks/useDependentFieldsEffect.ts
+++ b/frontend/benefit/applicant/src/hooks/useDependentFieldsEffect.ts
@@ -1,10 +1,8 @@
-import { BENEFIT_TYPES, PAY_SUBSIDY_GRANTED } from 'benefit-shared/constants';
+import { PAY_SUBSIDY_GRANTED } from 'benefit-shared/constants';
 import React from 'react';
 
 interface FieldValues {
   useAlternativeAddress?: boolean | null;
-  apprenticeshipProgram?: boolean | null;
-  benefitType?: BENEFIT_TYPES | '';
   paySubsidyGranted?: PAY_SUBSIDY_GRANTED | null;
   associationHasBusinessActivities?: boolean | null;
   startDate?: string;
@@ -46,8 +44,6 @@ type State = EFFECTS[];
 export const useDependentFieldsEffect = (
   {
     useAlternativeAddress,
-    apprenticeshipProgram,
-    benefitType,
     paySubsidyGranted,
     associationHasBusinessActivities,
     startDate,
@@ -118,13 +114,6 @@ export const useDependentFieldsEffect = (
       );
     }
   }, [paySubsidyGranted]);
-
-  // Effects when apprenticeshipProgram changes
-  React.useEffect(() => {
-    if (benefitType === BENEFIT_TYPES.COMMISSION && apprenticeshipProgram) {
-      dispatch(createUpdateAction([EFFECTS.CLEAR_BENEFIT_VALUES]));
-    }
-  }, [apprenticeshipProgram, benefitType]);
 
   // Effects when associationHasBusinessActivities changes
   React.useEffect(() => {


### PR DESCRIPTION
## Description :sparkles:

Clicking pay subsidy and apprenticeship selection in GUI resulted to situation where apprenticeship is required even if pay subsidy type is selected as "no pay subsidy". Force the value to the backend as selecting null with formik/yup/radio is a serious PITA. 

Also removed some old code from days when there were more benefit types than just 1 (salary). 