### PR TITLE
feat: offset application content when sidebar is open (hl-1200)

### DIFF
--- a/backend/benefit/messages/tests/test_api.py
+++ b/backend/benefit/messages/tests/test_api.py
@@ -591,7 +591,7 @@ def test_list_messages_read_receipt_applicant(
 @pytest.mark.parametrize(
     "first_message_type,second_message_type,expected_count_after_mark_unread",
     [
-        (MessageType.APPLICANT_MESSAGE, MessageType.HANDLER_MESSAGE, 2),
+        (MessageType.APPLICANT_MESSAGE, MessageType.HANDLER_MESSAGE, 1),
         (MessageType.HANDLER_MESSAGE, MessageType.APPLICANT_MESSAGE, 1),
     ],
 )

--- a/backend/benefit/messages/views.py
+++ b/backend/benefit/messages/views.py
@@ -93,11 +93,13 @@ class HandlerMessageViewSet(ApplicantMessageViewSet):
     @transaction.atomic
     @action(detail=False, methods=["post"])
     def mark_unread(self, *args, **kwargs):
-        last_message = self.get_queryset().order_by("-created_at").first()
-        if (
-            last_message is not None
-            and last_message.message_type == MessageType.APPLICANT_MESSAGE
-        ):
+        last_message = (
+            self.get_queryset()
+            .order_by("-created_at")
+            .filter(message_type=MessageType.APPLICANT_MESSAGE)
+            .first()
+        )
+        if last_message is not None:
             last_message.seen_by_handler = False
             last_message.save()
 

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/useHandlingApplicationActions.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/useHandlingApplicationActions.ts
@@ -40,6 +40,7 @@ const useHandlingApplicationActions = (
   const { updateStatus } = useApplicationActions(application);
   const { handledApplication, setHandledApplication } =
     React.useContext(AppContext);
+  const { setIsSidebarVisible } = React.useContext(AppContext);
   const router = useRouter();
   const { openDrawer } = router.query;
   const [isMessagesDrawerVisible, toggleMessagesDrawerVisibility] = useToggle(
@@ -82,7 +83,10 @@ const useHandlingApplicationActions = (
     if (application.status === APPLICATION_STATUSES.CANCELLED) {
       setIsConfirmationModalOpen(false);
     }
-  }, [application]);
+    if (isMessagesDrawerVisible !== null) {
+      setIsSidebarVisible(isMessagesDrawerVisible);
+    }
+  }, [application, isMessagesDrawerVisible, setIsSidebarVisible]);
 
   const handleCancel = (cancelledApplication: HandledAplication): void => {
     // workaround for broken hds dialog

--- a/frontend/benefit/handler/src/components/sidebar/Sidebar.tsx
+++ b/frontend/benefit/handler/src/components/sidebar/Sidebar.tsx
@@ -52,9 +52,11 @@ const Sidebar: React.FC<ComponentProps> = ({
     });
   };
 
-  const isLastMessageFromApplicant =
-    messages.length > 0 &&
-    messages.at(-1).messageType === MESSAGE_TYPES.APPLICANT_MESSAGE;
+  const haveApplicantMessages =
+    messages?.length > 0 &&
+    messages.some(
+      (message) => message.messageType === MESSAGE_TYPES.APPLICANT_MESSAGE
+    );
 
   return (
     <Drawer
@@ -87,7 +89,7 @@ const Sidebar: React.FC<ComponentProps> = ({
                   theme="black"
                   size="small"
                   key="markAsUnread"
-                  disabled={!isLastMessageFromApplicant}
+                  disabled={!haveApplicantMessages}
                 >
                   {t('common:messenger.markAsUnread')}
                 </Button>,

--- a/frontend/benefit/handler/src/context/AppContext.tsx
+++ b/frontend/benefit/handler/src/context/AppContext.tsx
@@ -7,23 +7,27 @@ import { HandledAplication } from '../types/application';
 export type AppContextType = {
   isNavigationVisible: boolean;
   isFooterVisible: boolean;
+  isSidebarVisible: boolean;
   layoutBackgroundColor: string;
   handledApplication: HandledAplication | null;
   setIsNavigationVisible: (value: boolean) => void;
   setIsFooterVisible: (value: boolean) => void;
   setLayoutBackgroundColor: (value: string) => void;
   setHandledApplication: (handledApplication: HandledAplication | null) => void;
+  setIsSidebarVisible: (value: boolean) => void;
 };
 
 const AppContext = React.createContext<AppContextType>({
   isNavigationVisible: false,
   isFooterVisible: true,
+  isSidebarVisible: false,
   layoutBackgroundColor: theme.colors.white,
   handledApplication: null,
   setIsNavigationVisible: noop,
   setIsFooterVisible: noop,
   setLayoutBackgroundColor: noop,
   setHandledApplication: noop,
+  setIsSidebarVisible: noop,
 });
 
 export default AppContext;

--- a/frontend/benefit/handler/src/context/AppContextProvider.tsx
+++ b/frontend/benefit/handler/src/context/AppContextProvider.tsx
@@ -6,6 +6,8 @@ import AppContext from './AppContext';
 const AppContextProvider = <P,>({
   children,
 }: React.PropsWithChildren<P>): JSX.Element => {
+  const [isSidebarVisible, setIsSidebarVisible] =
+    React.useState<boolean>(false);
   const [isFooterVisible, setIsFooterVisible] = React.useState<boolean>(false);
   const [isNavigationVisible, setIsNavigationVisible] =
     React.useState<boolean>(false);
@@ -25,6 +27,8 @@ const AppContextProvider = <P,>({
         setIsNavigationVisible,
         setIsFooterVisible,
         setLayoutBackgroundColor,
+        isSidebarVisible,
+        setIsSidebarVisible,
       }}
     >
       {children}

--- a/frontend/benefit/handler/src/layout/Layout.sc.ts
+++ b/frontend/benefit/handler/src/layout/Layout.sc.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+type MainProps = {
+  isSidebarVisible: boolean;
+};
+
+export const $Main = styled.main<MainProps>`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 100vh;
+  width: calc(100% - ${(props) => (props.isSidebarVisible ? '520px' : '0px')});
+  transition: width 0.225s ease-out;
+`;

--- a/frontend/benefit/handler/src/layout/Layout.tsx
+++ b/frontend/benefit/handler/src/layout/Layout.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import AppContext from '../context/AppContext';
+import { $Main } from './Layout.sc';
+
+type Props = { children: React.ReactNode };
+
+const Layout: React.FC<Props> = ({ children, ...rest }) => {
+  const { isSidebarVisible } = React.useContext(AppContext);
+
+  return (
+    <$Main {...rest} isSidebarVisible={isSidebarVisible}>
+      {children}
+    </$Main>
+  );
+};
+
+export default Layout;

--- a/frontend/benefit/handler/src/pages/_app.tsx
+++ b/frontend/benefit/handler/src/pages/_app.tsx
@@ -22,6 +22,8 @@ import BackendAPIProvider from 'shared/backend-api/BackendAPIProvider';
 import BaseApp from 'shared/components/app/BaseApp';
 import useLocale from 'shared/hooks/useLocale';
 
+import Layout from '../layout/Layout';
+
 const queryClient = new QueryClient();
 
 const App: React.FC<AppProps> = (appProps) => {
@@ -40,7 +42,12 @@ const App: React.FC<AppProps> = (appProps) => {
       <AppContextProvider>
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
-            <BaseApp header={<Header />} footer={<Footer />} {...appProps} />
+            <BaseApp
+              header={<Header />}
+              footer={<Footer />}
+              {...appProps}
+              layout={Layout}
+            />
           </AuthProvider>
         </QueryClientProvider>
       </AppContextProvider>

--- a/frontend/shared/src/components/drawer/Drawer.sc.tsx
+++ b/frontend/shared/src/components/drawer/Drawer.sc.tsx
@@ -5,27 +5,43 @@ type DrawerProps = {
 };
 
 export const $Drawer = styled.aside<DrawerProps>`
+  @keyframes animate-open {
+    100% {
+      margin-right: 0;
+    }
+  }
+
   position: fixed;
   top: 0;
   right: 0;
   bottom: 0;
   width: 520px;
+  margin-right: -520px;
   height: calc(100vh - ${(props) => (props.stickyBarInUse ? '80' : '0')}px);
   background-color: ${({ theme }) => theme.colors.white};
   z-index: 100;
   box-shadow: -2px 0px 10px 0px rgb(0 0 0 / 10%);
   display: flex;
+  animation: animate-open 0.3s ease-out forwards;
   flex-direction: column;
+  overflow: hidden;
 `;
 
 export const $Close = styled.div`
+  @keyframes animate-open {
+    100% {
+      right: 520px;
+    }
+  }
   display: flex;
   justify-content: center;
   align-items: center;
   position: fixed;
   background-color: ${({ theme }) => theme.colors.white};
   padding: 0 ${({ theme }) => theme.spacing.s};
-  right: 520px;
+  right: 0px;
+  animation: animate-open 0.3s ease-in-out forwards;
+
   box-shadow: -2px 0px 10px 0px rgb(0 0 0 / 10%);
   cursor: pointer;
 `;


### PR DESCRIPTION
## Description :sparkles:

* Sidebar now pushes main content to the left when drawer is opened. 
  * This results to a better view when handling application. Content now remains readable and is not hidden by the sidebar.
* As a bonus, mark as unread now works even though the handler had already sent a message in between.

![sidebar](https://github.com/user-attachments/assets/5e96094a-9bd2-4598-84b9-e92eb94922be)
