### PR TITLE
fix: HL 1558 ahjo fixes

### DIFF
--- a/backend/benefit/applications/api/v1/ahjo_integration_views.py
+++ b/backend/benefit/applications/api/v1/ahjo_integration_views.py
@@ -27,15 +27,12 @@ from applications.enums import (
     DEFAULT_AHJO_CALLBACK_ERROR_MESSAGE,
 )
 from applications.models import AhjoStatus, Application, ApplicationBatch, Attachment
+from applications.services.ahjo.exceptions import AhjoCallbackError
 from common.permissions import BFIsHandler, SafeListPermission
 from shared.audit_log import audit_logging
 from shared.audit_log.enums import Operation
 
 LOGGER = logging.getLogger(__name__)
-
-
-class AhjoCallbackError(Exception):
-    pass
 
 
 class AhjoApplicationView(APIView):

--- a/backend/benefit/applications/api/v1/serializers/ahjo_callback.py
+++ b/backend/benefit/applications/api/v1/serializers/ahjo_callback.py
@@ -18,7 +18,7 @@ class AhjoCallbackSerializer(serializers.Serializer):
 
 
 class AhjoDecisionCallbackSerializer(serializers.Serializer):
-    updatetype = serializers.CharField(required=True)
-    id = serializers.CharField(required=True)
-    caseId = serializers.CharField(required=True)
-    caseGuid = serializers.UUIDField(format="hex_verbose", required=True)
+    updatetype = serializers.CharField(required=False)
+    id = serializers.CharField(required=False)
+    caseId = serializers.CharField(required=False)
+    caseGuid = serializers.UUIDField(format="hex_verbose", required=False)

--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -1252,7 +1252,9 @@ class AhjoStatus(TimeStampedModel):
     )
 
     def __str__(self):
-        return self.status
+        return f"{self.status} for application {self.application.application_number}, \
+created_at: {self.created_at}, modified_at: {self.modified_at}, \
+ahjo_request_id: {self.ahjo_request_id}"
 
     class Meta:
         db_table = "bf_applications_ahjo_status"

--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -174,6 +174,7 @@ class ApplicationManager(models.Manager):
         """Query applications with instalments with past due date and a specific status."""
         return (
             self.filter(
+                status=ApplicationStatus.ACCEPTED,
                 calculation__instalments__due_date__lte=timezone.now().date(),
                 calculation__instalments__status=status,
             )

--- a/backend/benefit/applications/services/ahjo/exceptions.py
+++ b/backend/benefit/applications/services/ahjo/exceptions.py
@@ -13,10 +13,93 @@ class DecisionProposalAlreadyAcceptedError(DecisionProposalError):
     but for some reason a decision proposal for the application is still being sent.
 
     Attributes:
-        ahjo_status (AhjosStatusEnum): The decision_proposal_accepted status.
+        ahjo_status (AhjosStatus): The decision_proposal_accepted status.
     """
 
     def __init__(self, message: str, ahjo_status: AhjoStatus) -> None:
         self.message = message
         self.ahjo_status = ahjo_status
         super().__init__(self.message)
+
+
+class AhjoApiClientException(Exception):
+    """
+    Raised when an error occurs in the AhjoApiClient.
+    """
+
+    pass
+
+
+class MissingAhjoCaseIdError(AhjoApiClientException):
+    """
+    Raised when a Ahjo request that requires a case id is missing the case id.
+    """
+
+    pass
+
+
+class MissingHandlerIdError(AhjoApiClientException):
+    """
+    Raised when a Ahjo request that requires a handler id is missing the handler id.
+    """
+
+    pass
+
+
+class MissingOrganizationIdentifier(Exception):
+    """
+    Raised when an organization identifier is missing from AhjoSettings in the database.
+    """
+
+    pass
+
+
+class AhjoTokenExpiredException(Exception):
+    """
+    Raised when the Ahjo token has expired. The token should be re-configured manually, see instructions at:
+    https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/8687517756/Siirto+yll+pitoon#Ahjo-autentikaatio-tokenin-haku-ja-asettaminen-manuaalisesti.
+    """
+
+    pass
+
+
+class AhjoTokenRetrievalException(Exception):
+    """
+    Raised when the Ahjo token has expired or it could not be otherwise refreshed automatically.
+    The token should be re-configured manually, see instructions at:
+    https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/8687517756/Siirto+yll+pitoon#Ahjo-autentikaatio-tokenin-haku-ja-asettaminen-manuaalisesti.
+    """
+
+    pass
+
+
+class InvalidAhjoTokenException(Exception):
+    """
+    Raised when the Ahjo token is missing data or is otherwise invalid.
+    """
+
+    pass
+
+
+class AhjoCallbackError(Exception):
+    """
+    Raised when an error occurs in the Ahjo callback.
+    """
+
+    pass
+
+
+class AhjoDecisionError(Exception):
+    """
+    Raised when an error occurs in substituting application data into the decision text.
+    """
+
+    pass
+
+
+class AhjoDecisionDetailsParsingError(Exception):
+    """
+    Raised when an error occurs in parsing the decision details after a details query to Ahjo.
+    """
+
+    pass

--- a/backend/benefit/applications/services/ahjo/exceptions.py
+++ b/backend/benefit/applications/services/ahjo/exceptions.py
@@ -1,0 +1,22 @@
+from applications.models import AhjoStatus
+
+
+class DecisionProposalError(Exception):
+    """Custom exception for errors in the sending of decision proposals."""
+
+    pass
+
+
+class DecisionProposalAlreadyAcceptedError(DecisionProposalError):
+    """
+    Raised when a decision proposal already has been accepted in Ahjo,
+    but for some reason a decision proposal for the application is still being sent.
+
+    Attributes:
+        ahjo_status (AhjosStatusEnum): The decision_proposal_accepted status.
+    """
+
+    def __init__(self, message: str, ahjo_status: AhjoStatus) -> None:
+        self.message = message
+        self.ahjo_status = ahjo_status
+        super().__init__(self.message)

--- a/backend/benefit/applications/services/ahjo_authentication.py
+++ b/backend/benefit/applications/services/ahjo_authentication.py
@@ -7,21 +7,13 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 
 from applications.models import AhjoSetting
+from applications.services.ahjo.exceptions import (
+    AhjoTokenExpiredException,
+    AhjoTokenRetrievalException,
+)
 
 AUTH_TOKEN_GRANT_TYPE = "authorization_code"
 REFRESH_TOKEN_GRANT_TYPE = "refresh_token"
-
-
-class AhjoTokenExpiredException(Exception):
-    pass
-
-
-class AhjoTokenRetrievalException(Exception):
-    pass
-
-
-class InvalidTokenException(Exception):
-    pass
 
 
 @dataclass
@@ -111,7 +103,9 @@ class AhjoConnector:
                 self.token_url, headers=self.headers, data=payload, timeout=self.timeout
             )
         except requests.exceptions.RequestException as e:
-            raise Exception(f"Failed to get or refresh token from Ahjo: {e}")
+            raise AhjoTokenRetrievalException(
+                f"Failed to get or refresh token from Ahjo: {e}"
+            )
 
         # Check if the request was successful
         if response.status_code == 200:

--- a/backend/benefit/applications/services/ahjo_client.py
+++ b/backend/benefit/applications/services/ahjo_client.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 
 from applications.enums import AhjoRequestType, AhjoStatus as AhjoStatusEnum
 from applications.models import AhjoSetting, AhjoStatus, Application
-from applications.services.ahjo_error_writer import AhjoErrorWriter
 from applications.services.ahjo.exceptions import (
     AhjoApiClientException,
     InvalidAhjoTokenException,
@@ -18,6 +17,7 @@ from applications.services.ahjo.exceptions import (
     MissingOrganizationIdentifier,
 )
 from applications.services.ahjo_authentication import AhjoToken
+from applications.services.ahjo_error_writer import AhjoErrorWriter, AhjoFormattedError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -265,18 +265,27 @@ class AhjoApiClient:
         except MissingHandlerIdError as e:
             error_message = f"Missing handler id for application {self.request.application.application_number}: {e}"
             LOGGER.error(error_message)
-            self.write_error_to_ahjo_status(error_message)
+            self.write_error_to_ahjo_status(
+                context=error_message,
+                message_to_handler="Hakemuksen käsittelijältä puuttuu AD-tunnus.",
+            )
         except MissingAhjoCaseIdError as e:
             error_message = f"Missing Ahjo case id for application {self.request.application.application_number}: {e}"
             LOGGER.error(error_message)
-            self.write_error_to_ahjo_status(error_message)
+            self.write_error_to_ahjo_status(
+                context=error_message,
+                message_to_handler="Hakemuksella ei ole Ahjosta saatua Diaaria.",
+            )
         except requests.exceptions.HTTPError as e:
             self.handle_http_error(e)
         except requests.exceptions.RequestException as e:
             error_message = (
                 f"A network error occurred while sending {self._request} to Ahjo: {e}"
             )
-            self.write_error_to_ahjo_status(error_message)
+            self.write_error_to_ahjo_status(
+                context=error_message,
+                message_to_handler="Ahjo-pyynnössä tapahtui verkkoyhteysvirhe.",
+            )
             LOGGER.error(error_message)
         except AhjoApiClientException as e:
             LOGGER.error(
@@ -303,8 +312,11 @@ class AhjoApiClient:
             error_message = self.format_error_message(e)
 
         if error_json:
-            error_message += f" Error message: {error_json}"
-            self.write_error_to_ahjo_status(error_message)
+            error_message += f"{error_json}"
+            self.write_error_to_ahjo_status(
+                context=error_json,
+                message_to_handler="Ahjo palautti validaatiovirheen tai muun HTTP-virheen.",
+            )
 
         LOGGER.error(error_message)
 
@@ -316,11 +328,15 @@ class AhjoApiClient:
         return f"A HTTP or network error occurred while sending {self.request} for application \
     {application_number} to Ahjo: {e}"
 
-    def write_error_to_ahjo_status(self, error_message: str) -> None:
+    def write_error_to_ahjo_status(self, context: str, message_to_handler: str) -> None:
         """Write the error message to the Ahjo status of the application for all requests that have an application.
         The DecisionMaker request does not have an application, so it does not have an Ahjo status.
         """
         if self.request.has_application:
             AhjoErrorWriter.write_to_validation_error(
-                self.request.application, error_message
+                AhjoFormattedError(
+                    application=self.request.application,
+                    context=context,
+                    message_to_handler=message_to_handler,
+                )
             )

--- a/backend/benefit/applications/services/ahjo_decision_service.py
+++ b/backend/benefit/applications/services/ahjo_decision_service.py
@@ -11,14 +11,14 @@ from applications.models import (
     Application,
     DecisionProposalTemplateSection,
 )
+from applications.services.ahjo.exceptions import (
+    AhjoDecisionDetailsParsingError,
+    AhjoDecisionError,
+)
 from applications.tests.factories import (
     AcceptedDecisionProposalFactory,
     DeniedDecisionProposalFactory,
 )
-
-
-class AhjoDecisionError(Exception):
-    pass
 
 
 def replace_decision_template_placeholders(
@@ -126,9 +126,11 @@ def parse_details_from_decision_response(decision_data: Dict) -> AhjoDecisionDet
             decision_date=decision_date,
         )
     except KeyError as e:
-        raise AhjoDecisionError(f"Error in parsing decision details: {e}")
+        raise AhjoDecisionDetailsParsingError(f"Error in parsing decision details: {e}")
     except ValueError as e:
-        raise AhjoDecisionError(f"Error in parsing decision details date: {e}")
+        raise AhjoDecisionDetailsParsingError(
+            f"Error in parsing decision details date: {e}"
+        )
 
 
 def parse_decision_maker_from_html(html_content: str) -> str:

--- a/backend/benefit/applications/services/ahjo_error_writer.py
+++ b/backend/benefit/applications/services/ahjo_error_writer.py
@@ -1,14 +1,27 @@
+from dataclasses import dataclass
+
 from applications.models import Application
+
+
+@dataclass
+class AhjoFormattedError:
+    application: Application
+    context: str = ""
+    error_id: str = "NO_ID"
+    message_to_handler: str = (
+        "Ahjo-pyynnössä tapahtui virhe, mutta tarkempia tietoja virheestä ei saatu."
+    )
 
 
 class AhjoErrorWriter:
     @staticmethod
-    def write_error_to_ahjo_status(application: Application, error: str) -> None:
-        latest_ahjo_status = application.ahjo_status.latest()
+    def write_error_to_ahjo_status(formatted_error: AhjoFormattedError) -> None:
+        latest_ahjo_status = formatted_error.application.ahjo_status.latest()
+
         latest_ahjo_status.error_from_ahjo = {
-            "id": "NO_ID",
-            "context": f"{error}",
-            "message": "Ahjo-pyynnössä tapahtui virhe, mutta Ahjo ei palauttanut tarkempia tietoja.",
+            "id": formatted_error.error_id,
+            "context": formatted_error.context,
+            "message": formatted_error.message_to_handler,
         }
         latest_ahjo_status.save()
 

--- a/backend/benefit/applications/services/ahjo_error_writer.py
+++ b/backend/benefit/applications/services/ahjo_error_writer.py
@@ -26,9 +26,14 @@ class AhjoErrorWriter:
         latest_ahjo_status.save()
 
     @staticmethod
-    def write_to_validation_error(application: Application, error_message: str) -> None:
+    def write_to_validation_error(formatted_error: AhjoFormattedError) -> None:
         """Write the error message to the Ahjo status of the application."""
 
-        status = application.ahjo_status.latest()
-        status.validation_error_from_ahjo = error_message
+        status = formatted_error.application.ahjo_status.latest()
+
+        status.validation_error_from_ahjo = {
+            "id": formatted_error.error_id,
+            "context": formatted_error.context,
+            "message": formatted_error.message_to_handler,
+        }
         status.save()

--- a/backend/benefit/applications/tests/test_ahjo_requests.py
+++ b/backend/benefit/applications/tests/test_ahjo_requests.py
@@ -9,11 +9,15 @@ from django.utils import timezone
 
 from applications.enums import AhjoRequestType, AhjoStatus as AhjoStatusEnum
 from applications.models import AhjoSetting, AhjoStatus
-from applications.services.ahjo_authentication import AhjoToken, InvalidTokenException
+from applications.services.ahjo.exceptions import (
+    AhjoApiClientException,
+    InvalidAhjoTokenException,
+    MissingHandlerIdError,
+)
+from applications.services.ahjo_authentication import AhjoToken
 from applications.services.ahjo_client import (
     AhjoAddRecordsRequest,
     AhjoApiClient,
-    AhjoApiClientException,
     AhjoDecisionDetailsRequest,
     AhjoDecisionMakerRequest,
     AhjoDecisionProposalRequest,
@@ -21,7 +25,6 @@ from applications.services.ahjo_client import (
     AhjoOpenCaseRequest,
     AhjoSubscribeDecisionRequest,
     AhjoUpdateRecordsRequest,
-    MissingHandlerIdError,
 )
 
 API_CASES_BASE = "/cases"
@@ -291,10 +294,10 @@ def test_requests_exceptions(
         with pytest.raises(MissingHandlerIdError):
             ahjo_request_without_ad_username.api_url()
 
-    with pytest.raises(InvalidTokenException):
+    with pytest.raises(InvalidAhjoTokenException):
         AhjoApiClient(ahjo_token="foo", ahjo_request=ahjo_request_without_ad_username)
 
-    with pytest.raises(InvalidTokenException):
+    with pytest.raises(InvalidAhjoTokenException):
         AhjoApiClient(
             ahjo_token=AhjoToken(access_token=None),
             ahjo_request=ahjo_request_without_ad_username,

--- a/backend/benefit/applications/tests/test_ahjo_requests.py
+++ b/backend/benefit/applications/tests/test_ahjo_requests.py
@@ -332,7 +332,7 @@ def test_requests_exceptions(
         assert ahjo_status.validation_error_from_ahjo is not None
 
         for validation_error in validation_error:
-            assert f"{validation_error}" in ahjo_status.validation_error_from_ahjo
+            assert validation_error in ahjo_status.validation_error_from_ahjo["context"]
 
     exception = requests.exceptions.RequestException
     with requests_mock.Mocker() as m:

--- a/backend/benefit/applications/tests/test_application_tasks.py
+++ b/backend/benefit/applications/tests/test_application_tasks.py
@@ -233,7 +233,10 @@ def test_send_ahjo_requests(
             mock_response = f"{uuid.uuid4()}"
 
         applications = [
-            MagicMock(spec=Application, handled_by_ahjo_automation=True)
+            MagicMock(
+                spec=Application,
+                handled_by_ahjo_automation=True,
+            )
             for _ in range(number_to_send)
         ]
         applications_qs = MagicMock()
@@ -245,6 +248,8 @@ def test_send_ahjo_requests(
             mock_response,
         )
 
+        app_numbers = ", ".join([str(application.application_number)] * number_to_send)
+
         # Call the command
         out = StringIO()
         call_command(
@@ -254,13 +259,15 @@ def test_send_ahjo_requests(
             stdout=out,
         )
 
+        print(out.getvalue())
+
         assert (
             f"Sending {request_type} request to Ahjo for {number_to_send} applications"
             in out.getvalue()
         )
 
         assert (
-            f"Sent {request_type} requests for {number_to_send} applications to Ahjo"
+            f"Sent {request_type} requests for {number_to_send} application(s): {app_numbers} to Ahjo"
             in out.getvalue()
         )
 


### PR DESCRIPTION
## Description :sparkles:
[HL-1564](https://helsinkisolutionoffice.atlassian.net/browse/HL-1564)

Talpa CSV query did not check application status correctly, when querying is based on instalments, added a check for application.status == 'accepted'.

[HL 1558](https://helsinkisolutionoffice.atlassian.net/browse/HL-1558) and [HL-1549](https://helsinkisolutionoffice.atlassian.net/browse/HL-1549)
Fix for a situation where a successful add_records ahjo request caused an already successful send_decision_proposal request to be sent again. Move some of the exceptions in a separate file and improve the error formatting for XML errors show that they are shown in the handler UI.

[chore: refactor ahjo exceptions into one place](https://github.com/City-of-Helsinki/yjdh/pull/3565/commits/3d2eb397c6d1a4fc37688f01b4fdc4b1ad6243ca)
Refactor rest of the Ahjo related exceptions to a single location for easier documenting of the various Ahjo error scenarios.

[feat: more readable error messages for handler](https://github.com/City-of-Helsinki/yjdh/pull/3565/commits/f43415014842a7c0a1ab419d344904d1226848bb)
Improve the error messages shown for the handler.

[HL-1538](https://helsinkisolutionoffice.atlassian.net/browse/HL-1538)
[feat: log request_type on callback failure](https://github.com/City-of-Helsinki/yjdh/pull/3565/commits/5e059ae100bc9d72226cfd182c675e925c752551)
When a Ahjo callback fails, log the request type into the audit log as well.

[HL-1509](https://helsinkisolutionoffice.atlassian.net/browse/HL-1509?atlOrigin=eyJpIjoiNDYyNDYwN2NhZDVkNDJmNDg0ZTRmZTI0MzQ1YWI2NjMiLCJwIjoiaiJ9)
[feat: print application numbers after requests](https://github.com/City-of-Helsinki/yjdh/pull/3565/commits/0865321a49a84b5a58fdddd9691ca39c7fc3e069)
Print the application numbers after an ahjo request is sent so they can be found from the logs more easily.

[HL-1562](https://helsinkisolutionoffice.atlassian.net/browse/HL-1562)
Remove required fields from decision details callback as it causes issues at Ahjo's end.

[HL-1561](https://helsinkisolutionoffice.atlassian.net/browse/HL-1561)
Always respond with 200 OK to the decision details callback as 404 was causing issues at Ahjo's end

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1564]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-1549]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-1538]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ