### PR TITLE
fix: use company.name instead of app.company_name

### DIFF
--- a/backend/benefit/applications/services/ahjo_payload.py
+++ b/backend/benefit/applications/services/ahjo_payload.py
@@ -69,7 +69,7 @@ hakemus {application.application_number}"
 def prepare_final_case_title(application: Application, limit: int = 150) -> str:
     """Prepare the final case title for Ahjo, if the full title is over 150 characters, \
     truncate the company name to fit the limit."""
-    full_case_title = prepare_case_title(application, application.company_name)
+    full_case_title = prepare_case_title(application, application.company.name)
     length_of_full_title = len(full_case_title)
 
     if length_of_full_title <= limit:
@@ -77,7 +77,7 @@ def prepare_final_case_title(application: Application, limit: int = 150) -> str:
     else:
         over_limit = length_of_full_title - limit
         truncated_company_name = truncate_string_to_limit(
-            application.company_name, len(application.company_name) - over_limit
+            application.company.name, len(application.company.name) - over_limit
         )
         return prepare_case_title(application, truncated_company_name)
 

--- a/backend/benefit/applications/services/pdf_templates/benefit_template.html
+++ b/backend/benefit/applications/services/pdf_templates/benefit_template.html
@@ -28,7 +28,7 @@
     %}
     <tr>
         <td>{{ app.ahjo_application_number }}</td>
-        <td>{{ app.company_name }}</td>
+        <td>{{ app.company.name }}</td>
         <td>{{ app.company.business_id }}</td>
         {% if show_employee_names %}
         <td>{{ app.employee.first_name }} {{ app.employee.last_name }}</td>
@@ -58,7 +58,7 @@
     {% else %} {% for ahjo_row in app.ahjo_rows %}
     <tr>
         <td>{{ app.ahjo_application_number }}</td>
-        <td>{{ app.company_name }}</td>
+        <td>{{ app.company.name }}</td>
         <td>{{ app.company.business_id }}</td>
         {% if show_employee_names %}
         <td>{{ app.employee.first_name }} {{ app.employee.last_name }}</td>

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -30,9 +30,9 @@ from common.utils import hash_file
 def test_prepare_case_title(decided_application):
     application = decided_application
     wanted_title = f"Avustukset työnantajille, työllisyyspalvelut, \
-Helsinki-lisä, {application.company_name}, \
+Helsinki-lisä, {application.company.name}, \
 hakemus {application.application_number}"
-    got = prepare_case_title(application, decided_application.company_name)
+    got = prepare_case_title(application, decided_application.company.name)
     assert wanted_title == got
 
 
@@ -68,7 +68,8 @@ def test_prepare_final_case_title_truncate(
     decided_application, company_name, limit, expected_length
 ):
     application = decided_application
-    application.company_name = company_name
+    application.company.name = company_name
+    application.company.save()
     assert len(prepare_final_case_title(application, limit)) <= expected_length
 
 


### PR DESCRIPTION
## Description :sparkles:
[HL-1524](https://helsinkisolutionoffice.atlassian.net/browse/HL-1524)
Use application.company.name instead of application.company_name as the latter is not always present.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1524]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ