### PR TITLE
fix: django 5 deprecation warning by using datetime.timezone.utc

### DIFF
--- a/backend/shared/shared/audit_log/tests/test_audit_logging.py
+++ b/backend/shared/shared/audit_log/tests/test_audit_logging.py
@@ -1,10 +1,10 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
-from django.utils import timezone
+from django.utils.timezone import now
 
 from shared.audit_log import audit_logging
 from shared.audit_log.enums import Operation, Status
@@ -388,11 +388,11 @@ def test_clear_audit_log(user, fixed_datetime):
     new_sent_log.is_sent = True
     new_sent_log.save()
 
-    expired_unsent_log.created_at = timezone.now() - timedelta(days=35)
+    expired_unsent_log.created_at = now() - timedelta(days=35)
     expired_unsent_log.save()
 
     expired_sent_log.is_sent = True
-    expired_sent_log.created_at = timezone.now() - timedelta(days=35)
+    expired_sent_log.created_at = now() - timedelta(days=35)
     expired_sent_log.save()
 
     deleted_count = clear_audit_log_entries()

--- a/backend/shared/shared/common/tests/conftest.py
+++ b/backend/shared/shared/common/tests/conftest.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import pytest
 from django.test import Client
-from django.utils import timezone
+from django.utils.timezone import now
 
 from shared.common.tests.factories import (
     StaffSuperuserFactory,
@@ -14,26 +14,19 @@ from shared.common.tests.factories import (
 
 def store_tokens_in_session(client):
     s = client.session
+    now_plus_1_hour = now() + timedelta(hours=1)
     s.update(
         {
             "oidc_id_token": "test",
             "oidc_access_token": "test",
             "oidc_refresh_token": "test",
-            "oidc_access_token_expires": (
-                timezone.now() + timedelta(hours=1)
-            ).isoformat(),
-            "oidc_refresh_token_expires": (
-                timezone.now() + timedelta(hours=1)
-            ).isoformat(),
+            "oidc_access_token_expires": now_plus_1_hour.isoformat(),
+            "oidc_refresh_token_expires": now_plus_1_hour.isoformat(),
             "eauth_id_token": "test",
             "eauth_access_token": "test",
             "eauth_refresh_token": "test",
-            "eauth_access_token_expires": (
-                timezone.now() + timedelta(hours=1)
-            ).isoformat(),
-            "eauth_refresh_token_expires": (
-                timezone.now() + timedelta(hours=1)
-            ).isoformat(),
+            "eauth_access_token_expires": now_plus_1_hour.isoformat(),
+            "eauth_refresh_token_expires": now_plus_1_hour.isoformat(),
         }
     )
     s.save()


### PR DESCRIPTION
## Description :sparkles:

### fix: django 5 deprecation warning by using datetime.timezone.utc

RemovedInDjango50Warning:
 - The django.utils.timezone.utc alias is deprecated.
   Please update your code to use datetime.timezone.utc instead.

refs YJDH-696

## Issues :bug:

[YJDH-696](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-696)

## Testing :alembic:

Ran the shared backend tests locally in docker and they passed:
```bash
pytest --pyargs shared -vv
...
=== 665 passed, 9 warnings in 8.04s ===
```

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-696]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ