### PR TITLE
feat: clone application on applicant side (hl-1447)

### DIFF
--- a/backend/benefit/applications/services/clone_application.py
+++ b/backend/benefit/applications/services/clone_application.py
@@ -1,0 +1,86 @@
+from applications.enums import ApplicationStep
+from applications.models import Application, DeMinimisAid, Employee
+from companies.models import Company
+
+
+def clone_application_based_on_other(
+    application_base,
+    clone_employee=False,
+    clone_work=False,
+    clone_subsidies=False,
+):
+    company = Company.objects.get(id=application_base.company.id)
+    cloned_application = Application(
+        **{
+            "alternative_company_city": application_base.alternative_company_city,
+            "alternative_company_postcode": application_base.alternative_company_postcode,
+            "alternative_company_street_address": application_base.alternative_company_street_address,
+            "applicant_language": "fi",
+            "application_step": ApplicationStep.STEP_1,
+            "archived": False,
+            "association_has_business_activities": application_base.association_has_business_activities,
+            "association_immediate_manager_check": application_base.association_immediate_manager_check,
+            "benefit_type": "salary_benefit",
+            "co_operation_negotiations": application_base.co_operation_negotiations,
+            "co_operation_negotiations_description": application_base.co_operation_negotiations_description,
+            "company_bank_account_number": application_base.company_bank_account_number,
+            "company_contact_person_email": application_base.company_contact_person_email,
+            "company_contact_person_first_name": application_base.company_contact_person_first_name,
+            "company_contact_person_last_name": application_base.company_contact_person_last_name,
+            "company_contact_person_phone_number": application_base.company_contact_person_phone_number,
+            "company_department": application_base.company_department,
+            "company_form_code": company.company_form_code,
+            "de_minimis_aid": application_base.de_minimis_aid,
+            "status": "draft",
+            "use_alternative_address": application_base.use_alternative_address,
+        }
+    )
+
+    cloned_application.company = company
+
+    if clone_employee or clone_work:
+        employee = Employee.objects.get(id=application_base.employee.id)
+        employee.pk = None
+        employee.application = cloned_application
+    else:
+        employee = Employee.objects.create(application=cloned_application)
+
+    if not clone_employee:
+        employee.first_name = ""
+        employee.last_name = ""
+        employee.social_security_number = ""
+        employee.is_living_in_helsinki = False
+
+    if not clone_work:
+        employee.job_title = ""
+        employee.monthly_pay = None
+        employee.vacation_money = None
+        employee.other_expenses = None
+        employee.working_hours = None
+        employee.collective_bargaining_agreement = ""
+
+    employee.save()
+
+    if clone_subsidies:
+        cloned_application.pay_subsidy_granted = application_base.pay_subsidy_granted
+        cloned_application.apprenticeship_program = (
+            application_base.apprenticeship_program
+        )
+        cloned_application.pay_subsidy_percent = application_base.pay_subsidy_percent
+
+    de_minimis_aids = DeMinimisAid.objects.filter(
+        application__pk=application_base.id
+    ).all()
+
+    if de_minimis_aids.exists():
+        cloned_application.de_minimis_aid = True
+
+        last_order = DeMinimisAid.objects.last().ordering + 1
+        for index, aid in enumerate(de_minimis_aids):
+            aid.pk = None
+            aid.ordering = last_order + index
+            aid.application = cloned_application
+            aid.save()
+
+    cloned_application.save()
+    return cloned_application

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -74,6 +74,7 @@
       "edit": "Edit",
       "close": "Close",
       "print": "Print the application",
+      "clone": "Copy as new application base",
       "openTermsAsPDF": "Open the terms as a PDF file",
       "continueToService": "Continue to the service",
       "pauseAndExit": "Cancel and exit",
@@ -418,7 +419,11 @@
       }
     },
     "errors": {
-      "dirtyOrInvalidForm": "Please fill any missing or invalid form fields"
+      "dirtyOrInvalidForm": "Please fill any missing or invalid form fields",
+      "cloneError": {
+        "title": "No previous applications found",
+        "message": "Please fill in a new application form"
+      }
     },
     "decision": {
       "description": {
@@ -614,7 +619,11 @@
       "description1": "Welcome to the Helsinki benefit service.",
       "description2": "Before filling out the application, review the necessary information and required attachments if needed. You can save an incomplete application as a draft and return to it later.",
       "linkText": " Please take a look at the required information and attachments before filling in the application.",
-      "newApplicationBtnText": "Submit a new application"
+      "newApplicationBtnText": "Submit a new application",
+      "cloneApplication": {
+        "helperText": "The application which was submitted last will be used as a template",
+        "buttonText": "Copy previous application"
+      }
     },
     "decisions": {
       "heading": "Archive",

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -74,6 +74,7 @@
       "edit": "Muokkaa",
       "close": "Sulje",
       "print": "Tulosta hakemus",
+      "clone": "Käytä uuden hakemuksen pohjana",
       "openTermsAsPDF": "Avaa ehdot PDF-tiedostona",
       "continueToService": "Jatka palveluun",
       "pauseAndExit": "Keskeytä ja poistu",
@@ -418,7 +419,11 @@
       }
     },
     "errors": {
-      "dirtyOrInvalidForm": "Täytä lomakkeen puuttuvat tai virheelliset kentät"
+      "dirtyOrInvalidForm": "Täytä lomakkeen puuttuvat tai virheelliset kentät",
+      "cloneError": {
+        "title": "Ei aiempia lähetettyjä hakemuksia",
+        "message": "Ole hyvä ja tee kokonaan uusi hakemus"
+      }
     },
     "decision": {
       "description": {
@@ -614,7 +619,11 @@
       "description1": "Tervetuloa Helsinki-lisän asiointipalveluun.",
       "description2": "Ennen hakemuksen täyttämistä tutustu hakemisessa vaadittaviin tietoihin ja liitteisiin. Voit tallentaa hakemuksen keskeneräisenä luonnokseksi ja jatkaa sen täyttämistä myöhemmin.",
       "linkText": " Tutustu vaadittaviin tietoihin ja tarvittaviin liitteisiin ennen hakemuksen täyttämistä.",
-      "newApplicationBtnText": "Tee uusi hakemus"
+      "newApplicationBtnText": "Tee uusi hakemus",
+      "cloneApplication": {
+        "helperText": "Pohjana käytetään viimeksi lähetettyä hakemusta",
+        "buttonText": "Kopioi aiempi hakemus"
+      }
     },
     "decisions": {
       "heading": "Arkisto",

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -74,6 +74,7 @@
       "edit": "Redigera",
       "close": "Stäng",
       "print": "Skriv ut ansökan",
+      "clone": "Kopiera ansökan",
       "openTermsAsPDF": "Öppna villkoren som PDF-fil",
       "continueToService": "Fortsätt till tjänsten",
       "pauseAndExit": "Avbryt och lämna sidan",
@@ -418,7 +419,11 @@
       }
     },
     "errors": {
-      "dirtyOrInvalidForm": "Fyll i eventuella saknade eller ogiltiga formulärfält"
+      "dirtyOrInvalidForm": "Fyll i eventuella saknade eller ogiltiga formulärfält",
+      "cloneError": {
+        "title": "Inga tidigare ansökningar har hittats",
+        "message": "Vänligen skapa en ny ansökan"
+      }
     },
     "decision": {
       "description": {
@@ -614,7 +619,11 @@
       "description1": "Välkommen till e-tjänsten för Helsingforstillägg.",
       "description2": "Innan du fyller i ansökan, bekanta dig med den information och de bilagor som krävs för att ansöka. Du kan spara en halvfärdig ansökan och komplettera den senare.",
       "linkText": " Se vilka uppgifter och bilagor som krävs innan du fyller i ansökan.",
-      "newApplicationBtnText": "Gör en ny ansökan"
+      "newApplicationBtnText": "Gör en ny ansökan",
+      "cloneApplication": {
+        "helperText": "Den ansökan som skickades in senast kommer att användas som en mall",
+        "buttonText": "Kopiera den senaste ansökan"
+      }
     },
     "decisions": {
       "heading": "Arkiv",

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/ApplicationFormStep5.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/ApplicationFormStep5.tsx
@@ -1,13 +1,16 @@
 import SummarySection from 'benefit/applicant/components/summarySection/SummarySection';
+import { SUPPORTED_LANGUAGES } from 'benefit/applicant/constants';
+import useCloneApplicationMutation from 'benefit/applicant/hooks/useCloneApplicationMutation';
 import { DynamicFormStepComponentProps } from 'benefit/applicant/types/common';
 import {
   BackendEndpoint,
   getBackendUrl,
 } from 'benefit-shared/backend-api/backend-api';
 import { ATTACHMENT_TYPES, BENEFIT_TYPES } from 'benefit-shared/constants';
-import { Button, IconPen, IconPrinter } from 'hds-react';
+import { Button, IconPen, IconPlus, IconPrinter } from 'hds-react';
 import isEmpty from 'lodash/isEmpty';
-import React from 'react';
+import { useRouter } from 'next/router';
+import React, { useEffect } from 'react';
 import {
   $Grid,
   $GridCell,
@@ -40,6 +43,25 @@ const ApplicationFormStep5: React.FC<
     translationsBase,
     isSubmit,
   } = useApplicationFormStep5(data, setIsSubmittedApplication);
+
+  const {
+    data: clonedData,
+    isLoading,
+    mutate: cloneApplication,
+  } = useCloneApplicationMutation();
+
+  const handleCloneApplication = (): void => cloneApplication(data?.id);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (clonedData?.id && data?.id) {
+      void router.push(
+        `${
+          router.locale !== SUPPORTED_LANGUAGES.FI ? router.locale : ''
+        }${router.asPath.replace(data?.id, clonedData.id)}`
+      );
+    }
+  }, [clonedData?.id, router, data?.id]);
 
   const theme = useTheme();
 
@@ -157,7 +179,7 @@ const ApplicationFormStep5: React.FC<
               {t('common:utility.close')}
             </Button>
           </$GridCell>
-          <$GridCell $colSpan={11}>
+          <$GridCell $colSpan={3}>
             <Button
               iconLeft={<IconPrinter />}
               theme="coat"
@@ -174,6 +196,18 @@ const ApplicationFormStep5: React.FC<
               }
             >
               {t(`common:applications.actions.print`)}
+            </Button>
+          </$GridCell>
+          <$GridCell $colSpan={8} justifySelf="end">
+            <Button
+              isLoading={isLoading}
+              iconLeft={<IconPlus />}
+              theme="coat"
+              role="link"
+              variant="secondary"
+              onClick={() => handleCloneApplication()}
+            >
+              {t(`common:applications.actions.clone`)}
             </Button>
           </$GridCell>
         </$Grid>

--- a/frontend/benefit/applicant/src/components/header/Header.tsx
+++ b/frontend/benefit/applicant/src/components/header/Header.tsx
@@ -1,4 +1,4 @@
-import { ROUTES } from 'benefit/applicant/constants';
+import { ROUTES, SUPPORTED_LANGUAGES } from 'benefit/applicant/constants';
 import useLogin from 'benefit/applicant/hooks/useLogin';
 import useLogout from 'benefit/applicant/hooks/useLogout';
 import useUserQuery from 'benefit/applicant/hooks/useUserQuery';
@@ -27,7 +27,7 @@ const Header: React.FC = () => {
     isNavigationVisible,
   } = useHeader();
   const router = useRouter();
-  const { asPath } = router;
+  const { asPath, locale } = router;
 
   const login = useLogin();
   const userQuery = useUserQuery();
@@ -42,7 +42,11 @@ const Header: React.FC = () => {
     <>
       <BaseHeader
         title={t('common:appName')}
-        titleUrl={ROUTES.HOME}
+        titleUrl={
+          locale === SUPPORTED_LANGUAGES.FI
+            ? ROUTES.HOME
+            : `/${locale}${ROUTES.HOME}`
+        }
         skipToContentLabel={t('common:header.linkSkipToContent')}
         menuToggleAriaLabel={t('common:header.menuToggleAriaLabel')}
         languages={languageOptions}

--- a/frontend/benefit/applicant/src/components/mainIngress/frontPage/FrontPageMainIngress.sc.ts
+++ b/frontend/benefit/applicant/src/components/mainIngress/frontPage/FrontPageMainIngress.sc.ts
@@ -4,8 +4,21 @@ import styled from 'styled-components';
 export const $ActionContainer = styled.div`
   display: flex;
   align-items: center;
-  flex: 1 0 30%;
+  flex-flow: column;
+  flex: 1 0 40%;
   box-sizing: border-box;
+
+  hr {
+    min-width: 280px;
+    border: 0;
+    border-top: 1px solid ${(props) => props.theme.colors.black30};
+    border-bottom: 1px solid ${(props) => props.theme.colors.black10};
+  }
+  > button,
+  .custom-combobox {
+    width: 280px;
+    margin: 5px 0;
+  }
   ${respondAbove('sm')`
     justify-content: flex-end;
   `}

--- a/frontend/benefit/applicant/src/components/mainIngress/frontPage/FrontPageMainIngress.tsx
+++ b/frontend/benefit/applicant/src/components/mainIngress/frontPage/FrontPageMainIngress.tsx
@@ -1,11 +1,24 @@
 import { $ActionContainer } from 'benefit/applicant/components/mainIngress/frontPage/FrontPageMainIngress.sc';
 import { useFrontPageMainIngress } from 'benefit/applicant/components/mainIngress/frontPage/useFrontPageMainIngress';
 import MainIngress from 'benefit/applicant/components/mainIngress/MainIngress';
-import { Button, IconPlus } from 'hds-react';
+import useCloneApplicationMutation from 'benefit/applicant/hooks/useCloneApplicationMutation';
+import { Button, IconCopy, IconPlus } from 'hds-react';
+import { useRouter } from 'next/router';
 import React from 'react';
 
 const FrontPageMainIngress: React.FC = () => {
   const { t, handleNewApplicationClick } = useFrontPageMainIngress();
+
+  const { data: clonedData, mutate: cloneApplication } =
+    useCloneApplicationMutation();
+
+  const router = useRouter();
+
+  React.useEffect(() => {
+    if (clonedData?.id) {
+      void router.push(`/application?id=${clonedData.id}`);
+    }
+  }, [clonedData?.id, router]);
 
   return (
     <MainIngress
@@ -32,6 +45,19 @@ const FrontPageMainIngress: React.FC = () => {
         >
           {t('common:mainIngress.frontPage.newApplicationBtnText')}
         </Button>
+        <hr />
+        <Button
+          theme="coat"
+          variant="secondary"
+          iconLeft={<IconCopy />}
+          onClick={() => cloneApplication(null)}
+          aria-labelledby="clone-application-button-helper"
+        >
+          {t('common:mainIngress.frontPage.cloneApplication.buttonText')}
+        </Button>
+        <small id="clone-application-button-helper">
+          {t('common:mainIngress.frontPage.cloneApplication.helperText')}
+        </small>
       </$ActionContainer>
     </MainIngress>
   );

--- a/frontend/benefit/applicant/src/hooks/useCloneApplicationMutation.ts
+++ b/frontend/benefit/applicant/src/hooks/useCloneApplicationMutation.ts
@@ -1,0 +1,48 @@
+import { AxiosError } from 'axios';
+import {
+  ApplicantEndpoint,
+  BackendEndpoint,
+} from 'benefit-shared/backend-api/backend-api';
+import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult } from 'react-query';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+type Response = {
+  id?: string;
+};
+
+const useCloneApplicationMutation = (): UseMutationResult<
+  Response,
+  unknown,
+  string | null
+> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const { t } = useTranslation();
+
+  return useMutation(
+    'clone_application',
+    (id?: string) =>
+      id
+        ? handleResponse<Response>(
+            axios.get(ApplicantEndpoint.APPLICATIONS_CLONE_AS_DRAFT(id))
+          )
+        : handleResponse<Response>(
+            axios.get(BackendEndpoint.APPLICATIONS_CLONE_LATEST)
+          ),
+    {
+      onError: (error: AxiosError) => {
+        if (error?.response?.status === 404)
+          showErrorToast(
+            t('common:applications.errors.cloneError.title'),
+            t('common:applications.errors.cloneError.message')
+          );
+        else {
+          showErrorToast('Error cloning application', '');
+        }
+      },
+    }
+  );
+};
+
+export default useCloneApplicationMutation;

--- a/frontend/benefit/shared/src/backend-api/backend-api.ts
+++ b/frontend/benefit/shared/src/backend-api/backend-api.ts
@@ -28,10 +28,13 @@ export const BackendEndpoint = {
   APPLICATIONS_WITH_UNREAD_MESSAGES:
     'v1/handlerapplications/with_unread_messages/',
   AHJO_SETTINGS: 'v1/ahjosettings/decision-maker/',
+  APPLICATIONS_CLONE_AS_DRAFT: 'v1/applications/clone_as_draft/',
+  APPLICATIONS_CLONE_LATEST: 'v1/applications/clone_latest/',
 } as const;
 
 const singleBatchBase = (id: string): string =>
   `${BackendEndpoint.APPLICATION_BATCHES}${id}/`;
+
 export const HandlerEndpoint = {
   BATCH_APP_ASSIGN: `${BackendEndpoint.APPLICATION_BATCHES}assign_applications/`,
   BATCH_APP_DEASSIGN: (id: string): string =>
@@ -41,6 +44,14 @@ export const HandlerEndpoint = {
     `${BackendEndpoint.HANDLER_APPLICATIONS}batch_pdf_files?batch_id=${id}`,
   BATCH_DOWNLOAD_P2P_FILE: (id: string): string =>
     `${BackendEndpoint.HANDLER_APPLICATIONS}batch_p2p_file?batch_id=${id}`,
+} as const;
+
+const singleApplicationBase = (id: string): string =>
+  `${BackendEndpoint.APPLICATIONS}${id}/`;
+
+export const ApplicantEndpoint = {
+  APPLICATIONS_CLONE_AS_DRAFT: (id: string) =>
+    `${singleApplicationBase(id)}clone_as_draft/`,
 } as const;
 
 export const BackendEndPoints = Object.values(BackendEndpoint);

--- a/frontend/benefit/shared/src/utils/dates.ts
+++ b/frontend/benefit/shared/src/utils/dates.ts
@@ -66,10 +66,10 @@ export const validateIsTodayOrPastDate = (value: string): boolean => {
 };
 
 export const validateDateWithinMonths = (
-  value: string,
+  value: string | Date,
   months: number
 ): boolean => {
-  const date = getDateFromDateString(value);
+  const date = typeof value === 'string' ? getDateFromDateString(value) : value;
 
   if (!date) {
     return false;


### PR DESCRIPTION
## Description :sparkles:

Add feature to clone any application on applicant's side. Only step 1 information is cloned. There are some switches that can be used to clone work conditions, pay subsidy and employee information, but they are yet to be unused. They will be useful on later ticket when handler side cloning is added.

* Clone the latest submitted application (front page)
* Clone any application (application review page)
* Fix language prefix dropping off when clicking Helsinki logo in Header
* Fix some type issue