### PR TITLE
fix: text improvements & added localizations (Hl-1425 & HL-1486)

### DIFF
--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -1391,7 +1391,7 @@ def test_application_status_change_as_handler(
         if to_status == ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED:
             assert application.messages.count() == 1
             assert (
-                "Please make the corrections by 11.06.2021"
+                "Please make the corrections and send application again by 11.06.2021"
                 in application.messages.first().content
             )
             assert len(mailoutbox) == 1

--- a/backend/benefit/locale/en/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/en/LC_MESSAGES/django.po
@@ -1399,7 +1399,7 @@ msgstr "Swedish"
 
 #, python-brace-format
 msgid ""
-"Your application has been opened for editing. Please make the corrections by "
+"Your application has been opened for editing. Please make the corrections and send application again by "
 "{additional_information_needed_by}, otherwise the application cannot be "
 "processed."
 msgstr ""

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -1441,11 +1441,11 @@ msgstr "Ruotsi"
 
 #, python-brace-format
 msgid ""
-"Your application has been opened for editing. Please make the corrections by "
+"Your application has been opened for editing. Please make the corrections and send application again by "
 "{additional_information_needed_by}, otherwise the application cannot be "
 "processed."
 msgstr ""
-"Hakemuksesi on avattu muokattavaksi. Tee korjaukset viimeistään "
+"Hakemuksesi on avattu muokattavaksi. Tee korjaukset ja lähetä lomake uudelleen viimeistään "
 "{additional_information_needed_by} mennessä, muuten hakemusta ei voida "
 "käsitellä."
 

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -1466,11 +1466,11 @@ msgstr "Svenska"
 
 #, python-brace-format
 msgid ""
-"Your application has been opened for editing. Please make the corrections by "
+"Your application has been opened for editing. Please make the corrections and send application again by "
 "{additional_information_needed_by}, otherwise the application cannot be "
 "processed."
 msgstr ""
-"Din ansökan har öppnats för redigering. Gör ändringarna senast "
+"Din ansökan har öppnats för redigering. Gör ändringarna och skicka ansökan igen senast "
 "{additional_information_needed_by}, annars kan ansökan inte behandlas."
 
 msgid ""

--- a/backend/benefit/messages/automatic_messages.py
+++ b/backend/benefit/messages/automatic_messages.py
@@ -16,7 +16,7 @@ from messages.models import Message, MessageType
 LOGGER = logging.getLogger(__name__)
 
 APPLICATION_REOPENED_MESSAGE = _(
-    "Your application has been opened for editing. Please make the corrections by "
+    "Your application has been opened for editing. Please make the corrections and send application again by "
     "{additional_information_needed_by}, otherwise the application cannot be processed."
 )
 

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -430,7 +430,6 @@
         "accepted": "Hakemus on hyväksytty ja Helsinki-lisää on myönnetty aikavälille {{dateRangeStart}} – {{dateRangeEnd}}",
         "rejected": "Hakemus on hylätty. Helsinki-lisää ei myönnetä.",
         "handling": "Hakemus on käsittelyssä.",
-        "received": "Hakemus on vastaanotettu.",
         "cancelled": "Hakemus on peruttu.",
         "additional_information_needed": "Hakemus on käsittelyssä."
       },

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -430,6 +430,7 @@
         "accepted": "Hakemus on hyväksytty ja Helsinki-lisää on myönnetty aikavälille {{dateRangeStart}} – {{dateRangeEnd}}",
         "rejected": "Hakemus on hylätty. Helsinki-lisää ei myönnetä.",
         "handling": "Hakemus on käsittelyssä.",
+        "received": "Hakemus on vastaanotettu.",
         "cancelled": "Hakemus on peruttu.",
         "additional_information_needed": "Hakemus on käsittelyssä."
       },

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -740,6 +740,7 @@
         "accepted": "Hakemus on hyväksytty ja Helsinki-lisää on myönnetty aikavälille {{dateRangeStart}} – {{dateRangeEnd}}",
         "rejected": "Hakemus on hylätty. Helsinki-lisää ei myönnetä.",
         "handling": "Hakemus on käsittelyssä.",
+        "received": "Hakemus on vastaanotettu.",
         "cancelled": "Hakemus on peruttu.",
         "additional_information_needed": "Hakemus on käsittelyssä."
       },

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1819,6 +1819,21 @@
       },
       "handledByAhjoAutomation": {
         "label": "Käsitelty Ahjo automaatiolla"
+      },
+      "officialCompanyStreetAddress": {
+        "label": "Katuosoite"
+      },
+      "companyName": {
+        "label": "Työantaja"
+      },
+      "officialCompanyPostcode": {
+        "label": "Postinumero"
+      },
+      "officialCompanyCity": {
+        "label": "Postitoimipaikka"
+      },
+      "companyForm": {
+        "label": "Yritysmuoto"
       }
     }
   }

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -740,6 +740,7 @@
         "accepted": "Hakemus on hyväksytty ja Helsinki-lisää on myönnetty aikavälille {{dateRangeStart}} – {{dateRangeEnd}}",
         "rejected": "Hakemus on hylätty. Helsinki-lisää ei myönnetä.",
         "handling": "Hakemus on käsittelyssä.",
+        "received": "Hakemus on vastaanotettu.",
         "cancelled": "Hakemus on peruttu.",
         "additional_information_needed": "Hakemus on käsittelyssä."
       },

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1818,6 +1818,21 @@
       },
       "handledByAhjoAutomation": {
         "label": "Käsitelty Ahjo automaatiolla"
+      },
+      "officialCompanyStreetAddress": {
+        "label": "Katuosoite"
+      },
+      "companyName": {
+        "label": "Työantaja"
+      },
+      "officialCompanyPostcode": {
+        "label": "Postinumero"
+      },
+      "officialCompanyCity": {
+        "label": "Postitoimipaikka"
+      },
+      "companyForm": {
+        "label": "Yritysmuoto"
       }
     }
   }

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -740,6 +740,7 @@
         "accepted": "Hakemus on hyväksytty ja Helsinki-lisää on myönnetty aikavälille {{dateRangeStart}} – {{dateRangeEnd}}",
         "rejected": "Hakemus on hylätty. Helsinki-lisää ei myönnetä.",
         "handling": "Hakemus on käsittelyssä.",
+        "received": "Hakemus on vastaanotettu.",
         "cancelled": "Hakemus on peruttu.",
         "additional_information_needed": "Hakemus on käsittelyssä."
       },

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1819,6 +1819,21 @@
       },
       "handledByAhjoAutomation": {
         "label": "Käsitelty Ahjo automaatiolla"
+      },
+      "officialCompanyStreetAddress": {
+        "label": "Katuosoite"
+      },
+      "companyName": {
+        "label": "Työantaja"
+      },
+      "officialCompanyPostcode": {
+        "label": "Postinumero"
+      },
+      "officialCompanyCity": {
+        "label": "Postitoimipaikka"
+      },
+      "companyForm": {
+        "label": "Yritysmuoto"
       }
     }
   }


### PR DESCRIPTION
## Description :sparkles:
Better text for applicant when application opend for editing. Reminder that a resend is needed.
Added some missing localizations for handler change log.
Added localization for received application status.
However this status is not used in Applicant app, Mistake to add it there (and only in fi-file) corrected.
Text in test updated

## Issues :bug:
HL-1425, HL-1486
