### PR TITLE
fix(handler): de minimis date validation as in applicant form (HL-1204)

### DIFF
--- a/frontend/benefit/handler/src/components/applicationForm/formContent/companySection/deMinimisAid/utils/validation.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/companySection/deMinimisAid/utils/validation.ts
@@ -1,10 +1,14 @@
-import { DE_MINIMIS_AID_GRANTED_AT_MAX_DATE } from 'benefit/handler/constants';
+import {
+  DE_MINIMIS_AID_GRANTED_AT_MAX_DATE,
+  DE_MINIMIS_AID_GRANTED_AT_MIN_DATE,
+} from 'benefit/handler/constants';
 import {
   DE_MINIMIS_AID_KEYS,
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
 import { DeMinimisAid } from 'benefit-shared/types/application';
-import isFuture from 'date-fns/isFuture';
+import { validateIsTodayOrPastDate } from 'benefit-shared/utils/dates';
+import isBefore from 'date-fns/isBefore';
 import { TFunction } from 'next-i18next';
 import { convertToUIDateFormat, parseDate } from 'shared/utils/date.utils';
 import { getNumberValue } from 'shared/utils/string.utils';
@@ -33,12 +37,18 @@ export const getValidationSchema = (t: TFunction): Yup.SchemaOf<DeMinimisAid> =>
         message: t(VALIDATION_MESSAGE_KEYS.DATE_MAX, {
           max: convertToUIDateFormat(DE_MINIMIS_AID_GRANTED_AT_MAX_DATE),
         }),
+        test: (value) => validateIsTodayOrPastDate(value),
+      })
+      .test({
+        message: t(VALIDATION_MESSAGE_KEYS.DATE_MIN, {
+          min: convertToUIDateFormat(DE_MINIMIS_AID_GRANTED_AT_MIN_DATE),
+        }),
         test: (value) => {
           if (!value) return false;
 
           const date = parseDate(value);
 
-          if (date && isFuture(date)) {
+          if (date && isBefore(date, DE_MINIMIS_AID_GRANTED_AT_MIN_DATE)) {
             return false;
           }
           return true;

--- a/frontend/benefit/handler/src/constants.ts
+++ b/frontend/benefit/handler/src/constants.ts
@@ -94,6 +94,12 @@ export const ACTIONLESS_STATUSES: APPLICATION_STATUSES[] = [
 ];
 
 export const DE_MINIMIS_AID_GRANTED_AT_MAX_DATE = new Date();
+// Set the minimum date of the deMinimimis aid granted at datepicker to the beginning of the year 4 years ago
+export const DE_MINIMIS_AID_GRANTED_AT_MIN_DATE = new Date(
+  new Date().getFullYear() - 4,
+  0,
+  1
+);
 
 export const APPLICATION_START_DATE = new Date(new Date().getFullYear(), 0, 1);
 


### PR DESCRIPTION
## Description :sparkles:

Previously, paper filled application's de minimis row's date could be filled with arbitrary numbers like 111 and the parsing would fail completely, leaving blank value to the row. 

Copy & paste behaviour from applicant's validation schema 😅 🪄 🎩 🐰  works like a charm. 