### PR TITLE
fix: remove comma from xml filenames

### DIFF
--- a/backend/benefit/applications/services/ahjo_xml_builder.py
+++ b/backend/benefit/applications/services/ahjo_xml_builder.py
@@ -90,7 +90,9 @@ class AhjoPublicXMLBuilder(AhjoXMLBuilder):
 
     def generate_xml_file_name(self) -> str:
         date_str = self.application.created_at.strftime("%d.%m.%Y")
-        return f"Hakemus {date_str}, päätösteksti, {self.application.application_number}.xml"
+        return (
+            f"Hakemus {date_str} päätösteksti {self.application.application_number}.xml"
+        )
 
 
 @dataclass
@@ -223,6 +225,4 @@ class AhjoSecretXMLBuilder(AhjoXMLBuilder):
 
     def generate_xml_file_name(self) -> str:
         date_str = self.application.created_at.strftime("%d.%m.%Y")
-        return (
-            f"Hakemus {date_str}, liite 1/1, {self.application.application_number}.xml"
-        )
+        return f"Hakemus {date_str} päätöksen liite {self.application.application_number}.xml"

--- a/backend/benefit/applications/tests/test_ahjo_xml_builder.py
+++ b/backend/benefit/applications/tests/test_ahjo_xml_builder.py
@@ -109,8 +109,8 @@ def test_public_xml_file_name(decided_application, public_xml_builder):
     application = decided_application
     xml_file_name = public_xml_builder.generate_xml_file_name()
 
-    wanted_file_name = f"Hakemus {application.created_at.strftime('%d.%m.%Y')}, \
-päätösteksti, {application.application_number}.xml"
+    wanted_file_name = f"Hakemus {application.created_at.strftime('%d.%m.%Y')} \
+päätösteksti {application.application_number}.xml"
 
     assert xml_file_name == wanted_file_name
 
@@ -177,8 +177,8 @@ def test_secret_xml_file_name(decided_application, secret_xml_builder):
     application = decided_application
     xml_file_name = secret_xml_builder.generate_xml_file_name()
 
-    wanted_file_name = f"Hakemus {application.created_at.strftime('%d.%m.%Y')}, \
-liite 1/1, {application.application_number}.xml"
+    wanted_file_name = f"Hakemus {application.created_at.strftime('%d.%m.%Y')} \
+päätöksen liite {application.application_number}.xml"
 
     assert xml_file_name == wanted_file_name
 


### PR DESCRIPTION
## Description :sparkles:
Ahjo cannot handle commas in filenames, so we remove the commas from the auto-generated decision xml-files.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
