### PR TITLE
feat: add application number to 'Ahjo submission complete' splash screen

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1238,7 +1238,8 @@
       },
       "submitted": {
         "title": "Päätösehdotus on lähetetty Ahjoon",
-        "text": "Viimeistele päätöskäsittely Ahjossa."
+        "text": "Viimeistele päätöskäsittely Ahjossa.",
+        "altText": "Hakemusnumero"
       }
     }
   },

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1238,7 +1238,8 @@
       },
       "submitted": {
         "title": "Päätösehdotus on lähetetty Ahjoon",
-        "text": "Viimeistele päätöskäsittely Ahjossa."
+        "text": "Viimeistele päätöskäsittely Ahjossa.",
+        "altText": "Hakemusnumero"
       }
     }
   },

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1238,7 +1238,8 @@
       },
       "submitted": {
         "title": "Päätösehdotus on lähetetty Ahjoon",
-        "text": "Viimeistele päätöskäsittely Ahjossa."
+        "text": "Viimeistele päätöskäsittely Ahjossa.",
+        "altText": "Hakemusnumero"
       }
     }
   },

--- a/frontend/benefit/handler/src/components/applicationReview/notificationView/NotificationView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/notificationView/NotificationView.tsx
@@ -4,6 +4,7 @@ import { useDetermineAhjoMode } from 'benefit/handler/hooks/useDetermineAhjoMode
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { Application } from 'benefit-shared/types/application';
 import { Button, IconLinkExternal } from 'hds-react';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
@@ -60,10 +61,21 @@ const NotificationView: React.FC<Props> = ({ data }) => {
           <$GridCell $colSpan={10}>
             <$NotificationTitle>
               {isNewAhjoMode
-                ? t(`common:review.decisionProposal.submitted.title`)
+                ? t(`common:review.decisionProposal.submitted.title`, {
+                    applicationNumber: data?.applicationNumber,
+                  })
                 : t(`${translationsBase}.${translationKey}.title`)}
             </$NotificationTitle>
             <$NotificationMessage>
+              {isNewAhjoMode && (
+                <p>
+                  {t('common:review.decisionProposal.submitted.altText')}
+                  {': '}
+                  <Link href={`${ROUTES.APPLICATION}?id=${data?.id}`}>
+                    {data?.applicationNumber}
+                  </Link>
+                </p>
+              )}
               {isNewAhjoMode
                 ? t(`common:review.decisionProposal.submitted.text`)
                 : t(`${translationsBase}.${translationKey}.message`, {


### PR DESCRIPTION
## Description :sparkles:

Just add application number and link back to application after Ahjo submission is done.

![image](https://github.com/user-attachments/assets/d230d0c2-dd0d-40f0-b84e-e4e04cf37cb3)

