### PR TITLE
fix: use correct API endpoint for alteration creation for handler

### DIFF
--- a/frontend/benefit/handler/src/hooks/useCreateApplicationAlterationQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useCreateApplicationAlterationQuery.ts
@@ -27,7 +27,7 @@ const useCreateApplicationQuery = ({
     'createApplicationAlteration',
     (alteration: ApplicationAlterationData) =>
       handleResponse<ApplicationAlterationData>(
-        axios.post(BackendEndpoint.APPLICATION_ALTERATION, alteration)
+        axios.post(BackendEndpoint.HANDLER_APPLICATION_ALTERATION, alteration)
       ),
     {
       onSuccess,


### PR DESCRIPTION
## Additional notes :spiral_notepad:
The previous version somehow worked in development environment even though it shouldn't have, presumably because of the auth mock flag.
