### PR TITLE
fix: record title for add records request

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1398,9 +1398,9 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
 
         for idx, aid_item in enumerate(serializer.validated_data):
             aid_item["application_id"] = application.pk
-            aid_item["ordering"] = (
-                idx  # use the ordering defined in the JSON sent by the client
-            )
+            aid_item[
+                "ordering"
+            ] = idx  # use the ordering defined in the JSON sent by the client
 
         de_minimis_list = serializer.save()
         for de_minimis in de_minimis_list:
@@ -1809,9 +1809,9 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
             )
         for idx, nested_object in enumerate(serializer.validated_data):
             nested_object["application_id"] = application.pk
-            nested_object["ordering"] = (
-                idx  # use the ordering defined in the JSON sent by the client
-            )
+            nested_object[
+                "ordering"
+            ] = idx  # use the ordering defined in the JSON sent by the client
         serializer.save()
         if hasattr(application, "calculation"):
             call_now_or_later(

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -72,30 +72,59 @@ def test_prepare_final_case_title_truncate(
 
 
 @pytest.mark.parametrize(
-    "record_title, record_type, request_type, wanted_title_addition",
+    "record_title, record_type, request_type, wanted_title_addition, part, total",
     [
         (
             AhjoRecordTitle.APPLICATION,
             AhjoRecordType.APPLICATION,
             AhjoRequestType.OPEN_CASE,
             "",
+            0,
+            0,
         ),
         (
             AhjoRecordTitle.APPLICATION,
             AhjoRecordType.APPLICATION,
             AhjoRequestType.UPDATE_APPLICATION,
-            " täydennys,",
+            ", täydennys",
+            0,
+            0,
+        ),
+        (
+            AhjoRecordTitle.APPLICATION,
+            AhjoRecordType.ATTACHMENT,
+            AhjoRequestType.ADD_RECORDS,
+            ", täydennys",
+            0,
+            0,
+        ),
+        (
+            AhjoRecordTitle.APPLICATION,
+            AhjoRecordType.ATTACHMENT,
+            AhjoRequestType.OPEN_CASE,
+            "",
+            1,
+            3,
         ),
     ],
 )
 def test_prepare_record_title(
-    decided_application, record_title, record_type, request_type, wanted_title_addition
+    decided_application,
+    record_title,
+    record_type,
+    request_type,
+    wanted_title_addition,
+    part,
+    total,
 ):
     application = decided_application
     formatted_date = application.created_at.strftime("%d.%m.%Y")
 
-    wanted_title = f"{record_title},{wanted_title_addition} {formatted_date}, {application.application_number}"
-    got = _prepare_record_title(application, record_type, request_type)
+    if part and total:
+        wanted_title = f"{record_title}{wanted_title_addition} {formatted_date}, liite {part}/{total}, {application.application_number}"
+    else:
+        wanted_title = f"{record_title}{wanted_title_addition} {formatted_date}, {application.application_number}"
+    got = _prepare_record_title(application, record_type, request_type, part, total)
     assert wanted_title == got
 
 

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -121,7 +121,8 @@ def test_prepare_record_title(
     formatted_date = application.created_at.strftime("%d.%m.%Y")
 
     if part and total:
-        wanted_title = f"{record_title}{wanted_title_addition} {formatted_date}, liite {part}/{total}, {application.application_number}"
+        wanted_title = f"{record_title}{wanted_title_addition} {formatted_date},\
+ liite {part}/{total}, {application.application_number}"
     else:
         wanted_title = f"{record_title}{wanted_title_addition} {formatted_date}, {application.application_number}"
     got = _prepare_record_title(application, record_type, request_type, part, total)


### PR DESCRIPTION
## Description :sparkles:
If a record is added after open case, it's title should begin with "Hakemus, täydennys" etc.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
