### PR TITLE
fix: do not show cents for benefit amount (hl-1294)

### DIFF
--- a/backend/benefit/applications/services/ahjo_decision_service.py
+++ b/backend/benefit/applications/services/ahjo_decision_service.py
@@ -42,7 +42,7 @@ def replace_decision_template_placeholders(
             company=application.company.name,
             decision_maker=decision_maker,
             total_amount=(
-                application.calculation.calculated_benefit_amount
+                int(application.calculation.calculated_benefit_amount)
                 if decision_type == DecisionType.ACCEPTED
                 else ""
             ),

--- a/backend/benefit/applications/tests/test_ahjo_decisions.py
+++ b/backend/benefit/applications/tests/test_ahjo_decisions.py
@@ -18,12 +18,9 @@ def test_replace_accepted_decision_template_placeholders(
         accepted_ahjo_decision_section.decision_type,
         decided_application,
     )
-
+    total_amount = int(decided_application.calculation.calculated_benefit_amount)
     assert decided_application.company.name in replaced_template
-    assert (
-        f"{decided_application.calculation.calculated_benefit_amount}"
-        in replaced_template
-    )
+    assert f"{total_amount}" in replaced_template
     wanted_start_date = decided_application.calculation.start_date.strftime("%d.%m.%Y")
     wanted_end_date = decided_application.calculation.end_date.strftime("%d.%m.%Y")
     assert f"{wanted_start_date} - {wanted_end_date}" in replaced_template

--- a/frontend/benefit/handler/src/components/applicationReview/CalculationReview.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/CalculationReview.tsx
@@ -78,7 +78,12 @@ const CalculationReview: React.FC<ApplicationReviewStepProps> = ({
   const tableRows = filteredData.reduce((acc: BenefitRow[], row: Row) => {
     tableRow.id = row.id;
     if (row.rowType === 'helsinki_benefit_monthly_eur') {
-      tableRow.perMonth = `${formatFloatToCurrency(row.amount)} / kk`;
+      tableRow.perMonth = `${formatFloatToCurrency(
+        row.amount,
+        'EUR',
+        'fi-FI',
+        0
+      )} / kk`;
     }
     if (row.rowType === 'helsinki_benefit_sub_total_eur') {
       tableRow.dates = `${convertToUIDateFormat(
@@ -93,7 +98,7 @@ const CalculationReview: React.FC<ApplicationReviewStepProps> = ({
         new Date(row.startDate)
       );
 
-      tableRow.amount = formatFloatToCurrency(row.amount);
+      tableRow.amount = formatFloatToCurrency(row.amount, 'EUR', 'fi-FI', 0);
       tableRow.amountNumber = row.amount;
       acc.push(tableRow);
       tableRow = createBenefitRow();
@@ -115,7 +120,7 @@ const CalculationReview: React.FC<ApplicationReviewStepProps> = ({
         (acc: number, cur: BenefitRow) => acc + cur.duration,
         0
       ),
-      amount: formatFloatToCurrency(totalSum),
+      amount: formatFloatToCurrency(totalSum, 'EUR', 'fi-FI', 0),
     });
 
   return (
@@ -181,7 +186,7 @@ const CalculationReview: React.FC<ApplicationReviewStepProps> = ({
             <>
               <div>
                 <dt>{t('common:review.decisionProposal.list.totalAmount')}</dt>
-                <dd>{formatFloatToCurrency(totalSum)}</dd>
+                <dd>{formatFloatToCurrency(totalSum, 'EUR', 'fi-FI', 0)}</dd>
               </div>
               <div>
                 <dt>


### PR DESCRIPTION
## Description :sparkles:

Remove cent fractions from benefit calculation when making a decision for application.

<img width="1251" alt="image" src="https://github.com/City-of-Helsinki/yjdh/assets/5328394/b7dd08ab-df39-466b-8b49-4a0c2b9378ae">
