### PR TITLE
fix: clone application fixes for attachments and status change (hl-1511)

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -967,7 +967,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
             return
         if (
             pay_subsidy_granted == PaySubsidyGranted.NOT_GRANTED
-            and apprenticeship_program is not None
+            and apprenticeship_program not in [None, False]
         ):
             raise serializers.ValidationError(
                 {

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -1187,7 +1187,7 @@ def test_submit_application_without_de_minimis_aid(
         (PaySubsidyGranted.GRANTED_AGED, False, 200, 200),
         (PaySubsidyGranted.GRANTED_AGED, None, 200, 400),
         (PaySubsidyGranted.NOT_GRANTED, None, 200, 200),
-        (PaySubsidyGranted.NOT_GRANTED, False, 200, 400),
+        (PaySubsidyGranted.NOT_GRANTED, False, 200, 200),
         (PaySubsidyGranted.NOT_GRANTED, True, 200, 400),
     ],
 )


### PR DESCRIPTION
## Description :sparkles:

App would return 404 for cloned application's attachment because the file was written to docker container and Azure blob storage is unaware of the addition. Use a more Django-native way to handle created file as an upload with `InMemoryUploadedFile`.

In addition, fix another issue (BAD_REQUEST 400) when transitioning an application from `received` to `handling` if pay subsidy was `not_granted`.