### PR TITLE
chore: fix missing backend translations

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/attachment.py
+++ b/backend/benefit/applications/api/v1/serializers/attachment.py
@@ -137,6 +137,7 @@ class AttachmentSerializer(serializers.ModelSerializer):
             raise ClamAvServiceUnavailableException()
         except FileInfectedException as fie:
             log.error(f"File '{fie.file_name}' infected, viruses: {fie.viruses}")
+            translation_text = _("File is infected with")
             raise serializers.ValidationError(
-                f'{_("File is infected with")} {", ".join(fie.viruses)}'
+                f'{translation_text} {", ".join(fie.viruses)}'
             )

--- a/backend/benefit/applications/enums.py
+++ b/backend/benefit/applications/enums.py
@@ -218,3 +218,21 @@ class ApplicationAlterationState(models.TextChoices):
     RECEIVED = "received", _("Received")
     OPENED = "opened", _("Opened")
     HANDLED = "handled", _("Handled")
+
+
+# Call gettext on some of the enums so that "makemessages" command can find them when used dynamically in templates
+_("granted")
+_("granted_aged")
+_("not_granted")
+
+_("employment_contract")
+_("pay_subsidy_decision")
+_("commission_contract")
+_("education_contract")
+_("helsinki_benefit_voucher")
+_("employee_consent")
+_("full_application")
+_("other_attachment")
+_("pdf_summary")
+_("decision_text_xml")
+_("decision_text_secret_xml")

--- a/backend/benefit/applications/templates/application.html
+++ b/backend/benefit/applications/templates/application.html
@@ -203,7 +203,7 @@
                 {% if application.association_has_business_activities%}
                 <div class="row">
                     <div class="label">
-                        {{ _("Yhdistyksellä on yritystoimintaa") }}</div>
+                        {{ _("Association has business activities") }}</div>
                     <div class="value">{{ _("Yes") }}</div>
                 </div>
                 {%endif%}
@@ -248,20 +248,20 @@
             {% comment %}
             {% if application.handled_at %}
             <div class="row">
-                <div class="label">{{ _("Päätöksen päivämäärä") }}</div>
+                <div class="label">{{ _("Handled at date") }}</div>
                 <div class="value">{{ application.handled_at | date_fi }}</div>
             </div>
             {% endif %}
             {% if application.calculation.handler_details %}
             <div class="row">
-                <div class="label">{{ _("Käsittelijä") }}</div>
+                <div class="label">{{ _("Handler") }}</div>
                 <div class="value">{{ application.calculation.handler_details.first_name}} {{ application.calculation.handler_details.last_name}}</div>
                 {%endif%}
 
                 {% if application.status == "accepted" %}
                 <div class="row force-column">
-                    <div class="label">{{ _("Myönnetään de minimis -tukena") }}</div>
-                    <div class="value">{% if application.calculation.granted_as_de_minimis_aid %}Kyllä{% else %}Ei{%endif%}</div>
+                    <div class="label">{{ _("Granted as de minimis aid") }}</div>
+                    <div class="value">{% if application.calculation.granted_as_de_minimis_aid %}{{ _("Yes") }}{% else %}{{ _("No") }}{%endif%}</div>
                 </div>
                 {% endif %}
             {% endcomment %}

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -224,7 +224,17 @@ ROOT_URLCONF = "helsinkibenefit.urls"
 WSGI_APPLICATION = "helsinkibenefit.wsgi.application"
 
 LANGUAGE_CODE = "fi"
-LANGUAGES = (("fi", _("Finnish")), ("en", _("English")), ("sv", _("Swedish")))
+LANGUAGES = (
+    ("fi", _("Finnish")),
+    ("en", _("English")),
+    ("sv", _("Swedish")),
+)
+
+# Call gettext on languages so that "makemessages" command can find them when used dynamically in templates
+_("fi")
+_("en")
+_("sv")
+
 TIME_ZONE = "Europe/Helsinki"
 USE_I18N = True
 USE_L10N = True

--- a/backend/benefit/locale/en/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-26 12:21+0200\n"
+"POT-Creation-Date: 2024-04-09 11:23+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -268,14 +268,20 @@ msgstr ""
 msgid "Invalid application status change"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "Employment Benefit"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "Salary Benefit"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
+#, fuzzy
+#| msgid "education_contract"
 msgid "Commission Benefit"
-msgstr ""
+msgstr "Agreement on providing apprenticeship training"
 
 msgid "Step 1 - company details"
 msgstr ""
@@ -295,26 +301,36 @@ msgstr ""
 msgid "Step 6 - terms and send"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "Company"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "Association"
 msgstr ""
 
+#, fuzzy
+#| msgid "employment_contract"
 msgid "employment contract"
-msgstr ""
+msgstr "Employment contract"
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "pay subsidy decision"
-msgstr ""
+msgstr "Pay subsidy decision"
 
+#, fuzzy
+#| msgid "education_contract"
 msgid "commission contract"
-msgstr ""
+msgstr "Agreement on providing apprenticeship training"
 
 msgid "education contract of the apprenticeship office"
 msgstr ""
 
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
 msgid "helsinki benefit voucher"
-msgstr ""
+msgstr "The Helsinki Benefit card"
 
 #, fuzzy
 #| msgid "employee_consent"
@@ -378,14 +394,20 @@ msgstr ""
 msgid "Applicant"
 msgstr ""
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "Pay subsidy granted (default)"
-msgstr ""
+msgstr "Pay subsidy decision"
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "Pay subsidy granted (aged)"
-msgstr ""
+msgstr "Pay subsidy decision"
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "No granted pay subsidy"
-msgstr ""
+msgstr "Pay subsidy decision"
 
 msgid "Submitted but not sent to AHJO"
 msgstr ""
@@ -449,8 +471,10 @@ msgstr ""
 msgid "An accepted decision"
 msgstr ""
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "A denied decision"
-msgstr ""
+msgstr "Pay subsidy decision"
 
 msgid "Termination"
 msgstr ""
@@ -464,6 +488,54 @@ msgstr ""
 msgid "Handled"
 msgstr ""
 
+#, fuzzy
+#| msgid "not_granted"
+msgid "granted"
+msgstr "None"
+
+msgid "granted_aged"
+msgstr "Employment aid for people aged 55 and above"
+
+msgid "not_granted"
+msgstr "None"
+
+msgid "employment_contract"
+msgstr "Employment contract"
+
+msgid "pay_subsidy_decision"
+msgstr "Pay subsidy decision"
+
+#, fuzzy
+#| msgid "education_contract"
+msgid "commission_contract"
+msgstr "Agreement on providing apprenticeship training"
+
+msgid "education_contract"
+msgstr "Agreement on providing apprenticeship training"
+
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
+msgid "helsinki_benefit_voucher"
+msgstr "The Helsinki Benefit card"
+
+msgid "employee_consent"
+msgstr "Employee's consent for processing personal data"
+
+msgid "full_application"
+msgstr ""
+
+msgid "other_attachment"
+msgstr ""
+
+msgid "pdf_summary"
+msgstr ""
+
+msgid "decision_text_xml"
+msgstr ""
+
+msgid "decision_text_secret_xml"
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "Your application {id} will be deleted soon. If you want to continue the "
@@ -471,11 +543,15 @@ msgid ""
 "the application will deleted permanently."
 msgstr ""
 
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
 msgid "Your Helsinki benefit draft application will expire"
-msgstr ""
+msgstr "The Helsinki Benefit card"
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "company"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "status"
 msgstr ""
@@ -489,8 +565,10 @@ msgstr ""
 msgid "application number"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "company name"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "company form as user-readable text"
 msgstr ""
@@ -498,20 +576,28 @@ msgstr ""
 msgid "YTJ type code for company form"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "company department"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "company street address"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "company city"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "company post code"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "company bank account number"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "first name"
 msgstr ""
@@ -528,17 +614,23 @@ msgstr ""
 msgid "additional information about the ongoing co-operation negotiations"
 msgstr ""
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "Pay subsidy percent"
-msgstr ""
+msgstr "Pay subsidy decision"
 
 msgid "Pay subsidy percent for second pay subsidy grant"
 msgstr ""
 
+#, fuzzy
+#| msgid "not_granted"
 msgid "benefit start from date"
-msgstr ""
+msgstr "None"
 
+#, fuzzy
+#| msgid "not_granted"
 msgid "benefit end date"
-msgstr ""
+msgstr "None"
 
 msgid "paper application date"
 msgstr ""
@@ -558,8 +650,10 @@ msgstr ""
 msgid "amount of the de minimis aid"
 msgstr ""
 
+#, fuzzy
+#| msgid "not_granted"
 msgid "benefit granted at"
-msgstr ""
+msgstr "None"
 
 msgid "de minimis aid"
 msgstr ""
@@ -657,11 +751,15 @@ msgstr ""
 msgid "Description of the commission"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "employee"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "employees"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "attachment type in business rules"
 msgstr ""
@@ -681,14 +779,18 @@ msgstr ""
 msgid "paper"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "company contact person"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "co-operation negotiations"
 msgstr ""
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "pay subsidy"
-msgstr ""
+msgstr "Pay subsidy decision"
 
 msgid "benefit"
 msgstr ""
@@ -725,8 +827,10 @@ msgstr ""
 msgid "decision proposal template sections"
 msgstr ""
 
+#, fuzzy
+#| msgid "education_contract"
 msgid "decision text content"
-msgstr ""
+msgstr "Agreement on providing apprenticeship training"
 
 msgid "ahjo decision text"
 msgstr ""
@@ -734,8 +838,10 @@ msgstr ""
 msgid "ahjo decision texts"
 msgstr ""
 
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
 msgid "alteration of application"
-msgstr ""
+msgstr "The Helsinki Benefit card"
 
 msgid "type of alteration"
 msgstr ""
@@ -743,8 +849,10 @@ msgstr ""
 msgid "state of alteration"
 msgstr ""
 
+#, fuzzy
+#| msgid "not_granted"
 msgid "new benefit end date"
-msgstr ""
+msgstr "None"
 
 msgid "date when employment resumes after suspended"
 msgstr ""
@@ -784,8 +892,10 @@ msgstr ""
 msgid "Not found"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "Employer information"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "Name of the employer"
 msgstr ""
@@ -880,8 +990,10 @@ msgstr ""
 msgid "Has the person who is being employed been assigned a job supervisor?"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "Employment relationship"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "Job title"
 msgstr ""
@@ -901,7 +1013,7 @@ msgstr ""
 msgid "Applicable collective agreement"
 msgstr ""
 
-msgid "Yhdistyksellä on yritystoimintaa"
+msgid "Association has business activities"
 msgstr ""
 
 msgid "Is this an apprenticeship?"
@@ -919,9 +1031,6 @@ msgstr ""
 msgid "Attachments"
 msgstr ""
 
-msgid "granted_aged"
-msgstr "Employment aid for people aged 55 and above"
-
 msgid "Printed at"
 msgstr ""
 
@@ -933,16 +1042,52 @@ msgstr ""
 msgid "Helsinki-benefit online service"
 msgstr "The Helsinki Benefit card"
 
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
 msgid "Helsinki-benefit application"
-msgstr ""
+msgstr "The Helsinki Benefit card"
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "Employee"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "Application received"
 msgstr ""
 
 msgid "Application number"
+msgstr ""
+
+msgid "Granting of Helsinki-lisä benefit"
+msgstr ""
+
+msgid "Applicant company"
+msgstr ""
+
+#, fuzzy
+#| msgid "employee_consent"
+msgid "Employee name"
+msgstr "Employee's consent for processing personal data"
+
+msgid "Benefit type"
+msgstr ""
+
+msgid "Additional information"
+msgstr ""
+
+msgid "De Minimis description"
+msgstr ""
+
+msgid "Calculation of the benefit"
+msgstr ""
+
+msgid "Benefit per month"
+msgstr ""
+
+msgid "Total benefit"
+msgstr ""
+
+msgid "Total for benefit time period"
 msgstr ""
 
 msgid "Date range too large"
@@ -978,20 +1123,30 @@ msgstr ""
 msgid "State aid maximum %"
 msgstr ""
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "Pay subsidy/month"
-msgstr ""
+msgstr "Pay subsidy decision"
 
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
 msgid "Helsinki benefit amount monthly"
-msgstr ""
+msgstr "The Helsinki Benefit card"
 
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
 msgid "Helsinki benefit amount for a date range"
-msgstr ""
+msgstr "The Helsinki Benefit card"
 
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
 msgid "Helsinki benefit total amount"
-msgstr ""
+msgstr "The Helsinki Benefit card"
 
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
 msgid "Training compensation amount monthly"
-msgstr ""
+msgstr "The Helsinki Benefit card"
 
 msgid "Total amount of deductions monthly"
 msgstr ""
@@ -1024,23 +1179,31 @@ msgstr ""
 msgid "reason for overriding the calculated benefit amount"
 msgstr ""
 
+#, fuzzy
+#| msgid "helsinki_benefit_voucher"
 msgid "Incomplete application"
-msgstr ""
+msgstr "The Helsinki Benefit card"
 
 msgid "calculations"
 msgstr ""
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "Pay subsidy start date"
-msgstr ""
+msgstr "Pay subsidy decision"
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "Pay subsidy end date"
-msgstr ""
+msgstr "Pay subsidy decision"
 
 msgid "Work time percent"
 msgstr ""
 
+#, fuzzy
+#| msgid "pay_subsidy_decision"
 msgid "pay subsidies"
-msgstr ""
+msgstr "Pay subsidy decision"
 
 msgid "encrypted social security number"
 msgstr ""
@@ -1099,8 +1262,10 @@ msgstr ""
 msgid "bank account number"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "companies"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "Finnish"
 msgstr ""
@@ -1110,6 +1275,15 @@ msgstr ""
 
 msgid "Swedish"
 msgstr ""
+
+msgid "fi"
+msgstr "Finnish"
+
+msgid "en"
+msgstr "English"
+
+msgid "sv"
+msgstr "Swedish"
 
 #, python-brace-format
 msgid ""
@@ -1236,11 +1410,15 @@ msgstr ""
 msgid "swedish text for the consent checkbox"
 msgstr ""
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "application consent"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
+#, fuzzy
+#| msgid "employee_consent"
 msgid "application consents"
-msgstr ""
+msgstr "Employee's consent for processing personal data"
 
 msgid "timestamp of approval"
 msgstr ""
@@ -1265,30 +1443,3 @@ msgstr ""
 
 msgid "terms of service approvals"
 msgstr ""
-
-#~ msgid "fi"
-#~ msgstr "Finnish"
-
-#~ msgid "sv"
-#~ msgstr "Swedish"
-
-#~ msgid "en"
-#~ msgstr "English"
-
-#~ msgid "not_granted"
-#~ msgstr "None"
-
-#~ msgid "Processing of the personal data of the person to be employed"
-#~ msgstr "Behandlingen av personuppgifterna av personen som ska sysselsättas"
-
-#~ msgid "Agreement for employee's personal data processing"
-#~ msgstr "Avtal för anställds personuppgiftsbehandling"
-
-#~ msgid "employment_contract"
-#~ msgstr "Employment contract"
-
-#~ msgid "pay_subsidy_decision"
-#~ msgstr "Pay subsidy decision"
-
-#~ msgid "education_contract"
-#~ msgstr "Agreement on providing apprenticeship training"

--- a/backend/benefit/locale/en/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 11:23+0300\n"
+"POT-Creation-Date: 2024-04-09 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -197,6 +197,9 @@ msgid "Not a valid pdf file"
 msgstr ""
 
 msgid "Not a valid image file"
+msgstr ""
+
+msgid "File is infected with"
 msgstr ""
 
 msgid "Applications in a batch can not be changed when batch is in this status"

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-26 12:21+0200\n"
+"POT-Creation-Date: 2024-04-09 11:23+0300\n"
 "PO-Revision-Date: 2022-11-01 10:45+0200\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
@@ -168,9 +168,9 @@ msgstr "Verkkolaskuoperaattorin tunnus"
 msgid "E-invoice address"
 msgstr "Verkkolaskuosoite"
 
+#, python-brace-format
 msgid "{field} must be filled if using an e-invoice address"
-msgstr ""
-"{field} on pakollinen tieto, mikäli lasku lähetetään verkkolaskuna"
+msgstr "{field} on pakollinen tieto, mikäli lasku lähetetään verkkolaskuna"
 
 msgid "Alteration cannot start before first benefit day"
 msgstr "Muutos työsuhteessa ei voi alkaa ennen tukijakson alkua"
@@ -346,11 +346,15 @@ msgstr "liite"
 msgid "pdf summary"
 msgstr "Vaihe 4 – yhteenveto"
 
+#, fuzzy
+#| msgid "application attachment content"
 msgid "public decision text xml attachment"
-msgstr ""
+msgstr "hakemuksen liitteen sisältö"
 
+#, fuzzy
+#| msgid "application attachment content"
 msgid "non-public decision text xml attachment"
-msgstr ""
+msgstr "hakemuksen liitteen sisältö"
 
 msgid "attachment is required"
 msgstr "liite on pakollinen"
@@ -508,6 +512,62 @@ msgstr "Avattu"
 msgid "Handled"
 msgstr "Käsitelty"
 
+msgid "granted"
+msgstr "Palkkatuki"
+
+msgid "granted_aged"
+msgstr "55 vuotta täyttäneiden työllistämistuki"
+
+msgid "not_granted"
+msgstr "Ei myönnetty"
+
+msgid "employment_contract"
+msgstr "Työsopimus"
+
+msgid "pay_subsidy_decision"
+msgstr "Palkkatukipäätös"
+
+#, fuzzy
+#| msgid "commission contract"
+msgid "commission_contract"
+msgstr "toimeksiantosopimus"
+
+msgid "education_contract"
+msgstr "Sopimus oppisopimuskoulutuksen järjestämisestä"
+
+msgid "helsinki_benefit_voucher"
+msgstr "Helsinki-lisä -kortti"
+
+#, fuzzy
+#| msgid "employee_consent"
+msgid "employee_consent"
+msgstr "Suostumus työntekijän henkilötietojen käsittelyyn"
+
+#, fuzzy
+#| msgid "application"
+msgid "full_application"
+msgstr "hakemus"
+
+#, fuzzy
+#| msgid "attachment"
+msgid "other_attachment"
+msgstr "liite"
+
+#, fuzzy
+#| msgid "Step 4 - summary"
+msgid "pdf_summary"
+msgstr "Vaihe 4 – yhteenveto"
+
+#, fuzzy
+#| msgid "status"
+msgid "decision_text_xml"
+msgstr "tila"
+
+#, fuzzy
+#| msgid "application attachment content"
+msgid "decision_text_secret_xml"
+msgstr "hakemuksen liitteen sisältö"
+
 #, python-brace-format
 msgid ""
 "Your application {id} will be deleted soon. If you want to continue the "
@@ -651,8 +711,10 @@ msgstr "Asiantuntijatarkastajan nimi"
 msgid "P2P inspector's email address"
 msgstr "Asiantuntijatarkastajan sähköpostiosoite"
 
+#, fuzzy
+#| msgid "Expert inspector's name"
 msgid "P2P acceptor's title"
-msgstr ""
+msgstr "Asiantuntijatarkastajan nimi"
 
 msgid "Expert inspector's name"
 msgstr "Asiantuntijatarkastajan nimi"
@@ -742,8 +804,10 @@ msgstr ""
 msgid "company contact person"
 msgstr "yrityksen yhteyshenkilön sähköpostiosoite"
 
+#, fuzzy
+#| msgid "alteration of application"
 msgid "co-operation negotiations"
-msgstr ""
+msgstr "Muutos hakemukseen"
 
 msgid "pay subsidy"
 msgstr "palkkatuki"
@@ -771,8 +835,10 @@ msgstr "tila"
 msgid "ahjo statuses"
 msgstr "tila"
 
+#, fuzzy
+#| msgid "Decision date"
 msgid "type of the decision proposal template section"
-msgstr ""
+msgstr "Päätöksen päivämäärä"
 
 #, fuzzy
 #| msgid "date of the decision in Ahjo"
@@ -784,8 +850,10 @@ msgstr "päätöksen päivämäärä Ahjossa"
 msgid "decision proposal section text content"
 msgstr "Päätöksen päivämäärä"
 
+#, fuzzy
+#| msgid "Decision date"
 msgid "name of the decision proposal template section"
-msgstr ""
+msgstr "Päätöksen päivämäärä"
 
 #, fuzzy
 #| msgid "Decision date"
@@ -802,8 +870,10 @@ msgstr "Päätöksen päivämäärä"
 msgid "decision text content"
 msgstr "hakemuksen liitteen sisältö"
 
+#, fuzzy
+#| msgid "status"
 msgid "ahjo decision text"
-msgstr ""
+msgstr "tila"
 
 #, fuzzy
 #| msgid "status"
@@ -985,8 +1055,8 @@ msgstr "Sivukulut / kuukausi"
 msgid "Applicable collective agreement"
 msgstr "Työehtosopimus"
 
-msgid "Yhdistyksellä on yritystoimintaa"
-msgstr ""
+msgid "Association has business activities"
+msgstr "Yrityksellä on liiketoimintaa"
 
 msgid "Is this an apprenticeship?"
 msgstr "Onko kyseessä oppisopimus?"
@@ -1002,9 +1072,6 @@ msgstr "Ajalle"
 
 msgid "Attachments"
 msgstr "Liitteet"
-
-msgid "granted_aged"
-msgstr "55 vuotta täyttäneiden työllistämistuki"
 
 msgid "Printed at"
 msgstr "Tulostettu"
@@ -1027,6 +1094,37 @@ msgstr "Hakemus saapunut"
 
 msgid "Application number"
 msgstr "Hakemusnumero"
+
+# For Ahjo secret decision XML
+msgid "Granting of Helsinki-lisä benefit"
+msgstr "Työllisyydenhoidon Helsinki-lisän myöntäminen"
+
+msgid "Applicant company"
+msgstr "Hakija"
+
+msgid "Employee name"
+msgstr "Työllistetyn nimi"
+
+msgid "Benefit type"
+msgstr "Tukimuoto"
+
+msgid "Additional information"
+msgstr "Lisätietoja"
+
+msgid "De Minimis description"
+msgstr "Tuki myönnetään vähämerkityksisenä eli de minimis-tukena"
+
+msgid "Calculation of the benefit"
+msgstr "Helsinki-lisän tukijaksot"
+
+msgid "Benefit per month"
+msgstr "tuki/kk"
+
+msgid "Total benefit"
+msgstr "tuki yhteensä"
+
+msgid "Total for benefit time period"
+msgstr "Yhteensä koko tukiajalta"
 
 msgid "Date range too large"
 msgstr "Päivämääräalue liian suuri"
@@ -1083,16 +1181,20 @@ msgstr "Koulutuskorvauksen määrä kuukaudelta"
 msgid "Total amount of deductions monthly"
 msgstr "Vähennysten kokonaismäärä kuukaudelta"
 
+#, fuzzy
+#| msgid "Date range too large"
 msgid "Basic date range description"
-msgstr ""
+msgstr "Päivämääräalue liian suuri"
 
 #, fuzzy
 #| msgid "Date range too large"
 msgid "Date range description for total row"
 msgstr "Päivämääräalue liian suuri"
 
+#, fuzzy
+#| msgid "De Minimis description"
 msgid "Deduction description"
-msgstr ""
+msgstr "Tuki myönnetään vähämerkityksisenä eli de minimis-tukena"
 
 msgid "Calculation already exists"
 msgstr "Laskelma on jo olemassa"
@@ -1198,6 +1300,15 @@ msgid "English"
 msgstr "Englanti"
 
 msgid "Swedish"
+msgstr "Ruotsi"
+
+msgid "fi"
+msgstr "Suomi"
+
+msgid "en"
+msgstr "Englanti"
+
+msgid "sv"
 msgstr "Ruotsi"
 
 #, python-brace-format
@@ -1371,39 +1482,11 @@ msgstr "palveluehtojen hyväksyntä"
 msgid "terms of service approvals"
 msgstr "palveluehtojen hyväksynnät"
 
-# For Ahjo secret decision XML
-msgid "Granting of Helsinki-lisä benefit"
-msgstr "Työllisyydenhoidon Helsinki-lisän myöntäminen"
+#~ msgid "Granted as de minimis aid"
+#~ msgstr "Myönnetään de minimis -tukena"
 
-msgid "Benefit type"
-msgstr "Tukimuoto"
-
-msgid "Total benefit"
-msgstr "tuki yhteensä"
-
-msgid "Benefit per month"
-msgstr "tuki/kk"
-
-msgid "Employee name"
-msgstr "Työllistetyn nimi"
-
-msgid "Additional information"
-msgstr "Lisätietoja"
-
-msgid "De Minimis description"
-msgstr "Tuki myönnetään vähämerkityksisenä eli de minimis-tukena"
-
-msgid "Total for benefit time period"
-msgstr "Yhteensä koko tukiajalta"
-
-msgid "Applicant company"
-msgstr "Hakija"
-
-msgid "Calculation of the benefit"
-msgstr "Helsinki-lisän tukijaksot"
-
-msgid "File is infected with"
-msgstr "Ladatusta tiedostosta löytyi seuraavat haittaohjelmat: "
+#~ msgid "File is infected with"
+#~ msgstr "Ladatusta tiedostosta löytyi seuraavat haittaohjelmat: "
 
 #~ msgid "applicant"
 #~ msgstr "hakija"
@@ -1419,42 +1502,3 @@ msgstr "Ladatusta tiedostosta löytyi seuraavat haittaohjelmat: "
 
 #~ msgid "Pay subsidy percent required"
 #~ msgstr "Palkkatukiprosentti on pakollinen"
-
-#~ msgid "Helsinki benefit is granted"
-#~ msgstr "Helsinki-lisää myönnetään"
-
-#~ msgid "Helsinki benefit is not granted"
-#~ msgstr "Helsinki-lisää ei myönnetä"
-
-#~ msgid "Granted as de minimis aid"
-#~ msgstr "Myönnetään de minimis -tukena"
-
-#~ msgid "Processing of the personal data of the person to be employed"
-#~ msgstr "Työllistettävän henkilötietojen käsittely"
-
-#~ msgid "employment_contract"
-#~ msgstr "Työsopimus"
-
-#~ msgid "pay_subsidy_decision"
-#~ msgstr "Palkkatukipäätös"
-
-#~ msgid "education_contract"
-#~ msgstr "Sopimus oppisopimuskoulutuksen järjestämisestä"
-
-#~ msgid "helsinki_benefit_voucher"
-#~ msgstr "Helsinki-lisä -kortti"
-
-#~ msgid "fi"
-#~ msgstr "Suomi"
-
-#~ msgid "sv"
-#~ msgstr "Ruotsi"
-
-#~ msgid "en"
-#~ msgstr "Englanti"
-
-#~ msgid "granted"
-#~ msgstr "Palkkatuki"
-
-#~ msgid "not_granted"
-#~ msgstr "Ei myönnetty"

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 11:23+0300\n"
+"POT-Creation-Date: 2024-04-09 11:28+0300\n"
 "PO-Revision-Date: 2022-11-01 10:45+0200\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
@@ -206,6 +206,9 @@ msgstr "Epäkelpo PDF-tiedosto"
 
 msgid "Not a valid image file"
 msgstr "Epäkelpo kuvatiedosto"
+
+msgid "File is infected with"
+msgstr "Ladatusta tiedostosta löytyi seuraavat haittaohjelmat: "
 
 msgid "Applications in a batch can not be changed when batch is in this status"
 msgstr "Erän hakemuksia ei voida muuttaa erän ollessa tässä tilassa"
@@ -1484,9 +1487,6 @@ msgstr "palveluehtojen hyväksynnät"
 
 #~ msgid "Granted as de minimis aid"
 #~ msgstr "Myönnetään de minimis -tukena"
-
-#~ msgid "File is infected with"
-#~ msgstr "Ladatusta tiedostosta löytyi seuraavat haittaohjelmat: "
 
 #~ msgid "applicant"
 #~ msgstr "hakija"

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-26 12:21+0200\n"
+"POT-Creation-Date: 2024-04-09 11:23+0300\n"
 "PO-Revision-Date: 2022-11-01 10:47+0200\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
@@ -160,8 +160,10 @@ msgstr ""
 msgid "E-invoice provider name"
 msgstr "Arbetsgivarens namn"
 
+#, fuzzy
+#| msgid "Name of the employer"
 msgid "E-invoice provider identifier"
-msgstr ""
+msgstr "Arbetsgivarens namn"
 
 #, fuzzy
 #| msgid "Delivery address"
@@ -172,14 +174,20 @@ msgstr "Leveransadress"
 msgid "{field} must be filled if using an e-invoice address"
 msgstr ""
 
+#, fuzzy
+#| msgid "application end_date can not be less than start_date"
 msgid "Alteration cannot start before first benefit day"
-msgstr ""
+msgstr "end_date för ansökan kan inte vara tidigare än start_date"
 
+#, fuzzy
+#| msgid "application end_date can not be less than start_date"
 msgid "Alteration cannot start after last benefit day"
-msgstr ""
+msgstr "end_date för ansökan kan inte vara tidigare än start_date"
 
+#, fuzzy
+#| msgid "application end_date can not be less than start_date"
 msgid "Alteration cannot end after last benefit day"
-msgstr ""
+msgstr "end_date för ansökan kan inte vara tidigare än start_date"
 
 #, fuzzy
 #| msgid "application end_date can not be less than start_date"
@@ -349,11 +357,15 @@ msgstr "bilaga"
 msgid "pdf summary"
 msgstr "Steg 4 – sammanfattning"
 
+#, fuzzy
+#| msgid "application attachment content"
 msgid "public decision text xml attachment"
-msgstr ""
+msgstr "innehåll i bilaga till ansökan"
 
+#, fuzzy
+#| msgid "application attachment content"
 msgid "non-public decision text xml attachment"
-msgstr ""
+msgstr "innehåll i bilaga till ansökan"
 
 msgid "attachment is required"
 msgstr "bilaga är obligatorisk"
@@ -517,6 +529,62 @@ msgstr ""
 msgid "Handled"
 msgstr "Handläggare"
 
+msgid "granted"
+msgstr "Lönesubvention"
+
+msgid "granted_aged"
+msgstr "Sysselsättningsstöd för personer som fyllt 55 år"
+
+msgid "not_granted"
+msgstr "Inget stöd"
+
+msgid "employment_contract"
+msgstr "Arbetsavtal"
+
+msgid "pay_subsidy_decision"
+msgstr "Beslut om lönesubvention"
+
+#, fuzzy
+#| msgid "commission contract"
+msgid "commission_contract"
+msgstr "uppdragsavtal"
+
+msgid "education_contract"
+msgstr "Avtal om ordnandet av läroavtalsutbildning"
+
+msgid "helsinki_benefit_voucher"
+msgstr "Helsingforstilläggskortet"
+
+#, fuzzy
+#| msgid "employee_consent"
+msgid "employee_consent"
+msgstr "Behandlingen av personuppgifterna av personen som ska sysselsättas"
+
+#, fuzzy
+#| msgid "application"
+msgid "full_application"
+msgstr "Ansökan"
+
+#, fuzzy
+#| msgid "attachment"
+msgid "other_attachment"
+msgstr "bilaga"
+
+#, fuzzy
+#| msgid "Step 4 - summary"
+msgid "pdf_summary"
+msgstr "Steg 4 – sammanfattning"
+
+#, fuzzy
+#| msgid "status"
+msgid "decision_text_xml"
+msgstr "status"
+
+#, fuzzy
+#| msgid "application attachment content"
+msgid "decision_text_secret_xml"
+msgstr "innehåll i bilaga till ansökan"
+
 #, python-brace-format
 msgid ""
 "Your application {id} will be deleted soon. If you want to continue the "
@@ -660,8 +728,10 @@ msgstr "Namn på sakkunnig inspektör"
 msgid "P2P inspector's email address"
 msgstr "E-postadress till sakkunnig inspektör"
 
+#, fuzzy
+#| msgid "Expert inspector's name"
 msgid "P2P acceptor's title"
-msgstr ""
+msgstr "Namn på sakkunnig inspektör"
 
 msgid "Expert inspector's name"
 msgstr "Namn på sakkunnig inspektör"
@@ -751,8 +821,10 @@ msgstr ""
 msgid "company contact person"
 msgstr "kontaktpersonens e-postadress"
 
+#, fuzzy
+#| msgid "application batches"
 msgid "co-operation negotiations"
-msgstr ""
+msgstr "ansökningssatser"
 
 msgid "pay subsidy"
 msgstr "lönesubvention"
@@ -780,8 +852,10 @@ msgstr "status"
 msgid "ahjo statuses"
 msgstr "status"
 
+#, fuzzy
+#| msgid "Decision date"
 msgid "type of the decision proposal template section"
-msgstr ""
+msgstr "Beslutsdatum"
 
 #, fuzzy
 #| msgid "date of the decision in Ahjo"
@@ -793,8 +867,10 @@ msgstr "datum då beslut fattas vid Ahjo"
 msgid "decision proposal section text content"
 msgstr "Beslutsdatum"
 
+#, fuzzy
+#| msgid "Decision date"
 msgid "name of the decision proposal template section"
-msgstr ""
+msgstr "Beslutsdatum"
 
 #, fuzzy
 #| msgid "Decision date"
@@ -811,8 +887,10 @@ msgstr "Beslutsdatum"
 msgid "decision text content"
 msgstr "innehåll i bilaga till ansökan"
 
+#, fuzzy
+#| msgid "status"
 msgid "ahjo decision text"
-msgstr ""
+msgstr "status"
 
 #, fuzzy
 #| msgid "status"
@@ -842,17 +920,23 @@ msgstr "slutdatum för understöd"
 msgid "date when employment resumes after suspended"
 msgstr ""
 
+#, fuzzy
+#| msgid "type of terms"
 msgid "reason for alteration"
-msgstr ""
+msgstr "typ av villkor"
 
 msgid "date when alteration notice was handled"
 msgstr ""
 
+#, fuzzy
+#| msgid "amount of the benefit granted, calculated by the system"
 msgid "the first day the unwarranted benefit will be collected from"
-msgstr ""
+msgstr "understödsbelopp som beviljats, beräknat av systemet"
 
+#, fuzzy
+#| msgid "amount of the benefit granted, calculated by the system"
 msgid "the last day the unwarranted benefit will be collected from"
-msgstr ""
+msgstr "understödsbelopp som beviljats, beräknat av systemet"
 
 #, fuzzy
 #| msgid "amount of the benefit granted, calculated by the system"
@@ -869,8 +953,10 @@ msgstr ""
 msgid "name of the e-invoice provider"
 msgstr "Arbetsgivarens namn"
 
+#, fuzzy
+#| msgid "Name of the employer"
 msgid "identifier of the e-invoice provider"
-msgstr ""
+msgstr "Arbetsgivarens namn"
 
 #, fuzzy
 #| msgid "Delivery address"
@@ -1008,8 +1094,8 @@ msgstr "Bikostnader per månad"
 msgid "Applicable collective agreement"
 msgstr "Kollektivavtal som tillämpas"
 
-msgid "Yhdistyksellä on yritystoimintaa"
-msgstr ""
+msgid "Association has business activities"
+msgstr "Arbetsgivaren har ekonomisk verksamhet"
 
 msgid "Is this an apprenticeship?"
 msgstr "Handlar det om ett läroavtal?"
@@ -1025,9 +1111,6 @@ msgstr "Ansöker om datum"
 
 msgid "Attachments"
 msgstr "Bilagor"
-
-msgid "granted_aged"
-msgstr "Sysselsättningsstöd för personer som fyllt 55 år"
 
 msgid "Printed at"
 msgstr "Tryckt"
@@ -1050,6 +1133,37 @@ msgstr "Ansökning mottagen"
 
 msgid "Application number"
 msgstr "Ansökningsnummer"
+
+# For Ahjo secret decision XML
+msgid "Granting of Helsinki-lisä benefit"
+msgstr "Beviljande av Helsingforstillägget för anställningsstöd"
+
+msgid "Applicant company"
+msgstr "Sökande"
+
+msgid "Employee name"
+msgstr "Den anställdes namn"
+
+msgid "Benefit type"
+msgstr "Typ av förmån"
+
+msgid "Additional information"
+msgstr "Ytterligare information"
+
+msgid "De Minimis description"
+msgstr "Stödet beviljas som stöd av mindre betydelse"
+
+msgid "Calculation of the benefit"
+msgstr "Beviljade stödperioder"
+
+msgid "Benefit per month"
+msgstr "Förmån per månad"
+
+msgid "Total benefit"
+msgstr "Total förmån"
+
+msgid "Total for benefit time period"
+msgstr "Totalt för hela perioden"
 
 msgid "Date range too large"
 msgstr "Tidsperiod för lång"
@@ -1102,16 +1216,20 @@ msgstr "Utbildningsersättningens belopp per månad"
 msgid "Total amount of deductions monthly"
 msgstr "Totalbelopp av avdrag per månad"
 
+#, fuzzy
+#| msgid "Date range too large"
 msgid "Basic date range description"
-msgstr ""
+msgstr "Tidsperiod för lång"
 
 #, fuzzy
 #| msgid "Date range too large"
 msgid "Date range description for total row"
 msgstr "Tidsperiod för lång"
 
+#, fuzzy
+#| msgid "De Minimis description"
 msgid "Deduction description"
-msgstr ""
+msgstr "Stödet beviljas som stöd av mindre betydelse"
 
 msgid "Calculation already exists"
 msgstr "Beräkning finns redan"
@@ -1218,6 +1336,15 @@ msgid "English"
 msgstr "Engelska"
 
 msgid "Swedish"
+msgstr "Svenska"
+
+msgid "fi"
+msgstr "Finska"
+
+msgid "en"
+msgstr "Engelska"
+
+msgid "sv"
 msgstr "Svenska"
 
 #, python-brace-format
@@ -1391,39 +1518,11 @@ msgstr "godkännande av villkoren för tjänsten"
 msgid "terms of service approvals"
 msgstr "godkännanden av villkoren för tjänsten"
 
-# For Ahjo secret decision XML
-msgid "Granting of Helsinki-lisä benefit"
-msgstr "Beviljande av Helsingforstillägget för anställningsstöd"
+#~ msgid "Granted as de minimis aid"
+#~ msgstr "Beviljas som stöd av de minimis stöd"
 
-msgid "Benefit type"
-msgstr "Typ av förmån"
-
-msgid "Total benefit"
-msgstr "Total förmån"
-
-msgid "Benefit per month"
-msgstr "Förmån per månad"
-
-msgid "Employee name"
-msgstr "Den anställdes namn"
-
-msgid "Additional information"
-msgstr "Ytterligare information"
-
-msgid "De Minimis description"
-msgstr "Stödet beviljas som stöd av mindre betydelse"
-
-msgid "Total for benefit time period"
-msgstr "Totalt för hela perioden"
-
-msgid "Applicant company"
-msgstr "Sökande"
-
-msgid "Calculation of the benefit"
-msgstr "Beviljade stödperioder"
-
-msgid "File is infected with"
-msgstr "Filen är infekterad med följande malware"
+#~ msgid "File is infected with"
+#~ msgstr "Filen är infekterad med följande malware"
 
 #~ msgid "applicant"
 #~ msgstr "sökande"
@@ -1439,39 +1538,3 @@ msgstr "Filen är infekterad med följande malware"
 
 #~ msgid "Pay subsidy percent required"
 #~ msgstr "Lönesubventionsprocent krävs"
-
-#~ msgid "Helsinki benefit is granted"
-#~ msgstr "Helsingforstillägg beviljas"
-
-#~ msgid "Helsinki benefit is not granted"
-#~ msgstr "Helsingforstillägg beviljas inte"
-
-#~ msgid "Granted as de minimis aid"
-#~ msgstr "Beviljas som stöd av de minimis stöd"
-
-#~ msgid "employment_contract"
-#~ msgstr "Arbetsavtal"
-
-#~ msgid "pay_subsidy_decision"
-#~ msgstr "Beslut om lönesubvention"
-
-#~ msgid "education_contract"
-#~ msgstr "Avtal om ordnandet av läroavtalsutbildning"
-
-#~ msgid "helsinki_benefit_voucher"
-#~ msgstr "Helsingforstilläggskortet"
-
-#~ msgid "fi"
-#~ msgstr "Finska"
-
-#~ msgid "sv"
-#~ msgstr "Svenska"
-
-#~ msgid "en"
-#~ msgstr "Engelska"
-
-#~ msgid "granted"
-#~ msgstr "Lönesubvention"
-
-#~ msgid "not_granted"
-#~ msgstr "Inget stöd"

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 11:23+0300\n"
+"POT-Creation-Date: 2024-04-09 11:28+0300\n"
 "PO-Revision-Date: 2022-11-01 10:47+0200\n"
 "Last-Translator: Kari Salminen <kari.salminen@anders.com>\n"
 "Language-Team: \n"
@@ -217,6 +217,9 @@ msgstr "Ingen giltig PDF-fil"
 
 msgid "Not a valid image file"
 msgstr "Ingen giltig bildfil"
+
+msgid "File is infected with"
+msgstr "Filen är infekterad med följande malware"
 
 msgid "Applications in a batch can not be changed when batch is in this status"
 msgstr "Ansökningar i en sats kan inte ändras när satsen har denna status"
@@ -1520,9 +1523,6 @@ msgstr "godkännanden av villkoren för tjänsten"
 
 #~ msgid "Granted as de minimis aid"
 #~ msgstr "Beviljas som stöd av de minimis stöd"
-
-#~ msgid "File is infected with"
-#~ msgstr "Filen är infekterad med följande malware"
 
 #~ msgid "applicant"
 #~ msgstr "sökande"


### PR DESCRIPTION
## Description :sparkles:

`makemessages` and `compilemessages` didn't catch some of the translations that were called programmatically using enum as `msgid`. This brought problems least in application print - both in applicant gui and new ahjo process.  Invoke `gettext` to register them. 