### PR TITLE
test(backend): option to reseed each test file and single test

### DIFF
--- a/backend/benefit/applications/tests/before_after.py
+++ b/backend/benefit/applications/tests/before_after.py
@@ -1,0 +1,21 @@
+import os
+
+from common.tests.conftest import reseed
+
+
+def before_test_reseed(no_reseed_for_tests: list[str] = []):
+    """
+    Tests would fail in CI if same seed is used throughout all tests.
+    Factories create too many similar objects and database will fail on unique
+    constraints. Use fixture to reseed before each test to avoid this issue.
+
+    :param no_reseed_for_tests: list of test names that should use the default seed defined in conftest.py
+    """
+    current_test = os.environ.get("PYTEST_CURRENT_TEST")
+
+    for test in no_reseed_for_tests:
+        if test in current_test:
+            print("passing reseed")
+        else:
+            print("reseeding with", current_test)
+            reseed(current_test)

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -52,6 +52,14 @@ DE_MINIMIS_AID_PARTIAL_TEXT = (
 )
 
 
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests():
+    from applications.tests.before_after import before_test_reseed
+
+    before_test_reseed([])
+    yield
+
+
 def _assert_html_content(html, include_keys=(), excluded_keys=()):
     for k in include_keys:
         assert k in html

--- a/backend/benefit/applications/tests/test_application_batch_api.py
+++ b/backend/benefit/applications/tests/test_application_batch_api.py
@@ -25,6 +25,14 @@ from applications.tests.faker import get_faker
 from applications.tests.test_applications_api import get_handler_detail_url
 
 
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests():
+    from applications.tests.before_after import before_test_reseed
+
+    before_test_reseed([])
+    yield
+
+
 def get_valid_batch_completion_data():
     return {
         "decision_maker_title": get_faker().job(),

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -56,7 +56,7 @@ from applications.tests.factories import (
 from calculator.models import Calculation
 from calculator.tests.conftest import fill_empty_calculation_fields
 from common.tests.conftest import *  # noqa
-from common.tests.conftest import get_client_user, reseed
+from common.tests.conftest import get_client_user
 from common.utils import duration_in_months
 from companies.tests.conftest import *  # noqa
 from companies.tests.factories import CompanyFactory
@@ -69,6 +69,14 @@ from shared.audit_log import models as audit_models
 from shared.service_bus.enums import YtjOrganizationCode
 from terms.models import TermsOfServiceApproval
 from terms.tests.conftest import *  # noqa
+
+
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests():
+    from applications.tests.before_after import before_test_reseed
+
+    before_test_reseed(["test_application_history_change_sets_for_handler"])
+    yield
 
 
 def get_detail_url(application):
@@ -2334,7 +2342,6 @@ def test_handler_application_filter_archived(handler_api_client):
 
 def test_application_pdf_print(api_client, application):
     settings.NEXT_PUBLIC_MOCK_FLAG = False  # noqa
-    reseed(12345)
 
     # Can access own applications
     response = api_client.get(
@@ -2345,7 +2352,6 @@ def test_application_pdf_print(api_client, application):
 
 def test_application_pdf_print_denied(api_client, anonymous_client):
     settings.NEXT_PUBLIC_MOCK_FLAG = False  # noqa
-    reseed(12345)
 
     application = DecidedApplicationFactory()
 

--- a/backend/benefit/applications/tests/test_applications_report.py
+++ b/backend/benefit/applications/tests/test_applications_report.py
@@ -28,10 +28,17 @@ from applications.tests.conftest import split_lines_at_semicolon
 from applications.tests.factories import DecidedApplicationFactory, DeMinimisAidFactory
 from calculator.tests.factories import PaySubsidyFactory
 from common.tests.conftest import *  # noqa
-from common.tests.conftest import reseed
 from companies.tests.conftest import *  # noqa
 from helsinkibenefit.tests.conftest import *  # noqa
 from terms.tests.conftest import *  # noqa
+
+
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests():
+    from applications.tests.before_after import before_test_reseed
+
+    before_test_reseed([])
+    yield
 
 
 def get_filenames_grouped_by_extension_from_zip(
@@ -191,7 +198,6 @@ def test_applications_csv_export_new_applications(handler_api_client):
         expected_without_quotes=True,
     )
     assert ApplicationBatch.objects.all().count() == 2
-    reseed(777)
 
 
 def test_applications_csv_export_without_calculation(


### PR DESCRIPTION
## Description :sparkles:

Get rid of seeding issues. Sometimes we're running into unique constrains when factory generates similar objects in CI. Prevent that by using a "before each" reseed function. 

Reseed itself uses the test file's name as time is frozen and `random` gives the tame value every time.

Idea is that you'd use a snippet for a file once a test starts acting out:

```
@pytest.fixture(autouse=True)
def run_before_and_after_tests():
    from applications.tests.before_after import before_test_reseed

    # Before test
    before_test_reseed(["test_skip_this_test_definition"])
    yield  # actual test run
```

That way the reseeding is controlled and can be enabled for each test case. A single test can also be excluded from reseed by giving `before_test_reseed` a list of test names (here, `test_skip_this_test_definition`). This gives backwards compability. Some tests were failing when reseeding was done for each test.

The results seem promising, I've been looping a test run for some time now without the unique constrain issues.

![pytests](https://github.com/City-of-Helsinki/yjdh/assets/5328394/6dbd161c-cddb-40a0-a922-607173dfc3cb)

