### PR TITLE
feat: add ahjo validation error message (hl-1482)

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/ahjo_status.py
+++ b/backend/benefit/applications/api/v1/serializers/ahjo_status.py
@@ -6,4 +6,4 @@ from applications.models import AhjoStatus
 class AhjoStatusSerializer(serializers.ModelSerializer):
     class Meta:
         model = AhjoStatus
-        fields = ["modified_at", "error_from_ahjo"]
+        fields = ["modified_at", "error_from_ahjo", "validation_error_from_ahjo"]

--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1956,9 +1956,10 @@ class HandlerApplicationListSerializer(serializers.Serializer):
             return None
         data = AhjoStatusSerializer(status).data
         if data["error_from_ahjo"] is None:
-            data = None
-        else:
-            data.update({"status": status.status})
+            if data["validation_error_from_ahjo"] is None:
+                data = None
+            else:
+                data["error_from_ahjo"] = data["validation_error_from_ahjo"]
         return data
 
     handled_by_ahjo_automation = serializers.BooleanField(


### PR DESCRIPTION
## Description :sparkles:

When fetching ahjo status errors invoked by GUI, see if there's a validation error from ahjo. Copy that information to errorFromAhjo object if it is not existing and voilà.

### With validation error (override error_from_ahjo)

![image](https://github.com/user-attachments/assets/d073814c-1a5a-4127-b706-7e8c474ef397)


### Without validation error (no override)

![image](https://github.com/user-attachments/assets/e0a0d67f-513c-4972-bdb5-0226ff2774a5)
