### PR TITLE
fix(handler): archived page to show cancelled applications (hl-1287)

### DIFF
--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -283,7 +283,8 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
 
         user = self.request.user
         if hasattr(user, "is_handler") and user.is_handler():
-            qs = qs.filter(archived=request.query_params.get("filter_archived") == "1")
+            should_filter_archived = request.query_params.get("filter_archived") == "1"
+            qs = qs.filter(archived=should_filter_archived)
 
         return qs
 

--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1627,6 +1627,7 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
                 pay_subsidy_data = None
         training_compensation_data = validated_data.pop("training_compensations", None)
         previous_status = instance.status
+
         application = self._base_update(instance, validated_data)
         if calculation_data is not None:
             self._update_calculation(instance, calculation_data, previous_status)
@@ -1728,8 +1729,14 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
             instance, previous_status, approve_terms, log_entry_comment
         )
         # Extend from base class function.
+        self._archive_application(instance)
         self._assign_handler_if_needed(instance)
         self._remove_batch_if_needed(instance)
+
+    def _archive_application(self, instance):
+        if instance.status == ApplicationStatus.CANCELLED:
+            instance.archived = True
+            instance.save()
 
     def _assign_handler_if_needed(self, instance):
         # Assign current user to the application.calculation.handler

--- a/backend/benefit/applications/management/commands/set_cancelled_as_archived.py
+++ b/backend/benefit/applications/management/commands/set_cancelled_as_archived.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+
+from applications.enums import ApplicationStatus
+from applications.models import Application
+
+
+class Command(BaseCommand):
+    help = "Set cancelled applications as archived"
+
+    def handle(self, *args, **options):
+        applications = Application.objects.filter(status=ApplicationStatus.CANCELLED)
+        total_changed = 0
+        for application in applications:
+            if application.archived is False:
+                total_changed += 1
+                application.archived = True
+                application.save()
+        self.stdout.write(f"Set {total_changed} applications as archived")

--- a/backend/benefit/applications/tests/factories.py
+++ b/backend/benefit/applications/tests/factories.py
@@ -273,6 +273,7 @@ class HandlingApplicationFactory(ReceivedApplicationFactory):
 
 class CancelledApplicationFactory(ApplicationWithAttachmentFactory):
     status = ApplicationStatus.CANCELLED
+    archived = True
 
     @factory.post_generation
     def cancelled_log_event(self, created, extracted, **kwargs):

--- a/backend/benefit/applications/tests/test_command_set_as_archived.py
+++ b/backend/benefit/applications/tests/test_command_set_as_archived.py
@@ -1,0 +1,69 @@
+from django.core.management import call_command
+
+from applications.api.v1.serializers.application import HandlerApplicationSerializer
+from applications.enums import ApplicationStatus, BenefitType, PaySubsidyGranted
+from applications.models import Application
+from applications.tests.factories import (
+    CancelledApplicationFactory,
+    DecidedApplicationFactory,
+    HandlingApplicationFactory,
+    ReceivedApplicationFactory,
+)
+
+data_for_application = {
+    "status": ApplicationStatus.CANCELLED,
+    "archived": False,
+    "use_alternative_address": False,
+    "de_minimis_aid_set": [],
+    "de_minimis_aid": False,
+    "application_step": "step_6",
+    "employee": {},
+    "pay_subsidy_granted": PaySubsidyGranted.NOT_GRANTED,
+    "bases": [],
+    "company_contact_person_first_name": "Test",
+    "company_contact_person_last_name": "Tester",
+    "co_operation_negotiations": False,
+    "benefit_type": BenefitType.SALARY_BENEFIT,
+    "start_date": "2021-01-01",
+    "end_date": "2021-01-31",
+    "company_contact_person_phone_number": "05012345678",
+    "company_contact_person_email": "test@example.com",
+    "company_bank_account_number": "FI8149754587000402",
+}
+
+
+def test_decision_proposal_drafting():
+    # Create a new application, set the other one as cancelled
+    application = ReceivedApplicationFactory(application_number=100002)
+    CancelledApplicationFactory(application_number=100002)
+    DecidedApplicationFactory(application_number=100003)
+    HandlingApplicationFactory(application_number=100004)
+
+    application.status = ApplicationStatus.RECEIVED
+    application.save()
+    serializer = HandlerApplicationSerializer(
+        application,
+        data=data_for_application,
+    )
+    serializer.is_valid()
+    serializer.save()
+
+    apps = Application.objects.filter(status=ApplicationStatus.CANCELLED)
+    assert len(apps) == 2 and apps[0].archived is True and apps[1].archived is True
+
+    application.status = ApplicationStatus.RECEIVED
+    application.archived = False
+    application.save()
+    apps = Application.objects.filter(status=ApplicationStatus.CANCELLED)
+    call_command("set_cancelled_as_archived")
+    assert len(apps) == 1
+
+    serializer = HandlerApplicationSerializer(
+        application,
+        data=data_for_application,
+    )
+    serializer.is_valid()
+    serializer.save()
+    call_command("set_cancelled_as_archived")
+    apps = Application.objects.filter(status=ApplicationStatus.CANCELLED)
+    assert len(apps) == 2


### PR DESCRIPTION
## Description :sparkles:

Previously, the cancelled applications where queried for but not marked for archieved. Mark them as archived to that filter works like intended.

I've also added a command which goes through all cancelled apps and marks them as archived:

`python manage.py set_cancelled_as_archived`