### PR TITLE
fix: add missing tags when saving decision text

### DIFF
--- a/backend/benefit/applications/api/v1/ahjo_decision_views.py
+++ b/backend/benefit/applications/api/v1/ahjo_decision_views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework import status
@@ -172,7 +173,12 @@ class DecisionProposalDraftUpdate(APIView):
         proposal.save()
 
         if data.get("decision_text") and data.get("justification_text"):
+            decision_part = data.get("decision_text")
+            justification_part = data.get("justification_text")
             ahjo_text = AhjoDecisionText.objects.filter(application=application)
+            decision_text = f'<section id="paatos"><h1>{_("Päätös")}</h1>{decision_part}</section>\
+<section id="paatoksenperustelut"><h1>{_("Päätöksen perustelut")}</h1>{justification_part}</section>'
+
             if ahjo_text:
                 ahjo_text.update(
                     language=application.applicant_language,
@@ -181,9 +187,7 @@ class DecisionProposalDraftUpdate(APIView):
                         if data["status"] == ApplicationStatus.ACCEPTED
                         else DecisionType.DENIED
                     ),
-                    decision_text=data["decision_text"]
-                    + "\n\n"
-                    + data.get("justification_text"),
+                    decision_text=decision_text,
                 )
             else:
                 AhjoDecisionText.objects.create(
@@ -194,9 +198,7 @@ class DecisionProposalDraftUpdate(APIView):
                         if data["status"] == ApplicationStatus.ACCEPTED
                         else DecisionType.DENIED
                     ),
-                    decision_text=data.get("decision_text")
-                    + "\n\n"
-                    + data.get("justification_text"),
+                    decision_text=decision_text,
                 )
 
         if data["review_step"] >= 4:

--- a/backend/benefit/applications/tests/test_ahjo_decision_proposal_drafts.py
+++ b/backend/benefit/applications/tests/test_ahjo_decision_proposal_drafts.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 import pytest
+from django.utils.translation import gettext_lazy as _
 from rest_framework.reverse import reverse
 
 from applications.enums import ApplicationStatus
@@ -139,5 +140,7 @@ def test_decision_proposal_drafting(
     if review_step == 4:
         final_ahjo_text = AhjoDecisionText.objects.get(application=application)
         assert (
-            final_ahjo_text.decision_text == f"{decision_text}\n\n{justification_text}"
+            final_ahjo_text.decision_text
+            == f'<section id="paatos"><h1>{_("Päätös")}</h1>{decision_text}</section>\
+<section id="paatoksenperustelut"><h1>{_("Päätöksen perustelut")}</h1>{justification_text}</section>'
         )


### PR DESCRIPTION
## Description :sparkles:
Wrap the decision text parts in
`<section id="paatos"><h1>{_("Päätös")}</h1></section>`
and 
`<section id="paatosteksti"><h1>{_("Päätöksen perustelut")}</h1></section>`
as required by the schema, when saving the decision into the database.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
