### PR TITLE
feat: add 'empty' text to unchanged app's change set

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1258,7 +1258,8 @@
   },
   "changes": {
     "header": {
-      "amountOfChanges": "Muutoksia yhteensä: {{ amount }}"
+      "amountOfChanges": "Muutoksia yhteensä: {{ amount }}",
+      "noChanges": "Ei havaittuja muutoksia"
     },
     "fields": {
       "jobTitle": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1258,7 +1258,8 @@
   },
   "changes": {
     "header": {
-      "amountOfChanges": "Muutoksia yhteensä: {{ amount }}"
+      "amountOfChanges": "Muutoksia yhteensä: {{ amount }}",
+      "noChanges": "Ei havaittuja muutoksia"
     },
     "fields": {
       "jobTitle": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1258,7 +1258,8 @@
   },
   "changes": {
     "header": {
-      "amountOfChanges": "Muutoksia yhteensä: {{ amount }}"
+      "amountOfChanges": "Muutoksia yhteensä: {{ amount }}",
+      "noChanges": "Ei havaittuja muutoksia"
     },
     "fields": {
       "jobTitle": {

--- a/frontend/benefit/handler/src/components/sidebar/ChangeList.tsx
+++ b/frontend/benefit/handler/src/components/sidebar/ChangeList.tsx
@@ -1,8 +1,14 @@
 import { ApplicationChangesData } from 'benefit/handler/types/application';
 import { ChangeListData } from 'benefit/handler/types/changes';
+import { IconHistory } from 'hds-react';
 import orderBy from 'lodash/orderBy';
+import { useTranslation } from 'next-i18next';
 import * as React from 'react';
-import { $Actions } from 'shared/components/messaging/Messaging.sc';
+import {
+  $Actions,
+  $Empty,
+  $MessagesList,
+} from 'shared/components/messaging/Messaging.sc';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
 
 import ChangeSet from './ChangeSet';
@@ -29,6 +35,17 @@ const ChangeList: React.FC<ChangeListProps> = ({ data }: ChangeListProps) => {
   const { handler, applicant } = data;
   const combined: ChangeListData[] = [...handler, ...applicant];
   const combinedAndOrderedChangeSets = orderBy(combined, ['date'], ['desc']);
+  const { t } = useTranslation();
+  if (combinedAndOrderedChangeSets.length === 0) {
+    return (
+      <$MessagesList variant="message">
+        <$Empty>
+          <IconHistory />
+          <p>{t('common:changes.header.noChanges')}</p>
+        </$Empty>
+      </$MessagesList>
+    );
+  }
 
   return (
     <$Actions>


### PR DESCRIPTION
## Description :sparkles:

Add a "empty state" to handler sidebar if there's no changes detected. 

![image](https://github.com/City-of-Helsinki/yjdh/assets/5328394/6c3c289c-f1e4-4465-aaa4-d38d0b018a15)
