### PR TITLE
chore: add a migration command to create needed proposal drafts

### DIFF
--- a/backend/benefit/applications/management/commands/create-proposal-drafts.py
+++ b/backend/benefit/applications/management/commands/create-proposal-drafts.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+
+from applications.models import AhjoDecisionProposalDraft, Application
+
+
+class Command(BaseCommand):
+    help = "Create decision proposal drafts for older than 2024-04-16 applications"
+
+    def handle(self, *args, **options):
+        applications = Application.objects.all()
+        total_created = 0
+        for application in applications:
+            try:
+                application.decision_proposal_draft
+            except:  # noqa
+                AhjoDecisionProposalDraft.objects.create(
+                    application=application,
+                )
+                total_created += 1
+        self.stdout.write(f"Created {total_created} decision proposal drafts")


### PR DESCRIPTION
## Description :sparkles:

Tool to create missing proposal drafts for older applications.

## Test

0. have some old applications or create with `python manage.py seed --number=10`
1. `git checkout main && git pull`
2. migrate by restarting backend docker container
3. run `python manage.py create-proposal-drafts`
4. you can re-run command by removing created rows from `bf_applications_decision_proposal_draft` table