### PR TITLE
fix: nonfunctional alteration submission and misc. oversights in date overlap detection

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application_alteration.py
+++ b/backend/benefit/applications/api/v1/serializers/application_alteration.py
@@ -255,9 +255,15 @@ class BaseApplicationAlterationSerializer(DynamicFieldsModelSerializer):
             application, alteration_start_date, alteration_end_date
         )
 
-        if alteration_end_date is not None and merged_data["state"] != ApplicationAlterationState.CANCELLED:
+        if (
+            alteration_end_date is not None
+            and merged_data["state"] != ApplicationAlterationState.CANCELLED
+        ):
             errors += self._validate_date_range_overlaps(
-                self_id, application, alteration_start_date, alteration_end_date
+                self_id,
+                application,
+                merged_data["recovery_start_date"] or alteration_start_date,
+                merged_data["recovery_end_date"] or alteration_end_date,
             )
 
         if len(errors) > 0:

--- a/backend/benefit/applications/api/v1/serializers/application_alteration.py
+++ b/backend/benefit/applications/api/v1/serializers/application_alteration.py
@@ -191,6 +191,7 @@ class BaseApplicationAlterationSerializer(DynamicFieldsModelSerializer):
             if (
                 alteration.recovery_start_date is None
                 or alteration.recovery_end_date is None
+                or alteration.state == ApplicationAlterationState.CANCELLED
             ):
                 continue
 

--- a/backend/benefit/applications/api/v1/serializers/application_alteration.py
+++ b/backend/benefit/applications/api/v1/serializers/application_alteration.py
@@ -255,7 +255,7 @@ class BaseApplicationAlterationSerializer(DynamicFieldsModelSerializer):
             application, alteration_start_date, alteration_end_date
         )
 
-        if alteration_end_date is not None:
+        if alteration_end_date is not None and merged_data["state"] != ApplicationAlterationState.CANCELLED:
             errors += self._validate_date_range_overlaps(
                 self_id, application, alteration_start_date, alteration_end_date
             )

--- a/frontend/benefit/handler/src/components/alterationHandling/useAlterationHandlingForm.ts
+++ b/frontend/benefit/handler/src/components/alterationHandling/useAlterationHandlingForm.ts
@@ -105,7 +105,7 @@ const useAlterationHandling = ({
     isSubmitting: updateStatus === 'loading',
     t,
     formik,
-    handleAlteration: () => void formik.submitForm,
+    handleAlteration: () => void formik.submitForm(),
     validateForm,
   };
 };


### PR DESCRIPTION
## Description :sparkles:
It looks like I broke the submit button in the last PR by accident at the last minute while fixing a code quality violation reported by sonarcloud.

I basically went from `handleAlteration: formik.submitForm` to `handleAlteration: () => void formik.submitForm` which actually doesn't call the function anymore.