### PR TITLE
fix: add SBOM to powerBI csv

### DIFF
--- a/backend/benefit/applications/api/v1/power_bi_integration_views.py
+++ b/backend/benefit/applications/api/v1/power_bi_integration_views.py
@@ -73,7 +73,7 @@ class PowerBiIntegrationView(APIView):
             prune_data_for_talpa,
         )
         response = StreamingHttpResponse(
-            csv_service.get_csv_string_lines_generator(),
+            csv_service.get_csv_string_lines_generator(add_bom=True),
             content_type="text/csv",
         )
 

--- a/backend/benefit/applications/tests/test_power_bi_integration.py
+++ b/backend/benefit/applications/tests/test_power_bi_integration.py
@@ -24,9 +24,9 @@ def test_get_power_bi_data(power_bi_client, decided_application_with_decision_da
     # Assert CSV has a header and at least one data row
     assert len(rows) > 1
     header = rows[0]
-    assert "Hakemusnumero" in header
+    assert '\ufeff"Hakemusnumero"' in header
     assert "Talpaan viennin päivä" in header
 
-    assert rows[1][header.index("Hakemusnumero")] == str(
+    assert rows[1][header.index('\ufeff"Hakemusnumero"')] == str(
         decided_application_with_decision_date.application_number
     )


### PR DESCRIPTION
## Description :sparkles:
Add missing SBOM character to the beginning of the CSV, so that the letters are not mangled.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
