### PR TITLE
feat: find related applications for a single employee (hl-1354)

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1398,9 +1398,9 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
 
         for idx, aid_item in enumerate(serializer.validated_data):
             aid_item["application_id"] = application.pk
-            aid_item["ordering"] = (
-                idx  # use the ordering defined in the JSON sent by the client
-            )
+            aid_item[
+                "ordering"
+            ] = idx  # use the ordering defined in the JSON sent by the client
 
         de_minimis_list = serializer.save()
         for de_minimis in de_minimis_list:
@@ -1809,9 +1809,9 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
             )
         for idx, nested_object in enumerate(serializer.validated_data):
             nested_object["application_id"] = application.pk
-            nested_object["ordering"] = (
-                idx  # use the ordering defined in the JSON sent by the client
-            )
+            nested_object[
+                "ordering"
+            ] = idx  # use the ordering defined in the JSON sent by the client
         serializer.save()
         if hasattr(application, "calculation"):
             call_now_or_later(

--- a/backend/benefit/applications/tests/test_command_import_archival_applications.py
+++ b/backend/benefit/applications/tests/test_command_import_archival_applications.py
@@ -142,7 +142,7 @@ class ImportArchivalApplicationsTestUtility:
             company.save()
 
 
-def test_decision_proposal_drafting():
+def test_import_archival_applications():
     assert ArchivalApplication.objects.all().count() == 0
     ImportArchivalApplicationsTestUtility.create_companies_for_archival_applications()
 

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1009,6 +1009,7 @@
       "saveAndContinue": "Tallenna ja sulje",
       "backToHandling": "Palauta käsittelyyn",
       "handlingPanel": "Käsittelypaneeli",
+      "search": "Hae arkistosta",
       "cancel": "Peruuta hakemus",
       "addAttachment": "Liitä uusi tiedosto",
       "addPreviouslyGrantedBenefit": "Lisää aikaisempi lisä",
@@ -1035,7 +1036,8 @@
       "description": "Perustelu",
       "acceptedSubsidy": "Myönnettävä tuki",
       "eurosTotal": "{{total}} euroa yhteensä",
-      "eurosPerMonth": "{{euros}} euroa kuukaudessa {{dateRange}}"
+      "eurosPerMonth": "{{euros}} euroa kuukaudessa {{dateRange}}",
+      "searchPriorApplications": "Hae työllistettävän aiempia tukia"
     },
     "headings": {
       "heading1": "Työnantajan tiedot",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1009,6 +1009,7 @@
       "saveAndContinue": "Tallenna ja sulje",
       "backToHandling": "Palauta käsittelyyn",
       "handlingPanel": "Käsittelypaneeli",
+      "search": "Hae arkistosta",
       "cancel": "Peruuta hakemus",
       "addAttachment": "Liitä uusi tiedosto",
       "addPreviouslyGrantedBenefit": "Lisää aikaisempi lisä",
@@ -1035,7 +1036,8 @@
       "description": "Perustelu",
       "acceptedSubsidy": "Myönnettävä tuki",
       "eurosTotal": "{{total}} euroa yhteensä",
-      "eurosPerMonth": "{{euros}} euroa kuukaudessa {{dateRange}}"
+      "eurosPerMonth": "{{euros}} euroa kuukaudessa {{dateRange}}",
+      "searchPriorApplications": "Hae työllistettävän aiempia tukia"
     },
     "headings": {
       "heading1": "Työnantajan tiedot",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1009,6 +1009,7 @@
       "saveAndContinue": "Tallenna ja sulje",
       "backToHandling": "Palauta käsittelyyn",
       "handlingPanel": "Käsittelypaneeli",
+      "search": "Hae arkistosta",
       "cancel": "Peruuta hakemus",
       "addAttachment": "Liitä uusi tiedosto",
       "addPreviouslyGrantedBenefit": "Lisää aikaisempi lisä",
@@ -1035,7 +1036,8 @@
       "description": "Perustelu",
       "acceptedSubsidy": "Myönnettävä tuki",
       "eurosTotal": "{{total}} euroa yhteensä",
-      "eurosPerMonth": "{{euros}} euroa kuukaudessa {{dateRange}}"
+      "eurosPerMonth": "{{euros}} euroa kuukaudessa {{dateRange}}",
+      "searchPriorApplications": "Hae työllistettävän aiempia tukia"
     },
     "headings": {
       "heading1": "Työnantajan tiedot",

--- a/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employeeView/EmployeeView.tsx
@@ -6,12 +6,18 @@ import ReviewSection from 'benefit/handler/components/reviewSection/ReviewSectio
 import { ACTIONLESS_STATUSES } from 'benefit/handler/constants';
 import { ApplicationReviewViewProps } from 'benefit/handler/types/application';
 import { ATTACHMENT_TYPES, ORGANIZATION_TYPES } from 'benefit-shared/constants';
+import { Button, IconSearch } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { getFullName } from 'shared/utils/application.utils';
 
 import AttachmentsListView from '../../attachmentsListView/AttachmentsListView';
+
+const openSearchPage = (id: string) => (): void => {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  window.open(`/archive/?appNo=${id}`);
+};
 
 const EmployeeView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
@@ -62,6 +68,17 @@ const EmployeeView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
           type={ATTACHMENT_TYPES.HELSINKI_BENEFIT_VOUCHER}
           attachments={data.attachments || []}
         />
+      </$GridCell>
+
+      <$GridCell $colSpan={6} $colStart={1}>
+        <Button
+          onClick={openSearchPage(String(data.applicationNumber))}
+          theme="black"
+          variant="secondary"
+          iconLeft={<IconSearch />}
+        >
+          {t('common:review.actions.searchPriorApplications')}
+        </Button>
       </$GridCell>
     </ReviewSection>
   );

--- a/frontend/benefit/handler/src/components/applicationsArchive/useApplicationsArchive.ts
+++ b/frontend/benefit/handler/src/components/applicationsArchive/useApplicationsArchive.ts
@@ -79,7 +79,8 @@ const useApplicationsArchive = (
   archived: boolean,
   includeArchivalApplications: boolean,
   subsidyInEffect: SUBSIDY_IN_EFFECT,
-  decisionRange: number
+  decisionRange: number,
+  applicationNum?: string
 ): ApplicationListProps => {
   const { t } = useTranslation();
 
@@ -93,7 +94,8 @@ const useApplicationsArchive = (
     archived,
     includeArchivalApplications,
     subsidyInEffect,
-    decisionRange
+    decisionRange,
+    applicationNum
   );
 
   const shouldHideList =

--- a/frontend/benefit/handler/src/hooks/useSearchApplicationQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useSearchApplicationQuery.ts
@@ -15,18 +15,30 @@ const useSearchApplicationQuery = (
   archived = false,
   includeArchivalApplications = false,
   subsidyInEffect?: SUBSIDY_IN_EFFECT,
-  decisionRange?: DECISION_RANGE
+  decisionRange?: DECISION_RANGE,
+  applicationNum?: string
 ): UseMutationResult<SearchResponse, Error> => {
   const { axios, handleResponse } = useBackendAPI();
   const { t } = useTranslation();
 
-  const params = {
+  const params: {
+    q: string;
+    archived?: string;
+    archival?: string;
+    subsidy_in_effect?: SUBSIDY_IN_EFFECT;
+    years_since_decision?: DECISION_RANGE;
+    app_no?: string;
+  } = {
     q,
     ...(archived && { archived: '1' }),
     ...(includeArchivalApplications && { archival: '1' }),
     ...(subsidyInEffect && { subsidy_in_effect: subsidyInEffect }),
     ...(decisionRange && { years_since_decision: decisionRange }),
   };
+
+  if (applicationNum) {
+    params.app_no = applicationNum;
+  }
 
   const handleError = (): void => {
     showErrorToast(


### PR DESCRIPTION
## Description :sparkles:

Handler can now efficiently find employee's previous benefits. 

* Modify search code to use an existing application as base to find related other applications
  * List any `Application` objects with matching SSN (note that first_name and last_name can change)
  * List any `ArchivalApplication` objects by matching with best guess keys: `first_name`, `last_name` and `year_of_birth` (parsed from SSN)
* Implement button to click in application view, seek for Employee section
* Refactor and implement search view

### 🔍 View of single application's search button

---

<img width="1243" alt="Screenshot 2024-09-12 at 10 21 18" src="https://github.com/user-attachments/assets/c0bb5309-cd46-4b12-8ef4-9b2e52124b62">

### 📁  View of related applications when button is clicked

---

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/574af45c-b580-4ed0-aead-4e5f66078880">
