### PR TITLE
feat(applicant): display chat icon in app view for statuses "accepted", "rejected" (hl-1292)

### DIFF
--- a/backend/benefit/applications/management/commands/seed.py
+++ b/backend/benefit/applications/management/commands/seed.py
@@ -35,6 +35,7 @@ from applications.tests.factories import (
     ReceivedApplicationFactory,
     RejectedApplicationFactory,
 )
+from messages.models import Message, MessageType
 from terms.models import Terms
 from users.models import User
 
@@ -142,6 +143,21 @@ def run_seed(number):
                 application.created_at = random_datetime
 
                 if factory == HandlingApplicationFactory:
+                    user = User.objects.filter(is_staff=False).first()
+                    staff_user = User.objects.filter(is_staff=True).first()
+                    Message.objects.create(
+                        content="Apua, en osaa täyttää hakemusta!",
+                        application=application,
+                        message_type=MessageType.APPLICANT_MESSAGE,
+                        sender=user,
+                        seen_by_applicant=True,
+                    )
+                    Message.objects.create(
+                        content="Ei hätää, autan sinua.",
+                        application=application,
+                        message_type=MessageType.HANDLER_MESSAGE,
+                        sender=staff_user,
+                    )
                     AhjoStatus.objects.create(
                         status=AhjoStatusEnum.SUBMITTED_BUT_NOT_SENT_TO_AHJO,
                         application=application,

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -780,7 +780,7 @@
     "isSecure": "Messages are encrypted",
     "noMessages": "No messages",
     "close": "Close",
-    "cannotWriteNewMessages": "Your application is being processed. You cannot write a new message right now. Please wait for your application to be processed."
+    "cannotWriteNewMessages": "Your application has progressed to the decision-making stage or it has already been processed. You can no longer write a new message."
   },
   "application": {
     "tooltipShowInfo": "Show information"

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -780,7 +780,7 @@
     "isSecure": "Viestit ovat salattuja",
     "noMessages": "Ei viestejä",
     "close": "Sulje",
-    "cannotWriteNewMessages": "Hakemuksesi käsittely on käynnissä. Et voi kirjoittaa uutta viestiä juuri nyt. Ole hyvä ja odota hakemuksesi käsittelyä."
+    "cannotWriteNewMessages": "Hakemuksesi käsittely on edennyt päätöksentekoon tai se on jo käsitelty. Et voi enää kirjoittaa uutta viestiä."
   },
   "application": {
     "tooltipShowInfo": "Näytä info"

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -780,7 +780,7 @@
     "isSecure": "Meddelandena är skyddade",
     "noMessages": "Inga meddelanden",
     "close": "Stäng",
-    "cannotWriteNewMessages": "Din ansökan behandlas. Du kan inte skriva ett nytt meddelande just nu. Vänta tills din ansökan behandlas."
+    "cannotWriteNewMessages": "Din ansökan har gått vidare till beslutsfattandet eller har redan behandlats. Du kan inte längre skriva ett nytt meddelande."
   },
   "application": {
     "tooltipShowInfo": "Visa information"

--- a/frontend/benefit/applicant/src/components/header/useHeader.ts
+++ b/frontend/benefit/applicant/src/components/header/useHeader.ts
@@ -76,8 +76,12 @@ const useHeader = (): ExtendedComponentProps => {
   );
   useEffect(() => {
     setHasMessenger(
-      status === APPLICATION_STATUSES.INFO_REQUIRED ||
-        status === APPLICATION_STATUSES.HANDLING
+      [
+        APPLICATION_STATUSES.INFO_REQUIRED,
+        APPLICATION_STATUSES.HANDLING,
+        APPLICATION_STATUSES.REJECTED,
+        APPLICATION_STATUSES.ACCEPTED,
+      ].includes(status)
     );
   }, [status, setHasMessenger]);
 


### PR DESCRIPTION
## Description :sparkles:

* Add a few dummy messages with seed tool
* Display chat toggle in header on "accepted", "rejected" status

## Note

New chat messages are disabled for now for the "accepted" and "rejected" status. To allow this in backend, serializer validation might require some attention.

Later, one can allow new chat in frontend, look for line

```const canWriteNewMessages = !application?.batch;```

and change it according to need. 

## Screenshot 📸 

![image](https://github.com/City-of-Helsinki/yjdh/assets/5328394/e2a0e4f2-a348-46b3-a6df-91ae59a2acf3)
