### PR TITLE
feat: use own endpoint for requesting more information

### DIFF
--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -848,6 +848,25 @@ class HandlerApplicationViewSet(BaseApplicationViewSet):
             status=status.HTTP_201_CREATED,
         )
 
+    @action(methods=["PATCH"], detail=True, url_path="require_additional_information")
+    @transaction.atomic
+    def require_additional_information(self, request, pk) -> HttpResponse:
+        application = self.get_object()
+        application_status = request.data["status"]
+        if application_status in [
+            ApplicationStatus.ADDITIONAL_INFORMATION_NEEDED,
+            ApplicationStatus.HANDLING,
+        ]:
+            application.status = application_status
+            application.save()
+
+            return Response(
+                status=status.HTTP_200_OK,
+            )
+        return Response(
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
     def _create_application_batch(self, status) -> QuerySet[Application]:
         """
         Create a new application batch out of the existing applications in the given status

--- a/frontend/benefit/handler/src/components/applicationReview/actions/editAction/EditAction.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/editAction/EditAction.tsx
@@ -1,5 +1,4 @@
-import { APPLICATION_ACTIONS } from 'benefit/handler/constants';
-import { useApplicationActions } from 'benefit/handler/hooks/useApplicationActions';
+import useRequireAdditionalInformation from 'benefit/handler/hooks/useRequireAdditionalInformation';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { Application } from 'benefit-shared/types/application';
 import { Button, IconLock, IconPen } from 'hds-react';
@@ -13,22 +12,20 @@ export type Props = {
 const EditAction: React.FC<Props> = ({ application }) => {
   const translationsBase = 'common:review.actions';
   const { t } = useTranslation();
-  const { updateStatus } = useApplicationActions(
-    application,
-    APPLICATION_ACTIONS.HANDLER_ALLOW_APPLICATION_EDIT
-  );
 
-  const [isUpdatingApplication, setIsUpdatingApplication] =
-    React.useState(false);
+  const {
+    mutate: requireAdditionalInformation,
+    isLoading: isUpdatingApplication,
+  } = useRequireAdditionalInformation();
 
-  const updateApplicationStatus = (status: APPLICATION_STATUSES): void => {
-    setIsUpdatingApplication(true);
-    updateStatus(status);
+  const updateApplicationStatus = (
+    status: APPLICATION_STATUSES.INFO_REQUIRED | APPLICATION_STATUSES.HANDLING
+  ): void => {
+    requireAdditionalInformation({
+      id: application.id,
+      status,
+    });
   };
-
-  React.useEffect(() => {
-    setIsUpdatingApplication(false);
-  }, [application.status]);
 
   return (
     <>
@@ -41,6 +38,7 @@ const EditAction: React.FC<Props> = ({ application }) => {
           variant="secondary"
           size="small"
           iconLeft={<IconPen />}
+          loadingText={t(`${translationsBase}.handlingToInfoRequired`)}
           isLoading={isUpdatingApplication}
         >
           {t(`${translationsBase}.handlingToInfoRequired`)}
@@ -53,6 +51,7 @@ const EditAction: React.FC<Props> = ({ application }) => {
           variant="secondary"
           size="small"
           iconLeft={<IconLock />}
+          loadingText={t(`${translationsBase}.infoRequiredToHandling`)}
           isLoading={isUpdatingApplication}
         >
           {t(`${translationsBase}.infoRequiredToHandling`)}

--- a/frontend/benefit/handler/src/hooks/useRequireAdditionalInformation.ts
+++ b/frontend/benefit/handler/src/hooks/useRequireAdditionalInformation.ts
@@ -1,0 +1,49 @@
+import { AxiosError } from 'axios';
+import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
+import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+type Payload = {
+  id: string;
+  status: APPLICATION_STATUSES.INFO_REQUIRED | APPLICATION_STATUSES.HANDLING;
+};
+
+const useRequireAdditionalInformation = (): UseMutationResult<
+  null,
+  Error,
+  Payload
+> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation<null, Error, Payload>(
+    'require_additional_information',
+    ({ id, status }: Payload) =>
+      handleResponse(
+        axios.patch(
+          `${HandlerEndpoint.HANDLER_REQUIRE_ADDITIONAL_INFORMATION(id)}`,
+          { status }
+        )
+      ),
+    {
+      onSuccess: () => {
+        void queryClient.invalidateQueries('application');
+        void queryClient.invalidateQueries('applications');
+      },
+      onError: (error: AxiosError<Error, Record<string, string[]>>) => {
+        showErrorToast(
+          t('common:error.generic.label'),
+          t('common:error.generic.text')
+        );
+        // eslint-disable-next-line no-console
+        console.log(error);
+      },
+    }
+  );
+};
+
+export default useRequireAdditionalInformation;

--- a/frontend/benefit/shared/src/backend-api/backend-api.ts
+++ b/frontend/benefit/shared/src/backend-api/backend-api.ts
@@ -54,6 +54,8 @@ export const HandlerEndpoint = {
     `${BackendEndpoint.HANDLER_APPLICATIONS}batch_p2p_file?batch_id=${id}`,
   HANDLER_APPLICATIONS_CLONE_AS_DRAFT: (id: string) =>
     `${handlerApplicationsBase(id)}clone_as_draft/`,
+  HANDLER_REQUIRE_ADDITIONAL_INFORMATION: (id: string) =>
+    `${handlerApplicationsBase(id)}require_additional_information/`,
   HANDLER_INSTALMENT_STATUS_TRANSITION: (id: string) =>
     `${handlerInstalmentBase(id)}`,
 } as const;


### PR DESCRIPTION
## Description :sparkles:

Fix a issue that could lead to big trouble. Changing the application status would always send the whole application as POST which could lead to data loss if there were changes done in between application load.

Instead of POSTing everything to the update endpoint, make a new endpoint that will only change the status as appropriate.