### PR TITLE
(DRAFT) YJDH-696 | Upgrade black/isort/flake8 to latest versions in all backends

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_stages: [commit, manual]
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 24.4.2
     hooks:
       - id: black
         name: (BF) black
@@ -23,7 +23,7 @@ repos:
         name: (Shared) black
         files: ^backend/shared
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: (BF) isort
@@ -42,7 +42,7 @@ repos:
         args: [--settings-file, backend/shared/setup.cfg]
         files: ^backend/shared
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.1.0
     hooks:
       - id: flake8
         name: (BF) flake8

--- a/backend/benefit/applications/api/v1/ahjo_integration_views.py
+++ b/backend/benefit/applications/api/v1/ahjo_integration_views.py
@@ -117,9 +117,9 @@ of type {attachment.attachment_type} was sent to AHJO!",
         file_handle = attachment.attachment_file.open()
         response = FileResponse(file_handle, content_type=attachment.content_type)
         response["Content-Length"] = attachment.attachment_file.size
-        response[
-            "Content-Disposition"
-        ] = f"attachment; filename={attachment.attachment_file.name}"
+        response["Content-Disposition"] = (
+            f"attachment; filename={attachment.attachment_file.name}"
+        )
         return response
 
 

--- a/backend/benefit/applications/api/v1/application_batch_views.py
+++ b/backend/benefit/applications/api/v1/application_batch_views.py
@@ -235,7 +235,7 @@ class ApplicationBatchViewSet(AuditLoggingModelViewSet):
 
         if (
             app_status not in [ApplicationStatus.ACCEPTED, ApplicationStatus.REJECTED]
-            or type(app_ids) != list
+            or type(app_ids) is not list
         ):
             return Response(
                 {"detail": "Status or application id is not valid"},

--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1384,9 +1384,9 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
 
         for idx, aid_item in enumerate(serializer.validated_data):
             aid_item["application_id"] = application.pk
-            aid_item[
-                "ordering"
-            ] = idx  # use the ordering defined in the JSON sent by the client
+            aid_item["ordering"] = (
+                idx  # use the ordering defined in the JSON sent by the client
+            )
 
         de_minimis_list = serializer.save()
         for de_minimis in de_minimis_list:
@@ -1780,9 +1780,9 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
             )
         for idx, nested_object in enumerate(serializer.validated_data):
             nested_object["application_id"] = application.pk
-            nested_object[
-                "ordering"
-            ] = idx  # use the ordering defined in the JSON sent by the client
+            nested_object["ordering"] = (
+                idx  # use the ordering defined in the JSON sent by the client
+            )
         serializer.save()
         if hasattr(application, "calculation"):
             call_now_or_later(

--- a/backend/benefit/applications/benefit_aggregation.py
+++ b/backend/benefit/applications/benefit_aggregation.py
@@ -17,9 +17,9 @@ from common.utils import date_range_overlap, duration_in_months, pairwise
 @dataclass
 class FormerBenefitInfo:
     warnings: List[str] = field(default_factory=list)
-    months_used: Optional[
-        Decimal
-    ] = None  # None is used if employee info is not entered yet
+    months_used: Optional[Decimal] = (
+        None  # None is used if employee info is not entered yet
+    )
     months_remaining: Optional[Decimal] = None  # None means that there is no limit
 
 

--- a/backend/benefit/applications/services/ahjo_integration.py
+++ b/backend/benefit/applications/services/ahjo_integration.py
@@ -78,9 +78,7 @@ COMPOSED_DECLINED_TEMPLATE_IDS = [
 
 
 ACCEPTED_TITLE = "Työllisyydenhoidon Helsinki-lisän myöntäminen työnantajille"
-REJECTED_TITLE = (
-    "Työllisyydenhoidon Helsinki-lisä, kielteiset päätökset työnantajille"
-)
+REJECTED_TITLE = "Työllisyydenhoidon Helsinki-lisä, kielteiset päätökset työnantajille"
 
 
 JINJA_TEMPLATES_COMPOSED = {
@@ -330,9 +328,11 @@ def generate_single_approved_file(
     return generate_pdf(
         apps=apps,
         template_config=JINJA_TEMPLATES_SINGLE[
-            TEMPLATE_ID_BENEFIT_WITH_DE_MINIMIS_AID
-            if any(filter(_get_granted_as_de_minimis_aid, apps))
-            else TEMPLATE_ID_BENEFIT_WITHOUT_DE_MINIMIS_AID
+            (
+                TEMPLATE_ID_BENEFIT_WITH_DE_MINIMIS_AID
+                if any(filter(_get_granted_as_de_minimis_aid, apps))
+                else TEMPLATE_ID_BENEFIT_WITHOUT_DE_MINIMIS_AID
+            )
         ],
         company=company,
         attachment_number=attachment_number,

--- a/backend/benefit/applications/services/ahjo_xml_builder.py
+++ b/backend/benefit/applications/services/ahjo_xml_builder.py
@@ -121,7 +121,10 @@ class AhjoSecretXMLBuilder(AhjoXMLBuilder):
     def _get_period_rows_for_xml(
         self,
         calculation: Calculation,
-    ) -> Tuple[CalculationRow, List[CalculationRow],]:
+    ) -> Tuple[
+        CalculationRow,
+        List[CalculationRow],
+    ]:
         total_amount_row = calculation.rows.filter(
             row_type=RowType.HELSINKI_BENEFIT_TOTAL_EUR
         ).first()

--- a/backend/benefit/applications/tests/factories.py
+++ b/backend/benefit/applications/tests/factories.py
@@ -227,7 +227,7 @@ class ReceivedApplicationFactory(ApplicationWithAttachmentFactory):
         )
 
     @factory.post_generation
-    def calculation(self, created, extracted, **kwargs):
+    def calculation(self, created, extracted, **kwargs):  # noqa: F811
         self.calculation = Calculation.objects.create_for_application(self, **kwargs)
         self.calculation.init_calculator()
         self.calculation.calculate()

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -613,9 +613,9 @@ def test_application_post_invalid_data(
     data["applicant_language"] = None  # non-null required
     data["company_bank_account_number"] = "FI91 4008 0282 0002 02"  # invalid number
 
-    data[
-        "company_contact_person_phone_number"
-    ] = "+359505658789"  # Invalid country code
+    data["company_contact_person_phone_number"] = (
+        "+359505658789"  # Invalid country code
+    )
 
     api_client.defaults["HTTP_ACCEPT_LANGUAGE"] = language
     response = api_client.post(
@@ -780,9 +780,9 @@ def test_application_put_read_only_fields(api_client, application):
 def test_application_put_invalid_data(api_client, application):
     data = ApplicantApplicationSerializer(application).data
     data["de_minimis_aid_set"][0]["amount"] = "300001.00"  # value too high
-    data[
-        "status"
-    ] = ApplicationStatus.ACCEPTED  # invalid value when transitioning from draft
+    data["status"] = (
+        ApplicationStatus.ACCEPTED
+    )  # invalid value when transitioning from draft
     data["bases"] = ["something_completely_different"]  # invalid value
     data["applicant_language"] = None  # non-null required
     response = api_client.put(

--- a/backend/benefit/messages/automatic_messages.py
+++ b/backend/benefit/messages/automatic_messages.py
@@ -95,12 +95,14 @@ def send_email_to_applicant(
     with translation.override(application.applicant_language):
         try:
             return send_mail(
-                subject=subject
-                if subject
-                else get_default_email_notification_subject(),
-                message=text_message
-                if text_message
-                else _message_notification_email_body(application),
+                subject=(
+                    subject if subject else get_default_email_notification_subject()
+                ),
+                message=(
+                    text_message
+                    if text_message
+                    else _message_notification_email_body(application)
+                ),
                 html_message=html_message or None,
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=[application.company_contact_person_email],

--- a/backend/benefit/requirements-dev.in
+++ b/backend/benefit/requirements-dev.in
@@ -1,7 +1,9 @@
-black
-flake8
+# These need to be kept in sync with .pre-commit-config.yaml in the root of the repository.
+black==24.4.2
+flake8==7.1.0
+isort==5.13.2
+
 ipython
-isort
 langdetect
 pip-tools==7.4.1
 pytest

--- a/backend/benefit/requirements-dev.txt
+++ b/backend/benefit/requirements-dev.txt
@@ -10,7 +10,7 @@ attrs==22.2.0
     # via pytest
 backcall==0.2.0
     # via ipython
-black==23.1.0
+black==24.4.2
     # via -r requirements-dev.in
 build==1.2.1
     # via pip-tools
@@ -36,7 +36,7 @@ executing==1.2.0
     # via stack-data
 filelock==3.9.0
     # via virtualenv
-flake8==6.0.0
+flake8==7.1.0
     # via -r requirements-dev.in
 freezegun==1.2.2
     # via pytest-freezegun
@@ -50,7 +50,7 @@ iniconfig==2.0.0
     # via pytest
 ipython==8.10.0
     # via -r requirements-dev.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-dev.in
 jedi==0.18.2
     # via ipython
@@ -95,9 +95,9 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pycodestyle==2.10.0
+pycodestyle==2.12.0
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
 pygments==2.14.0
     # via ipython

--- a/backend/benefit/users/api/v1/authentications.py
+++ b/backend/benefit/users/api/v1/authentications.py
@@ -3,6 +3,7 @@ Contents copied from tet.tet.views. More info there.
 As kesaseteli doesn't use helusers package, kesaseteli tests fail when these put
 under shared code, that's why copied.
 """
+
 from typing import Optional
 
 from django.contrib.auth import get_user_model

--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -358,9 +358,9 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
 
         for idx, summer_voucher_item in enumerate(serializer.validated_data):
             summer_voucher_item["application_id"] = application.pk
-            summer_voucher_item[
-                "ordering"
-            ] = idx  # use the ordering defined in the JSON sent by the client
+            summer_voucher_item["ordering"] = (
+                idx  # use the ordering defined in the JSON sent by the client
+            )
         serializer.save()
 
     def validate(self, data):

--- a/backend/kesaseteli/applications/tests/test_schools_api.py
+++ b/backend/kesaseteli/applications/tests/test_schools_api.py
@@ -18,7 +18,7 @@ def test_schools_list_status_ok(api_client, school_list):
 @pytest.mark.django_db
 def test_schools_list_returns_list(api_client, school_list):
     response = api_client.get(get_schools_api_url())
-    assert type(response.json()) == list
+    assert type(response.json()) is list
 
 
 @pytest.mark.django_db
@@ -36,7 +36,7 @@ def test_schools_list_returns_school_count(api_client, school_list):
 @pytest.mark.django_db
 def test_schools_list_returns_string_collection(api_client, school_list):
     response = api_client.get(get_schools_api_url())
-    assert all(type(element) == str for element in response.json())
+    assert all(type(element) is str for element in response.json())
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/applications/views.py
+++ b/backend/kesaseteli/applications/views.py
@@ -268,9 +268,9 @@ class YouthApplicationExcelExportViewSet(AuditLoggingModelViewSet):
                 ),
                 content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             )
-            response[
-                "Content-Disposition"
-            ] = f"attachment; filename={self.xlsx_filename}"
+            response["Content-Disposition"] = (
+                f"attachment; filename={self.xlsx_filename}"
+            )
             return response
 
     @property
@@ -288,9 +288,13 @@ class YouthApplicationExcelExportViewSet(AuditLoggingModelViewSet):
     def generate_data_row(self, app: YouthApplication, is_template: bool = False):
         data = self.serializer_class(app).data
         return [
-            YouthApplicationExcelExportSerializer.get_placeholder_value(source_field)
-            if is_template and not data.get(source_field)
-            else data.get(source_field)
+            (
+                YouthApplicationExcelExportSerializer.get_placeholder_value(
+                    source_field
+                )
+                if is_template and not data.get(source_field)
+                else data.get(source_field)
+            )
             for source_field in self.source_fields()
         ]
 

--- a/backend/kesaseteli/kesaseteli/__init__.py
+++ b/backend/kesaseteli/kesaseteli/__init__.py
@@ -1,6 +1,7 @@
 """
 Code from https://github.com/benslavin/django-db-prefix
 """
+
 from django.conf import settings
 from django.db.models.signals import class_prepared
 

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -353,9 +353,11 @@ AUTHENTICATION_BACKENDS = [
 # If Suomi.fi not enabled we will enable the legacy Kesäseteli auth.
 AUTHENTICATION_BACKENDS.insert(
     0,
-    "shared.suomi_fi.auth.SuomiFiSAML2AuthenticationBackend"
-    if NEXT_PUBLIC_ENABLE_SUOMIFI
-    else "shared.oidc.auth.HelsinkiOIDCAuthenticationBackend",
+    (
+        "shared.suomi_fi.auth.SuomiFiSAML2AuthenticationBackend"
+        if NEXT_PUBLIC_ENABLE_SUOMIFI
+        else "shared.oidc.auth.HelsinkiOIDCAuthenticationBackend"
+    ),
 )
 
 OIDC_RP_SIGN_ALGO = "RS256"

--- a/backend/kesaseteli/requirements-dev.in
+++ b/backend/kesaseteli/requirements-dev.in
@@ -1,7 +1,10 @@
 -c requirements.txt
-black
-flake8
-isort
+
+# These need to be kept in sync with .pre-commit-config.yaml in the root of the repository.
+black==24.4.2
+flake8==7.1.0
+isort==5.13.2
+
 langdetect
 openpyxl
 pip-tools

--- a/backend/kesaseteli/requirements-dev.txt
+++ b/backend/kesaseteli/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 attrs==21.4.0
     # via pytest
-black==23.1.0
+black==24.4.2
     # via -r requirements-dev.in
 certifi==2021.5.30
     # via
@@ -32,7 +32,7 @@ execnet==1.9.0
     # via pytest-xdist
 filelock==3.9.0
     # via virtualenv
-flake8==6.0.0
+flake8==7.1.0
     # via -r requirements-dev.in
 freezegun==1.2.1
     # via pytest-freezegun
@@ -44,7 +44,7 @@ idna==2.10
     #   requests
 iniconfig==1.1.1
     # via pytest
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-dev.in
 langdetect==1.0.9
     # via -r requirements-dev.in
@@ -80,9 +80,9 @@ py==1.11.0
     # via
     #   pytest
     #   pytest-forked
-pycodestyle==2.10.0
+pycodestyle==2.12.0
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
 pytest==7.1.2
     # via

--- a/backend/tet/events/transformations.py
+++ b/backend/tet/events/transformations.py
@@ -42,9 +42,9 @@ def _shorten_description(descobj):
         if len(desc) <= 125:
             shortened_obj[lang] = desc
         else:
-            shortened_obj[
-                lang
-            ] = f"{desc[:125]}{unicodedata.lookup('Horizontal ellipsis')}"
+            shortened_obj[lang] = (
+                f"{desc[:125]}{unicodedata.lookup('Horizontal ellipsis')}"
+            )
 
     return shortened_obj
 

--- a/backend/tet/requirements-dev.in
+++ b/backend/tet/requirements-dev.in
@@ -3,9 +3,9 @@
 -c requirements.txt
 
 # These need to be kept in sync with .pre-commit-config.yaml in the root of the repository.
-black==23.1.0
-flake8==6.0.0
-isort==5.12.0
+black==24.4.2
+flake8==7.1.0
+isort==5.13.2
 
 ipython
 pip-tools

--- a/backend/tet/requirements-dev.txt
+++ b/backend/tet/requirements-dev.txt
@@ -8,7 +8,7 @@ asttokens==2.4.1
     # via stack-data
 backcall==0.2.0
     # via ipython
-black==23.1.0
+black==24.4.2
     # via -r requirements-dev.in
 build==1.2.1
     # via pip-tools
@@ -40,7 +40,7 @@ executing==2.0.1
     # via stack-data
 filelock==3.14.0
     # via virtualenv
-flake8==6.0.0
+flake8==7.1.0
     # via -r requirements-dev.in
 freezegun==1.5.1
     # via pytest-freezegun
@@ -56,7 +56,7 @@ iniconfig==2.0.0
     # via pytest
 ipython==8.12.3
     # via -r requirements-dev.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-dev.in
 jedi==0.19.1
     # via ipython
@@ -102,9 +102,9 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pycodestyle==2.10.0
+pycodestyle==2.12.0
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
 pygments==2.18.0
     # via ipython


### PR DESCRIPTION
## Description :sparkles:

### feat: upgrade black/isort/flake8 to latest versions in all backends

also:
 - all backends
   - fix flake8 E721 ("Do not compare types, use 'isinstance()'")
	 warnings
	 - change `==` to `is` in type comparisons
	 - change `!=` to `is not` in type comparisons
   - make the dependency of .pre-commit-config.yaml's black/isort/flake8
	 versions and each backend's requirements explicit
 - benefit backend:
   - ignore flake8 F811 ("Redefinition of unused name from line n")
	 warning in ReceivedApplicationFactory's calculation post generation
	 function, so the pull request won't stall simply because of this
	 warning as the code has been like this already for some time.

refs YJDH-696

## Issues :bug:

[YJDH-696](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-696)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-696]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ