### PR TITLE
fix: locked user notice bar was on top of new messages list (hl-1456)

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.sc.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/ApplicationReview.sc.ts
@@ -148,7 +148,7 @@ export const $NoticeBar = styled.div`
   flex-flow: row wrap;
   justify-content: center;
   align-items: center;
-  z-index: 100;
+  z-index: 99;
   padding: ${(props) => props.theme.spacing.s};
   max-width: 100%;
   background-color: ${(props) => props.theme.colors.summerMediumLight};


### PR DESCRIPTION
## Description :sparkles:

Z-index issue with new message notice box and "locked to this handler" nag.


## Before

<img width="1283" alt="Screenshot 2024-09-06 at 13 17 35" src="https://github.com/user-attachments/assets/e7e2cbec-4d49-4668-abed-a77ce83eea44">

## After
 
<img width="1282" alt="Screenshot 2024-09-06 at 13 17 24" src="https://github.com/user-attachments/assets/7a92e729-6886-4c48-b09b-2414abf0f152">
