### PR TITLE
feat: add two calculation and application fields as notes (hl-1550)

### DIFF
--- a/backend/benefit/locale/en/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/en/LC_MESSAGES/django.po
@@ -1460,6 +1460,12 @@ msgstr ""
 msgid "Handler is not allowed to do this action"
 msgstr ""
 
+msgid "Handling comment"
+msgstr ""
+
+msgid "Manual calculation comment"
+msgstr ""
+
 msgid "Only the terms currently in effect can be approved"
 msgstr ""
 

--- a/backend/benefit/locale/fi/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/fi/LC_MESSAGES/django.po
@@ -1508,6 +1508,12 @@ msgstr "Hakija ei saa tehdä tätä toimenpidettä"
 msgid "Handler is not allowed to do this action"
 msgstr "Käsittelijä ei saa tehdä tätä toimenpidettä"
 
+msgid "Handling comment"
+msgstr "Käsittelyn perustelu"
+
+msgid "Manual calculation comment"
+msgstr "Manuaalisen laskelman perustelu"
+
 msgid "Only the terms currently in effect can be approved"
 msgstr "Vain voimassa olevat ehdot voidaan hyväksyä"
 

--- a/backend/benefit/locale/sv/LC_MESSAGES/django.po
+++ b/backend/benefit/locale/sv/LC_MESSAGES/django.po
@@ -1532,6 +1532,12 @@ msgstr "Sökande får inte utföra denna åtgärd"
 msgid "Handler is not allowed to do this action"
 msgstr "Handläggare får inte utföra denna åtgärd"
 
+msgid "Handling comment"
+msgstr ""
+
+msgid "Manual calculation comment"
+msgstr ""
+
 msgid "Only the terms currently in effect can be approved"
 msgstr "Endast de villkor som för tillfället gäller kan godkännas"
 

--- a/backend/benefit/messages/tests/test_api.py
+++ b/backend/benefit/messages/tests/test_api.py
@@ -408,7 +408,10 @@ def test_update_message_unauthorized(
                 "message_type": msg_type,
             },
         )
-        assert result.status_code == 403
+
+        assert (
+            result.status_code == 403 if view_name == "handler-message-detail" else 404
+        )
 
 
 def test_update_message_not_allowed(

--- a/backend/benefit/users/api/v1/views.py
+++ b/backend/benefit/users/api/v1/views.py
@@ -49,11 +49,7 @@ class UserOptionsView(APIView):
         lang = request.GET.get("lang")
 
         if lang in ["fi", "en", "sv"]:
-            token = request.COOKIES.get("yjdhcsrftoken")
-
-            response = Response(
-                {"lang": lang, "token": token}, status=status.HTTP_200_OK
-            )
+            response = Response({"lang": lang}, status=status.HTTP_200_OK)
             response.set_cookie(settings.LANGUAGE_COOKIE_NAME, lang, httponly=True)
             return response
 

--- a/frontend/benefit/handler/src/components/header/useHeader.tsx
+++ b/frontend/benefit/handler/src/components/header/useHeader.tsx
@@ -1,13 +1,27 @@
+import axios from 'axios';
 import NumberTag from 'benefit/handler/components/header/NumberTag';
-import { ROUTES } from 'benefit/handler/constants';
+import { ROUTES, SUPPORTED_LANGUAGES } from 'benefit/handler/constants';
 import AppContext from 'benefit/handler/context/AppContext';
 import useApplicationAlterationsQuery from 'benefit/handler/hooks/useApplicationAlterationsQuery';
 import { useDetermineAhjoMode } from 'benefit/handler/hooks/useDetermineAhjoMode';
+import {
+  BackendEndpoint,
+  getBackendDomain,
+} from 'benefit-shared/backend-api/backend-api';
 import { useRouter } from 'next/router';
 import { TFunction, useTranslation } from 'next-i18next';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { NavigationItem, OptionType } from 'shared/types/common';
 import { getLanguageOptions } from 'shared/utils/common';
+
+const setLanguageToFinnish = (): void => {
+  const optionsEndpoint = `${getBackendDomain()}/${
+    BackendEndpoint.USER_OPTIONS
+  }`;
+  void axios.get(optionsEndpoint, {
+    params: { lang: SUPPORTED_LANGUAGES.FI },
+  });
+};
 
 type ExtendedComponentProps = {
   t: TFunction;
@@ -32,6 +46,8 @@ const useHeader = (): ExtendedComponentProps => {
     (): OptionType<string>[] => getLanguageOptions(t, 'supportedLanguages'),
     [t]
   );
+
+  useEffect(setLanguageToFinnish, []);
 
   const { data: alterationData, isLoading: isAlterationListLoading } =
     useApplicationAlterationsQuery();


### PR DESCRIPTION
## Description :sparkles:

Override default `GET / list()` endpoint and add rejected application comment and calculation comment as notes.

* Include manual calculation comment into notes (`calculation.override_manual_benefit_amount_comment`)
* Include accepted/rejected comment into notes (`log_entry` with transition to `rejected` or `accepted`)
* Send handler language preference to backend so that correct django translations are loaded
  * force Finnish for now

![image](https://github.com/user-attachments/assets/3a842fd7-6870-406a-a2d9-6db9b91256c4)
