### PR TITLE
chore: add tsconfig.tsbuildinfo to frontend/.gitignore

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,6 +1,7 @@
 .next
 node_modules
 screenshots
+tsconfig.tsbuildinfo
 report
 coverage
 


### PR DESCRIPTION
## Description :sparkles:

### chore: add tsconfig.tsbuildinfo to frontend/.gitignore

refs YJDH-697 (noticed the need for adding this file to .gitignore)

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
