### PR TITLE
fix: query for the undownloaded attachments

### DIFF
--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -727,6 +727,13 @@ def test_with_non_downloaded_attachments(decided_application):
     attachments = applications[0].attachments.all()
     assert attachments.count() == 6
 
+    for a in attachments:
+        a.downloaded_by_ahjo = timezone.now()
+        a.save()
+
+    applications = Application.objects.with_non_downloaded_attachments()
+    assert applications.count() == 0
+
 
 dummy_case_id = "HEL 1999-123"
 


### PR DESCRIPTION
## Description :sparkles:
Query only the applications that have a ahjo_case_id AND that have one or more attachments that are not downloaded by Ahjo.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
