### PR TITLE
refactor: harmonise float to currency conversions (hl-1506)

### DIFF
--- a/frontend/benefit/applicant/browser-tests/utils/fieldMaps.ts
+++ b/frontend/benefit/applicant/browser-tests/utils/fieldMaps.ts
@@ -9,13 +9,13 @@ export type ApplicationField = {
 
 const formatFloatToCurrency = (
   value: string | number,
-  currency: 'EUR' | null,
+  currency: 'EUR' | null = 'EUR',
   locale = 'fi-FI'
 ): string => {
   const parsedValue = typeof value === 'string' ? parseFloat(value) : value;
   const currencyOptions = currency
     ? {
-        style: 'currency',
+        style: 'currency' as const,
         currency,
       }
     : {};
@@ -72,15 +72,15 @@ export const mapRequiredForm = (
   },
   {
     testId: 'application-field-monthlyPay',
-    value: formatFloatToCurrency(form.employee.monthlyPay, 'EUR'),
+    value: formatFloatToCurrency(form.employee.monthlyPay),
   },
   {
     testId: 'application-field-vacationMoney',
-    value: formatFloatToCurrency(form.employee.vacationMoney, 'EUR'),
+    value: formatFloatToCurrency(form.employee.vacationMoney),
   },
   {
     testId: 'application-field-otherExpenses',
-    value: formatFloatToCurrency(form.employee.otherExpenses, 'EUR'),
+    value: formatFloatToCurrency(form.employee.otherExpenses),
   },
   { testId: 'application-field-paySubsidyGranted', value: 'Palkkatuki' },
   { testId: 'application-field-apprenticeshipProgram', value: null },

--- a/frontend/benefit/applicant/src/components/applications/alteration/AlterationAccordionItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/alteration/AlterationAccordionItem.tsx
@@ -4,9 +4,7 @@ import useDeleteApplicationAlterationQuery from 'benefit/applicant/hooks/useDele
 import useLocale from 'benefit/applicant/hooks/useLocale';
 import { useTranslation } from 'benefit/applicant/i18n';
 import { ALTERATION_STATE, ALTERATION_TYPE } from 'benefit-shared/constants';
-import {
-  AlterationAccordionItemProps,
-} from 'benefit-shared/types/application';
+import { AlterationAccordionItemProps } from 'benefit-shared/types/application';
 import { prettyPrintObject } from 'benefit-shared/utils/errors';
 import camelcaseKeys from 'camelcase-keys';
 import { Button, IconTrash } from 'hds-react';
@@ -17,7 +15,7 @@ import {
 } from 'shared/components/forms/section/FormSection.sc';
 import hdsToast from 'shared/components/toast/Toast';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 const AlterationAccordionItem = ({
   alteration,
@@ -107,7 +105,7 @@ const AlterationAccordionItem = ({
                   'common:applications.decision.alterationList.item.recoveryAmount'
                 )}
               </dt>
-              <dd>{formatFloatToCurrency(alteration.recoveryAmount)}</dd>
+              <dd>{formatFloatToEvenEuros(alteration.recoveryAmount)}</dd>
             </$GridCell>
             <$GridCell $colSpan={6}>
               <dt>

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
@@ -234,7 +234,7 @@ const CompanyInfoView: React.FC<CompanyInfoViewProps> = ({
                 </$GridCell>
                 <$GridCell $colSpan={2}>
                   <$SummaryTableValue data-testid="application-field-deMinimisAidsAmount">
-                    {formatFloatToCurrency(aid.amount, 'EUR')}
+                    {formatFloatToCurrency(aid.amount)}
                   </$SummaryTableValue>
                 </$GridCell>
                 <$GridCell>

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/employeeView/EmployeeView.tsx
@@ -178,7 +178,7 @@ const EmployeeView: React.FC<EmployeeViewProps> = ({
                   {t(`${translationsBase}.employee.fields.monthlyPay.label`)}
                 </$ApplicationDetailLabel>
                 <$ApplicationDetailValue>
-                  {formatFloatToCurrency(data.employee?.monthlyPay, 'EUR')}
+                  {formatFloatToCurrency(data.employee?.monthlyPay)}
                 </$ApplicationDetailValue>
               </$ApplicationDetailRow>
 
@@ -187,7 +187,7 @@ const EmployeeView: React.FC<EmployeeViewProps> = ({
                   {t(`${translationsBase}.employee.fields.vacationMoney.label`)}
                 </$ApplicationDetailLabel>
                 <$ApplicationDetailValue>
-                  {formatFloatToCurrency(data.employee?.vacationMoney, 'EUR')}
+                  {formatFloatToCurrency(data.employee?.vacationMoney)}
                 </$ApplicationDetailValue>
               </$ApplicationDetailRow>
               <$ApplicationDetailRow data-testid="application-field-otherExpenses">
@@ -196,7 +196,7 @@ const EmployeeView: React.FC<EmployeeViewProps> = ({
                 </$ApplicationDetailLabel>
 
                 <$ApplicationDetailValue>
-                  {formatFloatToCurrency(data.employee?.otherExpenses, 'EUR')}
+                  {formatFloatToCurrency(data.employee?.otherExpenses)}
                 </$ApplicationDetailValue>
               </$ApplicationDetailRow>
               {data.paySubsidyGranted && (

--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -42,7 +42,7 @@ import {
   convertToUIDateAndTimeFormat,
   convertToUIDateFormat,
 } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
 import ErrorPage from '../../errorPage/ErrorPage';
@@ -105,7 +105,7 @@ const PageContent: React.FC = () => {
         key: 'status',
       },
       {
-        accessor: (app) => formatFloatToCurrency(app?.calculatedBenefitAmount),
+        accessor: (app) => formatFloatToEvenEuros(app?.calculatedBenefitAmount),
         key: 'benefitAmount',
         showIf: () => showMonetaryFields,
       },

--- a/frontend/benefit/handler/browser-tests/pages/7-handle-alteration.testcafe.ts
+++ b/frontend/benefit/handler/browser-tests/pages/7-handle-alteration.testcafe.ts
@@ -288,9 +288,11 @@ test('Handler handles the alteration from the last test properly', async (t: Tes
   // Recalculate and verify that the calculation is not zero
   await t.click(calculateButton);
   resultText = await calculationResult.textContent;
-  const expectedAmount = 68 * (0.03 / 0.27);
+  const expectedAmount = (68 * (0.03 / 0.27)).toFixed(0);
   await t
-    .expect(resultText.includes(getCurrencyString(expectedAmount, 0)))
+    .expect(
+      resultText.includes(getCurrencyString(parseInt(expectedAmount, 10), 0))
+    )
     .ok();
 
   // Select manual calculation mode

--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationHandlingConfirmationModal.tsx
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationHandlingConfirmationModal.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 import Modal from 'shared/components/modal/Modal';
 import theme from 'shared/styles/theme';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 type Props = {
   onClose: () => void;
@@ -50,7 +50,7 @@ const AlterationHandlingConfirmationModal = ({
               {t(`${translationBase}.description`, {
                 startDate: values.recoveryStartDate,
                 endDate: values.recoveryEndDate,
-                amount: formatFloatToCurrency(values.recoveryAmount),
+                amount: formatFloatToEvenEuros(values.recoveryAmount),
               })}
             </p>
           </Dialog.Content>

--- a/frontend/benefit/handler/src/components/applicationForm/review/companySection/CompanySection.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/review/companySection/CompanySection.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { getFullName } from 'shared/utils/application.utils';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
 import {
@@ -177,7 +177,7 @@ const CompanySection: React.FC<ReviewChildProps> = ({
               </$GridCell>
               <$GridCell $colSpan={2}>
                 <$SummaryTableValue>
-                  {formatFloatToCurrency(amount, 'EUR', 'FI-fi', 0)}
+                  {formatFloatToEvenEuros(amount)}
                 </$SummaryTableValue>
               </$GridCell>
               <$GridCell>
@@ -194,12 +194,7 @@ const CompanySection: React.FC<ReviewChildProps> = ({
           </$GridCell>
           <$GridCell $colSpan={2}>
             <$SummaryTableLastLine>
-              {formatFloatToCurrency(
-                data.totalDeminimisAmount,
-                'EUR',
-                'FI-fi',
-                0
-              )}
+              {formatFloatToEvenEuros(data.totalDeminimisAmount)}
             </$SummaryTableLastLine>
           </$GridCell>
         </SummarySection>

--- a/frontend/benefit/handler/src/components/applicationForm/review/employmentSection/EmploymentSection.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/review/employmentSection/EmploymentSection.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 import { $ViewField, $ViewFieldBold } from '../../ApplicationForm.sc';
 import EditButton from '../summarySection/EditButton';
@@ -52,12 +52,7 @@ const EmploymentSection: React.FC<ReviewChildProps> = ({
           <$ViewField>
             {data.employee?.monthlyPay &&
               t(`${translationsBase}.fields.monthlyPay.review`, {
-                monthlyPay: formatFloatToCurrency(
-                  data.employee.monthlyPay,
-                  'EUR',
-                  'FI-fi',
-                  0
-                ),
+                monthlyPay: formatFloatToEvenEuros(data.employee.monthlyPay),
               })}
           </$ViewField>
         </$GridCell>
@@ -68,11 +63,8 @@ const EmploymentSection: React.FC<ReviewChildProps> = ({
           <$ViewField>
             {data.employee?.vacationMoney &&
               t(`${translationsBase}.fields.vacationMoney.review`, {
-                vacationMoney: formatFloatToCurrency(
-                  data.employee.vacationMoney,
-                  'EUR',
-                  'FI-fi',
-                  0
+                vacationMoney: formatFloatToEvenEuros(
+                  data.employee.vacationMoney
                 ),
               })}
           </$ViewField>
@@ -84,11 +76,8 @@ const EmploymentSection: React.FC<ReviewChildProps> = ({
           <$ViewField>
             {data.employee?.otherExpenses &&
               t(`${translationsBase}.fields.otherExpenses.review`, {
-                otherExpenses: formatFloatToCurrency(
-                  data.employee.otherExpenses,
-                  'EUR',
-                  'FI-fi',
-                  0
+                otherExpenses: formatFloatToEvenEuros(
+                  data.employee.otherExpenses
                 ),
               })}
           </$ViewField>

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
@@ -20,7 +20,7 @@ import {
   sortFinnishDate,
   sortFinnishDateTime,
 } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
 import {
@@ -81,16 +81,13 @@ const getFirstInstalmentTotalAmount = (
   }
   return pendingInstalment ? (
     <>
-      {formatFloatToCurrency(firstInstalment, null, 'fi-FI', 0)} /{' '}
-      {formatFloatToCurrency(
-        parseInt(calculatedBenefitAmount, 10) - recoveryAmount,
-        'EUR',
-        'fi-FI',
-        0
+      {formatFloatToEvenEuros(firstInstalment)} /{' '}
+      {formatFloatToEvenEuros(
+        parseInt(calculatedBenefitAmount, 10) - recoveryAmount
       )}
     </>
   ) : (
-    formatFloatToCurrency(firstInstalment, 'EUR', 'fi-FI', 0)
+    formatFloatToEvenEuros(firstInstalment)
   );
 };
 const dateForAdditionalInformationNeededBy = (

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
@@ -33,7 +33,7 @@ import {
   convertToUIDateFormat,
   sortFinnishDate,
 } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
 import ConfirmModalContent from '../applicationReview/actions/ConfirmModalContent/confirm';
@@ -158,30 +158,18 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
         transform: ({ pendingInstalment }: ApplicationListTableTransforms) =>
           pendingInstalment?.amountAfterRecoveries > 0 ? (
             <>
-              {formatFloatToCurrency(
-                Math.max(0, pendingInstalment?.amountAfterRecoveries),
-                null,
-                'fi-FI',
-                0
+              {formatFloatToEvenEuros(
+                Math.max(0, pendingInstalment?.amountAfterRecoveries)
               )}
-
               {' / '}
-              {formatFloatToCurrency(
-                pendingInstalment.amount,
-                'EUR',
-                'fi-FI',
-                0
-              )}
+              {formatFloatToEvenEuros(pendingInstalment.amount)}
             </>
           ) : (
             <$Wrapper>
               <$Column>
                 <IconErrorFill color="var(--color-alert)" />{' '}
-                {formatFloatToCurrency(
-                  pendingInstalment.amountAfterRecoveries,
-                  'EUR',
-                  'fi-FI',
-                  0
+                {formatFloatToEvenEuros(
+                  pendingInstalment.amountAfterRecoveries
                 )}
               </$Column>
             </$Wrapper>
@@ -340,12 +328,7 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
                   'common:instalments.dialog.cancelInstalment.heading'
                 )}
                 text={t('common:instalments.dialog.cancelInstalment.text', {
-                  sum: formatFloatToCurrency(
-                    selectedInstalment?.amount,
-                    'EUR',
-                    'fi-FI',
-                    0
-                  ),
+                  sum: formatFloatToEvenEuros(selectedInstalment?.amount),
                   details: `${selectedApplication?.applicationNum}, ${selectedApplication?.companyName} / ${selectedApplication?.employeeName}`,
                 })}
                 onClose={() => setIsInstalmentCancelModalShown(false)}

--- a/frontend/benefit/handler/src/components/applicationReview/CalculationReview.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/CalculationReview.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import Heading from 'shared/components/forms/heading/Heading';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import theme from 'shared/styles/theme';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 import { $HorizontalList } from '../table/TableExtras.sc';
 
@@ -93,7 +93,7 @@ const CalculationReview: React.FC<ApplicationReviewStepProps> = ({
             <>
               <div>
                 <dt>{t('common:review.decisionProposal.list.totalAmount')}</dt>
-                <dd>{formatFloatToCurrency(totalSum, 'EUR', 'fi-FI', 0)}</dd>
+                <dd>{formatFloatToEvenEuros(totalSum)}</dd>
               </div>
               <div>
                 <dt>

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/DoneModalContent/DoneModalContent.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/DoneModalContent/DoneModalContent.tsx
@@ -9,7 +9,7 @@ import {
   $Grid,
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 import { $Header, $Text } from '../HandlingApplicationActions.sc';
 
@@ -53,19 +53,14 @@ const DoneModalContent: React.FC<ComponentProps> = ({
               <$GridCell $colSpan={12}>
                 <$Text>
                   {t(`${translationsBase}.eurosTotal`, {
-                    total: formatFloatToCurrency(
-                      totalRow.amount,
-                      null,
-                      'fi-FI',
-                      0
-                    ),
+                    total: formatFloatToEvenEuros(totalRow.amount),
                   })}
                 </$Text>
               </$GridCell>
               {helsinkiBenefitMonthlyRows.map((row, index) => (
                 <$Text key={row.id}>
                   {t(`${translationsBase}.eurosPerMonth`, {
-                    euros: formatFloatToCurrency(row.amount, null, 'fi-FI', 0),
+                    euros: formatFloatToEvenEuros(row.amount),
                     dateRange:
                       dateRangeRows[index]?.descriptionFi.toLocaleLowerCase(),
                   })}

--- a/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/ApplicationProcessingView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/ApplicationProcessingView.tsx
@@ -17,7 +17,7 @@ import {
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
 import theme from 'shared/styles/theme';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 import {
   $CalculatorHr,
@@ -186,7 +186,7 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                   <$CalculatorTableRow style={{ backgroundColor: 'white' }}>
                     <$ViewField>{totalRow.descriptionFi}</$ViewField>
                     <$ViewField isBold>
-                      {formatFloatToCurrency(totalRow.amount)}
+                      {formatFloatToEvenEuros(totalRow.amount)}
                     </$ViewField>
                   </$CalculatorTableRow>
                   {dateRangeRows.length === helsinkiBenefitMonthlyRows.length &&
@@ -197,7 +197,7 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                       >
                         <$ViewField>{row.descriptionFi}</$ViewField>
                         <$ViewField isBold>
-                          {formatFloatToCurrency(
+                          {formatFloatToEvenEuros(
                             helsinkiBenefitMonthlyRows[index].amount
                           )}
                           {t('common:utility.perMonth')}

--- a/frontend/benefit/handler/src/components/applicationReview/calculationTable/useCalculationTable.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/calculationTable/useCalculationTable.ts
@@ -1,7 +1,7 @@
 import { Calculation, Row } from 'benefit-shared/types/application';
 import clone from 'lodash/clone';
 import { convertToUIDateFormat, diffMonths } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 export type BenefitRow = {
   id: string;
@@ -41,7 +41,7 @@ const reduceTableRows = (filteredData: Row[]): BenefitRow[] => {
     const tableRow = createBenefitRow();
     tableRow.id = row.id;
     if (row.rowType === 'helsinki_benefit_monthly_eur') {
-      perMonth = `${formatFloatToCurrency(row.amount, 'EUR', 'fi-FI', 0)} / kk`;
+      perMonth = `${formatFloatToEvenEuros(row.amount)} / kk`;
     }
     if (row.rowType === 'helsinki_benefit_sub_total_eur') {
       tableRow.dates = `${convertToUIDateFormat(
@@ -56,7 +56,7 @@ const reduceTableRows = (filteredData: Row[]): BenefitRow[] => {
         new Date(row.startDate)
       );
 
-      tableRow.amount = formatFloatToCurrency(row.amount, 'EUR', 'fi-FI', 0);
+      tableRow.amount = formatFloatToEvenEuros(row.amount);
       tableRow.amountNumber = row.amount;
       tableRow.perMonth = perMonth;
       acc.push(tableRow);
@@ -90,21 +90,15 @@ const useCalculationTable = ({ calculation }: Props): CalculationTableProps => {
           duration,
           startDate: convertToUIDateFormat(calculation.rows.at(0).startDate),
           endDate: convertToUIDateFormat(calculation.rows.at(0).endDate),
-          amount: formatFloatToCurrency(
+          amount: formatFloatToEvenEuros(
             String(
               parseFloat(calculation.overrideMonthlyBenefitAmount as string) *
                 duration
-            ),
-            'EUR',
-            'fi-FI',
-            0
+            )
           ),
           amountNumber: calculation.rows.at(0).amount,
-          perMonth: `${formatFloatToCurrency(
-            calculation.overrideMonthlyBenefitAmount,
-            'EUR',
-            'fi-FI',
-            0
+          perMonth: `${formatFloatToEvenEuros(
+            calculation.overrideMonthlyBenefitAmount
           )} / kk`,
         },
       ]
@@ -130,7 +124,7 @@ const useCalculationTable = ({ calculation }: Props): CalculationTableProps => {
           .reduce((acc: number, cur: BenefitRow) => acc + cur.duration, 0)
           .toFixed(2)
       ),
-      amount: formatFloatToCurrency(totalSum, 'EUR', 'fi-FI', 0),
+      amount: formatFloatToEvenEuros(totalSum),
     });
 
   return {

--- a/frontend/benefit/handler/src/components/applicationReview/deminimisView/DeminimisView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/deminimisView/DeminimisView.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 const DeminimisView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
   const translationsBase = 'common:review';
@@ -56,9 +56,7 @@ const DeminimisView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
               </$GridCell>
               <$GridCell $colSpan={2}>
                 <$SummaryTableValue>
-                  {amount
-                    ? formatFloatToCurrency(amount, 'EUR', 'FI-fi', 0)
-                    : ''}
+                  {amount ? formatFloatToEvenEuros(amount) : ''}
                 </$SummaryTableValue>
               </$GridCell>
               <$GridCell>
@@ -76,12 +74,7 @@ const DeminimisView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
           <$GridCell $colSpan={2}>
             <$SummaryTableLastLine>
               {data?.totalDeminimisAmount
-                ? formatFloatToCurrency(
-                    data.totalDeminimisAmount,
-                    'EUR',
-                    'FI-fi',
-                    0
-                  )
+                ? formatFloatToEvenEuros(data.totalDeminimisAmount)
                 : ''}
             </$SummaryTableLastLine>
           </$GridCell>

--- a/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentView/EmpoymentView.tsx
@@ -11,7 +11,7 @@ import camelCase from 'lodash/camelCase';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 import AttachmentsListView from '../../attachmentsListView/AttachmentsListView';
 
@@ -47,12 +47,7 @@ const EmploymentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
         <$ViewField large>
           {data.employee?.monthlyPay &&
             t(`${translationsBase}.fields.monthlyPayText`, {
-              monthlyPay: formatFloatToCurrency(
-                data.employee.monthlyPay,
-                'EUR',
-                'FI-fi',
-                0
-              ),
+              monthlyPay: formatFloatToEvenEuros(data.employee.monthlyPay),
             })}
         </$ViewField>
       </$GridCell>
@@ -63,11 +58,8 @@ const EmploymentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
         <$ViewField large>
           {data.employee?.vacationMoney &&
             t(`${translationsBase}.fields.vacationMoneyText`, {
-              vacationMoney: formatFloatToCurrency(
-                data.employee.vacationMoney,
-                'EUR',
-                'FI-fi',
-                0
+              vacationMoney: formatFloatToEvenEuros(
+                data.employee.vacationMoney
               ),
             })}
         </$ViewField>
@@ -79,11 +71,8 @@ const EmploymentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
         <$ViewField large>
           {data.employee?.otherExpenses &&
             t(`${translationsBase}.fields.otherExpensesText`, {
-              otherExpenses: formatFloatToCurrency(
-                data.employee.otherExpenses,
-                'EUR',
-                'FI-fi',
-                0
+              otherExpenses: formatFloatToEvenEuros(
+                data.employee.otherExpenses
               ),
             })}
         </$ViewField>

--- a/frontend/benefit/handler/src/components/applicationReview/handledView/HandledView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/handledView/HandledView.tsx
@@ -12,7 +12,7 @@ import * as React from 'react';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { getFullName } from 'shared/utils/application.utils';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
 import {
@@ -67,11 +67,8 @@ const HandledView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
             </$GridCell>
             <$GridCell $colSpan={2}>
               <$ViewFieldBold large>
-                {formatFloatToCurrency(
-                  data.calculation?.overrideMonthlyBenefitAmount,
-                  'EUR',
-                  'fi-FI',
-                  0
+                {formatFloatToEvenEuros(
+                  data.calculation?.overrideMonthlyBenefitAmount
                 )}
                 {t('common:utility.perMonth')}
               </$ViewFieldBold>
@@ -91,7 +88,7 @@ const HandledView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
               </$GridCell>
               <$GridCell $colSpan={2}>
                 <$ViewFieldBold large>
-                  {formatFloatToCurrency(row.amount, 'EUR', 'fi-FI', 0)}
+                  {formatFloatToEvenEuros(row.amount)}
                   {t('common:utility.perMonth')}
                 </$ViewFieldBold>
               </$GridCell>
@@ -115,12 +112,7 @@ const HandledView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
               $colSpan={2}
             >
               <$ViewFieldBold large>
-                {formatFloatToCurrency(
-                  totalRow?.amount || 0,
-                  'EUR',
-                  'fi-FI',
-                  0
-                )}
+                {formatFloatToEvenEuros(totalRow?.amount || 0)}
               </$ViewFieldBold>
             </$GridCell>
           </$HandledRow>

--- a/frontend/benefit/handler/src/components/applicationReview/handlingView/AlterationAccordionItem.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/handlingView/AlterationAccordionItem.tsx
@@ -31,7 +31,7 @@ import {
 import hdsToast from 'shared/components/toast/Toast';
 import useLocale from 'shared/hooks/useLocale';
 import { convertToUIDateFormat, formatDate } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 const AlterationAccordionItem = ({
   alteration,
@@ -232,7 +232,7 @@ AlterationAccordionItemProps): JSX.Element => {
                     'common:applications.decision.alterationList.item.recoveryAmount'
                   )}
                 </dt>
-                <dd>{formatFloatToCurrency(alteration.recoveryAmount, "EUR", "fi-FI", 0)}</dd>
+                <dd>{formatFloatToEvenEuros(alteration.recoveryAmount)}</dd>
               </$GridCell>
               <$GridCell $colSpan={3}>
                 <dt>

--- a/frontend/benefit/handler/src/components/applicationReview/handlingView/DecisionCalculationAccordion.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/handlingView/DecisionCalculationAccordion.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $ViewField } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
 import {
@@ -133,7 +133,7 @@ const DecisionCalculationAccordion: React.FC<Props> = ({ data }) => {
                                 isBold
                                 style={{ marginRight: theme.spacing.xl4 }}
                               >
-                                {formatFloatToCurrency(row.amount)}
+                                {formatFloatToEvenEuros(row.amount)}
                                 {isPerMonth && t('common:utility.perMonth')}
                               </$ViewField>
                             )}

--- a/frontend/benefit/handler/src/components/applicationReview/handlingView/HandlingStep1.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/handlingView/HandlingStep1.tsx
@@ -21,7 +21,7 @@ import { useMemo } from 'react';
 import Container from 'shared/components/container/Container';
 import { getFullName } from 'shared/utils/application.utils';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 import ApplicationProcessingView from '../applicationProcessingView/ApplicationProcessingView';
 import BenefitView from '../benefitView/BenefitView';
@@ -78,7 +78,7 @@ const HandlingStep1: React.FC<HandlingStepProps> = ({
       },
       {
         accessor: (app) =>
-          formatFloatToCurrency(app.calculation?.calculatedBenefitAmount),
+          formatFloatToEvenEuros(app.calculation?.calculatedBenefitAmount),
         key: 'benefitAmount',
         showIf: () => showMonetaryFields,
       },

--- a/frontend/benefit/handler/src/components/applicationReview/handlingView/InstalmentAccordionSections.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/handlingView/InstalmentAccordionSections.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $ViewField } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 import { renderInstalmentTagPerStatus } from '../../applicationList/ApplicationListForInstalments';
 import {
@@ -44,14 +44,9 @@ const InstalmentAccordionSections: React.FC<Props> = ({ data }) => {
         <$CalculatorTableRow>
           <$ViewField>{t(`${translationsBase}.firstInstalment`)}</$ViewField>
           {data.pendingInstalment &&
-            formatFloatToCurrency(amounts.firstInstalment, 'EUR', 'fi-FI', 0)}
+            formatFloatToEvenEuros(amounts.firstInstalment)}
           {!data.pendingInstalment &&
-            formatFloatToCurrency(
-              data.calculatedBenefitAmount,
-              'EUR',
-              'fi-FI',
-              0
-            )}
+            formatFloatToEvenEuros(data.calculatedBenefitAmount)}
         </$CalculatorTableRow>
       </$Section>
 
@@ -86,23 +81,13 @@ const InstalmentAccordionSections: React.FC<Props> = ({ data }) => {
                     }}
                   >
                     {isSecondInstalmentReduced &&
-                      formatFloatToCurrency(
-                        data.pendingInstalment?.amount,
-                        'EUR',
-                        'fi-FI',
-                        0
-                      )}
+                      formatFloatToEvenEuros(data.pendingInstalment?.amount)}
                   </div>
                   {isSecondInstalmentReduced && <IconArrowRight />}
                 </>
               )}
 
-              {formatFloatToCurrency(
-                amounts.secondInstalment,
-                'EUR',
-                'fi-FI',
-                0
-              )}
+              {formatFloatToEvenEuros(amounts.secondInstalment)}
             </$RowWrap>
           </$CalculatorTableRow>
         </$Section>
@@ -130,12 +115,7 @@ const InstalmentAccordionSections: React.FC<Props> = ({ data }) => {
                     })}
                   </$ViewField>
                   <$RowWrap>
-                    {formatFloatToCurrency(
-                      alteration.recoveryAmount,
-                      'EUR',
-                      'fi-FI',
-                      0
-                    )}
+                    {formatFloatToEvenEuros(alteration.recoveryAmount)}
                   </$RowWrap>
                 </$CalculatorTableRow>
               </$Section>
@@ -146,9 +126,7 @@ const InstalmentAccordionSections: React.FC<Props> = ({ data }) => {
               <$ViewField isBold>
                 {t(`${translationsBase}.totalRecoveries`)}
               </$ViewField>
-              <$RowWrap>
-                {formatFloatToCurrency(amounts.alterations, 'EUR', 'fi-FI', 0)}
-              </$RowWrap>
+              <$RowWrap>{formatFloatToEvenEuros(amounts.alterations)}</$RowWrap>
             </$CalculatorTableRow>
           </$Section>
         </>
@@ -166,7 +144,7 @@ const InstalmentAccordionSections: React.FC<Props> = ({ data }) => {
                     ? t(`${translationsBase}.totalPaidSum`)
                     : t(`${translationsBase}.totalPlannedSum`)}
                 </$ViewField>
-                {formatFloatToCurrency(amounts.total, 'EUR', 'fi-FI', 0)}
+                {formatFloatToEvenEuros(amounts.total)}
               </$CalculatorTableRow>
             </$Section>
             <$Section className="">
@@ -181,11 +159,8 @@ const InstalmentAccordionSections: React.FC<Props> = ({ data }) => {
                     </$Column>
                   </$Wrapper>
                 </$ViewField>
-                {formatFloatToCurrency(
-                  amounts.secondInstalmentMax - amounts.alterations,
-                  'EUR',
-                  'fi-FI',
-                  0
+                {formatFloatToEvenEuros(
+                  amounts.secondInstalmentMax - amounts.alterations
                 )}
               </$CalculatorTableRow>
             </$Section>
@@ -198,12 +173,7 @@ const InstalmentAccordionSections: React.FC<Props> = ({ data }) => {
           <$ViewField isBold>
             {t(`${translationsBase}.totalAfterRecoveries`)}
           </$ViewField>
-          {formatFloatToCurrency(
-            amounts.totalAfterRecoveries,
-            'EUR',
-            'fi-FI',
-            0
-          )}
+          {formatFloatToEvenEuros(amounts.totalAfterRecoveries)}
         </$CalculatorTableRow>
       </$Section>
     </>

--- a/frontend/benefit/handler/src/components/applicationReview/handlingView/useInstalmentAccordionSections.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/handlingView/useInstalmentAccordionSections.ts
@@ -3,7 +3,7 @@ import {
   INSTALMENT_STATUSES,
 } from 'benefit-shared/constants';
 import { Application } from 'benefit-shared/types/application';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 
 type Props = {
   amounts: {
@@ -37,8 +37,8 @@ const useInstalmentAccordionSections = (data: Application): Props => {
     data.calculatedBenefitAmount - amounts.alterations;
 
   const isSecondInstalmentReduced =
-    formatFloatToCurrency(amounts.secondInstalment, null, 'fi-FI', 0) !==
-    formatFloatToCurrency(amounts.secondInstalmentMax, null, 'fi-FI', 0);
+    formatFloatToEvenEuros(amounts.secondInstalment) !==
+    formatFloatToEvenEuros(amounts.secondInstalmentMax);
 
   const areInstalmentsPaid =
     data.pendingInstalment?.status === INSTALMENT_STATUSES.COMPLETED ||

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryCalculatorResults/SalaryCalculatorHighlight.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryCalculatorResults/SalaryCalculatorHighlight.tsx
@@ -1,6 +1,6 @@
 import { $Highlight } from 'benefit/handler/components/applicationReview/ApplicationReview.sc';
 import React from 'react';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
 type Props = {
@@ -20,7 +20,7 @@ const SalaryCalculatorHighlight: React.FC<Props> = ({
     <$Highlight data-testid={testId}>
       <div style={{ fontSize: theme.fontSize.body.xl }}>{description}</div>
       <div style={{ fontSize: theme.fontSize.heading.xl }}>
-        {formatFloatToCurrency(amount, 'EUR', 'fi-FI', 0)}
+        {formatFloatToEvenEuros(amount)}
       </div>
     </$Highlight>
   );

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryCalculatorResults/SalaryCalculatorResults.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryCalculatorResults/SalaryCalculatorResults.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $ViewField } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 import { useTheme } from 'styled-components';
 
 import {
@@ -107,7 +107,7 @@ const SalaryCalculatorResults: React.FC<ApplicationReviewViewProps> = ({
                       isBold
                       style={{ marginRight: theme.spacing.xl4 }}
                     >
-                      {formatFloatToCurrency(row.amount)}
+                      {formatFloatToEvenEuros(row.amount)}
                       {isPerMonth && t('common:utility.perMonth')}
                     </$ViewField>
                   )}

--- a/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/BatchApplicationList.tsx
@@ -36,7 +36,7 @@ import {
   convertToUIDateAndTimeFormat,
   sortFinnishDate,
 } from 'shared/utils/date.utils';
-import { formatFloatToCurrency } from 'shared/utils/string.utils';
+import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 import styled from 'styled-components';
 
 import { $Empty } from '../applicationList/ApplicationList.sc';
@@ -144,7 +144,7 @@ const BatchApplicationList: React.FC<BatchProps> = ({ batch }: BatchProps) => {
       key: 'total_amount',
       isSortable: true,
       transform: ({ benefitAmount: amount }: { benefitAmount: number }) =>
-        formatFloatToCurrency(amount, 'EUR', 'fi-FI', 0),
+        formatFloatToEvenEuros(amount),
     });
   }
 

--- a/frontend/shared/src/utils/string.utils.ts
+++ b/frontend/shared/src/utils/string.utils.ts
@@ -66,6 +66,10 @@ export const formatFloatToCurrency = (
 
   return parsedValue.toLocaleString(locale, {
     minimumFractionDigits,
+    maximumFractionDigits: minimumFractionDigits,
     ...(currency ? { style: 'currency', currency } : {}),
   });
 };
+
+export const formatFloatToEvenEuros = (value: string | number): string =>
+  formatFloatToCurrency(value, 'EUR', 'fi-FI', 0);

--- a/frontend/shared/src/utils/string.utils.ts
+++ b/frontend/shared/src/utils/string.utils.ts
@@ -55,12 +55,6 @@ export const formatFloatToCurrency = (
   locale = 'fi-FI',
   minimumFractionDigits = 2
 ): string => {
-  const currencyOptions = currency
-    ? {
-        style: 'currency',
-        currency,
-      }
-    : {};
   let parsedValue: number;
   if (!value || value === '') {
     parsedValue = 0;
@@ -72,6 +66,6 @@ export const formatFloatToCurrency = (
 
   return parsedValue.toLocaleString(locale, {
     minimumFractionDigits,
-    ...currencyOptions,
+    ...(currency ? { style: 'currency', currency } : {}),
   });
 };


### PR DESCRIPTION
## Description :sparkles:

Use new function wrapper to cover most currency conversions in display. No cents are really necessary to display even though they might be paid in some very specific cases.