### PR TITLE
feat: add alteration count and state to archive listing

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -16,6 +16,7 @@ from rest_framework.exceptions import PermissionDenied
 from applications.api.v1.serializers.application_alteration import (
     ApplicantApplicationAlterationSerializer,
     HandlerApplicationAlterationSerializer,
+    SimpleApplicationAlterationSerializer,
 )
 from applications.api.v1.serializers.attachment import AttachmentSerializer
 from applications.api.v1.serializers.batch import ApplicationBatchSerializer
@@ -1858,6 +1859,7 @@ class HandlerApplicationListSerializer(serializers.Serializer):
             "handler",
             "additional_information_needed_by",
             "calculation",
+            "alterations",
         ]
 
         read_only_fields = [
@@ -1875,10 +1877,17 @@ class HandlerApplicationListSerializer(serializers.Serializer):
             "additional_information_needed_by",
             "handler",
             "calculation",
+            "alterations",
         ]
 
     additional_information_needed_by = serializers.SerializerMethodField(
         "get_additional_information_needed_by"
+    )
+
+    alterations = SimpleApplicationAlterationSerializer(
+        source="alteration_set",
+        read_only=True,
+        many=True,
     )
 
     handled_at = serializers.SerializerMethodField(

--- a/backend/benefit/applications/api/v1/serializers/application_alteration.py
+++ b/backend/benefit/applications/api/v1/serializers/application_alteration.py
@@ -15,6 +15,13 @@ from users.api.v1.serializers import UserSerializer
 from users.utils import get_company_from_request, get_request_user_from_context
 
 
+class SimpleApplicationAlterationSerializer(DynamicFieldsModelSerializer):
+    class Meta:
+        model = ApplicationAlteration
+        fields = ["state"]
+        read_only_fields = ["state"]
+
+
 class BaseApplicationAlterationSerializer(DynamicFieldsModelSerializer):
     class Meta:
         model = ApplicationAlteration

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.sc.ts
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.sc.ts
@@ -57,3 +57,21 @@ export const $UnreadMessagesCount = styled.div`
   color: ${(props) => props.theme.colors.white};
   background-color: ${(props) => props.theme.colors.coatOfArms};
 `;
+
+interface $AlterationBadgeProps {
+  $requiresAttention?: boolean;
+}
+export const $AlterationBadge = styled.div<$AlterationBadgeProps>`
+  background: ${(props) =>
+    props.$requiresAttention
+      ? props.theme.colors.coatOfArms
+      : props.theme.colors.black40};
+  color: ${({ theme }) => theme.colors.white};
+  font-size: 14px;
+  line-height: 1;
+  width: 14px;
+  height: 14px;
+  text-align: center;
+  padding: 0.3rem 0.35rem;
+  border-radius: 50%;
+`;

--- a/frontend/benefit/handler/src/components/applicationsArchive/ApplicationArchiveList.tsx
+++ b/frontend/benefit/handler/src/components/applicationsArchive/ApplicationArchiveList.tsx
@@ -1,6 +1,12 @@
 import { getTagStyleForStatus } from 'benefit/handler/utils/applications';
-import { APPLICATION_STATUSES } from 'benefit-shared/constants';
-import { ApplicationData } from 'benefit-shared/types/application';
+import {
+  ALTERATION_STATE,
+  APPLICATION_STATUSES,
+} from 'benefit-shared/constants';
+import {
+  ApplicationAlterationData,
+  ApplicationData,
+} from 'benefit-shared/types/application';
 import { IconAlertCircle, IconCheck, IconCross, Table, Tag } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -9,7 +15,10 @@ import { $Link } from 'shared/components/table/Table.sc';
 import { sortFinnishDate } from 'shared/utils/date.utils';
 import { useTheme } from 'styled-components';
 
-import { $TagWrapper } from '../applicationList/ApplicationList.sc';
+import {
+  $AlterationBadge,
+  $TagWrapper,
+} from '../applicationList/ApplicationList.sc';
 import { $ArchiveCount, $CompanyNameDisabled } from './ApplicationsArchive.sc';
 import { prepareSearchData } from './useApplicationsArchive';
 
@@ -42,6 +51,7 @@ const ApplicationArchiveList: React.FC<SearchProps> = ({
     id: string;
     companyName: string;
     status: APPLICATION_STATUSES;
+    alterations: ApplicationAlterationData[];
   }
 
   const rows = React.useMemo(() => prepareSearchData(data), [data]);
@@ -116,6 +126,22 @@ const ApplicationArchiveList: React.FC<SearchProps> = ({
       key: 'status',
       isSortable: true,
       customSortCompareFunction: sortByStatus,
+    },
+    {
+      transform: ({ alterations }: TableTransforms) =>
+        alterations.length > 0 && (
+          <$AlterationBadge
+            $requiresAttention={alterations.some(({ state }) =>
+              [ALTERATION_STATE.RECEIVED, ALTERATION_STATE.OPENED].includes(
+                state
+              )
+            )}
+          >
+            {alterations.length}
+          </$AlterationBadge>
+        ),
+      headerName: '',
+      key: 'alterations',
     },
   ];
 

--- a/frontend/benefit/handler/src/components/applicationsArchive/useApplicationsArchive.ts
+++ b/frontend/benefit/handler/src/components/applicationsArchive/useApplicationsArchive.ts
@@ -50,6 +50,7 @@ export const prepareSearchData = (
             application_number: applicationNum,
             status,
             calculation,
+            alterations,
           } = application;
 
           return {
@@ -62,6 +63,7 @@ export const prepareSearchData = (
               '-',
             handledAt: convertToUIDateFormat(handled_at) || '-',
             applicationNum,
+            alterations,
             calculationEndDate:
               convertToUIDateFormat(calculation?.end_date) || '-',
           };

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -455,6 +455,7 @@ export type ApplicationData = {
   archived_for_applicant?: boolean;
   is_granted_as_de_minimis_aid?: boolean | null;
   handled_by_ahjo_automation?: boolean;
+  alterations: ApplicationAlterationData[];
 };
 
 export type EmployeeData = {
@@ -551,6 +552,7 @@ export type ApplicationListItemData = {
   ahjoCaseId?: string;
   calculationEndDate?: string;
   handledByAhjoAutomation?: boolean;
+  alterations?: ApplicationAlterationData[];
 };
 
 export type TextProp = 'textFi' | 'textEn' | 'textSv';


### PR DESCRIPTION
## Description :sparkles:

* Add number of alterations
* Background is blue if any alteration is of unhandled state (`["received", "opened"])`, otherwise greyed out (`["cancelled", "handled]`) 
* In screenshot, the top two applications have alterations, which the top one has one alteration in `received` state and the second application has two alterations with only `cancelled` or `handled` alterations.

![image](https://github.com/user-attachments/assets/2719765e-a842-4b9c-b57a-0cd82b95dcd9)
