### PR TITLE
fix: open case title limit to 150 chars

### DIFF
--- a/backend/benefit/applications/services/ahjo_payload.py
+++ b/backend/benefit/applications/services/ahjo_payload.py
@@ -51,8 +51,8 @@ hakemus {application.application_number}"
     return full_title
 
 
-def prepare_final_case_title(application: Application, limit: int = 100) -> str:
-    """Prepare the final case title for Ahjo, if the full title is over 100 characters, \
+def prepare_final_case_title(application: Application, limit: int = 150) -> str:
+    """Prepare the final case title for Ahjo, if the full title is over 150 characters, \
     truncate the company name to fit the limit."""
     full_case_title = prepare_case_title(application, application.company_name)
     length_of_full_title = len(full_case_title)

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -56,11 +56,11 @@ def test_truncate_string_to_limit(
 @pytest.mark.parametrize(
     "company_name, limit, expected_length",
     [
-        ("a" * 100 + "b" * 100, 100, 100),
-        ("a" * 100 + "b" * 5, 100, 100),
-        ("a" * 100, 100, 100),
-        ("a" * 50, 100, 100),
-        ("1234567890AB", 10, 100),
+        ("a" * 100 + "b" * 100, 100, 150),
+        ("a" * 100 + "b" * 5, 100, 150),
+        ("a" * 100, 100, 150),
+        ("a" * 50, 100, 150),
+        ("1234567890AB", 10, 150),
     ],
 )
 def test_prepare_final_case_title_truncate(


### PR DESCRIPTION
## Description :sparkles:
Fix issue with open case title, limit was earlier too short, 100 chars, when actually it should have been 150.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
