### PR TITLE
fix: failing ahjo token refresh

### DIFF
--- a/backend/benefit/applications/management/commands/refresh_ahjo_token.py
+++ b/backend/benefit/applications/management/commands/refresh_ahjo_token.py
@@ -1,34 +1,23 @@
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
 
-from applications.models import AhjoSetting
-from applications.services.ahjo_authentication import AhjoConnector
+from applications.services.ahjo_authentication import (
+    AhjoConnector,
+    AhjoTokenRetrievalException,
+)
 
 
 class Command(BaseCommand):
     help = "Refresh the Ahjo token using the refresh_token stored in the database"
 
     def handle(self, *args, **options):
-        try:
-            ahjo_auth_code = AhjoSetting.objects.get(name="ahjo_code").data
-            self.stdout.write(f"Retrieved auth code: {ahjo_auth_code}")
-        except ObjectDoesNotExist:
-            self.stdout.write(
-                "Error: Ahjo auth code not found in database. Please set the 'ahjo_code' setting."
-            )
-            return
-
         ahjo_connector = AhjoConnector()
         if not ahjo_connector.is_configured():
-            self.stdout.write(
-                "Error: Ahjo connector is not properly configured. Please check your settings."
+            raise ImproperlyConfigured(
+                "Ahjo connector is not properly configured. Please check your settings."
             )
-            return
         try:
             token = ahjo_connector.refresh_token()
-            self.stdout.write(
-                f"Ahjo token refreshed, token valid until {token.expires_in}"
-            )
+            self.stdout.write(f"Ahjo token refreshed, new access token: {token}")
         except Exception as e:
-            self.stdout.write(f"Failed to refresh Ahjo token: {e}")
-            return
+            raise AhjoTokenRetrievalException(f"Failed to refresh Ahjo token: {e}")

--- a/backend/benefit/applications/services/ahjo_authentication.py
+++ b/backend/benefit/applications/services/ahjo_authentication.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Union
 
 import requests
@@ -8,12 +8,33 @@ from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 
 from applications.models import AhjoSetting
 
+AUTH_TOKEN_GRANT_TYPE = "authorization_code"
+REFRESH_TOKEN_GRANT_TYPE = "refresh_token"
+
+
+class AhjoTokenExpiredException(Exception):
+    pass
+
+
+class AhjoTokenRetrievalException(Exception):
+    pass
+
 
 @dataclass
 class AhjoToken:
     access_token: str = ""
     refresh_token: str = ""
-    expires_in: datetime = datetime.now()
+    expires_in: int = (0,)
+    created_at: datetime = (None,)
+
+    def expiry_datetime(self) -> datetime:
+        return self.created_at + timedelta(seconds=int(self.expires_in))
+
+    def has_expired(self) -> bool:
+        return self.expiry_datetime() < datetime.now(timezone.utc)
+
+    def __str__(self) -> str:
+        return f"Ahjo access token, expiry date: {self.expiry_datetime()}"
 
 
 class AhjoConnector:
@@ -23,12 +44,12 @@ class AhjoConnector:
         self.client_secret: str = settings.AHJO_CLIENT_SECRET
         self.redirect_uri: str = settings.AHJO_REDIRECT_URL
 
-        self.grant_type_for_auth_token: str = "authorization_code"
-        self.grant_type_for_refresh_token: str = "refresh_token"
+        self.grant_type_for_auth_token: str = AUTH_TOKEN_GRANT_TYPE
+        self.grant_type_for_refresh_token: str = REFRESH_TOKEN_GRANT_TYPE
         self.headers: Dict[str, str] = {
             "Content-Type": "application/x-www-form-urlencoded",
         }
-        self.timeout: int = 10
+        self.timeout: int = 60
 
     def is_configured(self) -> bool:
         """Check if all required config options are set"""
@@ -42,34 +63,31 @@ class AhjoConnector:
 
         return True
 
-    def get_access_token(self, auth_code: str) -> AhjoToken:
-        """Get access token from db first, then from Ahjo if not found or expired"""
-        token = self.get_token_from_db()
-        if token and not self._check_if_token_is_expired(token.expires_in):
-            return token
-        else:
-            return self.get_new_token(auth_code)
-
-    def get_new_token(self, auth_code: str) -> AhjoToken:
+    def get_initial_token(self) -> AhjoToken:
         """Retrieve the initial access token from Ahjo API using the auth code,
-        this is only used when getting the initial token or when the token has expired.
+        this is only used when getting and setting the initial token manually.
+        If the initial token fails for some reason, a new ahjo_code must be saved into django.
         """
-        if not auth_code:
-            raise ImproperlyConfigured("no auth code configured")
-        payload = {
-            "client_id": self.client_id,
-            "client_secret": self.client_secret,
-            "grant_type": self.grant_type_for_auth_token,
-            "code": auth_code,
-            "redirect_uri": self.redirect_uri,
-        }
-        return self.do_token_request(payload)
+        try:
+            auth_code = AhjoSetting.objects.get(name="ahjo_code")
+
+            payload = {
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "grant_type": self.grant_type_for_auth_token,
+                "code": auth_code.data.get("code", ""),
+                "redirect_uri": self.redirect_uri,
+            }
+            return self.do_token_request(payload)
+        except ObjectDoesNotExist:
+            raise ImproperlyConfigured("No auth code found in the database")
 
     def refresh_token(self) -> AhjoToken:
         """Refresh access token from Ahjo API using the refresh token of an existing token.
         This should be used by, for example, a cron job to keep the token up to date.
         """
         token = self.get_token_from_db()
+
         if not token.refresh_token:
             raise ImproperlyConfigured("No refresh token configured")
 
@@ -82,7 +100,7 @@ class AhjoConnector:
 
         return self.do_token_request(payload)
 
-    def do_token_request(self, payload: Dict[str, str]) -> AhjoToken:
+    def do_token_request(self, payload: Dict[str, str]) -> Union[AhjoToken, None]:
         # Make the POST request
         try:
             response = requests.post(
@@ -95,57 +113,62 @@ class AhjoConnector:
         if response.status_code == 200:
             # Extract the access token from the JSON response
             access_token = response.json().get("access_token", "")
-            expires_in = response.json().get("expires_in", "")
+            expires_in = int(response.json().get("expires_in", ""))
             refresh_token = response.json().get("refresh_token", "")
-            expiry_datetime = self.convert_expires_in_to_datetime(expires_in)
 
-            token = AhjoToken(
+            token_from_api = AhjoToken(
                 access_token=access_token,
                 refresh_token=refresh_token,
-                expires_in=expiry_datetime,
+                expires_in=expires_in,
             )
-            self.set_or_update_token(token)
-            return token
+
+            return self.create_token(token_from_api)
         else:
-            raise Exception(
-                f"Failed to get or refresh token: {response.status_code} {response.content.decode()}"
+            raise AhjoTokenRetrievalException(
+                f"Failed to retrieve or refresh token: {response.status_code} {response.content.decode()}"
             )
 
     def get_token_from_db(self) -> Union[AhjoToken, None]:
         """Get token from AhjoSetting table"""
         try:
-            token_data = AhjoSetting.objects.get(name="ahjo_access_token").data
-            access_token = token_data.get("access_token", "")
-            refresh_token = token_data.get("refresh_token", "")
-            expires_in = token_data.get("expires_in", "")
-            return AhjoToken(
-                access_token=access_token,
-                refresh_token=refresh_token,
-                expires_in=datetime.fromisoformat(expires_in),
+            token = AhjoSetting.objects.get(name="ahjo_access_token")
+            ahjo_token = AhjoToken(
+                access_token=token.data.get("access_token", ""),
+                refresh_token=token.data.get("refresh_token", ""),
+                expires_in=token.data.get("expires_in", ""),
+                created_at=token.created_at,
             )
+            if ahjo_token.has_expired():
+                raise AhjoTokenExpiredException(
+                    f"Ahjo access token has expired in {ahjo_token.expiry_datetime()}"
+                )
+            return ahjo_token
         except ObjectDoesNotExist:
-            return None
+            raise ImproperlyConfigured("No access token found in the database")
 
-    def _check_if_token_is_expired(self, expires_in: datetime) -> bool:
-        """Check if access token is expired"""
-        return expires_in < datetime.now()
-
-    def set_or_update_token(
+    def create_token(
         self,
         token: AhjoToken,
-    ) -> None:
+    ) -> AhjoToken:
         """Save or update token data to AhjoSetting table"""
 
         access_token_data = {
             "access_token": token.access_token,
             "refresh_token": token.refresh_token,
-            "expires_in": token.expires_in.isoformat(),
+            "expires_in": token.expires_in,
         }
 
-        AhjoSetting.objects.update_or_create(
-            name="ahjo_access_token", defaults={"data": access_token_data}
+        # Delete old access token if it exists, so that only one token is stored and there will be
+        # no need to calculate the expiry time of the token from the modified_at field
+        AhjoSetting.objects.filter(name="ahjo_access_token").delete()
+
+        token_setting = AhjoSetting.objects.create(
+            name="ahjo_access_token", data=access_token_data
         )
 
-    def convert_expires_in_to_datetime(self, expires_in: str) -> datetime:
-        """Convert expires_in seconds to datetime"""
-        return datetime.now() + timedelta(seconds=int(expires_in))
+        return AhjoToken(
+            access_token=token_setting.data.get("access_token", ""),
+            refresh_token=token_setting.data.get("refresh_token", ""),
+            expires_in=token_setting.data.get("expires_in", ""),
+            created_at=token_setting.created_at,
+        )

--- a/backend/benefit/applications/services/ahjo_integration.py
+++ b/backend/benefit/applications/services/ahjo_integration.py
@@ -23,13 +23,7 @@ from applications.enums import (
     ApplicationStatus,
     AttachmentType,
 )
-from applications.models import (
-    AhjoDecisionText,
-    AhjoSetting,
-    AhjoStatus,
-    Application,
-    Attachment,
-)
+from applications.models import AhjoDecisionText, AhjoStatus, Application, Attachment
 from applications.services.ahjo_authentication import AhjoConnector, AhjoToken
 from applications.services.ahjo_payload import (
     prepare_decision_proposal_payload,
@@ -430,17 +424,11 @@ def generate_application_attachment(
 
 def get_token() -> Union[AhjoToken, None]:
     """Get the access token from Ahjo Service."""
-    try:
-        ahjo_auth_code = AhjoSetting.objects.get(name="ahjo_code").data
-    except AhjoSetting.DoesNotExist:
-        raise ImproperlyConfigured(
-            "Error: Ahjo auth code not found in database. Please set the 'ahjo_code' setting."
-        )
     connector = AhjoConnector()
 
     if not connector.is_configured():
         raise ImproperlyConfigured("AHJO connector is not configured")
-    return connector.get_access_token(ahjo_auth_code["code"])
+    return connector.get_token_from_db()
 
 
 def prepare_headers(


### PR DESCRIPTION
## Description :sparkles:
The retrieval of the AHJO rest api access token was previously failing because the expiration date was based on created_at and the token  refresh was updating an existing token which kept the create_at date unchanged. This PR changes the logic so that an access token is only ever created and custom exceptions are raised if anything token-related is not behaving as intended or is configured incorrectly. 
Also adds `expiry_datetime()` and `has_expired()` methods and a  new string representation for the `AhjoToken` class, which can be used in error logs etc.
## Issues :bug:

## Testing :alembic:
With (huolto.hel.fi) BIG-IP EDGE VPN turned on:
Get an ahjo code from  [here](https://johdontyopoytahyte.hel.fi/ids4/Account/Login?ReturnUrl=%2Fids4%2Fconnect%2Fauthorize%2Fcallback%3Fscope%3Dopenid%2520offline_access%26response_type%3Dcode%26redirect_uri%3Dhttps%253A%252F%252Fhelsinkilisa%252Fdummyredirect.html%26client_id%3Dhelsinkilisa)

Set an ahjo_code in  Django admin.
In python shell:
```
from applications.services.ahjo_authentication import  AhjoConnector
connector = AhjoConnector()
connector.is_configured() # should return True if all necessary env variables are set

# this only needs to be run once, if this returns an invalid grant error, get and save a new ahjo_code in django admin
connector.get_initial_token()
# check that you have a token in the db now
token = connector.get_token_from_db()
print(token)
# after initial token is set, the token can be refreshed N number of times with:
connector.refresh_token()
```
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
