### PR TITLE
YJDH-696 | Fix SAML2 login, xmlsec1-openssl library was missing

### DIFF
--- a/backend/docker/kesaseteli.Dockerfile
+++ b/backend/docker/kesaseteli.Dockerfile
@@ -20,6 +20,7 @@ RUN dnf update -y \
            gcc \
            gettext \
            xmlsec1 \
+           xmlsec1-openssl \
            cyrus-sasl-devel \
            openssl-devel \
     && pip install -U pip \


### PR DESCRIPTION
## Description :sparkles:

### fix: saml2 login, xmlsec1-openssl library was missing

When trying to /saml2/login/ there was error
"Error: unable to load xmlsec-openssl library".

refs YJDH-696

## Issues :bug:

[YJDH-696](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-696)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-696]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ