### PR TITLE
(Revert PR #2964) fix(frontend): don't use cross-env in scripts, didn't work in pipelines

### DIFF
--- a/frontend/benefit/applicant/package.json
+++ b/frontend/benefit/applicant/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node ../../shared/src/server/next-server.js",
     "build": "next build",
-    "start": "cross-env NODE_ENV=production node ../../shared/src/server/next-server.js",
+    "start": "NODE_ENV=production node ../../shared/src/server/next-server.js",
     "lint": "eslint --ext js,ts,tsx src",
     "pre-commit": "lint-staged -c ../../.lintstagedrc.js",
     "test": "jest --passWithNoTests",

--- a/frontend/benefit/handler/package.json
+++ b/frontend/benefit/handler/package.json
@@ -3,9 +3,9 @@
   "version": "3.4.0",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env PORT=3100 node ../../shared/src/server/next-server.js",
+    "dev": "PORT=3100 node ../../shared/src/server/next-server.js",
     "build": "next build",
-    "start": "cross-env NODE_ENV=production PORT=3100 node ../../shared/src/server/next-server.js",
+    "start": "NODE_ENV=production PORT=3100 node ../../shared/src/server/next-server.js",
     "lint": "eslint --ext js,ts,tsx src",
     "pre-commit": "lint-staged -c ../../.lintstagedrc.js",
     "test": "jest --passWithNoTests",

--- a/frontend/kesaseteli/employer/package.json
+++ b/frontend/kesaseteli/employer/package.json
@@ -3,9 +3,9 @@
   "version": "1.3.0",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env PORT=3000 node ../../shared/src/server/next-server.js",
+    "dev": "PORT=3000 node ../../shared/src/server/next-server.js",
     "build": "next build",
-    "start": "cross-env NODE_ENV=production PORT=3000 node ../../shared/src/server/next-server.js",
+    "start": "NODE_ENV=production PORT=3000 node ../../shared/src/server/next-server.js",
     "lint": "eslint --ext js,ts,tsx src browser-tests",
     "pre-commit": "lint-staged -c ../../.lintstagedrc.js",
     "test": "jest --runInBand --no-cache",

--- a/frontend/kesaseteli/handler/package.json
+++ b/frontend/kesaseteli/handler/package.json
@@ -3,9 +3,9 @@
   "version": "1.2.0",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env PORT=3200 node ../../shared/src/server/next-server.js",
+    "dev": "PORT=3200 node ../../shared/src/server/next-server.js",
     "build": "next build",
-    "start": "cross-env NODE_ENV=production PORT=3200 node ../../shared/src/server/next-server.js",
+    "start": "NODE_ENV=production PORT=3200 node ../../shared/src/server/next-server.js",
     "lint": "eslint --ext js,ts,tsx src browser-tests",
     "pre-commit": "lint-staged -c ../../.lintstagedrc.js",
     "test": "jest --runInBand --no-cache",

--- a/frontend/kesaseteli/youth/package.json
+++ b/frontend/kesaseteli/youth/package.json
@@ -3,9 +3,9 @@
   "version": "1.3.0",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env PORT=3100 node ../../shared/src/server/next-server.js",
+    "dev": "PORT=3100 node ../../shared/src/server/next-server.js",
     "build": "next build",
-    "start": "cross-env NODE_ENV=production PORT=3100 node ../../shared/src/server/next-server.js",
+    "start": "NODE_ENV=production PORT=3100 node ../../shared/src/server/next-server.js",
     "lint": "eslint --ext js,ts,tsx src browser-tests",
     "pre-commit": "lint-staged -c ../../.lintstagedrc.js",
     "test": "jest --runInBand --no-cache",

--- a/frontend/tet/admin/package.json
+++ b/frontend/tet/admin/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env PORT=3000 node ../../shared/src/server/next-server.js",
+    "dev": "PORT=3000 node ../../shared/src/server/next-server.js",
     "build": "next build",
-    "start": "cross-env NODE_ENV=production PORT=3000 node ../../shared/src/server/next-server.js",
+    "start": "NODE_ENV=production PORT=3000 node ../../shared/src/server/next-server.js",
     "pre-commit": "lint-staged -c ../../.lintstagedrc.js",
     "test": "jest --runInBand --no-cache",
     "test:debug-dom": "cross-env DEBUG_PRINT_LIMIT=1000000 yarn test",

--- a/frontend/tet/youth/package.json
+++ b/frontend/tet/youth/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env PORT=3000 node ../../shared/src/server/next-server.js",
+    "dev": "PORT=3000 node ../../shared/src/server/next-server.js",
     "build": "next build",
-    "start": "cross-env NODE_ENV=production PORT=3000 node ../../shared/src/server/next-server.js",
+    "start": "NODE_ENV=production PORT=3000 node ../../shared/src/server/next-server.js",
     "pre-commit": "lint-staged -c ../../.lintstagedrc.js",
     "test": "jest --runInBand --no-cache --passWithNoTests",
     "test:debug-nock": "cross-env DEBUG=nock.* yarn test",


### PR DESCRIPTION
## Description :sparkles:

**This reverts PR** #2964!

### fix(frontend): don't use cross-env in scripts, didn't work in pipelines

This reverts commit 7307e5797d6b0a0bc24eded97d6724a5724a4547

refs YJDH-697 (noticed the missing cross-env uses)

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
