### PR TITLE
chore: wording 'delete' to 'cancel' if app is not a draft (hl-1469)

### DIFF
--- a/frontend/benefit/applicant/browser-tests/page-model/WizardStep.ts
+++ b/frontend/benefit/applicant/browser-tests/page-model/WizardStep.ts
@@ -24,13 +24,13 @@ class WizardStep extends ApplicantPageComponent {
   });
 
   protected deleteButton = this.component.findByRole('button', {
-    name: this.translations.applications.actions.deleteApplication,
+    name: this.translations.applications.actions.deleteApplication.action,
   });
 
   protected dialogConfirmDeleteButton = this.within(
     this.screen.getByRole('dialog')
   ).findByRole('button', {
-    name: this.translations.applications.actions.deleteApplication,
+    name: this.translations.applications.actions.deleteApplication.action,
   });
 
   public clickSubmit(): Promise<void> {

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -65,9 +65,20 @@
     },
     "actions": {
       "saveAndContinueLater": "Save and close",
-      "deleteApplication": "Delete the application",
-      "deleteApplicationConfirm": "Are you sure you want to delete the draft?",
-      "deleteApplicationDescription": "The application will be permanently deleted and cannot be recovered.",
+      "deleteApplication": {
+        "action": "Delete the application",
+        "confirm": {
+          "title": "Are you sure you want to delete the draft?",
+          "text": "The application will be permanently deleted and cannot be recovered."
+        }
+      },
+      "cancelApplication": {
+        "action": "Cancel the application",
+        "confirm": {
+          "title": "Are you sure you want to cancel the application?",
+          "text": "The application will be cancelled and it cannot be recovered."
+        }
+      },
       "continue": "Continue",
       "send": "Send application",
       "back": "Back",
@@ -589,8 +600,8 @@
       "message": "Helsinki-benefit application {{applicationNumber}} {{applicantName}} has been saved."
     },
     "applicationDeleted": {
-      "label": "Draft deleted",
-      "message": "Application has been deleted. "
+      "label": "Application cancelled",
+      "message": "Application and all it's data has been deleted. "
     },
     "alterationCreated": {
       "title": "Employment status change report sent",

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -65,9 +65,20 @@
     },
     "actions": {
       "saveAndContinueLater": "Tallenna ja sulje",
-      "deleteApplication": "Poista hakemus",
-      "deleteApplicationConfirm": "Haluatko varmasti poistaa luonnoksen?",
-      "deleteApplicationDescription": "Hakemus poistetaan lopullisesti eikä sitä voida enää palauttaa.",
+      "deleteApplication": {
+        "action": "Poista hakemus",
+        "confirm": {
+          "title": "Haluatko varmasti poistaa luonnoksen?",
+          "text": "Hakemus poistetaan lopullisesti eikä sitä voida enää palauttaa."
+        }
+      },
+      "cancelApplication": {
+        "action": "Peruuta hakemus",
+        "confirm": {
+          "title": "Haluatko varmasti peruuttaa hakemuksen?",
+          "text": "Hakemus peruutetaan, eikä sitä voida enää palauttaa."
+        }
+      },
       "continue": "Jatka",
       "send": "Lähetä",
       "back": "Takaisin",
@@ -589,8 +600,8 @@
       "message": "Helsinki-lisä hakemus {{applicationNumber}} {{applicantName}} on tallennettu."
     },
     "applicationDeleted": {
-      "label": "Luonnos poistettu",
-      "message": "Hakemus on poistettu."
+      "label": "Hakemus poistettu",
+      "message": "Hakemus on peruutettu ja sen tiedot on poistettu."
     },
     "alterationCreated": {
       "title": "Työsuhteen muutosilmoitus lähetetty",

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -65,9 +65,20 @@
     },
     "actions": {
       "saveAndContinueLater": "Spara och stäng",
-      "deleteApplication": "Ta bort ansökan",
-      "deleteApplicationConfirm": "Är du säker på att du vill ta bort utkastet?",
-      "deleteApplicationDescription": "Ansökan raderas permanent och den kan inte återställas.",
+      "deleteApplication": {
+        "action": "Ta bort ansökan",
+        "confirm": {
+          "title": "Är du säker på att du vill ta bort utkastet?",
+          "text": "Ansökan raderas permanent och den kan inte återställas."
+        }
+      },
+      "cancelApplication": {
+        "action": "Avbryta ansökan",
+        "confirm": {
+          "title": "Är du säker på att du vill avbryta ansökan?",
+          "text": "Ansökan kommer att avbrytas och den kan inte återställas."
+        }
+      },
       "continue": "Fortsätt",
       "send": "Skicka",
       "back": "Tillbaka",
@@ -589,8 +600,8 @@
       "message": "Helsingforstillägg applikationen {{applicationNumber}} {{applicantName}} sparas."
     },
     "applicationDeleted": {
-      "label": "Utkast raderat",
-      "message": "Ansökan har raderats."
+      "label": "Ansökan har avbrutits",
+      "message": "Ansökan och all information om den har raderats."
     },
     "alterationCreated": {
       "title": "Anmälan om ändring i anställningen har skickats",

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
@@ -322,6 +322,7 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
             : undefined
         }
         handleDelete={data?.id ? handleDelete : null}
+        applicationStatus={data?.status}
       />
     </form>
   );

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -549,6 +549,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
         }
         handleBack={handleBack}
         handleDelete={handleDelete}
+        applicationStatus={data?.status}
       />
     </form>
   );

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step3/ApplicationFormStep3.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step3/ApplicationFormStep3.tsx
@@ -93,6 +93,7 @@ const ApplicationFormStep3: React.FC<DynamicFormStepComponentProps> = ({
         handleSave={handleSave}
         handleBack={handleBack}
         handleDelete={handleDelete}
+        applicationStatus={data?.status}
       />
     </>
   );

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step4/ApplicationFormStep4.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step4/ApplicationFormStep4.tsx
@@ -167,6 +167,7 @@ const ApplicationFormStep4: React.FC<DynamicFormStepComponentProps> = ({
         handleSave={handleSave}
         handleBack={handleBack}
         handleDelete={handleDelete}
+        applicationStatus={data?.status}
       />
     </>
   );

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/ApplicationFormStep5.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/ApplicationFormStep5.tsx
@@ -218,6 +218,7 @@ const ApplicationFormStep5: React.FC<
           handleSubmit={handleSubmit}
           handleBack={handleBack}
           handleDelete={handleDelete}
+          applicationStatus={data?.status}
         />
       )}
     </>

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step6/ApplicationFormStep6.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step6/ApplicationFormStep6.tsx
@@ -94,6 +94,7 @@ const ApplicationFormStep6: React.FC<
         handleSave={handleSave}
         handleBack={handleBack}
         handleDelete={handleDelete}
+        applicationStatus={data?.status}
         lastStep
       />
     </form>

--- a/frontend/benefit/applicant/src/components/applications/forms/application/stepperActions/StepperActions.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/stepperActions/StepperActions.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'benefit/applicant/i18n';
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import {
   Button,
   IconAlertCircleFill,
@@ -22,6 +23,7 @@ type StepperActionsProps = {
   handleDelete?: () => void;
   handleSubmit: () => void;
   handleSave?: () => void;
+  applicationStatus: APPLICATION_STATUSES;
 };
 
 const onClickSave = (e: MouseEvent, handleSave: () => void | false): void => {
@@ -53,10 +55,16 @@ const StepperActions: React.FC<StepperActionsProps> = ({
   handleDelete,
   handleSubmit,
   handleSave,
+  applicationStatus,
 }: StepperActionsProps) => {
   const { t } = useTranslation();
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
   const translationsBase = 'common:applications.actions';
+
+  const cancelModalTranslationsBase =
+    applicationStatus === APPLICATION_STATUSES.DRAFT
+      ? 'deleteApplication'
+      : 'cancelApplication';
 
   return (
     <>
@@ -115,7 +123,7 @@ const StepperActions: React.FC<StepperActionsProps> = ({
               onClick={() => setIsConfirmationModalOpen(true)}
               data-testid="deleteButton"
             >
-              {t(`${translationsBase}.deleteApplication`)}
+              {t(`${translationsBase}.${cancelModalTranslationsBase}.action`)}
             </Button>
           </$GridCell>
         )}
@@ -124,14 +132,18 @@ const StepperActions: React.FC<StepperActionsProps> = ({
         <Modal
           id="StepperActions-confirmDeleteApplicationModal"
           isOpen={isConfirmationModalOpen}
-          title={t(`${translationsBase}.deleteApplicationConfirm`)}
-          submitButtonLabel={t(`${translationsBase}.deleteApplication`)}
+          title={t(
+            `${translationsBase}.${cancelModalTranslationsBase}.confirm.title`
+          )}
+          submitButtonLabel={t(
+            `${translationsBase}.${cancelModalTranslationsBase}.action`
+          )}
           cancelButtonLabel={t(`${translationsBase}.close`)}
           handleToggle={() => setIsConfirmationModalOpen(false)}
           handleSubmit={handleDelete}
           variant="danger"
         >
-          {t(`${translationsBase}.deleteApplicationDescription`)}
+          {t(`${translationsBase}.${cancelModalTranslationsBase}.confirm.text`)}
         </Modal>
       )}
     </>


### PR DESCRIPTION
## Description :sparkles:

Just changes applicant GUI's cancellation button and modal texts to "cancel" rather than "delete" if application has already been sent.