### PR TITLE
chore: loosen validation on application start/end dates (hl-1324 & hl-1174)

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/useApplicationFormStep2.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/useApplicationFormStep2.ts
@@ -10,7 +10,6 @@ import { getErrorText } from 'benefit/applicant/utils/forms';
 import {
   APPLICATION_FIELDS_STEP2,
   APPLICATION_FIELDS_STEP2_KEYS,
-  BENEFIT_TYPES,
   EMPLOYEE_KEYS,
   ORGANIZATION_TYPES,
 } from 'benefit-shared/constants';
@@ -198,9 +197,9 @@ const useApplicationFormStep2 = (
     setFieldValue,
   ]);
 
-  const minEndDate = getMinEndDate(values.startDate, BENEFIT_TYPES.SALARY);
+  const minEndDate = getMinEndDate(values.startDate);
   const minEndDateFormatted = convertToUIDateFormat(minEndDate);
-  const maxEndDate = getMaxEndDate(values.startDate, BENEFIT_TYPES.SALARY);
+  const maxEndDate = getMaxEndDate(values.startDate);
   const endDate = parseDate(values.endDate);
   const isEndDateEligible =
     endDate &&

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/__tests__/dates.test.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/utils/__tests__/dates.test.ts
@@ -3,65 +3,21 @@ import {
   getMinEndDate,
   validateDateWithinMonths,
 } from '@frontend/benefit-shared/src/utils/dates';
-import { BENEFIT_TYPES } from 'benefit-shared/constants';
 
 describe('dates', () => {
-  const undefinedBenefit = undefined;
-  const emptyBenefit = '';
-
   describe('getMinEndDate', () => {
-    it('should be one month minus one day after the start date for Employment benefits', () => {
-      const minEndDate = getMinEndDate('1.12.2020', BENEFIT_TYPES.EMPLOYMENT);
-
-      expect(minEndDate).toStrictEqual(new Date(2020, 11, 31));
-    });
-
     it('should be one month minus one day after the start date for Salary benefits', () => {
-      const minEndDate = getMinEndDate('1.12.2020', BENEFIT_TYPES.SALARY);
+      const minEndDate = getMinEndDate('1.12.2020');
 
       expect(minEndDate).toStrictEqual(new Date(2020, 11, 31));
-    });
-
-    it('should be the same as the start date for Commission benefits', () => {
-      const minEndDate = getMinEndDate('1.12.2020', BENEFIT_TYPES.COMMISSION);
-
-      expect(minEndDate).toStrictEqual(new Date(2020, 11, 1));
-    });
-
-    it('should be the same as the start date when benefit type is empty or undefined', () => {
-      const minEndDate1 = getMinEndDate('1.12.2020', undefinedBenefit as '');
-      const minEndDate2 = getMinEndDate('1.12.2020', emptyBenefit);
-
-      expect(minEndDate1).toStrictEqual(new Date(2020, 11, 1));
-      expect(minEndDate2).toStrictEqual(new Date(2020, 11, 1));
     });
   });
 
   describe('getMaxEndDate', () => {
-    it('should be one year minus one day after the start date for Employment benefits', () => {
-      const maxEndDate = getMaxEndDate('1.12.2020', BENEFIT_TYPES.EMPLOYMENT);
-
-      expect(maxEndDate).toStrictEqual(new Date(2021, 10, 30));
-    });
-
     it('should be one year minus one day after the start date for Salary benefits', () => {
-      const maxEndDate = getMaxEndDate('1.12.2020', BENEFIT_TYPES.SALARY);
+      const maxEndDate = getMaxEndDate('1.12.2020');
 
       expect(maxEndDate).toStrictEqual(new Date(2021, 10, 30));
-    });
-
-    it('should be undefined for Commission benefits', () => {
-      const maxEndDate = getMaxEndDate('1.12.2020', BENEFIT_TYPES.COMMISSION);
-
-      expect(maxEndDate).toBeUndefined();
-    });
-
-    it('should be undefined when benefit type is empty or undefined', () => {
-      const maxEndDate1 = getMaxEndDate('1.12.2020', undefinedBenefit as '');
-      const maxEndDate2 = getMaxEndDate('1.12.2020', emptyBenefit);
-
-      expect(maxEndDate1).toBeUndefined();
-      expect(maxEndDate2).toBeUndefined();
     });
   });
 

--- a/frontend/benefit/handler/src/components/applicationForm/utils/applicationForm.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/utils/applicationForm.ts
@@ -167,9 +167,9 @@ const handleErrorFieldKeys = (
 };
 
 const getDates = (values: Application): DatesType => {
-  const minEndDate = getMinEndDate(values.startDate, values.benefitType);
+  const minEndDate = getMinEndDate(values.startDate, true);
   const minEndDateFormatted = convertToUIDateFormat(minEndDate);
-  const maxEndDate = getMaxEndDate(values.startDate, values.benefitType);
+  const maxEndDate = getMaxEndDate(values.startDate, 24);
   const endDate = parseDate(values.endDate);
   const isEndDateEligible =
     endDate &&

--- a/frontend/benefit/shared/src/utils/dates.ts
+++ b/frontend/benefit/shared/src/utils/dates.ts
@@ -1,7 +1,4 @@
-import {
-  APPLICATION_START_DATE,
-  BENEFIT_TYPES,
-} from 'benefit-shared/constants';
+import { APPLICATION_START_DATE } from 'benefit-shared/constants';
 import addMonths from 'date-fns/addMonths';
 import isAfter from 'date-fns/isAfter';
 import isEqual from 'date-fns/isEqual';
@@ -15,36 +12,20 @@ import { parseDate } from 'shared/utils/date.utils';
 
 export const getMinEndDate = (
   startDate: string | undefined,
-  benefitType: BENEFIT_TYPES | undefined | ''
+  noRestriction?: boolean
 ): Date => {
   const parsedStartDate = parseDate(startDate) ?? APPLICATION_START_DATE;
-
-  switch (benefitType) {
-    case BENEFIT_TYPES.EMPLOYMENT:
-    case BENEFIT_TYPES.SALARY:
-      return subDays(addMonths(parsedStartDate, 1), 1);
-
-    case BENEFIT_TYPES.COMMISSION:
-    default:
-      return parsedStartDate;
-  }
+  return noRestriction
+    ? parsedStartDate
+    : subDays(addMonths(parsedStartDate, 1), 1);
 };
 
 export const getMaxEndDate = (
   startDate: string | undefined,
-  benefitType: BENEFIT_TYPES | undefined | ''
+  monthsFromStartDate = 12
 ): Date | undefined => {
   const parsedStartDate = parseDate(startDate) ?? APPLICATION_START_DATE;
-
-  switch (benefitType) {
-    case BENEFIT_TYPES.EMPLOYMENT:
-    case BENEFIT_TYPES.SALARY:
-      return subDays(addMonths(parsedStartDate, 12), 1);
-
-    case BENEFIT_TYPES.COMMISSION:
-    default:
-      return undefined;
-  }
+  return subDays(addMonths(parsedStartDate, monthsFromStartDate), 1);
 };
 
 export const validateFinnishDatePattern = (value = ''): boolean =>


### PR DESCRIPTION
## Description :sparkles:

* Check if user is staff and skip some of the date validation in application serializer
* Remove some deprecated `BENEFIT_TYPE` code


## Caveat

This new behaviour will lead to a rare case bug where:

* handler edits application and  sets start and end dates wildly over the applicant's date range options
* handler sets application to additional information is required from applicant
* applicant then goes to form -> start and end date field cannot be saved as the fields are now invalid

I'll write a new bug ticket to JIRA when this is merged. We'll have to ask the stakeholders if this is ok or if the issue should be covered.