### PR TITLE
Hl 1533 ahjo title

### DIFF
--- a/backend/benefit/applications/services/ahjo_payload.py
+++ b/backend/benefit/applications/services/ahjo_payload.py
@@ -78,17 +78,17 @@ class UpdateRecordsRecordTitle(AhjoTitle):
     A class for creating the title of an update record.
 
     Inherits from AhjoTitle. Uses the application's modification date and application number to format the title.
-    The prefix is set to ", täydennys," by default.
+    The prefix is set to ", täydennys" by default.
 
     Attributes:
-        prefix (str): A default string ", täydennys," that is used in the title of update records.
+        prefix (str): A default string ", täydennys" that is used in the title of update records.
         attachment_created_at (datetime): The created_at date of the attachment that is being updated to Ahjo.
 
     Methods:
         __str__(): Returns the formatted string representation of the update record title.
     """
 
-    prefix: str = field(default=", täydennys,")
+    prefix: str = field(default=", täydennys")
     attachment_created_at: datetime = None
 
     def __str__(self):
@@ -121,7 +121,7 @@ class AddRecordsRecordTitle(AhjoTitle):
         __str__(): Returns the formatted string representation of the additional record title.
     """
 
-    prefix: str = field(default=", täydennys,")
+    prefix: str = field(default=", täydennys")
     attachment_created_at: datetime = None
 
     def __str__(self):

--- a/backend/benefit/applications/tests/conftest.py
+++ b/backend/benefit/applications/tests/conftest.py
@@ -425,13 +425,13 @@ def ahjo_open_case_top_level_dict(decided_application):
     handler = application.calculation.handler
 
     return {
-        "Title": "message title",
+        "Title": "a" * 512,
         "Acquired": application.created_at.isoformat(),
         "ClassificationCode": "02 05 01 00",
         "ClassificationTitle": "Kunnan myöntämät avustukset",
         "Language": language,
         "PublicityClass": "Julkinen",
-        "InternalTitle": "message title",
+        "InternalTitle": "a" * 150,
         "Subjects": [
             {"Subject": "Helsinki-lisät", "Scheme": "hki-yhpa"},
             {"Subject": "kunnan myöntämät avustukset", "Scheme": "hki-yhpa"},

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -141,6 +141,8 @@ def test_truncate_string_to_limit(
         ("a" * 100, 100, 150),
         ("a" * 50, 100, 150),
         ("1234567890AB", 10, 150),
+        # 256 characters is the maximun length for the company name in the database
+        ("a" * 256, 512, 512),
     ],
 )
 def test_prepare_final_case_title_truncate(
@@ -370,8 +372,12 @@ def test_prepare_case_records(decided_application, settings):
 
 def test_prepare_top_level_dict(decided_application, ahjo_open_case_top_level_dict):
     application = Application.objects.get(pk=decided_application.pk)
+    long_title = "a" * 512
+    short_title = "a" * 150
 
-    got = _prepare_top_level_dict(application, [], "message title")
+    got = _prepare_top_level_dict(
+        application, [], public_case_title=long_title, internal_case_title=short_title
+    )
 
     assert ahjo_open_case_top_level_dict == got
 

--- a/backend/benefit/applications/tests/test_ahjo_payload.py
+++ b/backend/benefit/applications/tests/test_ahjo_payload.py
@@ -75,7 +75,7 @@ def test_update_records_record_title_str():
         application=mock_app, attachment_created_at=attachment_created_at
     )
     result = str(update_records_title)
-    expected = f"{AhjoRecordTitle.APPLICATION}, täydennys, 25.02.2023, 67890"
+    expected = f"{AhjoRecordTitle.APPLICATION}, täydennys 25.02.2023, 67890"
     assert result == expected
 
 
@@ -90,7 +90,7 @@ def test_add_records_record_title_str():
         application=mock_app, attachment_created_at=attachment_created_at
     )
     result = str(add_records_title)
-    expected = f"{AhjoRecordTitle.APPLICATION}, täydennys, 10.03.2023, 54321"
+    expected = f"{AhjoRecordTitle.APPLICATION}, täydennys 10.03.2023, 54321"
     assert result == expected
 
 
@@ -169,7 +169,7 @@ def test_prepare_final_case_title_truncate(
             AhjoRecordTitle.APPLICATION,
             AhjoRecordType.APPLICATION,
             AhjoRequestType.UPDATE_APPLICATION,
-            ", täydennys,",
+            ", täydennys",
             0,
             0,
         ),
@@ -178,7 +178,7 @@ def test_prepare_final_case_title_truncate(
             AhjoRecordTitle.APPLICATION,
             AhjoRecordType.ATTACHMENT,
             AhjoRequestType.ADD_RECORDS,
-            ", täydennys,",
+            ", täydennys",
             0,
             0,
         ),


### PR DESCRIPTION
## Description :sparkles:
[HL-1546](https://helsinkisolutionoffice.atlassian.net/browse/HL-1546)
Remove comma after the word "täydennys".
[HL-1533](https://helsinkisolutionoffice.atlassian.net/browse/HL-1533)
Public title in the  Ahjo open case request can be 512 characters long.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1546]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-1533]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ