### PR TITLE
fix: make ahjo_case_id read_only

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -239,6 +239,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
             "alterations",
             "calculated_benefit_amount",
             "ahjo_decision_date",
+            "ahjo_case_id",
         ]
         extra_kwargs = {
             "company_name": {


### PR DESCRIPTION
## Description :sparkles:
Application.ahjo_case_id (Diaarinumero) was not read_only, so in some scenarios, the frontend could update it as None which is not what we want ever.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
