### PR TITLE
feat:  change failure response to ahjo as 200 ok

### DIFF
--- a/backend/benefit/applications/api/v1/ahjo_integration_views.py
+++ b/backend/benefit/applications/api/v1/ahjo_integration_views.py
@@ -246,7 +246,7 @@ with request id: {callback_data['requestId']}"
         self._log_failure_details(application, callback_data)
         return Response(
             {"message": "Callback received but request was unsuccessful at AHJO"},
-            status=status.HTTP_400_BAD_REQUEST,
+            status=status.HTTP_200_OK,
         )
 
     def _handle_update_or_add_records_success(

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -574,7 +574,7 @@ def test_ahjo_open_case_callback_failure(
     auth_headers = {"HTTP_AUTHORIZATION": "Token " + ahjo_user_token.key}
     response = ahjo_client.post(url, **auth_headers, data=ahjo_callback_payload)
 
-    assert response.status_code == 400
+    assert response.status_code == 200
     assert response.data == {
         "message": "Callback received but request was unsuccessful at AHJO"
     }


### PR DESCRIPTION
## Description :sparkles:
Ahjo gets confused if the Helsinki-lisä responds to a failing callback request with 400 Bad request, so the 
response status needs to be changed to 200 OK.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
