### PR TITLE
fix: justify th elements to the right

### DIFF
--- a/backend/benefit/applications/templates/secret_decision.xml
+++ b/backend/benefit/applications/templates/secret_decision.xml
@@ -47,8 +47,8 @@
 			<thead>
 				<tr>
 					<th>{{ _("Applying for dates") }}</th>
-					<th>{{ _("Benefit per month") }}</th>
-					<th>{{ _("Total benefit") }} </th>
+					<th class="sum">{{ _("Benefit per month") }}</th>
+					<th class="sum">{{ _("Total benefit") }} </th>
 				</tr>
 			</thead>
 			<tbody>


### PR DESCRIPTION
## Description :sparkles:
Justify two th elements to the right in the secret xml attachment.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
