### PR TITLE
fix: do not remove batch if ahjo automation

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1836,7 +1836,11 @@ class HandlerApplicationSerializer(BaseApplicationSerializer):
         if instance.status == ApplicationStatus.CANCELLED:
             self._cancel_application(instance)
         self._assign_handler_if_needed(instance)
-        self._remove_batch_if_needed(instance)
+
+        if not instance.handled_by_ahjo_automation and instance.ahjo_case_id is None:
+            # If the application has been handled by the Ahjo automation, we don't want to
+            # remove the batch, as it's needed for the Ahjo automation
+            self._remove_batch_if_needed(instance)
 
     def _cancel_application(self, instance):
         instance.archived = True


### PR DESCRIPTION
## Description :sparkles:
[HL-1488](https://helsinkisolutionoffice.atlassian.net/browse/HL-1488?atlOrigin=eyJpIjoiZTczNDY5M2I4Y2VkNDcwNGE0NmYzNjExNjdlZDA3ODkiLCJwIjoiaiJ9)

Resolves an issue where if handler unlocks and locks an application and it's status is updated to handling, the associated batch is removed from applications that are handled via ahjo automation.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1488]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ