### PR TITLE
feat: separate credentials for PowerBI

### DIFF
--- a/backend/benefit/applications/api/v1/power_bi_integration_views.py
+++ b/backend/benefit/applications/api/v1/power_bi_integration_views.py
@@ -12,7 +12,7 @@ from applications.models import Application
 from applications.services.applications_power_bi_csv_report import (
     ApplicationsPowerBiCsvService,
 )
-from common.authentications import RobotBasicAuthentication
+from common.authentications import PowerBiAuthentication
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ class ApplicationPowerBiFilter(filters.FilterSet):
 
 
 class PowerBiIntegrationView(APIView):
-    authentication_classes = [RobotBasicAuthentication]
+    authentication_classes = [PowerBiAuthentication]
     permission_classes = [AllowAny]
     filter_backends = [DjangoFilterBackend]
     filterset_class = ApplicationPowerBiFilter

--- a/backend/benefit/common/authentications.py
+++ b/backend/benefit/common/authentications.py
@@ -38,3 +38,7 @@ class RobotBasicAuthentication(authentication.BaseAuthentication):
 
     def authenticate_header(self, request):
         return 'Basic realm="{}"'.format(self.www_authenticate_realm)
+
+
+class PowerBiAuthentication(RobotBasicAuthentication):
+    credentials = settings.POWER_BI_AUTH_CREDENTIAL


### PR DESCRIPTION
## Description :sparkles:
[HL-1529](https://helsinkisolutionoffice.atlassian.net/browse/HL-1529?atlOrigin=eyJpIjoiYmJjNGZhMWIxZDRmNDcxOGE3MGUzNjZhNzE3Yjc0N2MiLCJwIjoiaiJ9)

PowerBI was using the same authentication class as Talpa Robot, so the credentials were the same, this adds a separate authentication class for PowerBI api.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1529]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ