### PR TITLE
fix: loosen validation rules for new messages (hl-1424)

### DIFF
--- a/backend/benefit/messages/serializers.py
+++ b/backend/benefit/messages/serializers.py
@@ -54,11 +54,7 @@ class MessageSerializer(serializers.ModelSerializer):
             if company != application.company:
                 raise PermissionDenied(_("You are not allowed to do this action"))
 
-            if (
-                application.status not in self.APPLICANT_MESSAGE_ALLOWED_STATUSES
-                or application.batch
-                or application.archived
-            ):
+            if application.status not in self.APPLICANT_MESSAGE_ALLOWED_STATUSES:
                 raise serializers.ValidationError(
                     _(
                         "Cannot do this action because "

--- a/backend/benefit/messages/tests/test_api.py
+++ b/backend/benefit/messages/tests/test_api.py
@@ -245,8 +245,8 @@ def test_create_handler_message_invalid(handler_api_client, handling_application
         (ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED, False, 201),
         (ApplicationStatus.ACCEPTED, False, 201),
         (ApplicationStatus.REJECTED, False, 201),
-        (ApplicationStatus.ACCEPTED, True, 400),
-        (ApplicationStatus.REJECTED, True, 400),
+        (ApplicationStatus.ACCEPTED, True, 201),
+        (ApplicationStatus.REJECTED, True, 201),
         (ApplicationStatus.CANCELLED, False, 400),
     ],
 )


### PR DESCRIPTION
## Description :sparkles:

Frontend allowed new messages for `accepted` or `rejected` but backend did not. Remove archival and batch check for new message.