### PR TITLE
feat: add ahjo errors to handler's application lists (hl-1421)

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1892,6 +1892,7 @@ class HandlerApplicationListSerializer(serializers.Serializer):
             "handled_by_ahjo_automation",
             "ahjo_case_id",
             "batch",
+            "ahjo_error",
         ]
 
         read_only_fields = [
@@ -1914,6 +1915,7 @@ class HandlerApplicationListSerializer(serializers.Serializer):
             "handled_by_ahjo_automation",
             "ahjo_case_id",
             "batch",
+            "ahjo_error",
         ]
 
     archived = serializers.BooleanField()
@@ -1934,6 +1936,20 @@ class HandlerApplicationListSerializer(serializers.Serializer):
             "Timestamp when the application was handled (accepted/rejected/cancelled)"
         ),
     )
+    ahjo_error = serializers.SerializerMethodField("get_latest_ahjo_error")
+
+    def get_latest_ahjo_error(self, obj) -> Union[Dict, None]:
+        """Get the latest Ahjo error for the application"""
+        try:
+            status = obj.ahjo_status.latest()
+        except AhjoStatus.DoesNotExist:
+            return None
+        data = AhjoStatusSerializer(status).data
+        if data["error_from_ahjo"] is None:
+            data = None
+        else:
+            data.update({"status": status.status})
+        return data
 
     handled_by_ahjo_automation = serializers.BooleanField(
         read_only=True,

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -244,6 +244,11 @@
         "fetch": {
           "label": "Virhe noudettaessa hakemuksia",
           "text": "Hakemusten haku epäonnistui virhekoodilla {{status}}."
+        },
+        "ahjoError": {
+          "tooltipLabel": "Odottamaton virhe hakemuksen käsittelyssä",
+          "buttonLabel": "Avaa virheilmoitus näkyviin",
+          "buttonText": "Virhe"
         }
       },
       "total": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -244,6 +244,11 @@
         "fetch": {
           "label": "Virhe noudettaessa hakemuksia",
           "text": "Hakemusten haku epäonnistui virhekoodilla {{status}}."
+        },
+        "ahjoError": {
+          "tooltipLabel": "Odottamaton virhe hakemuksen käsittelyssä",
+          "buttonLabel": "Avaa virheilmoitus näkyviin",
+          "buttonText": "Virhe"
         }
       },
       "total": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -244,6 +244,11 @@
         "fetch": {
           "label": "Virhe noudettaessa hakemuksia",
           "text": "Hakemusten haku epäonnistui virhekoodilla {{status}}."
+        },
+        "ahjoError": {
+          "tooltipLabel": "Odottamaton virhe hakemuksen käsittelyssä",
+          "buttonLabel": "Avaa virheilmoitus näkyviin",
+          "buttonText": "Virhe"
         }
       },
       "total": {

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.sc.ts
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.sc.ts
@@ -14,11 +14,12 @@ export const $EmptyHeading = styled.h2`
   font-weight: 400;
 `;
 
-export const $CellContent = styled.div`
+export const $ActionMessages = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   position: relative;
+  margin-top: 8px;
 `;
 
 type TagWrapperProps = {
@@ -74,4 +75,70 @@ export const $AlterationBadge = styled.div<$AlterationBadgeProps>`
   text-align: center;
   padding: 0.3rem 0.35rem;
   border-radius: 50%;
+`;
+
+export const $ApplicationList = styled.div``;
+
+type $ActionErrorsProps = {
+  $errorText: string;
+};
+
+export const $ActionErrors = styled.div<$ActionErrorsProps>`
+  &:not(:first-child) {
+    margin-left: 20px;
+    border-left: 2px solid ${({ theme }) => theme.colors.black10};
+    padding-left: 8px;
+  }
+  .custom-tooltip-error {
+    display: flex;
+    align-items: center;
+    flex-flow: column;
+
+    button:focus {
+      box-shadow: 0 0 0 var(--button-focus-outline-width)
+        ${({ theme }) => theme.colors.error};
+    }
+
+    // Override HDS Tooltip styles
+    section {
+      background-color: ${({ theme }) => theme.colors.errorLight};
+      &[data-popper-placement='top'] {
+        border-bottom: 8px solid ${({ theme }) => theme.colors.error};
+        > div[class]:last-child {
+          border-top-color: ${({ theme }) => theme.colors.error};
+        }
+      }
+      &[data-popper-placement='bottom'] {
+        border-top: 8px solid ${({ theme }) => theme.colors.error};
+        > div[class]:last-child {
+          border-bottom-color: ${({ theme }) => theme.colors.error};
+        }
+      }
+    }
+
+    ul,
+    li {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    &:after {
+      display: block;
+      line-height: 1.05;
+      content: '${({ $errorText }) => $errorText}';
+      text-align: center;
+      font-size: 12px;
+      color: ${({ theme }) => theme.colors.error};
+    }
+
+    svg {
+      color: ${({ theme }) => theme.colors.error};
+    }
+  }
+`;
+
+export const $TableActions = styled.div`
+  display: flex;
+  align-items: center;
 `;

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
@@ -6,17 +6,24 @@ import {
 import { getTagStyleForStatus } from 'benefit/handler/utils/applications';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { ApplicationListItemData } from 'benefit-shared/types/application';
-import { IconSpeechbubbleText, Table, Tag } from 'hds-react';
+import { IconSpeechbubbleText, Table, Tag, Tooltip } from 'hds-react';
 import * as React from 'react';
 import LoadingSkeleton from 'react-loading-skeleton';
 import { $Link } from 'shared/components/table/Table.sc';
-import { sortFinnishDate, sortFinnishDateTime } from 'shared/utils/date.utils';
+import {
+  convertToUIDateAndTimeFormat,
+  sortFinnishDate,
+  sortFinnishDateTime,
+} from 'shared/utils/date.utils';
 import { useTheme } from 'styled-components';
 
 import {
-  $CellContent,
+  $ActionErrors,
+  $ActionMessages,
+  $ApplicationList,
   $EmptyHeading,
   $Heading,
+  $TableActions,
   $TagWrapper,
   $UnreadMessagesCount,
 } from './ApplicationList.sc';
@@ -214,17 +221,50 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
         unreadMessagesCount,
         id,
         status: applicationStatus,
+        ahjoError,
       }: ApplicationListTableTransforms) => (
-        <$CellContent>
+        <$TableActions>
           {Number(unreadMessagesCount) > 0 ? (
-            <$Link href={buildApplicationUrl(id, applicationStatus, true)}>
-              <IconSpeechbubbleText color={theme.colors.coatOfArms} />
-              <$UnreadMessagesCount>
-                {Number(unreadMessagesCount)}
-              </$UnreadMessagesCount>
-            </$Link>
+            <$ActionMessages>
+              <$Link href={buildApplicationUrl(id, applicationStatus, true)}>
+                <IconSpeechbubbleText color={theme.colors.coatOfArms} />
+                <$UnreadMessagesCount>
+                  {Number(unreadMessagesCount)}
+                </$UnreadMessagesCount>
+              </$Link>
+            </$ActionMessages>
           ) : null}
-        </$CellContent>
+          {ahjoError?.errorFromAhjo && (
+            <$ActionErrors
+              $errorText={t(
+                'common:applications.list.errors.ahjoError.buttonText'
+              )}
+            >
+              <Tooltip
+                placement="top"
+                boxShadow
+                className="custom-tooltip-error"
+                tooltipLabel={t(
+                  'common:applications.list.errors.ahjoError.tooltipLabel'
+                )}
+                buttonLabel={t(
+                  'common:applications.list.errors.ahjoError.buttonLabel'
+                )}
+              >
+                <div>
+                  <strong>
+                    Ahjo, {convertToUIDateAndTimeFormat(ahjoError?.modifiedAt)}
+                  </strong>
+                </div>
+                <ul>
+                  {ahjoError?.errorFromAhjo?.map(({ message }) => (
+                    <li>{message}</li>
+                  ))}
+                </ul>
+              </Tooltip>
+            </$ActionErrors>
+          )}
+        </$TableActions>
       ),
       headerName: getHeader('unreadMessagesCount'),
       key: 'unreadMessagesCount',
@@ -255,7 +295,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
   const statusAsString = isAllStatuses ? 'all' : status.join(',');
 
   return (
-    <div data-testid={`application-list-${statusAsString}`}>
+    <$ApplicationList data-testid={`application-list-${statusAsString}`}>
       {list.length > 0 ? (
         <Table
           heading={`${heading} (${list.length})`}
@@ -270,7 +310,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
           {t(`${translationsBase}.messages.empty.${statusAsString}`)}
         </$EmptyHeading>
       )}
-    </div>
+    </$ApplicationList>
   );
 };
 

--- a/frontend/benefit/handler/src/components/applicationList/useApplicationListData.ts
+++ b/frontend/benefit/handler/src/components/applicationList/useApplicationListData.ts
@@ -5,6 +5,7 @@ import {
   ApplicationData,
   ApplicationListItemData,
 } from 'benefit-shared/types/application';
+import camelcaseKeys from 'camelcase-keys';
 import { getFullName } from 'shared/utils/application.utils';
 import {
   convertToUIDateAndTimeFormat,
@@ -43,6 +44,7 @@ const useApplicationListData = (
         application_origin: applicationOrigin,
         handled_by_ahjo_automation,
         handled_at: handledAt,
+        ahjo_error,
       } = application;
 
       return {
@@ -70,6 +72,7 @@ const useApplicationListData = (
         ahjoCaseId: ahjo_case_id,
         handledByAhjoAutomation: handled_by_ahjo_automation,
         handledAt: convertToUIDateFormat(handledAt) || '-',
+        ahjoError: camelcaseKeys(ahjo_error, { deep: true }) || null,
       };
     })
     .filter(

--- a/frontend/benefit/handler/src/types/applicationList.d.ts
+++ b/frontend/benefit/handler/src/types/applicationList.d.ts
@@ -1,13 +1,14 @@
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
+import { AhjoError } from 'benefit-shared/types/application';
 
 export interface ApplicationListTableTransforms {
   id?: string;
   companyName?: string;
-  company_name?: string;
   unreadMessagesCount?: number;
   additionalInformationNeededBy?: string | Date;
   status?: APPLICATION_STATUSES;
   applicationOrigin?: APPLICATION_ORIGINS;
+  ahjoError: AhjoError;
 }
 
 export interface ApplicationListTableColumns {

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -264,6 +264,24 @@ export interface DecisionProposalDraft {
   decsionMakerName?: string;
 }
 
+export interface AhjoError {
+  errorFromAhjo: ErrorFromAhjo[];
+  modifiedAt: string;
+  status: string;
+}
+
+export interface AhjoErrorData {
+  error_from_ahjo: ErrorFromAhjo[];
+  modified_at: string;
+  status: string;
+}
+
+export interface ErrorFromAhjo {
+  id: string;
+  context: string;
+  message: string;
+}
+
 export type Application = {
   id?: string;
   status?: APPLICATION_STATUSES;
@@ -470,6 +488,7 @@ export type ApplicationData = {
   is_granted_as_de_minimis_aid?: boolean | null;
   handled_by_ahjo_automation?: boolean;
   alterations: ApplicationAlterationData[];
+  ahjo_error?: AhjoErrorData;
 };
 
 export type EmployeeData = {
@@ -567,6 +586,7 @@ export type ApplicationListItemData = {
   calculationEndDate?: string;
   handledByAhjoAutomation?: boolean;
   alterations?: ApplicationAlterationData[];
+  ahjoError?: AhjoError;
 };
 
 export type TextProp = 'textFi' | 'textEn' | 'textSv';


### PR DESCRIPTION
## Description :sparkles:

Add Ahjo error statuses to handler application listing. Clicking it opens a tooltip which gives the error message.

![screencapture-localhost-3100-2024-09-05-14_44_09](https://github.com/user-attachments/assets/f72e8182-cad9-4ac1-9fa6-733cb8d5619e)

![image](https://github.com/user-attachments/assets/b41783b9-6e5d-404a-b826-784f34045d3d)
