### PR TITLE
feat: truncate company name in open case request

### DIFF
--- a/backend/benefit/applications/services/ahjo_payload.py
+++ b/backend/benefit/applications/services/ahjo_payload.py
@@ -45,9 +45,15 @@ def _prepare_record_title(
 
 def _prepare_case_title(application: Application) -> str:
     full_title = f"Avustukset työnantajille, työllisyyspalvelut, \
-Helsinki-lisä, {application.company_name}, \
+Helsinki-lisä, {_truncate_company_name(application.company_name)}, \
 hakemus {application.application_number}"
     return full_title
+
+
+def _truncate_company_name(company_name: str) -> str:
+    """Truncate the company name to 100 characters, \
+    because Ahjo has a technical limitation of 100 characters for the company name."""
+    return company_name[:100]
 
 
 def resolve_payload_language(application: Application) -> str:

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -18,6 +18,7 @@ from applications.services.ahjo_payload import (
     _prepare_record_document_dict,
     _prepare_record_title,
     _prepare_top_level_dict,
+    _truncate_company_name,
     prepare_update_application_payload,
     resolve_payload_language,
 )
@@ -31,6 +32,15 @@ Helsinki-lisä, {application.company_name}, \
 hakemus {application.application_number}"
     got = _prepare_case_title(application)
     assert wanted_title == got
+
+
+def test_truncate_company_name():
+    short = "a" * 50
+    too_long = "a" * 105
+    not_too_long = "a" * 100
+    assert len(_truncate_company_name(too_long)) == 100
+    assert len(_truncate_company_name(not_too_long)) == 100
+    assert len(_truncate_company_name(short)) == 50
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description :sparkles:
[HL-1364](https://helsinkisolutionoffice.atlassian.net/browse/HL-1364?atlOrigin=eyJpIjoiZDEwZjA3NGQ4NjQ3NDNhZWFhN2ExYmViZjg3ODE5ZTIiLCJwIjoiaiJ9)
Truncate company name in open case payload title if it is longer than 100 characters, because currently Ahjo cannot handle company names longer that 100 characters.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1364]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ