### PR TITLE
fix: no calculation data for rejected applications

### DIFF
--- a/backend/benefit/applications/templates/secret_decision.xml
+++ b/backend/benefit/applications/templates/secret_decision.xml
@@ -26,22 +26,25 @@
 					<td>{{ benefit_type }}</td>
 				</tr>
 
-				<tr>
-					<th scope="row">{{ _("Applying for dates") }}</th>
-					<td>{{ total_amount_row.start_date | date:"d.m.Y" }} - {{ total_amount_row.end_date |date:"d.m.Y" }}</td>
-				</tr>
-				<tr>
-					<th>{{ _("Received aid") }}</th>
-					<td>{{ total_amount_row.amount }} €</td>
-				</tr>
-				{% if application.calculation.granted_as_de_minimis_aid %}
-				<tr>
-					<th>{{ _("Additional information") }}</th>
-					<td>{{ _("De Minimis description") }}</td>
-				</tr>
+				{% if include_calculation_data %}
+					<tr>
+						<th scope="row">{{ _("Applying for dates") }}</th>
+						<td>{{ total_amount_row.start_date | date:"d.m.Y" }} - {{ total_amount_row.end_date |date:"d.m.Y" }}</td>
+					</tr>
+					<tr>
+						<th>{{ _("Received aid") }}</th>
+						<td>{{ total_amount_row.amount }} €</td>
+					</tr>
+					{% if application.calculation.granted_as_de_minimis_aid %}
+					<tr>
+						<th>{{ _("Additional information") }}</th>
+						<td>{{ _("De Minimis description") }}</td>
+					</tr>
+					{% endif %}
 				{% endif %}
 			</tbody>
 		</table>
+		{% if include_calculation_data %}
 		<h2>{{ _("Calculation of the benefit") }}</h2>
 		<table class="rowbordersonly">
 			<thead>
@@ -62,6 +65,7 @@
 			<tr><th colspan="2">{{ _("Total for benefit time period") }}</th><td class="sum"><strong>{{ total_amount_row.amount }} €</strong></td></tr>
 			</tbody>
 		</table>
+		{% endif %}
 	</main>
 </body>
 


### PR DESCRIPTION
## Description :sparkles:
[HL-1353](https://helsinkisolutionoffice.atlassian.net/browse/HL-1353?atlOrigin=eyJpIjoiNzAzZDAxYmNlODM0NGU3OGI4MmQ4MGUwMWQ2YTQwYzAiLCJwIjoiaiJ9)
Fix for error that occurs when AhjoXMLBuilder tries to generate a secret xml attachment for a rejected application that has no calculation.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1353]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ