### PR TITLE
fix: retry command call and settings

### DIFF
--- a/backend/benefit/applications/jobs/hourly/hourly_ahjo_job.py
+++ b/backend/benefit/applications/jobs/hourly/hourly_ahjo_job.py
@@ -16,29 +16,29 @@ class Job(HourlyJob):
     def execute(self):
         call_command("refresh_ahjo_token")
 
-        retry_threshold = 1
+        retry_threshold = settings.AHJO_RETRY_FAILED_OLDER_THAN
 
         if settings.ENABLE_AHJO_AUTOMATION:
             call_command(
                 "send_ahjo_requests",
                 request_type=AhjoRequestType.OPEN_CASE,
-                retry_failed_older_than_hours=retry_threshold,
+                retry_failed_older_than=retry_threshold,
             )
             call_command(
                 "send_ahjo_requests",
                 request_type=AhjoRequestType.SEND_DECISION_PROPOSAL,
-                retry_failed_older_than_hours=retry_threshold,
+                retry_failed_older_than=retry_threshold,
             )
             call_command(
                 "send_ahjo_requests",
                 request_type=AhjoRequestType.UPDATE_APPLICATION,
-                retry_failed_older_than_hours=retry_threshold,
+                retry_failed_older_than=retry_threshold,
             )
 
             call_command(
                 "send_ahjo_requests",
                 request_type=AhjoRequestType.DELETE_APPLICATION,
-                retry_failed_older_than_hours=retry_threshold,
+                retry_failed_older_than=retry_threshold,
             )
             call_command(
                 "send_ahjo_requests", request_type=AhjoRequestType.GET_DECISION_DETAILS
@@ -46,5 +46,5 @@ class Job(HourlyJob):
             call_command(
                 "send_ahjo_requests",
                 request_type=AhjoRequestType.GET_DECISION_DETAILS,
-                retry_failed_older_than_hours=retry_threshold,
+                retry_failed_older_than=retry_threshold,
             )


### PR DESCRIPTION
## Description :sparkles:
Fix typo in retry command call and use the hour threshold from settings.py.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
