### PR TITLE
feat: add accordion to decision box to list instalments (hl-1497)

### DIFF
--- a/backend/benefit/calculator/api/v1/serializers.py
+++ b/backend/benefit/calculator/api/v1/serializers.py
@@ -71,6 +71,14 @@ class InstalmentSerializer(serializers.ModelSerializer):
             "modified_at",
         ]
 
+    def validate_status(self, status):
+        if status not in InstalmentStatus.values:
+            raise serializers.ValidationError(
+                {"status": f"status must be one of {InstalmentStatus.values}"},
+            )
+
+        return status
+
     status = serializers.ChoiceField(
         validators=[InstalmentStatusValidator()],
         choices=InstalmentStatus.choices,

--- a/backend/benefit/calculator/api/v1/views.py
+++ b/backend/benefit/calculator/api/v1/views.py
@@ -9,6 +9,7 @@ from calculator.api.v1.serializers import (
     InstalmentSerializer,
     PreviousBenefitSerializer,
 )
+from calculator.enums import InstalmentStatus
 from calculator.models import Instalment, PreviousBenefit
 from common.permissions import BFIsHandler
 from shared.audit_log.viewsets import AuditLoggingModelViewSet
@@ -52,5 +53,9 @@ class InstalmentView(APIView):
         )
         if serializer.is_valid():
             serializer.save()
+            if instalment_status == InstalmentStatus.CANCELLED:
+                application = instalment.calculation.application
+                application.archived = True
+                application.save()
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/benefit/calculator/api/v1/views.py
+++ b/backend/benefit/calculator/api/v1/views.py
@@ -46,8 +46,10 @@ class InstalmentView(APIView):
 
     def patch(self, request, instalment_id):
         instalment = get_object_or_404(Instalment, pk=instalment_id)
-
-        serializer = InstalmentSerializer(instalment, data=request.data)
+        instalment_status = request.data["status"]
+        serializer = InstalmentSerializer(
+            instalment, data={"status": instalment_status}, partial=True
+        )
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -224,7 +224,7 @@
           "cancelled": "Peruttu",
           "accepted": "Hyväksytty",
           "waiting": "Odottaa",
-          "completed": "Valmis",
+          "completed": "Maksettu",
           "error_in_talpa": "Virhe maksussa"
         },
         "calculationEndDate": "Viim. tukipäivä",
@@ -831,7 +831,8 @@
         "showDecision": "Tarkastele päätöstä",
         "reportAlteration": "Tee uusi muutosilmoitus"
       },
-      "calculation": "Laskelma"
+      "calculation": "Laskelma",
+      "instalments": "Maksuerät"
     },
     "alterations": {
       "new": {
@@ -1373,7 +1374,11 @@
     "result": {
       "header": "Myönnettävä Helsinki-lisä",
       "header2": "Arvio koostuu seuraavista tiedoista:",
-      "acceptedBenefit": "Myönnettävä Helsinki-lisä"
+      "header3": "Maksuerät",
+      "acceptedBenefit": "Myönnettävä Helsinki-lisä",
+      "firstInstalment": "Ensimmäinen maksuerä",
+      "secondInstalment": "Toinen maksuerä",
+      "total": "Yhteensä"
     },
     "errors": {
       "trainingCompensation": {
@@ -1854,6 +1859,14 @@
       },
       "status": {
         "label": "Tila"
+      }
+    }
+  },
+  "instalments": {
+    "dialog": {
+      "cancelInstalment": {
+        "heading": "Maksuerän peruutus",
+        "text": "Oletko varma, että haluat peruuttaa {{sum}} suuruisen maksuerän hakemukselle {{details}}?"
       }
     }
   }

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -224,7 +224,7 @@
           "cancelled": "Peruttu",
           "accepted": "Hyväksytty",
           "waiting": "Odottaa",
-          "completed": "Valmis",
+          "completed": "Maksettu",
           "error_in_talpa": "Virhe maksussa"
         },
         "calculationEndDate": "Viim. tukipäivä",
@@ -831,7 +831,8 @@
         "showDecision": "Tarkastele päätöstä",
         "reportAlteration": "Tee uusi muutosilmoitus"
       },
-      "calculation": "Laskelma"
+      "calculation": "Laskelma",
+      "instalments": "Maksuerät"
     },
     "alterations": {
       "new": {
@@ -1373,7 +1374,11 @@
     "result": {
       "header": "Myönnettävä Helsinki-lisä",
       "header2": "Arvio koostuu seuraavista tiedoista:",
-      "acceptedBenefit": "Myönnettävä Helsinki-lisä"
+      "header3": "Maksuerät",
+      "acceptedBenefit": "Myönnettävä Helsinki-lisä",
+      "firstInstalment": "Ensimmäinen maksuerä",
+      "secondInstalment": "Toinen maksuerä",
+      "total": "Yhteensä"
     },
     "errors": {
       "trainingCompensation": {
@@ -1853,6 +1858,14 @@
       },
       "status": {
         "label": "Tila"
+      }
+    }
+  },
+  "instalments": {
+    "dialog": {
+      "cancelInstalment": {
+        "heading": "Maksuerän peruutus",
+        "text": "Oletko varma, että haluat peruuttaa {{sum}} suuruisen maksuerän hakemukselle {{details}}?"
       }
     }
   }

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -224,7 +224,7 @@
           "cancelled": "Peruttu",
           "accepted": "Hyväksytty",
           "waiting": "Odottaa",
-          "completed": "Valmis",
+          "completed": "Maksettu",
           "error_in_talpa": "Virhe maksussa"
         },
         "calculationEndDate": "Viim. tukipäivä",
@@ -831,7 +831,8 @@
         "showDecision": "Tarkastele päätöstä",
         "reportAlteration": "Tee uusi muutosilmoitus"
       },
-      "calculation": "Laskelma"
+      "calculation": "Laskelma",
+      "instalments": "Maksuerät"
     },
     "alterations": {
       "new": {
@@ -1373,7 +1374,11 @@
     "result": {
       "header": "Myönnettävä Helsinki-lisä",
       "header2": "Arvio koostuu seuraavista tiedoista:",
-      "acceptedBenefit": "Myönnettävä Helsinki-lisä"
+      "header3": "Maksuerät",
+      "acceptedBenefit": "Myönnettävä Helsinki-lisä",
+      "firstInstalment": "Ensimmäinen maksuerä",
+      "secondInstalment": "Toinen maksuerä",
+      "total": "Yhteensä"
     },
     "errors": {
       "trainingCompensation": {
@@ -1854,6 +1859,14 @@
       },
       "status": {
         "label": "Tila"
+      }
+    }
+  },
+  "instalments": {
+    "dialog": {
+      "cancelInstalment": {
+        "heading": "Maksuerän peruutus",
+        "text": "Oletko varma, että haluat peruuttaa {{sum}} suuruisen maksuerän hakemukselle {{details}}?"
       }
     }
   }

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
@@ -327,6 +327,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
     if (inPayment) {
       cols.push(
         {
+          customSortCompareFunction: sortFinnishDate,
           headerName: getHeader('decisionDate'),
           key: 'decisionDate',
           isSortable: true,

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
@@ -8,6 +8,7 @@ import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import {
   AhjoError,
   ApplicationListItemData,
+  Instalment,
 } from 'benefit-shared/types/application';
 import { IconSpeechbubbleText, Table, Tag, Tooltip } from 'hds-react';
 import * as React from 'react';
@@ -59,18 +60,16 @@ const buildApplicationUrl = (
 
 const getFirstInstalmentTotalAmount = (
   calculatedBenefitAmount: string,
-  pendingInstalmentAmount?: string
+  pendingInstalment?: Instalment
 ): string | JSX.Element => {
   let firstInstalment = parseInt(calculatedBenefitAmount, 10);
-  if (pendingInstalmentAmount) {
-    firstInstalment -= parseInt(pendingInstalmentAmount, 10);
+  if (pendingInstalment) {
+    firstInstalment -= parseInt(String(pendingInstalment?.amount), 10);
   }
-  return pendingInstalmentAmount ? (
+  return pendingInstalment ? (
     <>
-      <strong>
-        {formatFloatToCurrency(firstInstalment, null, 'fi-FI', 0)}
-      </strong>{' '}
-      / {formatFloatToCurrency(calculatedBenefitAmount, 'EUR', 'fi-FI', 0)}
+      {formatFloatToCurrency(firstInstalment, null, 'fi-FI', 0)} /{' '}
+      {formatFloatToCurrency(calculatedBenefitAmount, 'EUR', 'fi-FI', 0)}
     </>
   ) : (
     formatFloatToCurrency(firstInstalment, 'EUR', 'fi-FI', 0)
@@ -348,7 +347,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
           }: ApplicationListTableTransforms) =>
             getFirstInstalmentTotalAmount(
               String(calculatedBenefitAmount),
-              String(pendingInstalment?.amount) || null
+              pendingInstalment || null
             ),
         }
       );

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
@@ -9,7 +9,10 @@ import {
   APPLICATION_STATUSES,
   INSTALMENT_STATUSES,
 } from 'benefit-shared/constants';
-import { ApplicationListItemData } from 'benefit-shared/types/application';
+import {
+  ApplicationListItemData,
+  Instalment,
+} from 'benefit-shared/types/application';
 import {
   Button,
   IconArrowUndo,
@@ -19,6 +22,7 @@ import {
   Table,
   Tag,
 } from 'hds-react';
+import { TFunction } from 'next-i18next';
 import * as React from 'react';
 import LoadingSkeleton from 'react-loading-skeleton';
 import { $Link } from 'shared/components/table/Table.sc';
@@ -63,6 +67,25 @@ const buildApplicationUrl = (
   }
   return applicationUrl;
 };
+
+export const renderInstalmentTagPerStatus = (
+  t: TFunction,
+  pendingInstalment: Instalment
+): JSX.Element => (
+  <$TagWrapper
+    $colors={getInstalmentTagStyleForStatus(
+      pendingInstalment?.status as INSTALMENT_STATUSES
+    )}
+  >
+    <Tag>
+      {t(
+        `common:applications.list.columns.instalmentStatuses.${
+          pendingInstalment?.status as INSTALMENT_STATUSES
+        }`
+      )}
+    </Tag>
+  </$TagWrapper>
+);
 
 const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
   heading,
@@ -128,21 +151,8 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
       },
 
       {
-        transform: ({ pendingInstalment }: ApplicationListTableTransforms) => (
-          <$TagWrapper
-            $colors={getInstalmentTagStyleForStatus(
-              pendingInstalment?.status as INSTALMENT_STATUSES
-            )}
-          >
-            <Tag>
-              {t(
-                `common:applications.list.columns.instalmentStatuses.${
-                  pendingInstalment?.status as INSTALMENT_STATUSES
-                }`
-              )}
-            </Tag>
-          </$TagWrapper>
-        ),
+        transform: ({ pendingInstalment }: ApplicationListTableTransforms) =>
+          renderInstalmentTagPerStatus(t, pendingInstalment),
         headerName: getHeader('paymentStatus'),
         key: 'status',
         isSortable: true,
@@ -153,14 +163,7 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
           pendingInstalment,
         }: ApplicationListTableTransforms) => (
           <>
-            <strong>
-              {formatFloatToCurrency(
-                pendingInstalment?.amount,
-                null,
-                'fi-FI',
-                0
-              )}{' '}
-            </strong>
+            {formatFloatToCurrency(pendingInstalment?.amount, null, 'fi-FI', 0)}{' '}
             /{' '}
             {formatFloatToCurrency(calculatedBenefitAmount, 'EUR', 'fi-FI', 0)}
           </>

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
@@ -18,13 +18,14 @@ import {
   IconArrowUndo,
   IconCheck,
   IconCross,
-  IconDocument,
   Table,
   Tag,
 } from 'hds-react';
+import noop from 'lodash/noop';
 import { TFunction } from 'next-i18next';
 import * as React from 'react';
 import LoadingSkeleton from 'react-loading-skeleton';
+import Modal from 'shared/components/modal/Modal';
 import { $Link } from 'shared/components/table/Table.sc';
 import {
   convertToUIDateFormat,
@@ -33,6 +34,7 @@ import {
 import { formatFloatToCurrency } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
+import ConfirmModalContent from '../applicationReview/actions/ConfirmModalContent/confirm';
 import {
   $Column,
   $Wrapper,
@@ -95,6 +97,8 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
   const { t, translationsBase, getHeader } = useApplicationList();
   const theme = useTheme();
   const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
+  const [isInstalmentCancelModalShown, setIsInstalmentCancelModalShown] =
+    React.useState(false);
   const { mutate: changeInstalmentStatus, isLoading: isLoadingStatusChange } =
     useInstalmentStatusTransition();
 
@@ -202,6 +206,14 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
         app.id === String(selectedApplication?.id)
     )?.pendingInstalment || null;
 
+  const onSubmitCancel = (): void => {
+    changeInstalmentStatus({
+      id: selectedInstalment?.id,
+      status: INSTALMENT_STATUSES.CANCELLED,
+    });
+    setIsInstalmentCancelModalShown(false);
+  };
+
   return (
     <$InstalmentList data-testid="instalment-list">
       {list.length > 0 ? (
@@ -252,12 +264,7 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
                           disabled={isLoading || isLoadingStatusChange}
                           theme="coat"
                           iconLeft={<IconCross />}
-                          onClick={() =>
-                            changeInstalmentStatus({
-                              id: selectedInstalment.id,
-                              status: INSTALMENT_STATUSES.CANCELLED,
-                            })
-                          }
+                          onClick={() => setIsInstalmentCancelModalShown(true)}
                         >
                           {t(`${translationsBase}.actions.cancel`)}
                         </Button>
@@ -283,32 +290,39 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
                           {t(`${translationsBase}.actions.return`)}
                         </Button>
                       )}
-
-                      {[
-                        INSTALMENT_STATUSES.CANCELLED,
-                        INSTALMENT_STATUSES.PAID,
-                      ].includes(
-                        selectedInstalment?.status as INSTALMENT_STATUSES
-                      ) && (
-                        <Button
-                          disabled={isLoading || isLoadingStatusChange}
-                          theme="coat"
-                          iconLeft={<IconDocument />}
-                          onClick={() =>
-                            changeInstalmentStatus({
-                              id: selectedInstalment.id,
-                              status: INSTALMENT_STATUSES.COMPLETED,
-                            })
-                          }
-                        >
-                          {t(`${translationsBase}.actions.finish`)}
-                        </Button>
-                      )}
                     </>
                   )}
               </$Column>
             </$Wrapper>
           </$TableFooter>
+          <Modal
+            id="instalment-cancel-confirm"
+            isOpen={isInstalmentCancelModalShown}
+            submitButtonLabel=""
+            cancelButtonLabel=""
+            handleSubmit={noop}
+            handleToggle={noop}
+            variant="danger"
+            customContent={
+              <ConfirmModalContent
+                variant="danger"
+                heading={t(
+                  'common:instalments.dialog.cancelInstalment.heading'
+                )}
+                text={t('common:instalments.dialog.cancelInstalment.text', {
+                  sum: formatFloatToCurrency(
+                    selectedInstalment?.amount,
+                    'EUR',
+                    'fi-FI',
+                    0
+                  ),
+                  details: `${selectedApplication?.applicationNum}, ${selectedApplication?.companyName} / ${selectedApplication?.employeeName}`,
+                })}
+                onClose={() => setIsInstalmentCancelModalShown(false)}
+                onSubmit={onSubmitCancel}
+              />
+            }
+          />
         </>
       ) : (
         <$EmptyHeading>

--- a/frontend/benefit/handler/src/components/applicationReview/handlingView/DecisionCalculationAccordion.sc.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/handlingView/DecisionCalculationAccordion.sc.ts
@@ -4,7 +4,11 @@ import styled from 'styled-components';
 export const $DecisionCalculatorAccordion = styled.div`
   position: relative;
 
-  div[role="heading"] > div[role="button"] > span.label {
+  &:not(:last-child) {
+    margin-bottom: ${(props) => props.theme.spacing.xs};
+  }
+
+  div[role='heading'] > div[role='button'] > span.label {
     padding-left: ${(props) => props.theme.spacing.xl};
   }
 `;

--- a/frontend/benefit/handler/src/components/applicationReview/handlingView/DecisionCalculationAccordion.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/handlingView/DecisionCalculationAccordion.tsx
@@ -13,16 +13,20 @@ import {
 import {
   CALCULATION_ROW_DESCRIPTION_TYPES,
   CALCULATION_ROW_TYPES,
+  INSTALMENT_STATUSES,
 } from 'benefit-shared/constants';
 import { Application } from 'benefit-shared/types/application';
-import { Accordion, IconGlyphEuro } from 'hds-react';
+import { Accordion, IconBagCogwheel, IconGlyphEuro } from 'hds-react';
+import Link from 'next/link';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $ViewField } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
+import { convertToUIDateFormat } from 'shared/utils/date.utils';
 import { formatFloatToCurrency } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
+import { renderInstalmentTagPerStatus } from '../../applicationList/ApplicationListForInstalments';
 import {
   $CalculatorTableHeader,
   $CalculatorTableRow,
@@ -43,110 +47,200 @@ const DecisionCalculationAccordion: React.FC<Props> = ({ data }) => {
   const sections = groupCalculatorRows(rowsWithoutTotal);
 
   const headingSize = { fontSize: theme.fontSize.heading.l };
+  const secondInstalmentText = data.pendingInstalment ? (
+    <>
+      {' '}
+      {t(`${translationsBase}.secondInstalment`)}{' '}
+      {convertToUIDateFormat(data.pendingInstalment.dueDate)}
+    </>
+  ) : null;
 
   return (
-    <$DecisionCalculatorAccordion>
-      <$DecisionCalculatorAccordionIconContainer aria-hidden="true">
-        <IconGlyphEuro />
-      </$DecisionCalculatorAccordionIconContainer>
-      <Accordion
-        heading={t('common:applications.decision.calculation')}
-        card
-        size="s"
-      >
-        <$GridCell
-          $colSpan={11}
-          style={{
-            padding: theme.spacing.m,
-          }}
+    <>
+      <$DecisionCalculatorAccordion>
+        <$DecisionCalculatorAccordionIconContainer aria-hidden="true">
+          <IconGlyphEuro />
+        </$DecisionCalculatorAccordionIconContainer>
+        <Accordion
+          heading={t('common:applications.decision.calculation')}
+          card
+          size="s"
         >
-          <$CalculatorContainer>
-            {totalRow && (
-              <>
-                <$CalculatorTableHeader css={headingSize}>
-                  {t(`${translationsBase}.header`)}
-                </$CalculatorTableHeader>
-                <SalaryCalculatorHighlight
-                  testId="calculation-results-total"
-                  description={
-                    totalRowDescription
-                      ? totalRowDescription.descriptionFi
-                      : totalRow?.descriptionFi
-                  }
-                  amount={totalRow.amount}
-                />
-                <hr style={{ margin: theme.spacing.s }} />
-              </>
-            )}
-            <$CalculatorTableHeader
-              style={{ paddingBottom: theme.spacing.m }}
-              css={headingSize}
-            >
-              {t(`${translationsBase}.header2`)}
-            </$CalculatorTableHeader>
-            {sections.map((section) => {
-              const firstRowIsMonthSubtotal = [
-                CALCULATION_ROW_TYPES.HELSINKI_BENEFIT_MONTHLY_EUR,
-                CALCULATION_ROW_TYPES.HELSINKI_BENEFIT_SUB_TOTAL_EUR,
-              ].includes(section[0]?.rowType);
+          <$GridCell
+            $colSpan={11}
+            style={{
+              padding: theme.spacing.m,
+            }}
+          >
+            <$CalculatorContainer>
+              {totalRow && (
+                <>
+                  <$CalculatorTableHeader css={headingSize}>
+                    {t(`${translationsBase}.header`)}
+                  </$CalculatorTableHeader>
+                  <SalaryCalculatorHighlight
+                    testId="calculation-results-total"
+                    description={
+                      totalRowDescription
+                        ? totalRowDescription.descriptionFi
+                        : totalRow?.descriptionFi
+                    }
+                    amount={totalRow.amount}
+                  />
+                  <hr style={{ margin: theme.spacing.s }} />
+                </>
+              )}
+              <$CalculatorTableHeader
+                style={{ paddingBottom: theme.spacing.m }}
+                css={headingSize}
+              >
+                {t(`${translationsBase}.header2`)}
+              </$CalculatorTableHeader>
+              {sections.map((section) => {
+                const firstRowIsMonthSubtotal = [
+                  CALCULATION_ROW_TYPES.HELSINKI_BENEFIT_MONTHLY_EUR,
+                  CALCULATION_ROW_TYPES.HELSINKI_BENEFIT_SUB_TOTAL_EUR,
+                ].includes(section[0]?.rowType);
 
-              return (
-                <$Section
-                  key={section[0].id || 'filler'}
-                  className={firstRowIsMonthSubtotal ? 'subtotal' : ''}
-                >
-                  {section.map((row) => {
-                    const isDateRange =
-                      CALCULATION_ROW_DESCRIPTION_TYPES.DATE ===
-                      row.descriptionType;
-                    const isDescriptionRowType =
-                      CALCULATION_ROW_TYPES.DESCRIPTION === row.rowType;
+                return (
+                  <$Section
+                    key={section[0].id || 'filler'}
+                    className={firstRowIsMonthSubtotal ? 'subtotal' : ''}
+                  >
+                    {section.map((row) => {
+                      const isDateRange =
+                        CALCULATION_ROW_DESCRIPTION_TYPES.DATE ===
+                        row.descriptionType;
+                      const isDescriptionRowType =
+                        CALCULATION_ROW_TYPES.DESCRIPTION === row.rowType;
 
-                    const isPerMonth = CALCULATION_PER_MONTH_ROW_TYPES.includes(
-                      row.rowType
-                    );
-                    return (
-                      <div key={row.id}>
-                        {CALCULATION_ROW_TYPES.HELSINKI_BENEFIT_MONTHLY_EUR ===
-                          row.rowType && (
-                          <$CalculatorTableRow>
-                            <$ViewField isBold>
-                              {t(`${translationsBase}.acceptedBenefit`)}
-                            </$ViewField>
-                          </$CalculatorTableRow>
-                        )}
-                        <$CalculatorTableRow
-                          isNewSection={isDateRange}
-                          style={{
-                            marginBottom: '7px',
-                          }}
-                        >
-                          <$ViewField
-                            isBold={isDateRange || isDescriptionRowType}
-                            isBig={isDateRange}
-                          >
-                            {row.descriptionFi}
-                          </$ViewField>
-                          {!isDescriptionRowType && (
-                            <$ViewField
-                              isBold
-                              style={{ marginRight: theme.spacing.xl4 }}
-                            >
-                              {formatFloatToCurrency(row.amount)}
-                              {isPerMonth && t('common:utility.perMonth')}
-                            </$ViewField>
+                      const isPerMonth =
+                        CALCULATION_PER_MONTH_ROW_TYPES.includes(row.rowType);
+                      return (
+                        <div key={row.id}>
+                          {CALCULATION_ROW_TYPES.HELSINKI_BENEFIT_MONTHLY_EUR ===
+                            row.rowType && (
+                            <$CalculatorTableRow>
+                              <$ViewField isBold>
+                                {t(`${translationsBase}.acceptedBenefit`)}
+                              </$ViewField>
+                            </$CalculatorTableRow>
                           )}
-                        </$CalculatorTableRow>
-                      </div>
-                    );
-                  })}
+                          <$CalculatorTableRow
+                            isNewSection={isDateRange}
+                            style={{
+                              marginBottom: '7px',
+                            }}
+                          >
+                            <$ViewField
+                              isBold={isDateRange || isDescriptionRowType}
+                              isBig={isDateRange}
+                            >
+                              {row.descriptionFi}
+                            </$ViewField>
+                            {!isDescriptionRowType && (
+                              <$ViewField
+                                isBold
+                                style={{ marginRight: theme.spacing.xl4 }}
+                              >
+                                {formatFloatToCurrency(row.amount)}
+                                {isPerMonth && t('common:utility.perMonth')}
+                              </$ViewField>
+                            )}
+                          </$CalculatorTableRow>
+                        </div>
+                      );
+                    })}
+                  </$Section>
+                );
+              })}
+            </$CalculatorContainer>
+          </$GridCell>
+        </Accordion>
+      </$DecisionCalculatorAccordion>
+      {data.pendingInstalment && (
+        <$DecisionCalculatorAccordion>
+          <$DecisionCalculatorAccordionIconContainer aria-hidden="true">
+            <IconBagCogwheel />
+          </$DecisionCalculatorAccordionIconContainer>
+          <Accordion
+            heading={t('common:applications.decision.instalments')}
+            card
+            size="s"
+          >
+            <$GridCell
+              $colSpan={11}
+              style={{
+                padding: theme.spacing.m,
+              }}
+            >
+              <$CalculatorContainer>
+                <$Section className="">
+                  <$CalculatorTableRow>
+                    <$ViewField>
+                      {t(`${translationsBase}.firstInstalment`)}
+                    </$ViewField>
+                    {formatFloatToCurrency(
+                      data.calculatedBenefitAmount -
+                        data.pendingInstalment.amount,
+                      'EUR',
+                      'fi-FI',
+                      0
+                    )}{' '}
+                  </$CalculatorTableRow>
                 </$Section>
-              );
-            })}
-          </$CalculatorContainer>
-        </$GridCell>
-      </Accordion>
-    </$DecisionCalculatorAccordion>
+                <$Section className="">
+                  <$CalculatorTableRow>
+                    <$ViewField>
+                      {[
+                        INSTALMENT_STATUSES.WAITING,
+                        INSTALMENT_STATUSES.ERROR_IN_TALPA,
+                        INSTALMENT_STATUSES.CANCELLED,
+                        INSTALMENT_STATUSES.ACCEPTED,
+                      ].includes(
+                        data.pendingInstalment.status as INSTALMENT_STATUSES
+                      ) ? (
+                        <Link href="/?tab=6">{secondInstalmentText}</Link>
+                      ) : (
+                        secondInstalmentText
+                      )}
+                    </$ViewField>
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 'var(--spacing-xs)',
+                      }}
+                    >
+                      {renderInstalmentTagPerStatus(t, data.pendingInstalment)}
+                      {formatFloatToCurrency(
+                        data.pendingInstalment.amount,
+                        'EUR',
+                        'fi-FI',
+                        0
+                      )}
+                    </div>
+                  </$CalculatorTableRow>
+                </$Section>
+                <$Section className="subtotal">
+                  <$CalculatorTableRow>
+                    <$ViewField isBold isBig>
+                      {t(`${translationsBase}.total`)}
+                    </$ViewField>
+                    {formatFloatToCurrency(
+                      data.calculatedBenefitAmount,
+                      'EUR',
+                      'fi-FI',
+                      0
+                    )}
+                  </$CalculatorTableRow>
+                </$Section>
+              </$CalculatorContainer>
+            </$GridCell>
+          </Accordion>
+        </$DecisionCalculatorAccordion>
+      )}
+    </>
   );
 };
 

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -323,6 +323,7 @@ export type Application = {
   ahjoStatus?: string;
   handledByAhjoAutomation?: boolean;
   batchStatus?: BATCH_STATUSES;
+  pendingInstalment?: Instalment;
 } & Step1 &
   Step2;
 
@@ -419,10 +420,18 @@ export type PaySubsidyData = {
   duration_in_months_rounded: string;
 };
 
+export type InstalmentData = {
+  id: string;
+  instalment_number: number;
+  amount: number;
+  due_date: string;
+  status: INSTALMENT_STATUSES;
+};
+
 export type Instalment = {
   id: string;
   instalmentNumber: number;
-  amount: string;
+  amount: number;
   dueDate: string;
   status: INSTALMENT_STATUSES;
 };
@@ -499,7 +508,7 @@ export type ApplicationData = {
   handled_by_ahjo_automation?: boolean;
   alterations: ApplicationAlterationData[];
   ahjo_error?: AhjoErrorData;
-  pending_instalment?: Instalment;
+  pending_instalment?: InstalmentData;
 };
 
 export type EmployeeData = {


### PR DESCRIPTION
## Description :sparkles:

Continued from #3498. 

* Implement "Instalments" accordion into decision box
  * Lists both instalments: the default one and the second too.
* Add `status` validation to `InstalmentSerializer`
* Make instalment patch endpoint change application to `archived` if second instalment is cancelled
* Cancelling 2nd instalment from `ApplicationListForInstalments` now uses popup
* Other minor details changed for `ApplicationListForInstalments`
