### PR TITLE
feat: replace deprecated react-leaflet-markercluster TETP-292

### DIFF
--- a/frontend/tet/shared/src/components/map/Map.tsx
+++ b/frontend/tet/shared/src/components/map/Map.tsx
@@ -7,7 +7,6 @@ import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import MarkerClusterGroup from 'react-leaflet-markercluster';
 import { useTheme } from 'styled-components';
 import {
   $Address,
@@ -19,6 +18,7 @@ import {
 import TetPosting from 'tet-shared/types/tetposting';
 
 import { Icon } from './MapIcon';
+import MarkerClusterGroup from './MarkerClusterGroup';
 
 type Props = {
   postings: TetPosting[];

--- a/frontend/tet/shared/src/components/map/MarkerClusterGroup.tsx
+++ b/frontend/tet/shared/src/components/map/MarkerClusterGroup.tsx
@@ -1,0 +1,33 @@
+import { createPathComponent } from '@react-leaflet/core';
+
+import * as L from 'leaflet';
+
+require('leaflet.markercluster');
+
+const MarkerClusterGroup = createPathComponent(
+  ({ children, ...props }, context) => {
+    const clusterProps = {};
+    const clusterEvents = {};
+
+    Object.entries(props).forEach(([propName, prop]) =>
+      propName.startsWith('on')
+        ? (clusterEvents[propName] = prop)
+        : (clusterProps[propName] = prop)
+    );
+
+    const markerClusterGroup = L.markerClusterGroup(clusterProps);
+
+    Object.entries(clusterEvents).forEach(([eventAsProp, callback]) => {
+      const clusterEvent = `${eventAsProp.substring(2).toLowerCase()}`;
+
+      markerClusterGroup.on(clusterEvent as any, callback as any);
+    });
+
+    return {
+      instance: markerClusterGroup,
+      context: { ...context, layerContainer: markerClusterGroup },
+    };
+  }
+);
+
+export default MarkerClusterGroup;

--- a/frontend/tet/youth/next-env.d.ts
+++ b/frontend/tet/youth/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/frontend/tet/youth/package.json
+++ b/frontend/tet/youth/package.json
@@ -34,7 +34,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^3.2.5",
-    "react-leaflet-markercluster": "^3.0.0-rc1",
     "react-query": "^3.34.0",
     "sharp": "^0.33.0",
     "styled-components": "^5.3.11"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14741,7 +14741,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14758,15 +14758,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -14889,7 +14880,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14902,13 +14893,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -16441,7 +16425,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16454,15 +16438,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description :sparkles:
Removing deprecated react-leaflet-markercluster package.

## Issues :bug:
https://helsinkisolutionoffice.atlassian.net/browse/TETP-292
## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
