### PR TITLE
fix: added missing localization keys and fixed one (hl-1406)

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -269,7 +269,7 @@
     },
     "statuses": {
       "draft": "Luonnos",
-      "additionalInformationNeeded": "Lisätietoja tarvitaan",
+      "additional_information_needed": "Lisätietoja tarvitaan",
       "received": "Vastaanotettu",
       "accepted": "Myönteinen",
       "rejected": "Kielteinen",
@@ -1796,6 +1796,12 @@
       },
       "handler": {
         "label": "Käsittelijä"
+      },
+      "batch": {
+        "label": "Koonti"
+      },
+      "handledByAhjoAutomation": {
+        "label": "Käsitelty Ahjo automaatiolla"
       }
     }
   }

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -269,7 +269,7 @@
     },
     "statuses": {
       "draft": "Luonnos",
-      "additionalInformationNeeded": "Lisätietoja tarvitaan",
+      "additional_information_needed": "Lisätietoja tarvitaan",
       "received": "Vastaanotettu",
       "accepted": "Myönteinen",
       "rejected": "Kielteinen",
@@ -1795,6 +1795,12 @@
       },
       "handler": {
         "label": "Käsittelijä"
+      },
+      "batch": {
+        "label": "Koonti"
+      },
+      "handledByAhjoAutomation": {
+        "label": "Käsitelty Ahjo automaatiolla"
       }
     }
   }

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -269,7 +269,7 @@
     },
     "statuses": {
       "draft": "Luonnos",
-      "additionalInformationNeeded": "Lisätietoja tarvitaan",
+      "additional_information_needed": "Lisätietoja tarvitaan",
       "received": "Vastaanotettu",
       "accepted": "Myönteinen",
       "rejected": "Kielteinen",
@@ -1796,6 +1796,12 @@
       },
       "handler": {
         "label": "Käsittelijä"
+      },
+      "batch": {
+        "label": "Koonti"
+      },
+      "handledByAhjoAutomation": {
+        "label": "Käsitelty Ahjo automaatiolla"
       }
     }
   }


### PR DESCRIPTION
## Description :sparkles:
Added localization keys:

- changes.fields.batch.label
- changes.fields.handledByAhjoAutomation.label

that are used in changed logs

Changes key:

- applications.decision.description.additionalInformationNeeded
to:

- applications.decision.description.additional_information_needed
it was used in place in CamelCase format, changed that.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
