### PR TITLE
fix: include archive status flag in application list query key

### DIFF
--- a/frontend/benefit/applicant/src/hooks/useApplicationsQuery.ts
+++ b/frontend/benefit/applicant/src/hooks/useApplicationsQuery.ts
@@ -15,7 +15,7 @@ const useApplicationsQuery = ({
   const { axios, handleResponse } = useBackendAPI();
 
   return useQuery<ApplicationData[], Error>(
-    ['applicationsList', ...status, orderBy],
+    ['applicationsList', ...status, orderBy, isArchived ? '1' : '0'],
     async () => {
       const res = axios.get<ApplicationData[]>(
         `${BackendEndpoint.APPLICATIONS_SIMPLIFIED}`,


### PR DESCRIPTION
## Description :sparkles:
This adds the archive status into the query key in the query hook for the application list in the applicant UI. Previously, lists that shared the other query values but not this one would share their state.

Before this fix, this happened with the processed applications list on the front page and the list on the archive page. If one navigated between the aforementioned pages by using the "show all applications" button, before the archived applications list finished loading, the view would show the list from the front page for a brief period (which was minimal in development environment) instead of a loader skeleton element as intended.