### PR TITLE
fix: fix applicant messager drawer refusing to close in some cases

### DIFF
--- a/frontend/benefit/applicant/src/components/header/useHeader.ts
+++ b/frontend/benefit/applicant/src/components/header/useHeader.ts
@@ -67,10 +67,13 @@ const useHeader = (): ExtendedComponentProps => {
     if (isMessagesDrawerVisible && Number(unreadMessagesCount) > 0) {
       setUnredMessagesCount(null);
     }
+  }, [isMessagesDrawerVisible, unreadMessagesCount]);
+
+  useEffect(() => {
     if (openDrawer) {
       setMessagesDrawerVisiblity(true);
     }
-  }, [isMessagesDrawerVisible, unreadMessagesCount, openDrawer]);
+  }, [openDrawer]);
 
   const status = React.useMemo(
     (): APPLICATION_STATUSES =>


### PR DESCRIPTION
## Description :sparkles:
Closing the sidebar changed the isMessagesDrawerVisible value, which was a dependency for the same useEffect that was responsible for opening it upon the query parameter in the first place. Now that function is isolated into its own useEffect and doesn't get rerun.
