### PR TITLE
feat: hide decisionSummary if details unreceived from ahjo

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -395,6 +395,19 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
 
     ahjo_decision_date = serializers.SerializerMethodField("get_ahjo_decision_date")
 
+    calculated_benefit_amount = serializers.SerializerMethodField()
+
+    def get_calculated_benefit_amount(self, obj):
+        # Check if ahjo_status is None or does not have any related objects
+        if obj.ahjo_status is None or not obj.ahjo_status.exists():
+            return None
+
+        latest_status = obj.ahjo_status.latest().status
+
+        if latest_status != AhjoStatusEnum.DETAILS_RECEIVED_FROM_AHJO:
+            return None
+        return obj.calculated_benefit_amount
+
     submitted_at = serializers.SerializerMethodField("get_submitted_at")
 
     modified_at = serializers.SerializerMethodField(

--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -225,26 +225,28 @@ const PageContent: React.FC = () => {
             </$HeaderRightColumnItem>
           )}
         </$PageHeader>
-        <DecisionSummary
-          application={application}
-          actions={
-            application.status === APPLICATION_STATUSES.ACCEPTED ? (
-              <Button
-                theme="coat"
-                onClick={() =>
-                  router.push(
-                    `${ROUTES.APPLICATION_ALTERATION}?id=${application.id}`
-                  )
-                }
-                disabled={hasHandledTermination}
-              >
-                {t('common:applications.decision.actions.reportAlteration')}
-              </Button>
-            ) : null
-          }
-          itemComponent={AlterationAccordionItem}
-          detailList={decisionDetailList}
-        />
+        {application.ahjoStatus === 'details_received' && ( 
+          <DecisionSummary
+            application={application}
+            actions={
+              application.status === APPLICATION_STATUSES.ACCEPTED ? (
+                <Button
+                  theme="coat"
+                  onClick={() =>
+                    router.push(
+                      `${ROUTES.APPLICATION_ALTERATION}?id=${application.id}`
+                    )
+                  }
+                  disabled={hasHandledTermination}
+                >
+                  {t('common:applications.decision.actions.reportAlteration')}
+                </Button>
+              ) : null
+            }
+            itemComponent={AlterationAccordionItem}
+            detailList={decisionDetailList}
+          />
+        )}
         <ApplicationFormStep5 isReadOnly data={application} />
       </Container>
     );

--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -22,6 +22,7 @@ import { useAskem } from 'benefit/applicant/hooks/useAnalytics';
 import DecisionSummary from 'benefit-shared/components/decisionSummary/DecisionSummary';
 import StatusIcon from 'benefit-shared/components/statusIcon/StatusIcon';
 import {
+  AHJO_STATUSES,
   ALTERATION_STATE,
   ALTERATION_TYPE,
   APPLICATION_STATUSES,
@@ -225,7 +226,7 @@ const PageContent: React.FC = () => {
             </$HeaderRightColumnItem>
           )}
         </$PageHeader>
-        {application.ahjoStatus === 'details_received' && ( 
+        {application.ahjoStatus === AHJO_STATUSES.DETAILS_RECEIVED && ( 
           <DecisionSummary
             application={application}
             actions={

--- a/frontend/benefit/shared/src/constants.ts
+++ b/frontend/benefit/shared/src/constants.ts
@@ -232,3 +232,7 @@ export enum DECISION_TYPES {
 export enum PAY_SUBSIDY_PERCENT {
   DEFAULT = 65,
 }
+
+export enum AHJO_STATUSES {
+  DETAILS_RECEIVED = 'details_received',
+}

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -300,6 +300,7 @@ export type Application = {
   decisionProposalDraft?: DecisionProposalDraft;
   applicationOrigin?: APPLICATION_ORIGINS;
   handler?: User;
+  ahjoStatus: string;
 } & Step1 &
   Step2;
 

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -300,7 +300,7 @@ export type Application = {
   decisionProposalDraft?: DecisionProposalDraft;
   applicationOrigin?: APPLICATION_ORIGINS;
   handler?: User;
-  ahjoStatus: string;
+  ahjoStatus?: string;
 } & Step1 &
   Step2;
 


### PR DESCRIPTION
## Description :sparkles:
Do not show decisionSummary component for applicant if latest ahjo_status is not 'details_received', which confirms it has been decided and processed in Ahjo.
Remove calculated_benefit_amount from JSON if decision details for application have not been received yet.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
Screenshot 2024-08-19 at 14.36.49
## Additional notes :spiral_notepad:
