### PR TITLE
feat: add talpa status and decision date to apps which are "in payment" state (hl-1307)

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -41,6 +41,7 @@ from applications.enums import (
     ApplicationBatchStatus,
     ApplicationOrigin,
     ApplicationStatus,
+    ApplicationTalpaStatus,
     AttachmentRequirement,
     AttachmentType,
     BenefitType,
@@ -1904,6 +1905,7 @@ class HandlerApplicationListSerializer(serializers.Serializer):
             "ahjo_case_id",
             "batch",
             "ahjo_error",
+            "talpa_status",
         ]
 
         read_only_fields = [
@@ -1927,6 +1929,7 @@ class HandlerApplicationListSerializer(serializers.Serializer):
             "ahjo_case_id",
             "batch",
             "ahjo_error",
+            "talpa_status",
         ]
 
     archived = serializers.BooleanField()
@@ -1971,10 +1974,13 @@ class HandlerApplicationListSerializer(serializers.Serializer):
         ),
     )
 
-    batch = serializers.SerializerMethodField("get_batch_status")
+    batch = serializers.SerializerMethodField("get_batch_info")
 
-    def get_batch_status(self, obj):
-        return {"status": getattr(obj.batch, "status", None)}
+    def get_batch_info(self, obj):
+        return {
+            "status": getattr(obj.batch, "status", None),
+            "decision_date": getattr(obj.batch, "decision_date", None),
+        }
 
     ahjo_case_id = serializers.CharField()
     application_number = serializers.IntegerField()
@@ -1982,7 +1988,12 @@ class HandlerApplicationListSerializer(serializers.Serializer):
     status = serializers.ChoiceField(
         choices=ApplicationStatus.choices,
         validators=[ApplicantApplicationStatusValidator()],
-        help_text="Status of the application, visible to the applicant",
+        help_text="Status of the application",
+    )
+
+    talpa_status = serializers.ChoiceField(
+        choices=ApplicationTalpaStatus.choices,
+        help_text="Talpa status of the application",
     )
 
     application_origin = serializers.CharField()

--- a/backend/benefit/calculator/api/v1/serializers.py
+++ b/backend/benefit/calculator/api/v1/serializers.py
@@ -357,8 +357,18 @@ class PreviousBenefitSerializer(serializers.ModelSerializer):
 class CalculationSearchSerializer(serializers.ModelSerializer):
     class Meta:
         model = Calculation
-        fields = ["start_date", "end_date", "handler_details"]
-        read_only_fields = ["start_date", "end_date", "handler_details"]
+        fields = [
+            "start_date",
+            "end_date",
+            "handler_details",
+            "calculated_benefit_amount",
+        ]
+        read_only_fields = [
+            "start_date",
+            "end_date",
+            "handler_details",
+            "calculated_benefit_amount",
+        ]
 
     handler_details = UserSerializer(
         help_text=(

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -188,6 +188,7 @@
         "statusArchive": "Päätös",
         "ahjoStatus": "Päätös",
         "talpaStatus": "Maksun tila",
+        "decisionDate": "Päätöspäivä",
         "benefitAmount": "Tuen määrä",
         "statuses": {
           "cancelled": "Peruutettu",
@@ -213,7 +214,13 @@
           "rejected": "Kielteinen",
           "archival": "Myönteinen"
         },
-        "calculationEndDate": "Viim. tukipäivä"
+        "talpaStatuses": {
+          "not_sent_to_talpa": "Odottaa maksua",
+          "rejected_by_talpa": "Virhe maksussa",
+          "successfully_sent_to_talpa": "Lähetetty maksuun"
+        },
+        "calculationEndDate": "Viim. tukipäivä",
+        "calculatedBenefitAmount": "Tukisumma"
       },
       "messages": {
         "empty": {
@@ -1144,7 +1151,7 @@
         "cancelled": "Hakemus peruttiin",
         "decisionMakerName": "Päättäjä",
         "decisionMakerTitle": "Päättäjän titteli",
-        "decisionDate": "Päätöspäivämäärä",
+        "decisionDate": "Päätöspäivä",
         "sectionOfTheLaw": "Pykälä",
         "p2pTitle": "P2P-tarkastuksen tiedot",
         "p2pInspector": "Tarkastaja, P2P",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -188,6 +188,7 @@
         "statusArchive": "Päätös tai tila",
         "ahjoStatus": "Päätös",
         "talpaStatus": "Maksun tila",
+        "decisionDate": "Päätöspäivä",
         "benefitAmount": "Tuen määrä",
         "statuses": {
           "cancelled": "Peruutettu",
@@ -213,7 +214,13 @@
           "rejected": "Kielteinen",
           "archival": "Myönteinen"
         },
-        "calculationEndDate": "Viim. tukipäivä"
+        "talpaStatuses": {
+          "not_sent_to_talpa": "Odottaa maksua",
+          "rejected_by_talpa": "Virhe maksussa",
+          "successfully_sent_to_talpa": "Lähetetty maksuun"
+        },
+        "calculationEndDate": "Viim. tukipäivä",
+        "calculatedBenefitAmount": "Tukisumma"
       },
       "messages": {
         "empty": {
@@ -1144,7 +1151,7 @@
         "cancelled": "Hakemus peruttiin",
         "decisionMakerName": "Päättäjä",
         "decisionMakerTitle": "Päättäjän titteli",
-        "decisionDate": "Päätöspäivämäärä",
+        "decisionDate": "Päätöspäivä",
         "sectionOfTheLaw": "Pykälä",
         "p2pTitle": "P2P-tarkastuksen tiedot",
         "p2pInspector": "Tarkastaja, P2P",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -188,6 +188,7 @@
         "statusArchive": "Päätös",
         "ahjoStatus": "Päätös",
         "talpaStatus": "Maksun tila",
+        "decisionDate": "Päätöspäivä",
         "benefitAmount": "Tuen määrä",
         "statuses": {
           "cancelled": "Peruutettu",
@@ -213,7 +214,13 @@
           "rejected": "Kielteinen",
           "archival": "Myönteinen"
         },
-        "calculationEndDate": "Viim. tukipäivä"
+        "talpaStatuses": {
+          "not_sent_to_talpa": "Odottaa maksua",
+          "rejected_by_talpa": "Virhe maksussa",
+          "successfully_sent_to_talpa": "Lähetetty maksuun"
+        },
+        "calculationEndDate": "Viim. tukipäivä",
+        "calculatedBenefitAmount": "Tukisumma"
       },
       "messages": {
         "empty": {
@@ -1144,7 +1151,7 @@
         "cancelled": "Hakemus peruttiin",
         "decisionMakerName": "Päättäjä",
         "decisionMakerTitle": "Päättäjän titteli",
-        "decisionDate": "Päätöspäivämäärä",
+        "decisionDate": "Päätöspäivä",
         "sectionOfTheLaw": "Pykälä",
         "p2pTitle": "P2P-tarkastuksen tiedot",
         "p2pInspector": "Tarkastaja, P2P",

--- a/frontend/benefit/handler/src/components/applicationList/HandlerIndex.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/HandlerIndex.tsx
@@ -116,6 +116,11 @@ const HandlerIndex: React.FC<ApplicationListProps> = ({
   const updateTabToUrl = (tabNumber: APPLICATION_LIST_TABS): void =>
     window.history.pushState({ tab }, '', `/?tab=${tabNumber}`);
 
+  const isInPayment = (application: ApplicationListItemData): boolean =>
+    [APPLICATION_STATUSES.ACCEPTED].includes(application.status) &&
+    !isString(application.batch) &&
+    [BATCH_STATUSES.DECIDED_ACCEPTED].includes(application?.batch?.status);
+
   return (
     <FrontPageProvider>
       <$BackgroundWrapper backgroundColor={layoutBackgroundColor}>
@@ -241,14 +246,8 @@ const HandlerIndex: React.FC<ApplicationListProps> = ({
             <Tabs.TabPanel>
               <ApplicationList
                 isLoading={isLoading}
-                list={list.filter(
-                  (app) =>
-                    [APPLICATION_STATUSES.ACCEPTED].includes(app.status) &&
-                    !isString(app.batch) &&
-                    [BATCH_STATUSES.DECIDED_ACCEPTED].includes(
-                      app?.batch?.status
-                    )
-                )}
+                list={list.filter((app) => isInPayment(app))}
+                inPayment={!!list.filter((app) => isInPayment(app))}
                 heading={t(`${translationBase}.inPayment`)}
                 status={[APPLICATION_STATUSES.ACCEPTED]}
               />

--- a/frontend/benefit/handler/src/components/applicationList/useApplicationListData.ts
+++ b/frontend/benefit/handler/src/components/applicationList/useApplicationListData.ts
@@ -11,6 +11,7 @@ import {
   convertToUIDateAndTimeFormat,
   convertToUIDateFormat,
 } from 'shared/utils/date.utils';
+import { formatFloatToCurrency } from 'shared/utils/string.utils';
 
 interface ApplicationListProps {
   list: ApplicationListItemData[];
@@ -73,6 +74,13 @@ const useApplicationListData = (
         handledByAhjoAutomation: handled_by_ahjo_automation,
         handledAt: convertToUIDateFormat(handledAt) || '-',
         ahjoError: camelcaseKeys(ahjo_error, { deep: true }) || null,
+        decisionDate: convertToUIDateFormat(batch?.decision_date) || '-',
+        calculatedBenefitAmount: formatFloatToCurrency(
+          calculation?.calculated_benefit_amount || 0,
+          'EUR',
+          'fi-FI',
+          0
+        ),
       };
     })
     .filter(

--- a/frontend/benefit/handler/src/types/applicationList.d.ts
+++ b/frontend/benefit/handler/src/types/applicationList.d.ts
@@ -9,6 +9,7 @@ export interface ApplicationListTableTransforms {
   status?: APPLICATION_STATUSES;
   applicationOrigin?: APPLICATION_ORIGINS;
   ahjoError: AhjoError;
+  calculatedBenefitAmount?: string;
 }
 
 export interface ApplicationListTableColumns {

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -589,6 +589,8 @@ export type ApplicationListItemData = {
   handledByAhjoAutomation?: boolean;
   alterations?: ApplicationAlterationData[];
   ahjoError?: AhjoError;
+  decisionDate?: string;
+  calculatedBenefitAmount?: string;
 };
 
 export type TextProp = 'textFi' | 'textEn' | 'textSv';


### PR DESCRIPTION
## Description :sparkles:

Add two new columns to application list for applications which are "in payment". That means decision making has progressed to accepted state. application status is `accepted`, batch status is `accepted` and batch has a decision date.

![image](https://github.com/user-attachments/assets/38ae1cf0-2e58-4789-b033-8194c588de8b)

## Testing

1. Get applications to "in payment" state, see up for details.
2. Set application's talpa status to any of `not_sent_to_talpa` `rejected_by_talpa` `successfully_sent_to_talpa`
3. Go to [https://localhost:3100/?tab=5](https://localhost:3100/?tab=5)