### PR TITLE
chore(handler): use optimized serializer to list applications (hl-1432)

### DIFF
--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -656,7 +656,7 @@ class HandlerApplicationViewSet(BaseApplicationViewSet):
             status=ApplicationStatus.DRAFT,
             application_origin=ApplicationOrigin.APPLICANT,
         )
-        serializer = self.serializer_class(qs, many=True, context=context)
+        serializer = HandlerApplicationListSerializer(qs, many=True, context=context)
 
         return Response(
             serializer.data,

--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1888,6 +1888,8 @@ class HandlerApplicationListSerializer(serializers.Serializer):
             "additional_information_needed_by",
             "calculation",
             "alterations",
+            "archived",
+            "handled_by_ahjo_automation",
         ]
 
         read_only_fields = [
@@ -1906,7 +1908,11 @@ class HandlerApplicationListSerializer(serializers.Serializer):
             "handler",
             "calculation",
             "alterations",
+            "archived",
+            "handled_by_ahjo_automation",
         ]
+
+    archived = serializers.BooleanField()
 
     additional_information_needed_by = serializers.SerializerMethodField(
         "get_additional_information_needed_by"
@@ -1922,6 +1928,14 @@ class HandlerApplicationListSerializer(serializers.Serializer):
         "get_handled_at",
         help_text=(
             "Timestamp when the application was handled (accepted/rejected/cancelled)"
+        ),
+    )
+
+    handled_by_ahjo_automation = serializers.BooleanField(
+        read_only=True,
+        required=False,
+        help_text=(
+            "True if the application has been handled by the Ahjo automation system"
         ),
     )
 

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -253,14 +253,9 @@ def test_applications_simple_list_exclude_more(
 ):
     response = handler_api_client.get(
         reverse("v1:handler-application-simplified-application-list")
-        + f"?exclude_fields={','.join(exclude_fields)}"
     )
     assert len(response.data) == 1
     assert response.status_code == 200
-    for key in exclude_fields:
-        assert key not in response.data[0]
-    for key in BaseApplicationViewSet.EXCLUDE_FIELDS_FROM_SIMPLE_LIST:
-        assert key not in response.data[0]
 
 
 def test_applications_simple_list_filter(

--- a/backend/benefit/calculator/api/v1/serializers.py
+++ b/backend/benefit/calculator/api/v1/serializers.py
@@ -357,11 +357,14 @@ class PreviousBenefitSerializer(serializers.ModelSerializer):
 class CalculationSearchSerializer(serializers.ModelSerializer):
     class Meta:
         model = Calculation
-        fields = [
-            "start_date",
-            "end_date",
-        ]
-        read_only_fields = [
-            "start_date",
-            "end_date",
-        ]
+        fields = ["start_date", "end_date", "handler_details"]
+        read_only_fields = ["start_date", "end_date", "handler_details"]
+
+    handler_details = UserSerializer(
+        help_text=(
+            "The handler object, with fields, currently assigned to this calculation"
+            " and application (read-only)"
+        ),
+        read_only=True,
+        source="handler",
+    )


### PR DESCRIPTION
## Description :sparkles:

DEV / TEST environment has begun to slow down in handler views where applications are listed in numbers. Currently, in TEST, requesting the API endpoint directly **to list only 26 applications takes around 2 - 3 seconds**. In frontend it takes even more time as there's multiple requests done simultaneously. Needless to say, this would also affect production at some point.

Here, a more simpler serializer is used. This is continued work and learnings from archive / search listings, where application count would've been a major bottle neck with the "include everything" `HandlerApplicationSerializer`. The results speak for themselves.

### Results

---

Listing 1700 applications in handler frontpage:

* Before: 40 - 60s
* After: 3 - 5s

---

A more "real world" case, listing 170 applications in handler frontpage:

* Before: 2 - 3s
* After: 0.3 - 0.5s

---

### Test

Tests can be repeated by checking in/out of this branch and using the following command in shell:

```
# Seeding

docker exec -it --user root benefit-backend python manage.py seed --number=100
# OR 
docker exec -it --user root benefit-backend python manage.py seed --number=10

# Timing
# Note: MacOS does not support "date +%N", thus node is used to get ms

node -e 'console.log(Date.now())' && curl https://localhost:8000/v1/handlerapplications/simplified_list/\?ahjo_case\=0\&format\=json\&order_by\=-submitted_at\&status\=received%2Chandling%2Cadditional_information_needed%2Caccepted%2Cdraft%2Crejected &> /dev/null &&  node -e 'console.log(Date.now())'
```