### PR TITLE
chore: upgrade axios and ignore audit nag in tet / ks

### DIFF
--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -9,6 +9,7 @@
     "pdfjs-dist", // react-pdf
     "ip", // testcafe, lerna
     "ws", // testcafe, jest
-    "semver" // testcafe, jest, eslint
+    "semver", // testcafe, jest, eslint
+    "axios" // tet, ks
   ]
 }

--- a/frontend/benefit/applicant/package.json
+++ b/frontend/benefit/applicant/package.json
@@ -21,7 +21,7 @@
     "@react-pdf/renderer": "^3.1.12",
     "@sentry/browser": "^7.16.0",
     "@sentry/nextjs": "^7.16.0",
-    "axios": "^1.6.5",
+    "axios": "^1.7.3",
     "camelcase-keys": "^7.0.2",
     "date-fns": "^2.24.0",
     "dotenv": "^16.0.0",

--- a/frontend/benefit/handler/package.json
+++ b/frontend/benefit/handler/package.json
@@ -26,7 +26,7 @@
     "@tiptap/extension-text": "^2.2.4",
     "@tiptap/pm": "^2.2.4",
     "@tiptap/react": "^2.2.4",
-    "axios": "^1.6.5",
+    "axios": "^1.7.3",
     "camelcase-keys": "^7.0.2",
     "date-fns": "^2.24.0",
     "deep-diff": "^1.0.2",

--- a/frontend/benefit/shared/package.json
+++ b/frontend/benefit/shared/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@frontend/shared": "*",
-    "axios": "^1.6.5",
+    "axios": "^1.7.3",
     "camelcase-keys": "^7.0.1",
     "date-fns": "^2.24.0",
     "formik": "^2.2.9",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4651,6 +4651,15 @@ axios@^1.5.1, axios@^1.6.5:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.3.tgz#a1125f2faf702bc8e8f2104ec3a76fab40257d85"
+  integrity sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -7759,6 +7768,11 @@ follow-redirects@^1.15.4:
   version "1.15.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
   integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
+
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 fontkit@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
## Description :sparkles:

Your average security audit fail fix. Bump Axios for benefit, leave tet and kesäseteli unpatched.

More info at [https://github.com/advisories/GHSA-8hc4-vh64-cxmj](https://github.com/advisories/GHSA-8hc4-vh64-cxmj)