### PR TITLE
chore: remove now built-in "next-transpile-modules" package

### DIFF
--- a/frontend/benefit/applicant/package.json
+++ b/frontend/benefit/applicant/package.json
@@ -34,7 +34,6 @@
     "next-router-mock": "0.9.12",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
-    "next-transpile-modules": "^9.1.0",
     "pdfjs-dist": "3.11.174",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/benefit/handler/package.json
+++ b/frontend/benefit/handler/package.json
@@ -43,7 +43,6 @@
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
     "next-router-mock": "0.9.12",
-    "next-transpile-modules": "^9.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-input-mask": "^2.0.4",

--- a/frontend/kesaseteli/employer/package.json
+++ b/frontend/kesaseteli/employer/package.json
@@ -32,7 +32,6 @@
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
     "next-router-mock": "0.9.12",
-    "next-transpile-modules": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.30.0",

--- a/frontend/kesaseteli/handler/package.json
+++ b/frontend/kesaseteli/handler/package.json
@@ -31,7 +31,6 @@
     "next": "14.2.12",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
-    "next-transpile-modules": "^9.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.30.0",

--- a/frontend/kesaseteli/youth/package.json
+++ b/frontend/kesaseteli/youth/package.json
@@ -33,7 +33,6 @@
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
     "next-router-mock": "0.9.12",
-    "next-transpile-modules": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.30.0",

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,8 +1,6 @@
 const webpack = require('webpack');
-const path = require('path');
 const withPlugins = require('next-compose-plugins');
 const { withSentryConfig } = require('@sentry/nextjs');
-const withTranspileModules = require('next-transpile-modules');
 // https://nextjs.org/docs/api-reference/next.config.js/introduction
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 const pc = require('picocolors');
@@ -63,7 +61,7 @@ const nextConfig = (override) => ({
   eslint: {
     ignoreDuringBuilds: NEXTJS_IGNORE_ESLINT,
   },
-
+  transpilePackages: ['@frontend'],
   webpack: (config) => {
     config.resolve.fallback = {
       fs: false,
@@ -124,11 +122,12 @@ if (!NEXTJS_DISABLE_SENTRY) {
     // https://github.com/getsentry/sentry-webpack-plugin#options.
     // silent: isProd, // Suppresses all logs
     dryRun: NEXTJS_SENTRY_UPLOAD_DRY_RUN,
+    disableLogger: !NEXTJS_SENTRY_DEBUG,
   });
 } else {
   console.warn(`${pc.yellow('notice')}- Sentry is disabled (NEXTJS_DISABLE_SENTRY)`);
 }
 
-const plugins = [[withTranspileModules, { transpileModules: ['@frontend'] }]];
+const plugins = [];
 
 module.exports = async (phase) => withPlugins(plugins, config(phase))(phase, { undefined });

--- a/frontend/tet/admin/package.json
+++ b/frontend/tet/admin/package.json
@@ -30,7 +30,6 @@
     "next": "14.2.12",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
-    "next-transpile-modules": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.30.0",

--- a/frontend/tet/youth/package.json
+++ b/frontend/tet/youth/package.json
@@ -30,7 +30,6 @@
     "next": "14.2.12",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
-    "next-transpile-modules": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^3.2.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6549,26 +6549,10 @@ enhance-visitors@^1.0.0:
   dependencies:
     lodash "^4.13.1"
 
-enhanced-resolve@^5.10.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
-  integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
-  dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.2.0"
-
 enhanced-resolve@^5.12.0:
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz#1af946c7d93603eb88e9896cee4904dc012e9c35"
   integrity sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==
-  dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.2.0"
-
-enhanced-resolve@^5.7.0:
-  version "5.9.2"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz#0224dcd6a43389ebfb2d55efee517e5466772dd9"
-  integrity sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -11885,22 +11869,6 @@ next-router-mock@0.9.12:
   version "0.9.12"
   resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.12.tgz#a64934c9c86f60f6b3c6a7e37e72e51ed5feeea0"
   integrity sha512-PzKn70RSqO50GHyYyhd4WJb9I526Abfq2VDP+YPV8yqlaR38OKtQAcWr3njR75UG+Ik6HououZHm7ucxl6LSnA==
-
-next-transpile-modules@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz#133b1742af082e61cc76b02a0f12ffd40ce2bf90"
-  integrity sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==
-  dependencies:
-    enhanced-resolve "^5.7.0"
-    escalade "^3.1.1"
-
-next-transpile-modules@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-9.1.0.tgz#dffd2563bf76f8afdb28f0611948f46252ca65ef"
-  integrity sha512-yzJji65xDqcIqjvx5vPJcs1M+MYQTzLM1pXH/qf8Q88ohx+bwVGDc1AeV+HKr1NwvMCNTpwVPSFI7cA5WdyeWA==
-  dependencies:
-    enhanced-resolve "^5.10.0"
-    escalade "^3.1.1"
 
 next@14.2.12:
   version "14.2.12"


### PR DESCRIPTION
## Description :sparkles:

* Remove built-in package that is deprecated. 
* Remove logger from sentry SDK logger on stage/production (reduce bundle size).