### PR TITLE
feat: don't create new status on retry, save error

### DIFF
--- a/backend/benefit/applications/services/ahjo_error_writer.py
+++ b/backend/benefit/applications/services/ahjo_error_writer.py
@@ -11,3 +11,11 @@ class AhjoErrorWriter:
             "message": "Ahjo-pyynnössä tapahtui virhe, mutta Ahjo ei palauttanut tarkempia tietoja.",
         }
         latest_ahjo_status.save()
+
+    @staticmethod
+    def write_to_validation_error(application: Application, error_message: str) -> None:
+        """Write the error message to the Ahjo status of the application."""
+
+        status = application.ahjo_status.latest()
+        status.validation_error_from_ahjo = error_message
+        status.save()

--- a/backend/benefit/applications/tests/test_ahjo_requests.py
+++ b/backend/benefit/applications/tests/test_ahjo_requests.py
@@ -267,7 +267,7 @@ def test_ahjo_application_requests(
             AhjoDecisionDetailsRequest,
             AhjoRequestType.GET_DECISION_DETAILS,
             "GET",
-            AhjoStatusEnum.DETAILS_RECEIVED_FROM_AHJO,
+            AhjoStatusEnum.DECISION_DETAILS_REQUEST_SENT,
         ),
     ],
 )
@@ -324,10 +324,12 @@ def test_requests_exceptions(
         )
         client.send_request_to_ahjo()
         mock_logger.error.assert_called()
-        assert (
-            application.ahjo_status.latest().validation_error_from_ahjo
-            == validation_error
-        )
+        ahjo_status = application.ahjo_status.latest()
+        assert ahjo_status.status == previous_status
+        assert ahjo_status.validation_error_from_ahjo is not None
+
+        for validation_error in validation_error:
+            assert f"{validation_error}" in ahjo_status.validation_error_from_ahjo
 
     exception = requests.exceptions.RequestException
     with requests_mock.Mocker() as m:


### PR DESCRIPTION
## Description :sparkles:
[HL-1514](https://helsinkisolutionoffice.atlassian.net/browse/HL-1514)
Do not create a new ahjoStatus every time a request to ahjo is attempted, but update the last one.

[HL-1515](https://helsinkisolutionoffice.atlassian.net/browse/HL-1515?atlOrigin=eyJpIjoiZmYzYWRiY2ExYTVmNGRkYTlhMmQxNWQwNGFlOTQzZWEiLCJwIjoiaiJ9)
Write possible network errors to the ahjoStatus.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1514]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HL-1515]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ