### PR TITLE
fix: whitespace crash in alteration csv

### DIFF
--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -530,7 +530,7 @@ class HandlerApplicationAlterationViewSet(BaseApplicationAlterationViewSet):
         csv_service = ApplicationAlterationCsvService(queryset, config, user)
 
         response = HttpResponse(
-            csv_service.get_csv_string(True).encode("utf-8"),
+            csv_service.get_csv_string(False).encode("utf-8"),
             content_type="text/csv",
         )
         response["Content-Disposition"] = "attachment; filename={filename}.csv".format(


### PR DESCRIPTION
## Description :sparkles:
Alteration csv generation had quoting turned off, which caused the csv generation to crash if there was a line break submitted by the alteration form.
## Issues :bug:

## Testing :alembic:
Handle an alteration and add some linebreaks or other special characters to the explanation text box and try to download the csv.
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
