### PR TITLE
HL 1461 + HL 1466 fixes

### DIFF
--- a/backend/benefit/applications/api/v1/ahjo_integration_views.py
+++ b/backend/benefit/applications/api/v1/ahjo_integration_views.py
@@ -362,7 +362,9 @@ class AhjoDecisionCallbackView(APIView):
         ahjo_case_id = callback_data["caseId"]
         update_type = callback_data["updatetype"]
 
-        application = get_object_or_404(Application, ahjo_case_id=ahjo_case_id)
+        application = get_object_or_404(
+            Application, ahjo_case_id=ahjo_case_id, handled_by_ahjo_automation=True
+        )
 
         if update_type == AhjoDecisionUpdateType.ADDED:
             AhjoStatus.objects.create(

--- a/backend/benefit/applications/management/commands/send_ahjo_requests.py
+++ b/backend/benefit/applications/management/commands/send_ahjo_requests.py
@@ -266,14 +266,15 @@ for application {application.id} and batch {batch.id} from Ahjo"
         response_text: str,
         request_type: AhjoRequestType,
     ) -> str:
-        # The guid is returned in the response text in text format {guid}, so remove brackets here
+        # The request id  is returned in the response text in text format {request_id}, so remove brackets here
         response_text = response_text.replace("{", "").replace("}", "")
-        application.ahjo_case_guid = response_text
-        application.save()
+        ahjo_status = application.ahjo_status.latest()
+        ahjo_status.ahjo_request_id = response_text
+        ahjo_status.save()
 
         return f"{counter}. Successfully submitted {request_type} request for application {application.id}, \
             number: {application.application_number}, to Ahjo, \
-            received GUID: {response_text}"
+            received Ahjo requestId: {response_text}"
 
     def _handle_successful_request(
         self,

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -555,6 +555,7 @@ def test_subscribe_to_decisions_callback_success(
 ):
     dummy_case_id = "HEL 1999-123"
     decided_application.ahjo_case_id = dummy_case_id
+    decided_application.handled_by_ahjo_automation = True
     decided_application.save()
 
     settings.NEXT_PUBLIC_MOCK_FLAG = True


### PR DESCRIPTION
## Description :sparkles:
[HL-1461](https://helsinkisolutionoffice.atlassian.net/browse/HL-1461)
AhjoRequestId was stored as application.ahjo guid, now store it at the application.ahjo_status as where it should be stored.
[HL 1466](https://helsinkisolutionoffice.atlassian.net/browse/HL-1466)
Fix an error where the decision detail callback would find multiple applications with the same ahjo_case_id, as in production there are application with handled_by_ahjo_automation=False that have share the same case_id.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1461]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ