### PR TITLE
feat: perform "back" actions througout the app using centralized hook (hl-1276)

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1004,7 +1004,7 @@
           "calculationOutOfDate": "Laskelma ei ole ajan tasalla"
         },
         "actions": {
-          "close": "Peruuta",
+          "close": "Sulje",
           "handle": "Merkitse käsitellyksi",
           "returnToApplication": "Palaa hakemukseen",
           "returnToAlterationList": "Palaa muutosilmoituksiin"

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1004,7 +1004,7 @@
           "calculationOutOfDate": "Laskelma ei ole ajan tasalla"
         },
         "actions": {
-          "close": "Peruuta",
+          "close": "Sulje",
           "handle": "Merkitse käsitellyksi",
           "returnToApplication": "Palaa hakemukseen",
           "returnToAlterationList": "Palaa muutosilmoituksiin"

--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationHandling.tsx
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationHandling.tsx
@@ -140,9 +140,6 @@ const AlterationHandling = (): JSX.Element => {
           alteration={alteration}
           onError={onError}
           onSuccess={onSuccess}
-          onClose={() =>
-            router.push(`${ROUTES.APPLICATION}?id=${application.id}`)
-          }
         />
       ) : (
         <Container>

--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationHandlingForm.tsx
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationHandlingForm.tsx
@@ -15,6 +15,7 @@ import useAlterationHandlingForm from 'benefit/handler/components/alterationHand
 import { $CustomNotesActions } from 'benefit/handler/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActions.sc';
 import Sidebar from 'benefit/handler/components/sidebar/Sidebar';
 import { DEFAULT_MINIMUM_RECOVERY_AMOUNT } from 'benefit/handler/constants';
+import { useRouterNavigation } from 'benefit/handler/hooks/applicationHandling/useRouterNavigation';
 import {
   Application,
   ApplicationAlteration,
@@ -46,7 +47,6 @@ type Props = {
   alteration: ApplicationAlteration;
   onError: (error: AxiosError<unknown>) => void;
   onSuccess: (isRecoverable: boolean) => void;
-  onClose: () => void;
 };
 
 const AlterationHandlingForm = ({
@@ -54,7 +54,6 @@ const AlterationHandlingForm = ({
   alteration,
   onError,
   onSuccess,
-  onClose,
 }: Props): JSX.Element => {
   const {
     t,
@@ -84,6 +83,7 @@ const AlterationHandlingForm = ({
   const handleAlterationCsvDownload = (): void => {
     setIsCSVDownloadDone(true);
   };
+  const { navigateBack } = useRouterNavigation(null, null, null, true);
 
   const getErrorMessage = (fieldName: string): string | undefined =>
     getErrorText(formik.errors, formik.touched, fieldName, t, isSubmitted);
@@ -256,8 +256,12 @@ const AlterationHandlingForm = ({
       <StickyActionBar>
         <$StickyBarWrapper>
           <$StickyBarColumn>
-            <Button onClick={onClose} theme="black" variant="secondary">
-              {t(`${translationBase}.actions.close`)}
+            <Button
+              onClick={() => navigateBack()}
+              theme="black"
+              variant="secondary"
+            >
+              {t(`${translationBase}.actions.returnToAlterationList`)}
             </Button>
             <Button
               onClick={() =>

--- a/frontend/benefit/handler/src/components/applicationForm/ApplicationForm.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/ApplicationForm.tsx
@@ -1,4 +1,5 @@
 import { ROUTES } from 'benefit/handler/constants';
+import { useRouterNavigation } from 'benefit/handler/hooks/applicationHandling/useRouterNavigation';
 import { useApplicationFormContext } from 'benefit/handler/hooks/useApplicationFormContext';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import {
@@ -64,6 +65,8 @@ const ApplicationForm: React.FC = () => {
   } = useApplicationForm();
 
   const { isFormActionEdit, isFormActionNew } = useApplicationFormContext();
+
+  const { navigateBack } = useRouterNavigation(application.status);
 
   const stepperCss = {
     'pointer-events': 'none',
@@ -245,7 +248,7 @@ const ApplicationForm: React.FC = () => {
               <Button
                 theme="coat"
                 variant="primary"
-                onClick={() => router.push(ROUTES.HOME)}
+                onClick={() => navigateBack()}
                 data-testid="modalBack"
               >
                 {t(`${translationsBase}.backWithoutSaving`)}

--- a/frontend/benefit/handler/src/components/applicationHeader/ApplicationHeader.tsx
+++ b/frontend/benefit/handler/src/components/applicationHeader/ApplicationHeader.tsx
@@ -93,7 +93,7 @@ const ApplicationHeader: React.FC<ApplicationReviewProps> = ({
               </$ItemWrapper>
             </$Col>
             <$Col>
-              <StatusLabel status={data.status} />
+              <StatusLabel status={data.status} archived={data.archived} />
             </$Col>
           </$InnerWrapper>
         </Container>

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActions.tsx
@@ -74,7 +74,7 @@ const HandlingApplicationActions: React.FC<Props> = ({
             {t(`${translationsBase}.saveAndContinue`)}
           </Button>
         ) : (
-          <Button onClick={onSaveAndClose} theme="coat" variant="primary">
+          <Button onClick={onSaveAndClose} theme="black" variant="secondary">
             {t(`${translationsBase}.close`)}
           </Button>
         )}

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActionsAhjo.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActionsAhjo.tsx
@@ -6,6 +6,7 @@ import {
   StepActionType,
   StepStateType,
 } from 'benefit/handler/hooks/applicationHandling/useHandlingStepper';
+import { useRouterNavigation } from 'benefit/handler/hooks/applicationHandling/useRouterNavigation';
 import useCloneApplicationMutation from 'benefit/handler/hooks/useCloneApplicationMutation';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { Application } from 'benefit-shared/types/application';
@@ -73,6 +74,12 @@ const HandlingApplicationActions: React.FC<Props> = ({
     onDoneConfirmation,
   } = useHandlingApplicationActions(application);
 
+  const { navigateBack } = useRouterNavigation(
+    application?.status,
+    application?.batch?.status,
+    application?.archived
+  );
+
   const lastStep =
     stepState.activeStepIndex === Number(stepState.steps?.length) - 1;
   const router = useRouter();
@@ -88,9 +95,13 @@ const HandlingApplicationActions: React.FC<Props> = ({
     (): void =>
       void router.push({
         pathname: '/',
-        query: { tab: APPLICATION_LIST_TABS.HANDLING },
+        query: {
+          tab: APPLICATION_LIST_TABS[
+            application?.status as unknown as keyof typeof APPLICATION_LIST_TABS
+          ],
+        },
       }),
-    [router]
+    [router, application.status]
   );
 
   const effectSaveAndClose = (): void => {
@@ -99,7 +110,7 @@ const HandlingApplicationActions: React.FC<Props> = ({
       isSavingAndClosing
     ) {
       setIsSavingAndClosing(false);
-      navigateToIndex();
+      void navigateBack();
     }
   };
 
@@ -136,6 +147,7 @@ const HandlingApplicationActions: React.FC<Props> = ({
     stepState.activeStepIndex,
     isSavingAndClosing,
     navigateToIndex,
+    navigateBack,
   ]);
   React.useEffect(() => {
     setIsSavingAndClosing(false);
@@ -256,7 +268,7 @@ const HandlingApplicationActions: React.FC<Props> = ({
     setIsSavingAndClosing(true);
   };
 
-  const handleClose = (): void => navigateToIndex();
+  const handleClose = (): void => void navigateBack();
 
   const { data: clonedData, mutate: cloneApplication } =
     useCloneApplicationMutation();
@@ -325,7 +337,7 @@ const HandlingApplicationActions: React.FC<Props> = ({
             <Button
               onClick={openDialog}
               theme="black"
-              disabled={isApplicationReadOnly}
+              disabled={isApplicationReadOnly && !application.ahjoCaseId}
               variant="supplementary"
               iconLeft={<IconTrash />}
             >

--- a/frontend/benefit/handler/src/components/applicationReview/actions/receivedApplicationActions/ReceivedApplicationActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/receivedApplicationActions/ReceivedApplicationActions.tsx
@@ -1,5 +1,5 @@
+import { useRouterNavigation } from 'benefit/handler/hooks/applicationHandling/useRouterNavigation';
 import { useDetermineAhjoMode } from 'benefit/handler/hooks/useDetermineAhjoMode';
-import useHandlerReviewActions from 'benefit/handler/hooks/useHandlerReviewActions';
 import useUpdateApplicationQuery from 'benefit/handler/hooks/useUpdateApplicationQuery';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { Application, ApplicationData } from 'benefit-shared/types/application';
@@ -24,7 +24,10 @@ const ReceivedApplicationActions: React.FC<Props> = ({
 }) => {
   const translationsBase = 'common:review.actions';
   const { t } = useTranslation();
-  const { onSaveAndClose } = useHandlerReviewActions(application);
+  const { navigateBack } = useRouterNavigation(
+    application?.status,
+    application?.batch?.status
+  );
 
   const { mutate: updateApplication } = useUpdateApplicationQuery();
 
@@ -61,14 +64,18 @@ const ReceivedApplicationActions: React.FC<Props> = ({
 
   return (
     <$Grid data-testid={dataTestId}>
+      <$GridCell>
+        <Button
+          onClick={() => navigateBack()}
+          theme="black"
+          variant="secondary"
+        >
+          {t(`${translationsBase}.close`)}
+        </Button>
+      </$GridCell>
       <$GridCell $colSpan={2}>
         <Button onClick={handleStatusChange} theme="coat">
           {t(`${translationsBase}.handle`)}
-        </Button>
-      </$GridCell>
-      <$GridCell>
-        <Button onClick={onSaveAndClose} theme="black" variant="secondary">
-          {t(`${translationsBase}.close`)}
         </Button>
       </$GridCell>
     </$Grid>

--- a/frontend/benefit/handler/src/components/statusLabel/StatusLabel.tsx
+++ b/frontend/benefit/handler/src/components/statusLabel/StatusLabel.tsx
@@ -4,12 +4,17 @@ import React from 'react';
 
 import { $StatusLabel } from './StatusLabel.sc';
 
-const StatusLabel: React.FC<{ status: APPLICATION_STATUSES }> = ({
-  status,
-}) => {
+const StatusLabel: React.FC<{
+  status: APPLICATION_STATUSES;
+  archived?: boolean;
+}> = ({ status, archived }) => {
   const { t } = useTranslation();
   return (
-    <$StatusLabel status={status}>{t(`common:status.${status}`)}</$StatusLabel>
+    <$StatusLabel status={status}>
+      {t(`common:status.${status}`)}
+      {archived &&
+        ` / ${t('common:header.navigation.archive').toLocaleLowerCase()}`}
+    </$StatusLabel>
   );
 };
 

--- a/frontend/benefit/handler/src/hooks/applicationHandling/useRouterNavigation.ts
+++ b/frontend/benefit/handler/src/hooks/applicationHandling/useRouterNavigation.ts
@@ -1,0 +1,119 @@
+import { APPLICATION_LIST_TABS, ROUTES } from 'benefit/handler/constants';
+import { APPLICATION_STATUSES, BATCH_STATUSES } from 'benefit-shared/constants';
+import { useRouter } from 'next/router';
+import React from 'react';
+import { getSessionStorageItem } from 'shared/utils/localstorage.utils';
+
+type NavigationProps = {
+  navigateBack: () => Promise<boolean> | void;
+};
+
+export const useRouterNavigation = (
+  status?: APPLICATION_STATUSES,
+  batchStatus?: BATCH_STATUSES,
+  isArchived?: boolean,
+  forceRouteToAlterations = false,
+  forceRouteToApplicationId?: string
+): NavigationProps => {
+  const router = useRouter();
+
+  const statusToTabId = React.useCallback(():
+    | APPLICATION_LIST_TABS
+    | number => {
+    if (batchStatus === BATCH_STATUSES.DECIDED_ACCEPTED) {
+      return APPLICATION_LIST_TABS.IN_PAYMENT;
+    }
+
+    switch (status) {
+      case APPLICATION_STATUSES.DRAFT:
+        return APPLICATION_LIST_TABS.DRAFT;
+
+      case APPLICATION_STATUSES.RECEIVED:
+        return APPLICATION_LIST_TABS.RECEIVED;
+
+      case APPLICATION_STATUSES.HANDLING:
+        return APPLICATION_LIST_TABS.HANDLING;
+
+      case APPLICATION_STATUSES.INFO_REQUIRED:
+        return APPLICATION_LIST_TABS.HANDLING;
+
+      case APPLICATION_STATUSES.ACCEPTED:
+        return APPLICATION_LIST_TABS.ACCEPTED;
+
+      case APPLICATION_STATUSES.REJECTED:
+        return APPLICATION_LIST_TABS.REJECTED;
+
+      default:
+        return 0;
+    }
+  }, [status, batchStatus]);
+
+  /**
+   * Get the previous location from the session storage. If not available or split fails, fallback to the root.
+   * @returns string - previous location URI or root
+   */
+  const getPreviousLocationData = React.useCallback(() => {
+    try {
+      const history = getSessionStorageItem('history')?.split(',') || [];
+      return {
+        pathname: history.length > 1 ? history.at(-2) : ROUTES.HOME,
+        length: history.length,
+      };
+    } catch (_) {
+      return {
+        pathname: ROUTES.HOME,
+        length: 1,
+      };
+    }
+  }, []);
+
+  const navigateBack = React.useCallback((): Promise<boolean> | void => {
+    if (forceRouteToAlterations) {
+      return router.push(ROUTES.ALTERATIONS);
+    }
+    if (forceRouteToApplicationId) {
+      return router.push(
+        `${ROUTES.APPLICATION}?id=${forceRouteToApplicationId}`
+      );
+    }
+
+    const previousLocation = getPreviousLocationData().pathname;
+
+    // When coming from the alteration page (open application in new window), return to the alteration page
+    if (
+      getPreviousLocationData().length === 1 &&
+      document.referrer.includes(ROUTES.ALTERATIONS)
+    ) {
+      return router.push(ROUTES.ALTERATIONS);
+    }
+
+    if (isArchived) {
+      // When looking matching applications, return to the archive with search params
+      if (ROUTES.HOME && /\?appNo|&appNo/.test(previousLocation)) {
+        return router.push(previousLocation);
+      }
+
+      // Otherwise just return to archive
+      return router.push(ROUTES.APPLICATIONS_ARCHIVE);
+    }
+
+    const isApplicationView =
+      router.pathname.includes(ROUTES.APPLICATION) && router.query?.id;
+
+    if (isApplicationView) {
+      return router.push(`/?tab=${statusToTabId()}`);
+    }
+    return router.push(previousLocation);
+  }, [
+    forceRouteToAlterations,
+    router,
+    forceRouteToApplicationId,
+    getPreviousLocationData,
+    isArchived,
+    statusToTabId,
+  ]);
+
+  return {
+    navigateBack,
+  };
+};

--- a/frontend/benefit/handler/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/handler/src/hooks/useFormActions.tsx
@@ -31,6 +31,7 @@ import { convertToBackendDateFormat, parseDate } from 'shared/utils/date.utils';
 import { getNumberValue, stringToFloatValue } from 'shared/utils/string.utils';
 import snakecaseKeys from 'snakecase-keys';
 
+import { useRouterNavigation } from './applicationHandling/useRouterNavigation';
 import { useApplicationFormContext } from './useApplicationFormContext';
 import useCreateApplicationQuery from './useCreateApplicationQuery';
 import useDeleteApplicationQuery from './useDeleteApplicationQuery';
@@ -130,6 +131,7 @@ const useFormActions = (
     useUpdateApplicationQuery();
 
   const { t } = useTranslation();
+  const { navigateBack } = useRouterNavigation(application.status);
 
   React.useEffect(() => {
     const error =
@@ -414,9 +416,9 @@ const useFormActions = (
         result?.employee?.first_name,
         result?.employee?.last_name
       );
+
       const applicantName = fullName ? `(${fullName})` : '';
       const applicationNumber = result?.application_number ?? '';
-
       hdsToast({
         autoDismissTime: 5000,
         type: 'success',
@@ -426,8 +428,8 @@ const useFormActions = (
           applicantName,
         }),
       });
+      await navigateBack();
 
-      await router.push('/');
       return result;
     } catch (error) {
       // useEffect will catch this error

--- a/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
+++ b/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
@@ -1,4 +1,3 @@
-import { ROUTES } from 'benefit/handler/constants';
 import AppContext from 'benefit/handler/context/AppContext';
 import {
   CalculationFormProps,
@@ -8,13 +7,13 @@ import { Application, ApplicationData } from 'benefit-shared/types/application';
 import { ErrorData } from 'benefit-shared/types/common';
 import camelcaseKeys from 'camelcase-keys';
 import isEmpty from 'lodash/isEmpty';
-import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React, { useEffect } from 'react';
 import { convertToBackendDateFormat } from 'shared/utils/date.utils';
 import { stringToFloatValue } from 'shared/utils/string.utils';
 import snakecaseKeys from 'snakecase-keys';
 
+import { useRouterNavigation } from './applicationHandling/useRouterNavigation';
 import { useApplicationActions } from './useApplicationActions';
 import useUpdateApplicationQuery from './useUpdateApplicationQuery';
 
@@ -31,8 +30,6 @@ const useHandlerReviewActions = (
   setCalculationErrors?: React.Dispatch<React.SetStateAction<ErrorData>>
 ): HandlerReviewActions => {
   const updateApplicationQuery = useUpdateApplicationQuery();
-
-  const router = useRouter();
 
   const { handledApplication } = React.useContext(AppContext);
 
@@ -190,8 +187,10 @@ const useHandlerReviewActions = (
     void updateApplicationQuery.mutate(getSalaryBenefitData(values));
   };
 
+  const { navigateBack } = useRouterNavigation(application.status);
+
   const onSaveAndClose = (): void => {
-    void router.push(ROUTES.HOME);
+    void navigateBack();
   };
 
   return {

--- a/frontend/benefit/handler/src/pages/_app.tsx
+++ b/frontend/benefit/handler/src/pages/_app.tsx
@@ -15,12 +15,17 @@ import {
 } from 'benefit-shared/backend-api/backend-api';
 import { setAppLoaded } from 'benefit-shared/utils/common';
 import { AppProps } from 'next/app';
+import { useRouter } from 'next/router';
 import { appWithTranslation } from 'next-i18next';
 import React, { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import BackendAPIProvider from 'shared/backend-api/BackendAPIProvider';
 import BaseApp from 'shared/components/app/BaseApp';
 import useLocale from 'shared/hooks/useLocale';
+import {
+  getSessionStorageItem,
+  setSessionStorageItem,
+} from 'shared/utils/localstorage.utils';
 
 import Layout from '../layout/Layout';
 
@@ -28,10 +33,24 @@ const queryClient = new QueryClient();
 
 const App: React.FC<AppProps> = (appProps) => {
   const locale = useLocale();
+  const router = useRouter();
 
   useEffect(() => {
     setAppLoaded();
-  }, []);
+  }, [router.pathname, router.isReady]);
+
+  useEffect(() => {
+    const pathname = window.location.pathname + window.location.search;
+    const history = getSessionStorageItem('history');
+    const historyArray = history ? history.split(',') : [];
+    const samePage = historyArray.at(-1) === pathname;
+
+    if (router.isReady && !samePage) {
+      const newHistory =
+        historyArray.length > 0 ? `${history},${pathname}` : pathname;
+      setSessionStorageItem('history', newHistory);
+    }
+  }, [router.pathname, router.isReady]);
 
   return (
     <BackendAPIProvider

--- a/frontend/shared/src/utils/localstorage.utils.ts
+++ b/frontend/shared/src/utils/localstorage.utils.ts
@@ -1,4 +1,5 @@
 /* eslint-disable scanjs-rules/identifier_localStorage */
+/* eslint-disable scanjs-rules/identifier_sessionStorage */
 
 const IS_CLIENT = typeof window !== 'undefined';
 
@@ -11,4 +12,14 @@ export const setLocalStorageItem = (key: string, value: string): void =>
 export const removeLocalStorageItem = (key: string): void =>
   IS_CLIENT && localStorage.removeItem(key);
 
+export const getSessionStorageItem = (key: string): string =>
+  IS_CLIENT ? sessionStorage.getItem(key) || '' : '';
+
+export const setSessionStorageItem = (key: string, value: string): void =>
+  IS_CLIENT && sessionStorage.setItem(key, value);
+
+export const removeSessionStoragItem = (key: string): void =>
+  IS_CLIENT && sessionStorage.removeItem(key);
+
 /* eslint-enable scanjs-rules/identifier_localStorage */
+/* eslint-enable scanjs-rules/identifier_sessionStorage */


### PR DESCRIPTION
## Description :sparkles:

Handler side changes. Back buttons each had custom function calls to next router. Use centralized hook to perform these actions with different logic and use cases.

* Use one function to invoke when Back buttons are pressed
  * Usually, go back from application to corresponding tab with matching status
  * Go to archive if the application is archived
    * One special case where similar applications were searched for with `?appNo=123456` param
  * Go to alterations if it was previously visited
  * If no other means is provided, route back to root of the app
* Browsing is now recorded to window.sessionStorage to allow for history tracking and usage where needed
* Fix one `key` prop issue