### PR TITLE
feat: don't block ahjo requests if xml build fails

### DIFF
--- a/backend/benefit/applications/services/ahjo_client.py
+++ b/backend/benefit/applications/services/ahjo_client.py
@@ -279,7 +279,7 @@ class AhjoApiClient:
             )
         return None, None
 
-    def handle_http_error(self, e: requests.exceptions.HTTPError) -> Tuple[None, dict]:
+    def handle_http_error(self, e: requests.exceptions.HTTPError) -> None:
         """Handle HTTP errors that occur when sending a request to Ahjo.
         Also log any validation errors received from Ahjo.
         """
@@ -292,13 +292,10 @@ class AhjoApiClient:
         if hasattr(self._request, "application"):
             application_number = self._request.application.application_number
 
-            error_message = f"A HTTP error occurred while sending {self._request} for application \
-    {application_number} to Ahjo: {e}"
+            error_message = self.format_error_message(e, application_number)
 
         else:
-            error_message = (
-                f"A HTTP error occurred while sending {self._request} to Ahjo: {e}"
-            )
+            error_message = self.format_error_message(e)
 
         if error_json:
             error_message += f" Error message: {error_json}"
@@ -307,3 +304,11 @@ class AhjoApiClient:
             status.save()
 
         LOGGER.error(error_message)
+
+    def format_error_message(
+        self,
+        e: Union[requests.exceptions.HTTPError, requests.exceptions.RequestException],
+        application_number: Union[int, None] = None,
+    ) -> str:
+        return f"A HTTP or network error occurred while sending {self.request} for application \
+    {application_number} to Ahjo: {e}"

--- a/backend/benefit/applications/services/ahjo_error_writer.py
+++ b/backend/benefit/applications/services/ahjo_error_writer.py
@@ -1,0 +1,13 @@
+from applications.models import Application
+
+
+class AhjoErrorWriter:
+    @staticmethod
+    def write_error_to_ahjo_status(application: Application, error: str) -> None:
+        latest_ahjo_status = application.ahjo_status.latest()
+        latest_ahjo_status.error_from_ahjo = {
+            "id": "NO_ID",
+            "context": f"{error}",
+            "message": "Ahjo-pyynnössä tapahtui virhe, mutta Ahjo ei palauttanut tarkempia tietoja.",
+        }
+        latest_ahjo_status.save()

--- a/backend/benefit/applications/services/ahjo_xml_builder.py
+++ b/backend/benefit/applications/services/ahjo_xml_builder.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import os
 from dataclasses import dataclass
 from datetime import date
@@ -23,6 +24,8 @@ XML_SCHEMA_PATH = os.path.join(
 SECRET_ATTACHMENT_TEMPLATE = "secret_decision.xml"
 
 AhjoXMLString = str
+
+LOGGER = logging.getLogger(__name__)
 
 
 class AhjoXMLBuilder:
@@ -60,14 +63,20 @@ class AhjoXMLBuilder:
             )  # This will raise an exception if the document is not valid
             return True  # Return True if no exception was raised
         except XMLSchemaParseError as e:
-            print(f"Schema Error: {e}")
+            LOGGER.error(
+                f"Decision proposal XML Schema Error for application {self.application.application_number}: {e}"
+            )
             raise
         except XMLSyntaxError as e:
-            print(f"XML Error: {e}")
+            LOGGER.error(
+                f"Decision proposal XML Syntax Error for application {self.application.application_number}: {e}"
+            )
             raise
         except etree.DocumentInvalid as e:
-            print(f"Validation Error: {e}")
-            return False  # Return False if the document is invalid
+            LOGGER.error(
+                f"Decision proposal Validation Error for application {self.application.application_number}: {e}"
+            )
+        return False  # Return False if the document is invalid
 
 
 class AhjoPublicXMLBuilder(AhjoXMLBuilder):


### PR DESCRIPTION
## Description :sparkles:
[HL-1503](url)
1. Do not block subsequent decision requests if the XML is malformed
2. Add any xml errors to ahjo_status
3. Log the application number with XML error
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1503]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ