### PR TITLE
fix: prevent submit of paperApplicationDate to application of applicant origin

### DIFF
--- a/frontend/benefit/handler/src/components/applicationForm/useApplicationForm.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/useApplicationForm.ts
@@ -17,6 +17,7 @@ import {
   ApplicationFields,
 } from 'benefit/handler/types/application';
 import {
+  APPLICATION_ORIGINS,
   ORGANIZATION_TYPES,
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
@@ -124,6 +125,14 @@ export const useApplicationForm = (): ExtendedComponentProps => {
     error: applicationDataError,
   } = useApplicationQueryWithState(id, setApplication);
 
+  const getPaperApplicationDate = (): string | null => {
+    if (application?.applicationOrigin === APPLICATION_ORIGINS.APPLICANT)
+      return null;
+    return application?.paperApplicationDate
+      ? formatDate(parseDate(application.paperApplicationDate))
+      : formatDate(new Date());
+  };
+
   const formik = useFormik({
     initialValues: {
       ...application,
@@ -133,12 +142,13 @@ export const useApplicationForm = (): ExtendedComponentProps => {
       [APPLICATION_FIELDS.END_DATE]: application.endDate
         ? formatDate(parseDate(application.endDate))
         : undefined,
-      [APPLICATION_FIELDS.PAPER_APPLICATION_DATE]:
-        application.paperApplicationDate
-          ? formatDate(parseDate(application.paperApplicationDate))
-          : formatDate(new Date()),
+      [APPLICATION_FIELDS.PAPER_APPLICATION_DATE]: getPaperApplicationDate(),
     },
-    validationSchema: getValidationSchema(organizationType, t),
+    validationSchema: getValidationSchema(
+      t,
+      organizationType,
+      application?.applicationOrigin || APPLICATION_ORIGINS.HANDLER
+    ),
     validateOnChange: true,
     validateOnBlur: true,
     enableReinitialize: true,

--- a/frontend/benefit/handler/src/components/applicationForm/utils/applicationForm.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/utils/applicationForm.ts
@@ -54,9 +54,10 @@ const getApplication = (
           ...applicationData,
           start_date: convertToUIDateFormat(applicationData.start_date),
           end_date: convertToUIDateFormat(applicationData.end_date),
-          paper_application_date: convertToUIDateFormat(
-            applicationData.paper_application_date
-          ),
+          paper_application_date:
+            applicationData.application_origin === APPLICATION_ORIGINS.HANDLER
+              ? convertToUIDateFormat(applicationData.paper_application_date)
+              : null,
           calculation: applicationData.calculation
             ? {
                 ...applicationData.calculation,

--- a/frontend/benefit/handler/src/components/applicationForm/utils/validation.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/utils/validation.ts
@@ -11,6 +11,7 @@ import {
   SUPPORTED_LANGUAGES,
 } from 'benefit/handler/constants';
 import {
+  APPLICATION_ORIGINS,
   EMPLOYEE_KEYS,
   MAX_MONTHLY_PAY,
   ORGANIZATION_TYPES,
@@ -39,8 +40,9 @@ import * as Yup from 'yup';
 import { getValidationSchema as getDeminimisValidationSchema } from '../formContent/companySection/deMinimisAid/utils/validation';
 
 export const getValidationSchema = (
+  t: TFunction,
   organizationType: string | undefined,
-  t: TFunction
+  applicationOrigin: APPLICATION_ORIGINS
 ): unknown =>
   Yup.object().shape({
     [APPLICATION_FIELD_KEYS.USE_ALTERNATIVE_ADDRESS]: Yup.boolean(),
@@ -288,10 +290,15 @@ export const getValidationSchema = (
     [APPLICATION_FIELD_KEYS.END_DATE]: Yup.string().required(
       t(VALIDATION_MESSAGE_KEYS.REQUIRED)
     ),
-    [APPLICATION_FIELD_KEYS.PAPER_APPLICATION_DATE]: Yup.string().test({
-      message: t(VALIDATION_MESSAGE_KEYS.DATE_MAX, {
-        max: convertToUIDateFormat(new Date()),
-      }),
-      test: (value = '') => value === '' || validateIsTodayOrPastDate(value),
-    }),
+    [APPLICATION_FIELD_KEYS.PAPER_APPLICATION_DATE]: Yup.string()
+      .test({
+        message: t(VALIDATION_MESSAGE_KEYS.DATE_MAX, {
+          max: convertToUIDateFormat(new Date()),
+        }),
+        test: (value = '') =>
+          applicationOrigin === APPLICATION_ORIGINS.APPLICANT ||
+          value === '' ||
+          validateIsTodayOrPastDate(value),
+      })
+      .nullable(),
   });


### PR DESCRIPTION
## Description :sparkles:

If application is of applicant origin, do not write paperApplicationDate when saving application during handling edit.