### PR TITLE
feat: fix routing; active tab function was off if locale was used

### DIFF
--- a/frontend/benefit/applicant/src/components/header/Header.tsx
+++ b/frontend/benefit/applicant/src/components/header/Header.tsx
@@ -25,6 +25,7 @@ const Header: React.FC = () => {
     canWriteNewMessages,
     navigationItems,
     isNavigationVisible,
+    isTabActive,
   } = useHeader();
   const router = useRouter();
   const { asPath } = router;
@@ -82,6 +83,7 @@ const Header: React.FC = () => {
               ]
             : undefined
         }
+        customActiveItemFn={isTabActive}
         navigationItems={navigationItems}
         isNavigationVisible={isNavigationVisible}
       />

--- a/frontend/shared/src/components/header/Header.tsx
+++ b/frontend/shared/src/components/header/Header.tsx
@@ -39,6 +39,7 @@ export type HeaderProps = {
   hideLogin?: boolean;
   onTitleClick?: () => void;
   className?: string;
+  customActiveItemFn?: (url: string) => boolean;
 };
 
 const Header: React.FC<HeaderProps> = ({
@@ -57,6 +58,7 @@ const Header: React.FC<HeaderProps> = ({
   theme,
   onTitleClick,
   className,
+  customActiveItemFn,
 }) => {
   const {
     locale,
@@ -101,7 +103,11 @@ const Header: React.FC<HeaderProps> = ({
             {navigationItems?.map((item) => (
               <Navigation.Item
                 key={item.url}
-                active={isTabActive(item.url)}
+                active={
+                  customActiveItemFn
+                    ? customActiveItemFn(item.url)
+                    : isTabActive(item.url)
+                }
                 href={item.url}
                 onClick={() => handleClickLink(item.url)}
                 icon={item.icon}


### PR DESCRIPTION
## Description :sparkles:

This was me opening a can of worms. 

Previously, applicant's `/sv`, `/en` header links were fixed. This however, broke the default language Finnish links without  having the explicit `/fi` URI prefix. This is now fixed here.

Also, it turned out that in `shared/Header` component, setting active link highlight, was not considering URI locale prefixes at all. So I implemented a custom function that can optionally be passed to set active navigation item the way we want it in helsinki-benefit.