### PR TITLE
fix: remove irrelevant fields from decision box etc. (HL-1332, HL-1371, HL-1380)

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -13,7 +13,7 @@
       "common": {
         "created": "Created",
         "employee": "Employee",
-        "saved": "Tallennettu",
+        "saved": "Saved",
         "edit": "Edit",
         "sent": "Submitted",
         "applicationNumber": "Application number",
@@ -425,7 +425,8 @@
         "accepted": "The application has been approved and the Helsinki benefit has been granted for the period of {{dateRangeStart}} - {{dateRangeEnd}}",
         "rejected": "The application was rejected. No Helsinki benefit is granted.",
         "handling": "The application is being processed.",
-        "cancelled": "The application has been cancelled."
+        "cancelled": "The application has been cancelled.",
+        "additional_information_needed": "The application is being processed."
       },
       "headings": {
         "mainHeading": "Decision details",
@@ -453,7 +454,8 @@
             "label": "Status",
             "received": "Received",
             "opened": "Handling",
-            "handled": "Processed"
+            "handled": "Processed",
+            "additional_information_needed": "Additional information is needed"
           },
           "recoveryAmount": "Recovered benefit",
           "recoveryPeriod": "Time period for which the benefit was recovered",

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -425,7 +425,8 @@
         "accepted": "Hakemus on hyväksytty ja Helsinki-lisää on myönnetty aikavälille {{dateRangeStart}} – {{dateRangeEnd}}",
         "rejected": "Hakemus on hylätty. Helsinki-lisää ei myönnetä.",
         "handling": "Hakemus on käsittelyssä.",
-        "cancelled": "Hakemus on peruttu."
+        "cancelled": "Hakemus on peruttu.",
+        "additional_information_needed": "Hakemus on käsittelyssä."
       },
       "headings": {
         "mainHeading": "Päätöksen tiedot",
@@ -453,7 +454,8 @@
             "label": "Tila",
             "received": "Lähetetty",
             "opened": "Vastaanotettu",
-            "handled": "Käsitelty"
+            "handled": "Käsitelty",
+            "additional_information_needed": "Lisätietoa tarvitaan"
           },
           "recoveryAmount": "Takaisinlaskutettu tuki",
           "recoveryPeriod": "Aika, jolta tukea laskutettiin takaisin",

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -425,7 +425,8 @@
         "accepted": "Ansökan har godkänts och Helsingforstillägg har beviljats för tiden {{dateRangeStart}} - {{dateRangeEnd}}",
         "rejected": "Ansökan har avslagits. Helsingforstillägg beviljas inte.",
         "handling": "Ansökan behandlas.",
-        "cancelled": "Ansökan har avbrutits."
+        "cancelled": "Ansökan har avbrutits.",
+        "additional_information_needed": "Ansökan behandlas."
       },
       "headings": {
         "mainHeading": "Uppgifter om beslutet",
@@ -453,7 +454,8 @@
             "label": "Status",
             "received": "Mottagen",
             "opened": "Behandling",
-            "handled": "Behandlad"
+            "handled": "Behandlad",
+            "additional_information_needed": "Ytterligare uppgifter behövs"
           },
           "recoveryAmount": "Stöd som återkrävts",
           "recoveryPeriod": "Tid för vilken stödet återkrävs",

--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -71,6 +71,11 @@ const PageContent: React.FC = () => {
   const router = useRouter();
   const canShowAskem = useAskem(router.locale, isSubmittedApplication);
 
+  const showMonetaryFields = ![
+    APPLICATION_STATUSES.CANCELLED,
+    APPLICATION_STATUSES.REJECTED,
+  ].includes(application.status);
+
   useEffect(() => {
     if (isReadOnly) document.title = t('common:pageTitles.viewApplication');
     else if (router.query.id)
@@ -96,6 +101,7 @@ const PageContent: React.FC = () => {
       {
         accessor: (app) => formatFloatToCurrency(app.calculatedBenefitAmount),
         key: 'benefitAmount',
+        showIf: () => showMonetaryFields,
       },
       {
         accessor: (app) =>
@@ -103,6 +109,7 @@ const PageContent: React.FC = () => {
             app.endDate
           )}`,
         key: 'benefitPeriod',
+        showIf: () => showMonetaryFields,
       },
       {
         accessor: (app) => convertToUIDateFormat(app.ahjoDecisionDate),
@@ -112,10 +119,11 @@ const PageContent: React.FC = () => {
         accessor: () => t('common:applications.decision.grantedAsDeMinimisAid'),
         key: 'extraDetails',
         width: 6,
-        showIf: (app) => app.isGrantedAsDeMinimisAid === true,
+        showIf: (app) =>
+          app.isGrantedAsDeMinimisAid === true && showMonetaryFields,
       },
     ],
-    [t]
+    [t, showMonetaryFields]
   );
 
   if (isLoading) {

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -728,7 +728,8 @@
         "accepted": "Hakemus on hyväksytty ja Helsinki-lisää on myönnetty aikavälille {{dateRangeStart}} – {{dateRangeEnd}}",
         "rejected": "Hakemus on hylätty. Helsinki-lisää ei myönnetä.",
         "handling": "Hakemus on käsittelyssä.",
-        "cancelled": "Hakemus on peruttu."
+        "cancelled": "Hakemus on peruttu.",
+        "additional_information_needed": "Hakemus on käsittelyssä."
       },
       "headings": {
         "mainHeading": "Päätöksen tiedot",
@@ -762,7 +763,8 @@
             "received": "Odottaa käsittelyä",
             "opened": "Käsittelyssä",
             "handled": "Käsitelty",
-            "cancelled": "Peruutettu"
+            "cancelled": "Peruutettu",
+            "additional_information_needed": "Odottaa lisätietoja"
           },
           "recoveryAmount": "Takaisinlaskutettu tuki",
           "recoveryPeriod": "Aika, jolta tukea laskutettiin takaisin",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -728,7 +728,8 @@
         "accepted": "Hakemus on hyväksytty ja Helsinki-lisää on myönnetty aikavälille {{dateRangeStart}} – {{dateRangeEnd}}",
         "rejected": "Hakemus on hylätty. Helsinki-lisää ei myönnetä.",
         "handling": "Hakemus on käsittelyssä.",
-        "cancelled": "Hakemus on peruttu."
+        "cancelled": "Hakemus on peruttu.",
+        "additional_information_needed": "Hakemus on käsittelyssä."
       },
       "headings": {
         "mainHeading": "Päätöksen tiedot",
@@ -762,7 +763,8 @@
             "received": "Odottaa käsittelyä",
             "opened": "Käsittelyssä",
             "handled": "Käsitelty",
-            "cancelled": "Peruutettu"
+            "cancelled": "Peruutettu",
+            "additional_information_needed": "Odottaa lisätietoja"
           },
           "recoveryAmount": "Takaisinlaskutettu tuki",
           "recoveryPeriod": "Aika, jolta tukea laskutettiin takaisin",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -728,7 +728,8 @@
         "accepted": "Hakemus on hyväksytty ja Helsinki-lisää on myönnetty aikavälille {{dateRangeStart}} – {{dateRangeEnd}}",
         "rejected": "Hakemus on hylätty. Helsinki-lisää ei myönnetä.",
         "handling": "Hakemus on käsittelyssä.",
-        "cancelled": "Hakemus on peruttu."
+        "cancelled": "Hakemus on peruttu.",
+        "additional_information_needed": "Hakemus on käsittelyssä."
       },
       "headings": {
         "mainHeading": "Päätöksen tiedot",
@@ -762,7 +763,8 @@
             "received": "Odottaa käsittelyä",
             "opened": "Käsittelyssä",
             "handled": "Käsitelty",
-            "cancelled": "Peruutettu"
+            "cancelled": "Peruutettu",
+            "additional_information_needed": "Odottaa lisätietoja"
           },
           "recoveryAmount": "Takaisinlaskutettu tuki",
           "recoveryPeriod": "Aika, jolta tukea laskutettiin takaisin",

--- a/frontend/benefit/handler/src/components/applicationReview/handlingView/HandlingStep1.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/handlingView/HandlingStep1.tsx
@@ -57,6 +57,14 @@ const HandlingStep1: React.FC<HandlingStepProps> = ({
     useApplicationReview();
   const router = useRouter();
 
+  const showMonetaryFields = ![
+    APPLICATION_STATUSES.CANCELLED,
+    APPLICATION_STATUSES.REJECTED,
+    APPLICATION_STATUSES.INFO_REQUIRED,
+  ].includes(application.status);
+  const showBasicDecisionFields =
+    application.status !== APPLICATION_STATUSES.CANCELLED;
+
   const decisionDetailList = useMemo<DecisionDetailList>(
     () => [
       {
@@ -71,6 +79,7 @@ const HandlingStep1: React.FC<HandlingStepProps> = ({
       {
         accessor: (app) => formatFloatToCurrency(app.calculatedBenefitAmount),
         key: 'benefitAmount',
+        showIf: () => showMonetaryFields,
       },
       {
         accessor: (app) =>
@@ -78,10 +87,12 @@ const HandlingStep1: React.FC<HandlingStepProps> = ({
             app.endDate
           )}`,
         key: 'benefitPeriod',
+        showIf: () => showMonetaryFields,
       },
       {
         accessor: (app) => app.batch?.sectionOfTheLaw,
         key: 'sectionOfLaw',
+        showIf: () => showBasicDecisionFields,
       },
       {
         accessor: (app) =>
@@ -89,10 +100,12 @@ const HandlingStep1: React.FC<HandlingStepProps> = ({
             ? t('utility.yes')
             : t('utility.no'),
         key: 'grantedAsDeMinimis',
+        showIf: () => showMonetaryFields,
       },
       {
         accessor: (app) => convertToUIDateFormat(app.ahjoDecisionDate),
         key: 'decisionDate',
+        showIf: () => showBasicDecisionFields,
       },
       {
         accessor: (app) =>
@@ -103,9 +116,10 @@ const HandlingStep1: React.FC<HandlingStepProps> = ({
       {
         accessor: (app) => app.batch?.decisionMakerName,
         key: 'decisionMaker',
+        showIf: () => showBasicDecisionFields,
       },
     ],
-    [t]
+    [t, showMonetaryFields, showBasicDecisionFields]
   );
 
   const hasPendingAlteration = application.alterations.some(
@@ -144,7 +158,11 @@ const HandlingStep1: React.FC<HandlingStepProps> = ({
           ]}
           itemComponent={AlterationAccordionItem}
           detailList={decisionDetailList}
-          extraInformation={<DecisionCalculationAccordion data={application} />}
+          extraInformation={
+            showMonetaryFields ? (
+              <DecisionCalculationAccordion data={application} />
+            ) : null
+          }
         />
         {application.applicationOrigin === APPLICATION_ORIGINS.HANDLER && (
           <PaperView data={application} />

--- a/frontend/benefit/shared/src/components/decisionSummary/DecisionSummary.tsx
+++ b/frontend/benefit/shared/src/components/decisionSummary/DecisionSummary.tsx
@@ -8,6 +8,7 @@ import {
   $DecisionNumber,
   $Subheading,
 } from 'benefit-shared/components/decisionSummary/DecisionSummary.sc';
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import {
   AlterationAccordionItemProps,
   Application,
@@ -23,7 +24,7 @@ import { convertToUIDateFormat } from 'shared/utils/date.utils';
 type Props = {
   application: Application;
   actions: ReactNode;
-  itemComponent: React.ComponentType<AlterationAccordionItemProps>;
+  itemComponent?: React.ComponentType<AlterationAccordionItemProps>;
   detailList: DecisionDetailList;
   extraInformation?: ReactNode;
 };
@@ -37,7 +38,12 @@ const DecisionSummary = ({
 }: Props): JSX.Element => {
   const { t } = useTranslation();
 
-  if (!application.ahjoCaseId) {
+  const isAccepted = ![
+    APPLICATION_STATUSES.REJECTED,
+    APPLICATION_STATUSES.CANCELLED,
+  ].includes(application.status);
+
+  if (!application.ahjoCaseId && isAccepted) {
     return null;
   }
 
@@ -57,11 +63,13 @@ const DecisionSummary = ({
       <$DecisionBoxTitle>
         {t('common:applications.decision.headings.mainHeading')}
       </$DecisionBoxTitle>
-      <$DecisionNumber>
-        {t('common:applications.decision.headings.caseId')}
-        {': '}
-        {application.ahjoCaseId}
-      </$DecisionNumber>
+      {isAccepted && (
+        <$DecisionNumber>
+          {t('common:applications.decision.headings.caseId')}
+          {': '}
+          {application.ahjoCaseId}
+        </$DecisionNumber>
+      )}
       <$Subheading>
         {t(`common:applications.decision.description.${application.status}`, {
           dateRangeStart: convertToUIDateFormat(application.startDate),
@@ -72,6 +80,10 @@ const DecisionSummary = ({
         {detailList.map((detail) => {
           if (detail.showIf && !detail.showIf(application)) {
             return null;
+          }
+
+          if (detail.invisible) {
+            return <$GridCell $colSpan={detail.width || 3} key={detail.key} />;
           }
 
           return (
@@ -85,41 +97,44 @@ const DecisionSummary = ({
         })}
       </$DecisionDetails>
       {extraInformation}
-      <$DecisionActionContainer>
-        <Button
-          iconRight={<IconLinkExternal />}
-          onClick={displayDecision}
-          theme="black"
-          variant="secondary"
-          role="link"
-        >
-          {t('common:applications.decision.actions.showDecision')}
-        </Button>
-      </$DecisionActionContainer>
-      {isTruthy(process.env.NEXT_PUBLIC_ENABLE_ALTERATION_FEATURES) && (
-        <>
-          <$Subheading>
-            {t('common:applications.decision.headings.existingAlterations')}
-          </$Subheading>
-          <$AlterationListCount>
-            {application.alterations?.length > 0
-              ? t('common:applications.decision.alterationList.count', {
-                  count: application.alterations.length,
-                })
-              : t('common:applications.decision.alterationList.empty')}
-          </$AlterationListCount>
-          <div data-testid="alteration-list">
-            {sortedAlterations.map((alteration) => (
-              <ItemComponent
-                key={alteration.id}
-                alteration={alteration}
-                application={application}
-              />
-            ))}
-          </div>
-          <$AlterationActionContainer>{actions}</$AlterationActionContainer>
-        </>
+      {isAccepted && (
+        <$DecisionActionContainer>
+          <Button
+            iconRight={<IconLinkExternal />}
+            onClick={displayDecision}
+            theme="black"
+            variant="secondary"
+            role="link"
+          >
+            {t('common:applications.decision.actions.showDecision')}
+          </Button>
+        </$DecisionActionContainer>
       )}
+      {isTruthy(process.env.NEXT_PUBLIC_ENABLE_ALTERATION_FEATURES) &&
+        isAccepted && (
+          <>
+            <$Subheading>
+              {t('common:applications.decision.headings.existingAlterations')}
+            </$Subheading>
+            <$AlterationListCount>
+              {application.alterations?.length > 0
+                ? t('common:applications.decision.alterationList.count', {
+                    count: application.alterations.length,
+                  })
+                : t('common:applications.decision.alterationList.empty')}
+            </$AlterationListCount>
+            <div data-testid="alteration-list">
+              {sortedAlterations.map((alteration) => (
+                <ItemComponent
+                  key={alteration.id}
+                  alteration={alteration}
+                  application={application}
+                />
+              ))}
+            </div>
+            <$AlterationActionContainer>{actions}</$AlterationActionContainer>
+          </>
+        )}
     </$DecisionBox>
   );
 };

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -685,4 +685,5 @@ export type DecisionDetailList = Array<{
   accessor: DecisionDetailAccessorFunction;
   width?: number;
   showIf?: (app: Application) => boolean;
+  invisible?: boolean;
 }>;

--- a/frontend/shared/src/components/forms/section/FormSection.sc.ts
+++ b/frontend/shared/src/components/forms/section/FormSection.sc.ts
@@ -1,4 +1,5 @@
 import { HeadingProps } from 'shared/components/forms/heading/Heading.sc';
+import { respondBelow } from 'shared/styles/mediaQueries';
 import styled, { DefaultTheme } from 'styled-components';
 
 type SpacingKeys = keyof DefaultTheme['spacing'];
@@ -102,6 +103,12 @@ export const $GridCell = styled.div<GridCellProps>`
   grid-row: auto / span ${(props) => props.$rowSpan ?? 1};
   align-self: ${(props) => props.alignSelf ?? 'initial'};
   justify-self: ${(props) => props.justifySelf ?? 'initial'};
+
+  ${respondBelow('sm')`
+    &:empty {
+      display: none;
+    }
+  `};
 `;
 
 export const $Action = styled.div`


### PR DESCRIPTION
## Additional notes :spiral_notepad:
This removes all fields related to monetary matters from the decision box for applications that are rejected, cancelled, or waiting for input from the applicant. It also changes the default visibility of the decision box to be shown for cancelled and rejected applications (first of which should rarely if ever have an Ahjo case ID in a real world scenario), and adds translation strings for an application that's waiting for additional details (in this case the Ahjo case ID should be present for the box to be shown).
