### PR TITLE
fix: truncate corporateName to 100 chars

### DIFF
--- a/backend/benefit/applications/services/ahjo_payload.py
+++ b/backend/benefit/applications/services/ahjo_payload.py
@@ -113,7 +113,7 @@ def _prepare_top_level_dict(
         "Agents": [
             {
                 "Role": "sender_initiator",
-                "CorporateName": application.company.name,
+                "CorporateName": truncate_company_name(application.company.name, 100),
                 "ContactPerson": application.contact_person,
                 "Type": "External",
                 "Email": application.company_contact_person_email,

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -27,7 +27,10 @@ from applications.models import (
 from applications.services.ahjo_decision_service import (
     replace_decision_template_placeholders,
 )
-from applications.services.ahjo_payload import resolve_payload_language
+from applications.services.ahjo_payload import (
+    resolve_payload_language,
+    truncate_company_name,
+)
 from applications.services.application_alteration_csv_report import (
     AlterationCsvConfigurableFields,
     ApplicationAlterationCsvService,
@@ -435,7 +438,7 @@ def ahjo_open_case_top_level_dict(decided_application):
         "Agents": [
             {
                 "Role": "sender_initiator",
-                "CorporateName": application.company.name,
+                "CorporateName": truncate_company_name(application.company.name, 100),
                 "ContactPerson": application.contact_person,
                 "Type": "External",
                 "Email": application.company_contact_person_email,


### PR DESCRIPTION
## Description :sparkles:
The CorporateName in open case JSON was not truncated to 100 characters previously.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
