### PR TITLE
YJDH-697 | feat(ks-handler): show/accept/reject youth applications that have no SSN

### DIFF
--- a/frontend/kesaseteli/handler/public/locales/fi/common.json
+++ b/frontend/kesaseteli/handler/public/locales/fi/common.json
@@ -29,6 +29,8 @@
     "title": "Hakemuksen tiedot",
     "name": "Nimi",
     "social_security_number": "Hlö-tunnus",
+    "non_vtj_birthdate": "Syntymäaika (Ei VTJ:stä!)",
+    "non_vtj_home_municipality": "Kotikunta (Ei VTJ:stä!)",
     "postcode": "Postinumero",
     "school": "Koulu",
     "is_unlisted_school": "(Koulua ei löytynyt listalta)",
@@ -56,6 +58,7 @@
     },
     "vtjException": {
       "notFound": "Väestötietojärjestelmästä ei löytynyt tietoja henkilötunnuksella: {{ social_security_number }}!",
+      "missingSsn": "Henkilötunnus puuttuu!",
       "differentLastName": "Sukunimi poikkeaa hakemukselle syötetystä sukunimestä ({{ last_name }})",
       "notInTargetAgeGroup": "Henkilö ei kuulu iän puolesta kohderyhmään ({{ age }}-vuotias)",
       "addressNotFound": "Osoitetietoja ei löytynyt!",

--- a/frontend/kesaseteli/handler/src/components/form/ActionButtons.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/ActionButtons.tsx
@@ -19,7 +19,12 @@ type Props = GridCellProps & {
 const ActionButtons: React.FC<Props> = ({ application, ...gridCellprops }) => {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { id, encrypted_handler_vtj_json } = application;
+  const {
+    id,
+    encrypted_handler_vtj_json,
+    non_vtj_birthdate,
+    social_security_number,
+  } = application;
   const { confirm } = useConfirm();
   const { isLoading, mutate } = useCompleteYouthApplicationQuery(id);
   const isVtjEnabled = !isVtjDisabled();
@@ -51,6 +56,13 @@ const ActionButtons: React.FC<Props> = ({ application, ...gridCellprops }) => {
     }
   };
 
+  const isDisabled =
+    isLoading ||
+    // Social security number requires VTJ data for processing
+    (social_security_number && vtjDataNotFound) ||
+    // Missing social security number requires birthdate for processing
+    (!social_security_number && !non_vtj_birthdate);
+
   return (
     <$GridCell {...gridCellprops}>
       <Button
@@ -59,7 +71,7 @@ const ActionButtons: React.FC<Props> = ({ application, ...gridCellprops }) => {
         iconLeft={icon.accept}
         onClick={() => complete('accept')}
         isLoading={isLoading}
-        disabled={vtjDataNotFound || isLoading}
+        disabled={isDisabled}
         css={`
           margin-right: ${theme.spacing.l};
         `}
@@ -73,7 +85,7 @@ const ActionButtons: React.FC<Props> = ({ application, ...gridCellprops }) => {
         onClick={() => complete('reject')}
         loadingText={t(`common:handlerApplication.saving`)}
         isLoading={isLoading}
-        disabled={vtjDataNotFound || isLoading}
+        disabled={isDisabled}
       >
         {t(`common:handlerApplication.reject`)}
       </Button>

--- a/frontend/kesaseteli/handler/src/components/form/HandlerForm.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/HandlerForm.tsx
@@ -14,7 +14,10 @@ import React from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import FormSectionHeading from 'shared/components/forms/section/FormSectionHeading';
 import { $Notification } from 'shared/components/notification/Notification.sc';
-import { convertToUIDateAndTimeFormat } from 'shared/utils/date.utils';
+import {
+  convertToUIDateAndTimeFormat,
+  convertToUIDateFormat,
+} from 'shared/utils/date.utils';
 import { useTheme } from 'styled-components';
 
 type Props = {
@@ -31,6 +34,8 @@ const HandlerForm: React.FC<Props> = ({ application }) => {
     first_name,
     last_name,
     social_security_number,
+    non_vtj_birthdate,
+    non_vtj_home_municipality,
     postcode,
     school,
     is_unlisted_school,
@@ -92,7 +97,21 @@ const HandlerForm: React.FC<Props> = ({ application }) => {
         {!isVtjDisabled() && <VtjInfo application={application} />}
       </$GridCell>
       <Field type="name" value={`${first_name} ${last_name}`} />
-      <Field type="social_security_number" value={social_security_number} />
+      {social_security_number && (
+        <Field type="social_security_number" value={social_security_number} />
+      )}
+      {non_vtj_birthdate && (
+        <Field
+          type="non_vtj_birthdate"
+          value={convertToUIDateFormat(non_vtj_birthdate)}
+        />
+      )}
+      {non_vtj_home_municipality && (
+        <Field
+          type="non_vtj_home_municipality"
+          value={non_vtj_home_municipality}
+        />
+      )}
       <Field type="postcode" value={postcode} />
       <Field
         type="school"
@@ -135,10 +154,9 @@ const HandlerForm: React.FC<Props> = ({ application }) => {
         </>
       )}
       {waitingForHandlerAction ? (
-        <ActionButtons
-          application={application}
-          $rowSpan={additionalInfoProvided ? 12 : 8}
-        />
+        <$GridCell $colSpan={2}>
+          <ActionButtons application={application} />
+        </$GridCell>
       ) : (
         <$GridCell>
           <$Notification

--- a/frontend/kesaseteli/handler/src/components/form/VtjInfo.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/VtjInfo.tsx
@@ -22,6 +22,10 @@ const VtjInfo: React.FC<Props> = ({ application }) => {
     postcode,
   } = application;
 
+  if (!social_security_number) {
+    return <VtjErrorNotification reason="missingSsn" type="error" />;
+  }
+
   if (!vtjData || !('Henkilo' in vtjData)) {
     return (
       <VtjErrorNotification

--- a/frontend/kesaseteli/handler/src/constants/vtj-exceptions.ts
+++ b/frontend/kesaseteli/handler/src/constants/vtj-exceptions.ts
@@ -1,5 +1,6 @@
 const VTJ_EXCEPTIONS = [
   'notFound',
+  'missingSsn',
   'differentLastName',
   'notInTargetAgeGroup',
   'addressNotFound',

--- a/frontend/kesaseteli/shared/src/types/youth-application.d.ts
+++ b/frontend/kesaseteli/shared/src/types/youth-application.d.ts
@@ -4,6 +4,8 @@ type YouthApplication = {
   first_name: string;
   last_name: string;
   social_security_number: string;
+  non_vtj_birthdate?: Date;
+  non_vtj_home_municipality?: string;
   postcode: string;
   school?: string;
   is_unlisted_school: boolean;

--- a/frontend/shared/src/utils/mask-gdpr-data.ts
+++ b/frontend/shared/src/utils/mask-gdpr-data.ts
@@ -66,6 +66,7 @@ export const ATTRIBUTES_TO_MASK = [
   'employee_name',
   'employee_ssn',
   'employee_phone_number',
+  'non_vtj_birthdate',
   // benefit attributes
   'lastName',
   'phoneNumber',


### PR DESCRIPTION
## Description :sparkles:

### feat(ks-handler): show/accept/reject youth applications that have no SSN

TODO:
 - Add UI for creating youth applications without social security number

refs YJDH-697 (handler UI for showing/accepting/rejecting)

## Issues :bug:

[YJDH-697](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-697)

## Testing :alembic:

Local testing:
 - checkout the PR's branch
 - `cp .env.kesaseteli.example .env.kesaseteli`
 - Terminal 1:
   - `docker compose -f compose.employer.yml up --build` to spin up **backend** at `localhost:8000`
     - The employer docker compose file is the least resource heavy docker compose file that spins up the Kesäseteli API so that's why using it
 - Terminal 2:
   - `docker exec -it kesaseteli-backend bash` to enter backend
     - `python manage.py shell_plus` to start Django shell inside backend
       - `from common.tests.factories import *`
       - `str(AcceptableNonVtjYouthApplicationFactory(non_vtj_home_municipality='Testikunta 1').id)` and save the output as ID₁
       - `str(AcceptableNonVtjYouthApplicationFactory(non_vtj_home_municipality='Testikunta 2').id)` and save the output as ID₂
       - `str(VtjTestCaseYouthApplicationFactory(last_name='Kotikunta Helsinki', status='additional_information_provided').id)` and save the output as ID₃
 - Terminal 3:
   - `nvm use 18` (i.e. use node v18)
   - `yarn` to install packages
   - `cd frontend/kesaseteli/handler/`
   - `yarn dev` to spin up the **handler UI** at `localhost:3200`
 - Open web browser at `http://localhost:3200/?id=ID₁` using the ID₁ value from backend shell
   - Check out that "Syntymäaika (Ei VTJ:stä!):" for `non_vtj_birthdate` and "Kotikunta (Ei VTJ:stä!):" for `non_vtj_municipality` fields are shown
   - Approve the application using the "Hyväksy" button
 - Open web browser at `http://localhost:3200/?id=ID₂` using the ID₂ value from backend shell
   - Check out that "Syntymäaika (Ei VTJ:stä!):" for `non_vtj_birthdate` and "Kotikunta (Ei VTJ:stä!):" for `non_vtj_municipality` fields are shown
   - Reject the application using the "Hylkää" button
 - Open web browser at `http://localhost:3200/?id=ID₃` using the ID₃ value from backend shell
   - Check out that "Syntymäaika (Ei VTJ:stä!):" for `non_vtj_birthdate` and "Kotikunta (Ei VTJ:stä!):" for `non_vtj_municipality` fields are NOT shown
   - Accept the application using the "Hyväksy" button

Ran "yarn test" under `frontend/kesaseteli/handler` and it passed:
```bash
Test Suites: 1 passed, 1 total
Tests:       40 passed, 40 total
Snapshots:   0 total
Time:        75.722 s
Ran all test suites.
Done in 93.25s.
```

## Screenshots :camera_flash:

### Approving non-VTJ youth application (ID₁)
![1-1](https://github.com/City-of-Helsinki/yjdh/assets/77663720/588f43a7-1746-4415-85c2-8095078327e1)
![1-2](https://github.com/City-of-Helsinki/yjdh/assets/77663720/7e17eb72-3e19-4fe9-8acc-c74a114e0be3)

## Rejecting non-VTJ youth application (ID₂)
![2-1](https://github.com/City-of-Helsinki/yjdh/assets/77663720/a0cd1725-c0dc-4e24-b83c-10fc9562e49c)
![2-2](https://github.com/City-of-Helsinki/yjdh/assets/77663720/bf4f3b02-3d86-4fd0-bb95-bc43ebf20dc1)

## Accepting VTJ youth application (ID₃)
![3-1](https://github.com/City-of-Helsinki/yjdh/assets/77663720/3705a77d-8ef9-4ef3-bea0-18b348398e50)
![3-2](https://github.com/City-of-Helsinki/yjdh/assets/77663720/fd3bdcdb-2754-4ddc-aaeb-f805cda15fbf)

## Additional notes :spiral_notepad:


[YJDH-697]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ