### PR TITLE
feat: prepare handler application index for new ahjo integration (hl-1278)

### DIFF
--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -287,6 +287,10 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
             should_filter_archived = request.query_params.get("filter_archived") == "1"
             qs = qs.filter(archived=should_filter_archived)
 
+        ahjo_cases = request.query_params.get("ahjo_case") == "1"
+        if ahjo_cases:
+            qs = qs.filter(ahjo_case_id__isnull=False, ahjo_case_id__gt="")
+
         return qs
 
     def _get_attachment(self, attachment_pk):

--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1608,6 +1608,7 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
             "pay_subsidies",
             "training_compensations",
             "batch",
+            "talpa_status",
             "create_application_for_company",
             "latest_decision_comment",
             "handled_at",

--- a/backend/benefit/applications/api/v1/serializers/batch.py
+++ b/backend/benefit/applications/api/v1/serializers/batch.py
@@ -143,8 +143,10 @@ class ApplicationBatchSerializer(serializers.ModelSerializer):
 class ApplicationBatchListSerializer(ApplicationBatchSerializer):
     def to_representation(self, instance):
         representation = super().to_representation(instance)
+
+        # Do not include applications that have been sent to Ahjo
         applications = BatchApplicationSerializer(
-            Application.objects.filter(batch=instance),
+            Application.objects.filter(batch=instance, ahjo_case_id__isnull=True),
             many=True,
         ).data
         representation["applications"] = applications

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -188,6 +188,7 @@
           "rejected": "Ei yhtään käsiteltyä kielteistä hakemusta.",
           "received": "Ei yhtään saapunutta hakemusta.",
           "archived": "Ei yhtään arkistoitua hakemusta.",
+          "accepted,rejected": "Ei yhtään päätettävänä olevaa hakemusta.",
           "additional_information_needed": "Ei yhtään lisätietoja odottavaa hakemusta.",
           "all": "Ei yhtään hakemusta.",
           "draft": "Ei yhtään luonnosta."
@@ -201,7 +202,9 @@
         "accepted": "Myönteiset",
         "rejected": "Kielteiset",
         "infoRequired": "Odottaa lisätietoja",
-        "decisions": "päätökset"
+        "decisions": "päätökset",
+        "pending": "Päätettävänä",
+        "inPayment": "Maksussa"
       },
       "errors": {
         "fetch": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -188,6 +188,7 @@
           "rejected": "Ei yhtään käsiteltyä kielteistä hakemusta.",
           "received": "Ei yhtään saapunutta hakemusta.",
           "archived": "Ei yhtään arkistoitua hakemusta.",
+          "accepted,rejected": "Ei yhtään päätettävänä olevaa hakemusta.",
           "additional_information_needed": "Ei yhtään lisätietoja odottavaa hakemusta.",
           "all": "Ei yhtään hakemusta.",
           "draft": "Ei yhtään luonnosta."
@@ -201,7 +202,9 @@
         "accepted": "Myönteiset",
         "rejected": "Kielteiset",
         "infoRequired": "Odottaa lisätietoja",
-        "decisions": "päätökset"
+        "decisions": "päätökset",
+        "pending": "Päätettävänä",
+        "inPayment": "Maksussa"
       },
       "errors": {
         "fetch": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -188,6 +188,7 @@
           "rejected": "Ei yhtään käsiteltyä kielteistä hakemusta.",
           "received": "Ei yhtään saapunutta hakemusta.",
           "archived": "Ei yhtään arkistoitua hakemusta.",
+          "accepted,rejected": "Ei yhtään päätettävänä olevaa hakemusta.",
           "additional_information_needed": "Ei yhtään lisätietoja odottavaa hakemusta.",
           "all": "Ei yhtään hakemusta.",
           "draft": "Ei yhtään luonnosta."
@@ -201,7 +202,9 @@
         "accepted": "Myönteiset",
         "rejected": "Kielteiset",
         "infoRequired": "Odottaa lisätietoja",
-        "decisions": "päätökset"
+        "decisions": "päätökset",
+        "pending": "Päätettävänä",
+        "inPayment": "Maksussa"
       },
       "errors": {
         "fetch": {

--- a/frontend/benefit/handler/src/components/applicationHeader/ApplicationHeader.tsx
+++ b/frontend/benefit/handler/src/components/applicationHeader/ApplicationHeader.tsx
@@ -8,11 +8,6 @@ import * as React from 'react';
 import Container from 'shared/components/container/Container';
 import { getFullName } from 'shared/utils/application.utils';
 import { convertToUIDateFormat, formatDate } from 'shared/utils/date.utils';
-import {
-  getLocalStorageItem,
-  removeLocalStorageItem,
-  setLocalStorageItem,
-} from 'shared/utils/localstorage.utils';
 
 import { $NoticeBar } from '../applicationReview/ApplicationReview.sc';
 import {
@@ -28,20 +23,6 @@ import {
 type ApplicationReviewProps = {
   data: Application;
   isApplicationReadOnly: boolean;
-};
-
-const toggleNewAhjoMode = (): void => {
-  // eslint-disable-next-line no-alert
-  const confirm = window.confirm(
-    'Kokeile Ahjo-integraation käyttöliittymää? Vain testiympäristöihin, älä käytä tuotannossa!'
-  );
-  if (!confirm) return;
-  if (getLocalStorageItem('newAhjoMode') !== '1') {
-    setLocalStorageItem('newAhjoMode', '1');
-  } else {
-    removeLocalStorageItem('newAhjoMode');
-  }
-  window.location.reload();
 };
 
 const ApplicationHeader: React.FC<ApplicationReviewProps> = ({
@@ -109,17 +90,6 @@ const ApplicationHeader: React.FC<ApplicationReviewProps> = ({
                 <$ItemValue>
                   {data.submittedAt && formatDate(new Date(data.submittedAt))}
                 </$ItemValue>
-              </$ItemWrapper>
-              <$ItemWrapper>
-                <button
-                  style={{ fontSize: '10px' }}
-                  type="button"
-                  onClick={toggleNewAhjoMode}
-                >
-                  Ahjo-kokeilu
-                  <br />
-                  {getLocalStorageItem('newAhjoMode') ? 'pois' : 'päälle'}
-                </button>
               </$ItemWrapper>
             </$Col>
             <$Col>

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.sc.ts
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.sc.ts
@@ -20,3 +20,17 @@ export const $CellContent = styled.div`
   align-items: center;
   background-color: ${(props) => props.theme.colors.white};
 `;
+
+type TagWrapperProps = {
+  $colors: {
+    background: string;
+    text: string;
+  };
+};
+
+export const $TagWrapper = styled.div<TagWrapperProps>`
+  #hds-tag {
+    background: ${(props) => props.$colors.background};
+    color: ${(props) => props.$colors.text};
+  }
+`;

--- a/frontend/benefit/handler/src/components/applicationList/useApplicationListData.ts
+++ b/frontend/benefit/handler/src/components/applicationList/useApplicationListData.ts
@@ -36,6 +36,8 @@ const useApplicationListData = (
         status: applicationStatus,
         unread_messages_count,
         batch,
+        talpa_status,
+        ahjo_case_id,
         application_origin: applicationOrigin,
       } = application;
 
@@ -60,6 +62,8 @@ const useApplicationListData = (
         unreadMessagesCount: unread_messages_count ?? 0,
         batch: batch ?? null,
         applicationOrigin,
+        talpaStatus: talpa_status,
+        ahjoCaseId: ahjo_case_id,
       };
     }
   );

--- a/frontend/benefit/handler/src/components/batchProcessing/useApplicationsHandled.ts
+++ b/frontend/benefit/handler/src/components/batchProcessing/useApplicationsHandled.ts
@@ -41,6 +41,7 @@ const useApplicationsHandled = (
         application_number: applicationNum,
         status: appStatus,
         batch,
+        talpa_status,
       } = application;
 
       return {
@@ -54,6 +55,7 @@ const useApplicationsHandled = (
         handledAt: convertToUIDateFormat(handled_at) || '-',
         dataReceived: getBatchDataReceived(status, batch?.created_at),
         applicationNum,
+        talpaStatus: talpa_status,
       };
     });
 

--- a/frontend/benefit/handler/src/components/header/Header.tsx
+++ b/frontend/benefit/handler/src/components/header/Header.tsx
@@ -3,6 +3,7 @@ import useLogin from 'benefit/handler/hooks/useLogin';
 import useLogout from 'benefit/handler/hooks/useLogout';
 import useUserQuery from 'benefit/handler/hooks/useUserQuery';
 import noop from 'lodash/noop';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import * as React from 'react';
 import BaseHeader from 'shared/components/header/Header';
@@ -24,9 +25,17 @@ const Header: React.FC = () => {
   const { asPath } = router;
   const isLoginPage = asPath?.startsWith(ROUTES.LOGIN);
 
+  const TemporaryAhjoModeSwitch = dynamic(
+    () => import('benefit/handler/components/header/TemporaryAhjoModeSwitch'),
+    {
+      ssr: false,
+    }
+  );
+
   return (
     <BaseHeader
       title={t('common:appName')}
+      customItems={[<TemporaryAhjoModeSwitch />]}
       titleUrl={ROUTES.HOME}
       skipToContentLabel={t('common:header.linkSkipToContent')}
       menuToggleAriaLabel={t('common:header.menuToggleAriaLabel')}

--- a/frontend/benefit/handler/src/components/header/TemporaryAhjoModeSwitch.tsx
+++ b/frontend/benefit/handler/src/components/header/TemporaryAhjoModeSwitch.tsx
@@ -1,0 +1,46 @@
+import { useDetermineAhjoMode } from 'benefit/handler/hooks/useDetermineAhjoMode';
+import { Button } from 'hds-react';
+import React from 'react';
+import {
+  removeLocalStorageItem,
+  setLocalStorageItem,
+} from 'shared/utils/localstorage.utils';
+
+const toggleNewAhjoMode = (isNewMode: boolean): void => {
+  // eslint-disable-next-line no-alert
+  const confirm = isNewMode
+    ? // eslint-disable-next-line no-alert
+      window.confirm(
+        'Haluatko palata vanhaan koontipohjaiseen käyttöliittymään?'
+      )
+    : // eslint-disable-next-line no-alert
+      window.confirm(
+        'Haluatko kokeilla uutta Ahjo-integraation käyttöliittymää? Vain testiympäristöihin, älä käytä tuotannossa!'
+      );
+  if (!confirm) return;
+  if (!isNewMode) {
+    setLocalStorageItem('newAhjoMode', '1');
+  } else {
+    removeLocalStorageItem('newAhjoMode');
+  }
+  window.location.reload();
+};
+
+const TemporaryAhjoModeSwitch: React.FC = () => {
+  const isNewAhjoMode = useDetermineAhjoMode();
+  return (
+    <Button
+      iconRight={null}
+      onClick={() => toggleNewAhjoMode(isNewAhjoMode)}
+      theme="coat"
+      variant="supplementary"
+      size="small"
+    >
+      Ahjo-kokeilu
+      <br />
+      {isNewAhjoMode ? 'on päällä' : 'on pois päältä'}
+    </Button>
+  );
+};
+
+export default TemporaryAhjoModeSwitch;

--- a/frontend/benefit/handler/src/components/header/useHeader.ts
+++ b/frontend/benefit/handler/src/components/header/useHeader.ts
@@ -1,5 +1,6 @@
 import { ROUTES } from 'benefit/handler/constants';
 import AppContext from 'benefit/handler/context/AppContext';
+import { useDetermineAhjoMode } from 'benefit/handler/hooks/useDetermineAhjoMode';
 import { useRouter } from 'next/router';
 import { TFunction, useTranslation } from 'next-i18next';
 import React from 'react';
@@ -23,14 +24,15 @@ const useHeader = (): ExtendedComponentProps => {
   const { t } = useTranslation();
   const router = useRouter();
   const { isNavigationVisible } = React.useContext(AppContext);
+  const isNewAhjoMode = useDetermineAhjoMode();
 
   const languageOptions = React.useMemo(
     (): OptionType<string>[] => getLanguageOptions(t, 'supportedLanguages'),
     [t]
   );
 
-  const navigationItems = React.useMemo(
-    (): NavigationItem[] => [
+  const items = {
+    default: [
       { label: t('common:header.navigation.applications'), url: ROUTES.HOME },
       {
         label: t('common:header.navigation.batches'),
@@ -45,7 +47,22 @@ const useHeader = (): ExtendedComponentProps => {
         url: ROUTES.APPLICATIONS_REPORTS,
       },
     ],
-    [t]
+    newAhjo: [
+      { label: t('common:header.navigation.applications'), url: ROUTES.HOME },
+      {
+        label: t('common:header.navigation.archive'),
+        url: ROUTES.APPLICATIONS_ARCHIVE,
+      },
+      {
+        label: t('common:header.navigation.reports'),
+        url: ROUTES.APPLICATIONS_REPORTS,
+      },
+    ],
+  };
+
+  const navigationItems = React.useMemo(
+    (): NavigationItem[] => (isNewAhjoMode ? items.newAhjo : items.default),
+    [items.default, items.newAhjo, isNewAhjoMode]
   );
 
   const handleLanguageChange = (

--- a/frontend/benefit/handler/src/hooks/useApplicationsQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useApplicationsQuery.ts
@@ -9,7 +9,8 @@ const useApplicationsQuery = (
   status: string[],
   orderBy = 'id',
   excludeBatched = false,
-  filterArchived = false
+  filterArchived = false,
+  filterAhjoCaseId = false
 ): UseQueryResult<ApplicationData[], Error> => {
   const { axios, handleResponse } = useBackendAPI();
   const { t } = useTranslation();
@@ -28,9 +29,11 @@ const useApplicationsQuery = (
     order_by: string;
     exclude_batched?: '1';
     filter_archived?: '1';
+    ahjo_case?: '0' | '1';
   } = {
     status: status.join(','),
     order_by: orderBy,
+    ahjo_case: filterAhjoCaseId ? '1' : '0',
   };
 
   if (excludeBatched) {

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -446,6 +446,8 @@ export type ApplicationData = {
   action?: APPLICATION_ACTIONS;
   company_contact_person_first_name: string;
   company_contact_person_last_name: string;
+  talpa_status: TALPA_STATUSES;
+  ahjo_case_id: string;
 };
 
 export type EmployeeData = {
@@ -538,6 +540,8 @@ export type ApplicationListItemData = {
   applicationOrigin?: APPLICATION_ORIGINS;
   validUntil?: string;
   contactPersonName?: string;
+  talpaStatus?: string;
+  ahjoCaseId?: string;
 };
 
 export type TextProp = 'textFi' | 'textEn' | 'textSv';


### PR DESCRIPTION
## Description :sparkles:

* Move ahjo mode toggle to main `<Header>` as custom item
* Fork from default behaviour index to `<HandlerIndex />`
  * New fork has some changes on how to filter the apps to the list, `<ApplicationsHandled>` is no longer used
* Some changes to API: allow filtering for `ahjo_case_id`
* Add color to application status `<Tag>`