### PR TITLE
fix: retain or remove training compensation on applicant changes (hl-1184) 

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
@@ -106,6 +106,9 @@ const useApplicationFormStep5 = (
           application?.paySubsidyGranted === PAY_SUBSIDY_GRANTED.NOT_GRANTED
             ? null
             : application?.apprenticeshipProgram,
+        trainingCompensations: application?.apprenticeshipProgram
+          ? application?.trainingCompensations
+          : [],
         calculation: application.calculation
           ? {
               ...application.calculation,

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step6/useApplicationFormStep6.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step6/useApplicationFormStep6.ts
@@ -97,6 +97,9 @@ const useApplicationFormStep6 = (
             application?.paySubsidyGranted === PAY_SUBSIDY_GRANTED.NOT_GRANTED
               ? null
               : application?.apprenticeshipProgram,
+          trainingCompensations: application?.apprenticeshipProgram
+            ? application?.trainingCompensations
+            : [],
           status:
             application.status === APPLICATION_STATUSES.DRAFT
               ? APPLICATION_STATUSES.RECEIVED

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -172,6 +172,10 @@ const SalaryBenefitCalculatorView: React.FC<
         <$HelpText>{t(eurosPerMonth)}</$HelpText>
       </$GridCell>
 
+      <$GridCell $colSpan={11}>
+        <hr />
+      </$GridCell>
+
       {!isManualCalculator && (
         <>
           <$GridCell $colSpan={11}>
@@ -202,6 +206,10 @@ const SalaryBenefitCalculatorView: React.FC<
             />
           </$GridCell>
 
+          <$GridCell $colSpan={11}>
+            <hr />
+          </$GridCell>
+
           {formik.values.paySubsidies?.length > 0 && (
             <$GridCell $colStart={1} $colSpan={11}>
               <$CalculatorHeader as="div">
@@ -222,38 +230,11 @@ const SalaryBenefitCalculatorView: React.FC<
               </$CalculatorHeader>
             </$GridCell>
           )}
+
           {formik.values.paySubsidies?.map(
             // eslint-disable-next-line sonarjs/cognitive-complexity
             (item: PaySubsidy, index: number) => (
               <React.Fragment key={item.id}>
-                <$GridCell $colStart={1}>
-                  <$CalculatorText>
-                    {t(`${translationsBase}.salarySubsidyPercentage`)}
-                  </$CalculatorText>
-                </$GridCell>
-                {item.paySubsidyPercent === 100 && (
-                  <$GridCell $colStart={3} $colSpan={2}>
-                    <$CalculatorText>
-                      {fields.workTimePercent.label}
-                    </$CalculatorText>
-                  </$GridCell>
-                )}
-                <$GridCell
-                  $colStart={item.paySubsidyPercent === 100 ? 6 : 3}
-                  $colSpan={4}
-                >
-                  <$CalculatorText>
-                    {t(`${translationsBase}.salarySupportPeriod`, {
-                      period: formatStringFloatValue(
-                        diffMonths(
-                          parseDate(item.endDate),
-                          parseDate(item.startDate)
-                        )
-                      ),
-                    })}
-                  </$CalculatorText>
-                </$GridCell>
-
                 <$GridCell $colStart={1}>
                   <Select
                     value={getPaySubsidyPercentageSelectValue(
@@ -261,7 +242,7 @@ const SalaryBenefitCalculatorView: React.FC<
                     )}
                     helper=""
                     optionLabelField="label"
-                    label=""
+                    label={t(`${translationsBase}.salarySubsidyPercentage`)}
                     onChange={(paySubsidyPercent: Option) => {
                       formik.setFieldValue(
                         fields.paySubsidies.name,
@@ -293,6 +274,7 @@ const SalaryBenefitCalculatorView: React.FC<
                     <TextInput
                       id={fields.workTimePercent.name}
                       name={fields.workTimePercent.name}
+                      label={fields.workTimePercent.label}
                       onChange={(e) => {
                         formik.setFieldValue(
                           fields.paySubsidies.name,
@@ -325,6 +307,14 @@ const SalaryBenefitCalculatorView: React.FC<
                   $colSpan={3}
                 >
                   <DateInput
+                    label={t(`${translationsBase}.salarySupportPeriod`, {
+                      period: formatStringFloatValue(
+                        diffMonths(
+                          parseDate(item.endDate),
+                          parseDate(item.startDate)
+                        )
+                      ),
+                    })}
                     id={fields.startDate.name}
                     name={fields.startDate.name}
                     placeholder={fields.startDate.placeholder}
@@ -354,6 +344,7 @@ const SalaryBenefitCalculatorView: React.FC<
                   $colSpan={3}
                 >
                   <DateInput
+                    label={fields.endDate.label}
                     id={fields.endDate.name}
                     name={fields.endDate.name}
                     placeholder={fields.endDate.placeholder}
@@ -380,6 +371,9 @@ const SalaryBenefitCalculatorView: React.FC<
                     value={convertToUIDateFormat(item.endDate)}
                     style={{ paddingRight: `${theme.spacing.s}` }}
                   />
+                </$GridCell>
+                <$GridCell $colSpan={11}>
+                  <hr />
                 </$GridCell>
               </React.Fragment>
             )
@@ -559,6 +553,9 @@ const SalaryBenefitCalculatorView: React.FC<
             >
               {t(`${translationsBase}.add`)}
             </Button>
+          </$GridCell>
+          <$GridCell $colSpan={11}>
+            <hr />
           </$GridCell>
         </>
       )}

--- a/frontend/benefit/handler/src/components/reviewSection/ReviewSection.tsx
+++ b/frontend/benefit/handler/src/components/reviewSection/ReviewSection.tsx
@@ -14,6 +14,7 @@ import {
   $Section,
   GridProps,
 } from 'shared/components/forms/section/FormSection.sc';
+import styled from 'styled-components';
 
 import {
   $ActionLeft,
@@ -34,6 +35,13 @@ export type ReviewSectionProps = {
   section?: keyof ReviewState;
 } & HeadingProps &
   GridProps;
+
+const $ReviewSection = styled($Grid)`
+  hr {
+    border-color: ${({ theme }) => theme.colors.coatOfArms};
+    opacity: 0.125;
+  }
+`;
 
 const ReviewSection: React.FC<ReviewSectionProps> = ({
   children,
@@ -80,7 +88,7 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({
   };
 
   return (
-    <$Grid
+    <$ReviewSection
       css={`
         background-color: ${bgColor};
         margin-bottom: ${theme.spacing.m};
@@ -160,7 +168,7 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({
           </$GridCell>
         </>
       )}
-    </$Grid>
+    </$ReviewSection>
   );
 };
 


### PR DESCRIPTION
## Description :sparkles:

Preserve training compensation data if apprenticeship is on applicant makes an update when status is "additional information needed". Remove training compensations on similar update if apprenticeship is off.

Additionally, fix some input labels and UI issues in handler calculation form by breaking different form groups into visible sections.

### Handler's calculation

![screencapture-localhost-3100-application-2024-08-12-10_46_52](https://github.com/user-attachments/assets/4868cf4d-3db4-4d4c-a6c5-798cc2200bde)
