### PR TITLE
Hl 1300 automation fix

### DIFF
--- a/backend/benefit/applications/jobs/quarter_hourly/quarter_hourly_ahjo_job.py
+++ b/backend/benefit/applications/jobs/quarter_hourly/quarter_hourly_ahjo_job.py
@@ -17,7 +17,7 @@ class Job(QuarterHourlyJob):
             )
             call_command(
                 "send_ahjo_requests",
-                request_type=AhjoRequestType.SEND_DECISION_PROPOSAL,
+                request_type=AhjoRequestType.ADD_RECORDS,
             )
             call_command(
                 "send_ahjo_requests", request_type=AhjoRequestType.UPDATE_APPLICATION

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -732,10 +732,11 @@ dummy_case_id = "HEL 1999-123"
 
 
 @pytest.mark.parametrize(
-    "application_status,talpa_status, case_id, decision_text, count",
+    "application_status, ahjo_status,talpa_status, case_id, decision_text, count",
     [
         (
             ApplicationStatus.DRAFT,
+            AhjoStatusEnum.CASE_OPENED,
             ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
             dummy_case_id,
             False,
@@ -743,6 +744,7 @@ dummy_case_id = "HEL 1999-123"
         ),
         (
             ApplicationStatus.HANDLING,
+            AhjoStatusEnum.CASE_OPENED,
             ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
             dummy_case_id,
             False,
@@ -750,6 +752,7 @@ dummy_case_id = "HEL 1999-123"
         ),
         (
             ApplicationStatus.RECEIVED,
+            AhjoStatusEnum.CASE_OPENED,
             ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
             dummy_case_id,
             False,
@@ -757,6 +760,7 @@ dummy_case_id = "HEL 1999-123"
         ),
         (
             ApplicationStatus.CANCELLED,
+            AhjoStatusEnum.CASE_OPENED,
             ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
             dummy_case_id,
             False,
@@ -764,6 +768,7 @@ dummy_case_id = "HEL 1999-123"
         ),
         (
             ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED,
+            AhjoStatusEnum.CASE_OPENED,
             ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
             dummy_case_id,
             False,
@@ -771,6 +776,7 @@ dummy_case_id = "HEL 1999-123"
         ),
         (
             ApplicationStatus.ACCEPTED,
+            AhjoStatusEnum.CASE_OPENED,
             ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
             dummy_case_id,
             True,
@@ -778,21 +784,62 @@ dummy_case_id = "HEL 1999-123"
         ),
         (
             ApplicationStatus.REJECTED,
+            AhjoStatusEnum.CASE_OPENED,
             ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
             dummy_case_id,
             True,
             1,
         ),
+        (
+            ApplicationStatus.ACCEPTED,
+            AhjoStatusEnum.DECISION_PROPOSAL_SENT,
+            ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
+            dummy_case_id,
+            True,
+            0,
+        ),
+        (
+            ApplicationStatus.REJECTED,
+            AhjoStatusEnum.DECISION_PROPOSAL_SENT,
+            ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
+            dummy_case_id,
+            True,
+            0,
+        ),
+        (
+            ApplicationStatus.ACCEPTED,
+            AhjoStatusEnum.DECISION_PROPOSAL_ACCEPTED,
+            ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
+            dummy_case_id,
+            True,
+            0,
+        ),
+        (
+            ApplicationStatus.REJECTED,
+            AhjoStatusEnum.DECISION_PROPOSAL_ACCEPTED,
+            ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
+            dummy_case_id,
+            True,
+            0,
+        ),
     ],
 )
 @pytest.mark.django_db
 def test_get_for_ahjo_decision(
-    decided_application, application_status, talpa_status, case_id, decision_text, count
+    decided_application,
+    application_status,
+    ahjo_status,
+    talpa_status,
+    case_id,
+    decision_text,
+    count,
 ):
     decided_application.status = application_status
     decided_application.talpa_status = talpa_status
     decided_application.ahjo_case_id = case_id
     decided_application.save()
+
+    decided_application.ahjo_status.create(status=ahjo_status)
 
     if decision_text:
         AhjoDecisionText.objects.create(


### PR DESCRIPTION
## Description :sparkles:
Fix quarter hourly jobs so that decision request is run only once instead of twice.
Adjust the query for decision request so that it will fetch applications  which have been `accepted` or` rejected`, their talpa status is `not_processed_by_talpa`, they have a `ahjo_case_id`, a `decisiontext` and their **latest** `ahjo_status` is `case_opened`.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
