### PR TITLE
Hl 1455

### DIFF
--- a/backend/benefit/applications/api/v1/ahjo_integration_views.py
+++ b/backend/benefit/applications/api/v1/ahjo_integration_views.py
@@ -203,6 +203,11 @@ class AhjoCallbackView(APIView):
     ) -> Response:
         try:
             with transaction.atomic():
+                # Clear any previous error messages before creating a new success status
+                latest_status = application.ahjo_status.latest()
+                if latest_status.error_from_ahjo is not None:
+                    latest_status.error_from_ahjo = None
+                    latest_status.save()
                 info = self.cb_info_message(application, callback_data, request_type)
                 if request_type == AhjoRequestType.OPEN_CASE:
                     self._handle_open_case_success(application, callback_data)

--- a/backend/benefit/applications/services/ahjo_integration.py
+++ b/backend/benefit/applications/services/ahjo_integration.py
@@ -506,10 +506,16 @@ def update_application_summary_record_in_ahjo(
     application: Application, ahjo_token: AhjoToken
 ) -> Union[Tuple[Application, str], None]:
     """Update the application summary pdf in Ahjo.
-    Should be done just before the decision proposal is sent.
+    Should be done about the same time proposal is sent.
     """
-
     ahjo_request = AhjoUpdateRecordsRequest(application)
+    if application.ahjo_status.latest().error_from_ahjo:
+        # If there are errors from Ahjo, do not send the update request
+        raise ValueError(
+            f"Application {application.id} has errors \
+in Ahjo status {application.ahjo_status.latest().status}, not sending {ahjo_request}."
+        )
+
     ahjo_client = AhjoApiClient(ahjo_token, ahjo_request)
 
     pdf_summary = generate_application_attachment(


### PR DESCRIPTION
## Description :sparkles:
[HL-1455](https://helsinkisolutionoffice.atlassian.net/browse/HL-1455)
When trying to send a update application summary request to ahjo, if previous ahjo_status has error_from ahjo, raise an error and do not run perform the request. 
When a request succeeds with a success callback, set the error_from_ahjo of the previous status, if any, to None/null.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1455]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ