### PR TITLE
feat: disable handle button until CSV has been downloaded (hl-1433)

### DIFF
--- a/frontend/benefit/handler/browser-tests/pages/7-handle-alteration.testcafe.ts
+++ b/frontend/benefit/handler/browser-tests/pages/7-handle-alteration.testcafe.ts
@@ -33,6 +33,9 @@ const recoveryEndDate = Selector('#recovery-end-date');
 const accordionItemTitle = 'div[role="heading"]';
 const recoveryStartDateError = '#recovery-start-date-error';
 const recoveryEndDateError = '#recovery-end-date-error';
+const csvButton = Selector(
+  'button[data-testid="button-download-alteration-csv"]'
+);
 const handleButton = Selector('button').withText(
   fi.applications.alterations.handling.actions.handle
 );
@@ -110,9 +113,11 @@ test('Handler creates another alteration and tries to handle it with errors', as
       )
   );
 
-  // Attempt to submit the empty form, verify that validation fails
-  await t.click(handleButton);
+  // Verify that validation fails
   await expectHandleButtonDisabled(t);
+  await t.click(csvButton);
+  await t.click(handleButton);
+
   await t
     .expect(
       Selector('div').withText(
@@ -120,6 +125,7 @@ test('Handler creates another alteration and tries to handle it with errors', as
       ).exists
     )
     .ok();
+
   await t
     .expect(
       Selector('#recovery-justification-error').withText(
@@ -351,7 +357,9 @@ test('Handler handles the alteration from the last test properly', async (t: Tes
   await t.typeText('#recovery-justification', 'Selvä kuin pläkki');
 
   // Submit the handling form
+  await t.click(csvButton);
   await t.click(handleButton);
+
   const modal = Selector('div[role="dialog"]').withText(
     fi.applications.alterations.handling.confirmation.recoverable.title
   );

--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationCsvButton.tsx
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationCsvButton.tsx
@@ -47,6 +47,7 @@ const AlterationCsvButton: React.FC<AlterationCsvProps> = ({
 
   return (
     <Button
+      data-testid="button-download-alteration-csv"
       theme={theme}
       variant={secondary ? 'secondary' : 'primary'}
       iconLeft={<IconDownload />}

--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationHandlingForm.tsx
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationHandlingForm.tsx
@@ -49,10 +49,6 @@ type Props = {
   onClose: () => void;
 };
 
-const handleAlterationCsvDownload = (): void => {
-  // TODO add any necessary logic here after the CSV download
-};
-
 const AlterationHandlingForm = ({
   application,
   alteration,
@@ -82,6 +78,12 @@ const AlterationHandlingForm = ({
 
   const [isMessagesDrawerVisible, toggleMessagesDrawerVisibility] =
     useState<boolean>(false);
+
+  const [isCSVDownloadDone, setIsCSVDownloadDone] = useState<boolean>(false);
+
+  const handleAlterationCsvDownload = (): void => {
+    setIsCSVDownloadDone(true);
+  };
 
   const getErrorMessage = (fieldName: string): string | undefined =>
     getErrorText(formik.errors, formik.touched, fieldName, t, isSubmitted);
@@ -287,7 +289,9 @@ const AlterationHandlingForm = ({
               onClick={openConfirmationModal}
               theme="coat"
               iconLeft={<IconCheck />}
-              disabled={isSubmitting || (isSubmitted && hasErrors)}
+              disabled={
+                isSubmitting || (isSubmitted && hasErrors) || !isCSVDownloadDone
+              }
               isLoading={isSubmitting}
               loadingText={t('common:utility.submitting')}
             >


### PR DESCRIPTION
## Description :sparkles:

Cont. from #3406. Do not allow handle before CSV has been downloaded.