### PR TITLE
fix: excluded full_application attachment

### DIFF
--- a/backend/benefit/applications/services/ahjo_payload.py
+++ b/backend/benefit/applications/services/ahjo_payload.py
@@ -191,8 +191,7 @@ def _prepare_case_records(
 
     open_case_attachments = application.attachments.exclude(
         attachment_type__in=[
-            AttachmentType.PDF_SUMMARY,
-            AttachmentType.FULL_APPLICATION,
+            AttachmentType.PDF_SUMMARY,  # The main document is already added
             AttachmentType.DECISION_TEXT_XML,
             AttachmentType.DECISION_TEXT_SECRET_XML,
         ]

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -184,7 +184,6 @@ def test_prepare_case_records(decided_application, settings):
     open_case_attachments = application.attachments.exclude(
         attachment_type__in=[
             AttachmentType.PDF_SUMMARY,
-            AttachmentType.FULL_APPLICATION,
             AttachmentType.DECISION_TEXT_XML,
             AttachmentType.DECISION_TEXT_SECRET_XML,
         ]


### PR DESCRIPTION
## Description :sparkles:
Full application was missing from the attachments sent in open case request, this PR includes it in the payload.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
