### PR TITLE
fix: quotes crashing talpa csv

### DIFF
--- a/backend/benefit/applications/api/v1/application_batch_views.py
+++ b/backend/benefit/applications/api/v1/application_batch_views.py
@@ -210,7 +210,7 @@ class ApplicationBatchViewSet(AuditLoggingModelViewSet):
         )
 
         response = HttpResponse(
-            csv_service.get_csv_string(True).encode("utf-8"),
+            csv_service.get_csv_string(remove_quotes=False).encode("utf-8"),
             content_type="text/csv",
         )
 


### PR DESCRIPTION
## Description :sparkles:

[HL-1565](https://helsinkisolutionoffice.atlassian.net/browse/HL-1565)

[Sentry issue](https://sentry.hel.fi/organizations/city-of-helsinki/issues/38195/?query=is%3Aunresolved&referrer=issue-stream)

The talpa csv was a unquoted csv string without an escape character, which causes the csv generation to fail when there are semicolons in the data. Add quoting so any special chars are escaped automatically.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:




[HL-1565]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ