### PR TITLE
fix: reset values when apprenticeship or pay subsidy type is changed

### DIFF
--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -145,7 +145,10 @@ const useFormActions = (application: Partial<Application>): FormActions => {
       endDate: endDate
         ? convertToBackendDateFormat(parseDate(endDate))
         : undefined,
-      apprenticeshipProgram,
+      apprenticeshipProgram:
+        paySubsidyGranted !== PAY_SUBSIDY_GRANTED.NOT_GRANTED
+          ? apprenticeshipProgram
+          : null,
     };
 
     // Use context on first step, otherwise pass data from backend

--- a/frontend/benefit/handler/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/handler/src/hooks/useFormActions.tsx
@@ -215,8 +215,7 @@ const useFormActions = (
     values: Partial<Application>
   ): TrainingCompensation[] => {
     if (
-      values.apprenticeshipProgram ===
-        initialApplication?.apprenticeshipProgram &&
+      values.apprenticeshipProgram &&
       values.paySubsidyGranted !== PAY_SUBSIDY_GRANTED.NOT_GRANTED
     ) {
       // Return the training compensation values as they are


### PR DESCRIPTION
## Description :sparkles:

Calculator would get ghost rows, inputs and calculations without proper reset of values when apprenticeship was toggled off or pay subsidy got changed to `not_granted`