### PR TITLE
fix: pdf_summary delete on application update

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1267,7 +1267,13 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
         valid_attachment_types = {req[0] for req in attachment_requirements}
         attachments_with_invalid_type = []
 
-        for attachment in instance.attachments.all().order_by("created_at"):
+        for attachment in (
+            # exclude the PDF summary from the list of attachments,
+            # otherwise it may get deleted
+            instance.attachments.filter()
+            .exclude(attachment_type=AttachmentType.PDF_SUMMARY)
+            .order_by("created_at")
+        ):
             if attachment.attachment_type == AttachmentType.EMPLOYEE_CONSENT:
                 # validated separately
                 continue


### PR DESCRIPTION
## Description :sparkles:
[HL-1477](https://helsinkisolutionoffice.atlassian.net/browse/HL-1477?atlOrigin=eyJpIjoiYTQwNWU3NzgwNjJkNDQwM2JhZDgyMDIyYTUxZTRlZjUiLCJwIjoiaiJ9)

An existing pdf_summary attachment was being deleted whenever an application was updated.
This PR excludes the attachment of type pdf_summary from the serializer code, that purges non-valid attachments.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1477]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ