### PR TITLE
fix: send decision also after new records are sent

### DIFF
--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -239,7 +239,10 @@ class ApplicationManager(models.Manager):
                     application_id=OuterRef("id")
                 ).values("application_id"),
                 ahjo_status__id=F("latest_ahjo_status_id"),
-                ahjo_status__status__in=[AhjoStatusEnum.CASE_OPENED],
+                ahjo_status__status__in=[
+                    AhjoStatusEnum.CASE_OPENED,
+                    AhjoStatusEnum.NEW_RECORDS_RECEIVED,
+                ],
             )
             .select_related("ahjodecisiontext")
         )

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -799,7 +799,7 @@ dummy_case_id = "HEL 1999-123"
 
 
 @pytest.mark.parametrize(
-    "application_status, ahjo_status,talpa_status, case_id, decision_text, count",
+    "application_status, ahjo_status, talpa_status, case_id, decision_text, count",
     [
         (
             ApplicationStatus.DRAFT,
@@ -887,6 +887,38 @@ dummy_case_id = "HEL 1999-123"
             ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
             dummy_case_id,
             True,
+            0,
+        ),
+        (
+            ApplicationStatus.ACCEPTED,
+            AhjoStatusEnum.NEW_RECORDS_RECEIVED,
+            ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
+            dummy_case_id,
+            True,
+            1,
+        ),
+        (
+            ApplicationStatus.REJECTED,
+            AhjoStatusEnum.NEW_RECORDS_RECEIVED,
+            ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
+            dummy_case_id,
+            True,
+            1,
+        ),
+        (
+            ApplicationStatus.ACCEPTED,
+            AhjoStatusEnum.NEW_RECORDS_RECEIVED,
+            ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
+            dummy_case_id,
+            False,
+            0,
+        ),
+        (
+            ApplicationStatus.REJECTED,
+            AhjoStatusEnum.NEW_RECORDS_RECEIVED,
+            ApplicationTalpaStatus.NOT_PROCESSED_BY_TALPA,
+            dummy_case_id,
+            False,
             0,
         ),
     ],


### PR DESCRIPTION
## Description :sparkles:
[HL-1347](https://helsinkisolutionoffice.atlassian.net/browse/HL-1347?atlOrigin=eyJpIjoiNGJlNTNhZjU3MTQ4NGY4NGJhYjZmMTEyZTA4MjdlNzkiLCJwIjoiaiJ9)
Ahjo decision texts were not sent for applications that had new attachments uploaded after open case request, because their latests ahjo_status was `new_record_received`. This PR modifies the query for decision requests to include applications with that status as well.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1347]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ