### PR TITLE
fix: move cancelled applications to archive page (HL-1321)

### DIFF
--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -105,10 +105,12 @@ class BaseApplicationFilter(filters.FilterSet):
             "batch__decision_date__lte": archive_threshold.isoformat(),
         }
 
+        query = Q(**query) | Q(status=ApplicationStatus.CANCELLED)
+
         if value:
-            return queryset.filter(**query)
+            return queryset.filter(query)
         else:
-            return queryset.filter(~Q(**query))
+            return queryset.filter(~query)
 
 
 class ApplicantApplicationFilter(BaseApplicationFilter):

--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1411,6 +1411,9 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
         Make sure any changes here are reflected in the filter set as well.
         """
 
+        if application.status == ApplicationStatus.CANCELLED:
+            return True
+
         if application.batch is None:
             return False
 


### PR DESCRIPTION
## Description :sparkles:
Previously, cancelled applications stayed on the applicant's front page view forever. After this patch, applications will move to the archive page immediately after they are cancelled.