### PR TITLE
feat: use applicant's startDate as initial value for calculation (hl-1471)

### DIFF
--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
@@ -83,10 +83,10 @@ const useSalaryBenefitCalculatorData = (
   const formik = useFormik<CalculationFormProps>({
     initialValues: {
       [CALCULATION_SALARY_KEYS.START_DATE]: convertToUIDateFormat(
-        application?.calculation?.startDate
+        application?.calculation?.startDate || application?.startDate
       ),
       [CALCULATION_SALARY_KEYS.END_DATE]: convertToUIDateFormat(
-        application?.calculation?.endDate
+        application?.calculation?.endDate || application?.endDate
       ),
       [CALCULATION_SALARY_KEYS.MONTHLY_PAY]:
         application?.calculation?.monthlyPay,


### PR DESCRIPTION
## Description :sparkles:

Fill in calculator initial values for start date and end date. Applicant's entry is used as default.