### PR TITLE
fix: return missing admin fields

### DIFF
--- a/backend/benefit/applications/admin.py
+++ b/backend/benefit/applications/admin.py
@@ -129,16 +129,6 @@ class ApplicationAdmin(admin.ModelAdmin):
 
     readonly_fields = ["batch_details"]
 
-    fieldsets = (
-        (None, {"fields": ("status", "batch")}),
-        (
-            "Batch Information",
-            {
-                "fields": ("batch_details",),
-            },
-        ),
-    )
-
     def batch_details(self, obj):
         if obj.batch:
             url = reverse(


### PR DESCRIPTION
## Description :sparkles:
[HL-1306
](https://github.com/City-of-Helsinki/yjdh/pull/3048)
caused some admin fields for application to go missing.
This PR makes them visible again.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
<img width="1103" alt="Screenshot 2024-06-05 at 15 34 40" src="https://github.com/City-of-Helsinki/yjdh/assets/33894149/c5a86b0c-3833-450a-a734-a1301d220165">

## Additional notes :spiral_notepad:
