### PR TITLE
fix: send ahjo_version_series_id in update payload

### DIFF
--- a/backend/benefit/applications/services/ahjo_payload.py
+++ b/backend/benefit/applications/services/ahjo_payload.py
@@ -231,14 +231,19 @@ def prepare_update_application_payload(
 ) -> dict:
     """Prepare the payload that is sent to Ahjo when an application is updated, \
           in this case it only contains a Records dict"""
+    if not pdf_summary.ahjo_version_series_id:
+        raise ValueError("Attachment must have an ahjo_version_series_id for update.")
     return {
         "records": [
             _prepare_record(
-                _prepare_record_title(application, AhjoRecordType.APPLICATION),
-                AhjoRecordType.APPLICATION,
-                pdf_summary.created_at.isoformat("T", "seconds"),
-                [_prepare_record_document_dict(pdf_summary)],
-                application.calculation.handler,
+                record_title=_prepare_record_title(
+                    application, AhjoRecordType.APPLICATION
+                ),
+                record_type=AhjoRecordType.APPLICATION,
+                acquired=pdf_summary.created_at.isoformat("T", "seconds"),
+                documents=[_prepare_record_document_dict(pdf_summary)],
+                handler=application.calculation.handler,
+                ahjo_version_series_id=pdf_summary.ahjo_version_series_id,
             )
         ]
     }

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.core.files.base import ContentFile
 from django.urls import reverse
 
@@ -201,6 +203,7 @@ def test_prepare_update_application_payload(decided_application):
         attachment_file=fake_file,
         content_type="application/pdf",
         attachment_type=AttachmentType.PDF_SUMMARY,
+        ahjo_version_series_id=str(uuid.uuid4()),
     )
 
     want = {
@@ -213,7 +216,7 @@ def test_prepare_update_application_payload(decided_application):
                 "SecurityReasons": ["JulkL (621/1999) 24.1 § 25 k"],
                 "Language": "fi",
                 "PersonalData": "Sisältää erityisiä henkilötietoja",
-                "MannerOfReceipt": "sähköinen asiointi",
+                "VersionSeriesId": str(fake_summary.ahjo_version_series_id),
                 "Documents": [_prepare_record_document_dict(fake_summary)],
                 "Agents": [
                     {


### PR DESCRIPTION
## Description :sparkles:
Fix missing ahjo_version_series_id when sending update records request to Ahjo.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
