### PR TITLE
fix: query handled applications for open case

### DIFF
--- a/backend/benefit/applications/management/commands/send_ahjo_requests.py
+++ b/backend/benefit/applications/management/commands/send_ahjo_requests.py
@@ -62,8 +62,13 @@ class Command(BaseCommand):
     ) -> QuerySet[Application]:
         if request_type == AhjoRequestType.OPEN_CASE:
             applications = Application.objects.get_by_statuses(
-                [ApplicationStatus.HANDLING],
+                [
+                    ApplicationStatus.HANDLING,
+                    ApplicationStatus.ACCEPTED,
+                    ApplicationStatus.REJECTED,
+                ],
                 AhjoStatusEnum.SUBMITTED_BUT_NOT_SENT_TO_AHJO,
+                True,
             )
         elif request_type == AhjoRequestType.SEND_DECISION_PROPOSAL:
             applications = Application.objects.get_for_ahjo_decision()
@@ -75,11 +80,13 @@ class Command(BaseCommand):
             applications = Application.objects.get_by_statuses(
                 [ApplicationStatus.ACCEPTED, ApplicationStatus.REJECTED],
                 AhjoStatusEnum.DECISION_PROPOSAL_ACCEPTED,
+                False,
             )
         elif request_type == AhjoRequestType.GET_DECISION_DETAILS:
             applications = Application.objects.get_by_statuses(
                 [ApplicationStatus.ACCEPTED, ApplicationStatus.REJECTED],
                 AhjoStatusEnum.SIGNED_IN_AHJO,
+                False,
             )
 
         return applications

--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -167,11 +167,14 @@ class ApplicationManager(models.Manager):
         return qs.prefetch_related(attachments_prefetch)
 
     def get_by_statuses(
-        self, application_statuses: List[ApplicationStatus], ahjo_status: AhjoStatusEnum
+        self,
+        application_statuses: List[ApplicationStatus],
+        ahjo_status: AhjoStatusEnum,
+        has_no_case_id: bool,
     ):
         """
         Query applications by their latest AhjoStatus relation
-        and their current ApplicationStatus.
+        and their current ApplicationStatus and if they have a case id in Ahjo or not.
         """
         # Subquery to get the latest AhjoStatus id for each application
         latest_ahjo_status_subquery = (
@@ -201,6 +204,7 @@ class ApplicationManager(models.Manager):
                 status__in=application_statuses,
                 ahjo_status__id=F("latest_ahjo_status_id"),
                 ahjo_status__status=ahjo_status,
+                ahjo_case_id__isnull=has_no_case_id,
             )
             .prefetch_related(attachments_prefetch, "calculation", "company")
         )

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -93,6 +93,16 @@ def multiple_handling_applications(mock_get_organisation_roles_and_create_compan
 
 
 @pytest.fixture
+def multiple_decided_applications_for_open_case(
+    mock_get_organisation_roles_and_create_company,
+):
+    with factory.Faker.override_default_locale("fi_FI"):
+        return DecidedApplicationFactory.create_batch(
+            5, company=mock_get_organisation_roles_and_create_company
+        )
+
+
+@pytest.fixture
 def application_batch():
     with factory.Faker.override_default_locale("fi_FI"):
         return ApplicationBatchFactory()

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -714,10 +714,15 @@ def test_generate_ahjo_secret_decision_text_xml(decided_application):
 
 @pytest.mark.django_db
 def test_get_applications_for_open_case(
-    multiple_decided_applications, multiple_handling_applications
+    multiple_decided_applications,
+    multiple_decided_applications_for_open_case,
+    multiple_handling_applications,
 ):
     now = timezone.now()
-    for application in multiple_handling_applications:
+    applications_for_open_case = (
+        multiple_decided_applications_for_open_case + multiple_handling_applications
+    )
+    for application in applications_for_open_case:
         status = AhjoStatus.objects.create(
             application=application,
             status=AhjoStatusEnum.SUBMITTED_BUT_NOT_SENT_TO_AHJO,
@@ -737,11 +742,17 @@ def test_get_applications_for_open_case(
             ahjo_status.save()
 
     applications_for_open_case = Application.objects.get_by_statuses(
-        [ApplicationStatus.HANDLING], AhjoStatusEnum.SUBMITTED_BUT_NOT_SENT_TO_AHJO
+        [
+            ApplicationStatus.HANDLING,
+            ApplicationStatus.ACCEPTED,
+            ApplicationStatus.REJECTED,
+        ],
+        AhjoStatusEnum.SUBMITTED_BUT_NOT_SENT_TO_AHJO,
+        True,
     )
     # only handled_applications should be returned as their last  AhjoStatus is SUBMITTED_BUT_NOT_SENT_TO_AHJO
     # and their application status is HANDLING
-    assert applications_for_open_case.count() == len(multiple_handling_applications)
+    assert applications_for_open_case.count() == len(applications_for_open_case)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description :sparkles:
The previous version of the query that  fetches the applications for open case request only queried applications in handling status, which could result in a scenario in where a handler handles an application before it has been picked up for open case request and it's status had changed into decided or rejected and it would not be picked up for future open case requests.
This PR fixes the query so that it includes applications which are handled but do not yet have an ahjo_case_id.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
