### PR TITLE
fix: filter batches using auto_generated_by_ahjo value (hl-1304)

### DIFF
--- a/backend/benefit/applications/api/v1/application_batch_views.py
+++ b/backend/benefit/applications/api/v1/application_batch_views.py
@@ -71,8 +71,10 @@ class ApplicationBatchViewSet(AuditLoggingModelViewSet):
     ]
 
     def get_queryset(self):
-        order_by = self.request.query_params.get("order_by") or None
+        # Do not include applications that have been sent to Ahjo via integration
+        self.queryset = self.queryset.filter(auto_generated_by_ahjo=False)
 
+        order_by = self.request.query_params.get("order_by") or None
         if order_by:
             self.queryset = self.queryset.order_by(order_by)
 

--- a/backend/benefit/applications/api/v1/serializers/batch.py
+++ b/backend/benefit/applications/api/v1/serializers/batch.py
@@ -144,9 +144,8 @@ class ApplicationBatchListSerializer(ApplicationBatchSerializer):
     def to_representation(self, instance):
         representation = super().to_representation(instance)
 
-        # Do not include applications that have been sent to Ahjo
         applications = BatchApplicationSerializer(
-            Application.objects.filter(batch=instance, ahjo_case_id__isnull=True),
+            Application.objects.filter(batch=instance),
             many=True,
         ).data
         representation["applications"] = applications

--- a/frontend/benefit/applicant/browser-tests/pages/company.testcafe.ts
+++ b/frontend/benefit/applicant/browser-tests/pages/company.testcafe.ts
@@ -2,7 +2,8 @@ import { HttpRequestHook } from '@frontend/shared/browser-tests/http-utils/http-
 import requestLogger from '@frontend/shared/browser-tests/utils/request-logger';
 import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
 import { convertToUIDateFormat } from '@frontend/shared/src/utils/date.utils';
-import { addMonths, subMonths } from 'date-fns';
+import addDays from 'date-fns/addDays';
+import subMonths from 'date-fns/subMonths';
 import { t } from 'testcafe';
 
 import DeMinimisAid from '../page-model/deminimis';
@@ -28,7 +29,7 @@ fixture('Company')
   });
 
 const startDate = subMonths(new Date(), 4);
-const endDate = addMonths(new Date(), 3);
+const endDate = addDays(startDate, 30);
 const form: ApplicationFormData = {
   organization: {
     iban: '6051437344779954',

--- a/frontend/benefit/handler/src/components/applicationList/HandlerIndex.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/HandlerIndex.tsx
@@ -52,12 +52,16 @@ const HandlerIndex: React.FC<ApplicationListProps> = ({
         [APPLICATION_STATUSES.ACCEPTED].includes(app.status)
     ).length;
 
+  const getTabCountAll = (): number =>
+    list.filter((app: ApplicationListItemData) => !app.batch).length;
+
   const getTabCount = (
     statuses: APPLICATION_STATUSES[],
     handled?: 'inPayment' | 'pending'
   ): number => {
     if (handled === 'pending') return getTabCountPending();
     if (handled === 'inPayment') return getTabCountInPayment();
+    if (handled === 'all') return getTabCountAll();
     return list.filter((app: ApplicationListItemData) =>
       statuses.includes(app.status)
     ).length;
@@ -133,7 +137,7 @@ const HandlerIndex: React.FC<ApplicationListProps> = ({
             <Tabs.TabPanel>
               <ApplicationList
                 isLoading={isLoading}
-                list={list}
+                list={list.filter((app) => !app.batch)}
                 heading={t(`${translationBase}.all`)}
                 status={ALL_APPLICATION_STATUSES}
               />

--- a/frontend/benefit/handler/src/pages/index.tsx
+++ b/frontend/benefit/handler/src/pages/index.tsx
@@ -42,12 +42,13 @@ const ApplicantIndex: NextPage = () => {
 
   const translationBase = 'common:applications.list.headings';
 
+  const isNewAhjoMode = useDetermineAhjoMode();
+
   const { list, shouldShowSkeleton } = useApplicationListData(
     ALL_APPLICATION_STATUSES,
-    true
+    !isNewAhjoMode
   );
   const { t } = useApplicationList();
-  const isNewAhjoMode = useDetermineAhjoMode();
 
   const getHeadingTranslation = (
     headingStatus: APPLICATION_STATUSES | 'all'


### PR DESCRIPTION
## Description :sparkles:

Filter out ahjo integration batches in views, not just the applications.