### PR TITLE
fix: do not require a batch when cancelling an application (hl-1470)

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActionsAhjo.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActionsAhjo.tsx
@@ -289,7 +289,6 @@ const HandlingApplicationActions: React.FC<Props> = ({
           APPLICATION_STATUSES.ACCEPTED,
           APPLICATION_STATUSES.REJECTED,
         ].includes(application.status) &&
-          !application.batch &&
           !application.archived && (
             <Button
               onClick={openDialog}


### PR DESCRIPTION
## Description :sparkles:

No need to check for batch existed on cancellation.