### PR TITLE
feat: ensure ahjo_status is saved during  request

### DIFF
--- a/backend/benefit/applications/services/ahjo_client.py
+++ b/backend/benefit/applications/services/ahjo_client.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.urls import reverse
 
 from applications.enums import AhjoRequestType, AhjoStatus as AhjoStatusEnum
-from applications.models import AhjoSetting, Application
+from applications.models import AhjoSetting, AhjoStatus, Application
 from applications.services.ahjo_authentication import AhjoToken, InvalidTokenException
 
 LOGGER = logging.getLogger(__name__)
@@ -235,6 +235,13 @@ class AhjoApiClient:
                 timeout=self._timeout,
                 data=data,
             )
+
+            if hasattr(self._request, "result_status") and self._request.result_status:
+                AhjoStatus.objects.create(
+                    application=self._request.application,
+                    status=self._request.result_status,
+                )
+
             response.raise_for_status()
 
             if response.ok:

--- a/backend/benefit/applications/services/ahjo_integration.py
+++ b/backend/benefit/applications/services/ahjo_integration.py
@@ -488,10 +488,6 @@ def send_open_case_request_to_ahjo(
     data = prepare_open_case_payload(application, pdf_summary)
 
     result, response_text = ahjo_client.send_request_to_ahjo(data)
-    if result:
-        create_status_for_application(
-            application, AhjoStatusEnum.REQUEST_TO_OPEN_CASE_SENT
-        )
     return result, response_text
 
 
@@ -504,8 +500,7 @@ def delete_application_in_ahjo(
     ahjo_client = AhjoApiClient(ahjo_token, ahjo_request)
 
     result, response_text = ahjo_client.send_request_to_ahjo(None)
-    if result:
-        create_status_for_application(application, ahjo_request.result_status)
+
     return result, response_text
 
 
@@ -532,8 +527,6 @@ in Ahjo status {application.ahjo_status.latest().status}, not sending {ahjo_requ
 
     result, response_text = ahjo_client.send_request_to_ahjo(data)
 
-    if result:
-        create_status_for_application(application, AhjoStatusEnum.UPDATE_REQUEST_SENT)
     return result, response_text
 
 
@@ -554,8 +547,6 @@ def send_new_attachment_records_to_ahjo(
 
     result, response_text = ahjo_client.send_request_to_ahjo(data)
 
-    if result:
-        create_status_for_application(application, ahjo_request.result_status)
     return result, response_text
 
 
@@ -584,7 +575,6 @@ def send_decision_proposal_to_ahjo(
         secret_xml=secret_xml,
     )
     response, response_text = ahjo_client.send_request_to_ahjo(data)
-    create_status_for_application(application, AhjoStatusEnum.DECISION_PROPOSAL_SENT)
     return response, response_text
 
 


### PR DESCRIPTION
## Description :sparkles:
Move the logic of saving the new ahjo_status into the ahjoClient class to ensure that the each of the following statuses,
```
request_to_open_case_sent,
decision_proposal_sent,
update_request_sent,
delete_request_sent,
new_record_request_sent
```
is created even if the request does not succeed so that the error_from_ahjo is stored in to the correct status.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
