### PR TITLE
fix: chat is open until it's archived for applicant (hl-1401)

### DIFF
--- a/frontend/benefit/applicant/src/components/header/useHeader.ts
+++ b/frontend/benefit/applicant/src/components/header/useHeader.ts
@@ -50,10 +50,14 @@ const useHeader = (): ExtendedComponentProps => {
   );
 
   const { data: application } = useApplicationQuery(id);
-  const canWriteNewMessages = !(
-    application?.has_batch ||
-    application?.status === APPLICATION_STATUSES.CANCELLED
-  );
+
+  const hasCorrectStatus = ![
+    APPLICATION_STATUSES.CANCELLED,
+    APPLICATION_STATUSES.ARCHIVAL,
+  ].includes(application?.status);
+
+  const canWriteNewMessages =
+    hasCorrectStatus && !application?.archived_for_applicant;
 
   useEffect(() => {
     if (application?.unread_messages_count) {


### PR DESCRIPTION
## Description :sparkles:

Remove conditions so that applicant can create new messages in chat a little longer. 

Logic is as follows; chat is closed when application is:

1. Is decided in Ahjo
2. Decision made >= 14 days ago
