### PR TITLE
YJDH-696 | Downgrade Kesäseteli's Elasticsearch to v7 to fix sending audit logs

### DIFF
--- a/backend/kesaseteli/requirements-dev.txt
+++ b/backend/kesaseteli/requirements-dev.txt
@@ -134,7 +134,7 @@ typing-extensions==4.12.2
     # via
     #   -c requirements.txt
     #   black
-urllib3==2.2.2
+urllib3==1.26.19
     # via
     #   -c requirements.txt
     #   requests

--- a/backend/kesaseteli/requirements.in
+++ b/backend/kesaseteli/requirements.in
@@ -10,7 +10,7 @@ django-simple-history
 django-storages[azure]
 djangorestframework
 django~=4.2
-elasticsearch
+elasticsearch~=7.17  # TODO: remove and update to 8.x when elasticsearch servers are updated to elasticsearch 8
 factory-boy
 filetype
 ipython

--- a/backend/kesaseteli/requirements.txt
+++ b/backend/kesaseteli/requirements.txt
@@ -20,7 +20,7 @@ azure-storage-blob==12.21.0
     # via django-storages
 certifi==2024.7.4
     # via
-    #   elastic-transport
+    #   elasticsearch
     #   requests
     #   sentry-sdk
 cffi==1.16.0
@@ -82,9 +82,7 @@ djangorestframework==3.15.2
     # via -r requirements.in
 djangosaml2==1.9.3
     # via yjdh-backend-shared
-elastic-transport==8.13.1
-    # via elasticsearch
-elasticsearch==8.14.0
+elasticsearch==7.17.9
     # via -r requirements.in
 elementpath==4.4.0
     # via xmlschema
@@ -185,10 +183,10 @@ typing-extensions==4.12.2
     #   azure-core
     #   azure-storage-blob
     #   ipython
-urllib3==2.2.2
+urllib3==1.26.19
     # via
     #   django-auth-adfs
-    #   elastic-transport
+    #   elasticsearch
     #   requests
     #   sentry-sdk
 wcwidth==0.2.13


### PR DESCRIPTION
## Description :sparkles:

### fix(kesaseteli): downgrade to elasticsearch v7 to fix send_audit_log

elasticsearch was upgraded to v8 as part of PR #3157
"Upgrade Django to 4.2 & all dependencies except black/isort/flake8",

After merging that PR the quarter hourly cronjobs running send_audit_log
using `manage.py runjobs quarter_hourly` started failing:
```
ERROR OCCURED IN JOB: send_audit_log (APP: shared.audit_log)
TypeError: '<' not supported between instances of 'str' and 'int'
```

Similar Elasticsearch v7 downgrade was done for Helsinki benefit
application in PR #1942:
 - https://github.com/City-of-Helsinki/yjdh/pull/1942

refs YJDH-696 (after elasticsearch v8 upgrade audit log sending failed)

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
