### PR TITLE
fix: enable justification text variable replacement (hl-1290)

### DIFF
--- a/backend/benefit/applications/services/ahjo_decision_service.py
+++ b/backend/benefit/applications/services/ahjo_decision_service.py
@@ -62,6 +62,9 @@ def process_template_sections(
         section.template_decision_text = replace_decision_template_placeholders(
             section.template_decision_text, section.decision_type, application
         )
+        section.template_justification_text = replace_decision_template_placeholders(
+            section.template_justification_text, section.decision_type, application
+        )
     return template_sections
 
 


### PR DESCRIPTION
## Description :sparkles:

Add missing function call to populate justification text $variables with appropriate values.

![image](https://github.com/City-of-Helsinki/yjdh/assets/5328394/bfe410e0-a15b-478c-8928-28f454a183ef)
