### PR TITLE
fix: handle single-day alteration calculation on row terminus date correctly

### DIFF
--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationCalculator.tsx
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationCalculator.tsx
@@ -150,7 +150,8 @@ const AlterationCalculator = ({
             {
               start: rowStartDate,
               end: rowEndDate,
-            }
+            },
+            { inclusive: true }
           )
         ) {
           return sum;


### PR DESCRIPTION
## Additional notes :spiral_notepad:
Previously, by setting the recovery calculator dates for an alteration to both start and end on the very first or last date of any row of the original calculation, the handler would receive an erroneous calculation of €0 since the row was not detected to intersect with the single-day range correctly.