### PR TITLE
feat: add ahjo_status to Django admin

### DIFF
--- a/backend/benefit/applications/admin.py
+++ b/backend/benefit/applications/admin.py
@@ -5,6 +5,7 @@ from django.utils.safestring import mark_safe
 from applications.models import (
     AhjoDecisionText,
     AhjoSetting,
+    AhjoStatus,
     Application,
     ApplicationAlteration,
     ApplicationBasis,
@@ -20,6 +21,16 @@ from calculator.admin import CalculationInline
 
 class ApplicationBasisInline(admin.TabularInline):
     model = Application.bases.through
+
+
+class AhjoStatusInline(admin.TabularInline):
+    model = AhjoStatus
+    fk_name = "application"
+    extra = 0
+    readonly_fields = (
+        "created_at",
+        "status",
+    )
 
 
 class DeMinimisAidInline(admin.StackedInline):
@@ -72,6 +83,7 @@ class ApplicationAdmin(admin.ModelAdmin):
         AttachmentInline,
         CalculationInline,
         ApplicationAlterationInline,
+        AhjoStatusInline,
     )
     list_filter = ("status", "application_origin", "company")
     list_display = (


### PR DESCRIPTION
## Description :sparkles:
Add application's ahjo statuses to the Application view in Django admin
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
<img width="1692" alt="Screenshot 2024-04-25 at 15 05 47" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/84be701b-71d8-4378-99ac-d03e034d12ce">

## Additional notes :spiral_notepad:
