### PR TITLE
fix: add monthly pay for manual calculation for accepted application

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/handledView/HandledView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/handledView/HandledView.tsx
@@ -53,6 +53,31 @@ const HandledView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
             </$ViewFieldBold>
           </$GridCell>
         )}
+        {data.calculation?.overrideMonthlyBenefitAmount && (
+          <$HandledRow key="manual-calculation-per-month">
+            <$GridCell $colSpan={9} $colStart={1}>
+              <$ViewField large>
+                {t(`${translationsBase}.common.dateRange`, {
+                  dateRange: dateRangeRows
+                    .at(0)
+                    ?.descriptionFi.toLocaleLowerCase(),
+                })}{' '}
+                ({t('calculators.salary.manualInput').toLowerCase()})
+              </$ViewField>
+            </$GridCell>
+            <$GridCell $colSpan={2}>
+              <$ViewFieldBold large>
+                {formatFloatToCurrency(
+                  data.calculation?.overrideMonthlyBenefitAmount,
+                  'EUR',
+                  'fi-FI',
+                  0
+                )}
+                {t('common:utility.perMonth')}
+              </$ViewFieldBold>
+            </$GridCell>
+          </$HandledRow>
+        )}
         {data.status === APPLICATION_STATUSES.ACCEPTED &&
           helsinkiBenefitMonthlyRows.map((row, index) => (
             <$HandledRow key={row.id}>


### PR DESCRIPTION
## Description :sparkles:

Add row **amount per month** for manual calculation when reviewing an accepted application. Screenshot's left side has the added row. On the right is the normal calculation.

![image](https://github.com/user-attachments/assets/1b290875-1e01-4521-bec2-9a5f800fa8f1)
