### PR TITLE
fix: limit search list items to 30 without user action

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1469,7 +1469,8 @@
     "previous": "Edellinen",
     "send": "Lähetä",
     "deleting": "Poistetaan...",
-    "submitting": "Lähetetään..."
+    "submitting": "Lähetetään...",
+    "loadMore": "Lataa lisää"
   },
   "status": {
     "draft": "Luonnos",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1469,7 +1469,8 @@
     "previous": "Edellinen",
     "send": "Lähetä",
     "deleting": "Poistetaan...",
-    "submitting": "Lähetetään..."
+    "submitting": "Lähetetään...",
+    "loadMore": "Lataa lisää"
   },
   "status": {
     "draft": "Luonnos",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1469,7 +1469,8 @@
     "previous": "Edellinen",
     "send": "Lähetä",
     "deleting": "Poistetaan...",
-    "submitting": "Lähetetään..."
+    "submitting": "Lähetetään...",
+    "loadMore": "Lataa lisää"
   },
   "status": {
     "draft": "Luonnos",

--- a/frontend/benefit/handler/src/components/applicationsArchive/ApplicationsArchive.tsx
+++ b/frontend/benefit/handler/src/components/applicationsArchive/ApplicationsArchive.tsx
@@ -1,5 +1,6 @@
 import { ROUTES } from 'benefit/handler/constants';
 import {
+  Button,
   IconCross,
   RadioButton,
   SearchInput,
@@ -15,6 +16,7 @@ import {
   $Grid,
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
+import { focusAndScrollToSelector } from 'shared/utils/dom.utils';
 import styled from 'styled-components';
 
 import ApplicationArchiveList from './ApplicationArchiveList';
@@ -45,6 +47,9 @@ const $SearchInputArea = styled.div`
 const ApplicationsArchive: React.FC = () => {
   const [searchString, setSearchString] = React.useState<string>('');
   const [initialQuery, setInitialQuery] = React.useState<boolean>(true);
+  const [loadAll, setLoadAll] = React.useState<boolean>(false);
+  const [displayLoadAll, setDisplayLoadAll] = React.useState<boolean>(true);
+
   const [subsidyInEffect, setSubsidyInEffect] =
     React.useState<SUBSIDY_IN_EFFECT | null>(
       SUBSIDY_IN_EFFECT.RANGE_THREE_YEARS
@@ -65,7 +70,8 @@ const ApplicationsArchive: React.FC = () => {
       true,
       subsidyInEffect,
       decisionRange,
-      applicationNum ? applicationNum.toString() : null
+      applicationNum ? applicationNum.toString() : null,
+      loadAll
     );
 
   const onSearch = (value: string): void => {
@@ -80,6 +86,8 @@ const ApplicationsArchive: React.FC = () => {
     setFilterSelection(selection);
     setDecisionRange(null);
     setSubsidyInEffect(value);
+    setDisplayLoadAll(true);
+    setLoadAll(false);
   };
   const handleDecisionFilterChange = (
     selection: FILTER_SELECTION,
@@ -88,11 +96,15 @@ const ApplicationsArchive: React.FC = () => {
     setFilterSelection(selection);
     setDecisionRange(value);
     setSubsidyInEffect(null);
+    setDisplayLoadAll(true);
+    setLoadAll(false);
   };
   const handleFiltersOff = (): void => {
     setDecisionRange(null);
     setSubsidyInEffect(null);
     setFilterSelection(FILTER_SELECTION.NO_FILTER);
+    setDisplayLoadAll(true);
+    setLoadAll(false);
   };
 
   React.useEffect(() => {
@@ -102,9 +114,10 @@ const ApplicationsArchive: React.FC = () => {
       setInitialQuery(false);
     } else if (!isSearchLoading) {
       submitSearch(searchString);
+      setLoadAll(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterSelection, applicationNum, router, initialQuery]);
+  }, [filterSelection, applicationNum, router, initialQuery, loadAll]);
 
   return (
     <Container data-testid="application-list-archived">
@@ -220,6 +233,22 @@ const ApplicationsArchive: React.FC = () => {
         data={searchResults?.matches}
         isSearchLoading={isSearchLoading}
       />
+      {displayLoadAll &&
+        !isSearchLoading &&
+        searchString.length === 0 &&
+        searchResults?.matches?.length >= 30 && (
+          <Button
+            style={{ marginTop: 'var(--spacing-m)' }}
+            theme="coat"
+            onClick={() => {
+              setLoadAll(true);
+              setDisplayLoadAll(false);
+              focusAndScrollToSelector('header');
+            }}
+          >
+            {t('common:utility.loadMore')}
+          </Button>
+        )}
     </Container>
   );
 };

--- a/frontend/benefit/handler/src/components/applicationsArchive/useApplicationsArchive.ts
+++ b/frontend/benefit/handler/src/components/applicationsArchive/useApplicationsArchive.ts
@@ -80,7 +80,8 @@ const useApplicationsArchive = (
   includeArchivalApplications: boolean,
   subsidyInEffect: SUBSIDY_IN_EFFECT,
   decisionRange: number,
-  applicationNum?: string
+  applicationNum?: string,
+  loadAll?: boolean
 ): ApplicationListProps => {
   const { t } = useTranslation();
 
@@ -95,7 +96,8 @@ const useApplicationsArchive = (
     includeArchivalApplications,
     subsidyInEffect,
     decisionRange,
-    applicationNum
+    applicationNum,
+    loadAll
   );
 
   const shouldHideList =

--- a/frontend/benefit/handler/src/hooks/useSearchApplicationQuery.ts
+++ b/frontend/benefit/handler/src/hooks/useSearchApplicationQuery.ts
@@ -16,7 +16,8 @@ const useSearchApplicationQuery = (
   includeArchivalApplications = false,
   subsidyInEffect?: SUBSIDY_IN_EFFECT,
   decisionRange?: DECISION_RANGE,
-  applicationNum?: string
+  applicationNum?: string,
+  loadAll = false
 ): UseMutationResult<SearchResponse, Error> => {
   const { axios, handleResponse } = useBackendAPI();
   const { t } = useTranslation();
@@ -28,12 +29,14 @@ const useSearchApplicationQuery = (
     subsidy_in_effect?: SUBSIDY_IN_EFFECT;
     years_since_decision?: DECISION_RANGE;
     app_no?: string;
+    load_all?: string;
   } = {
     q,
     ...(archived && { archived: '1' }),
     ...(includeArchivalApplications && { archival: '1' }),
     ...(subsidyInEffect && { subsidy_in_effect: subsidyInEffect }),
     ...(decisionRange && { years_since_decision: decisionRange }),
+    ...(loadAll && { load_all: '1' }),
   };
 
   if (applicationNum) {


### PR DESCRIPTION
## Description :sparkles:

Production is a bit slow in the archive page. No need to display every item that exists; usually there's no point in that. Limit initial query to some 30 items only. User can then click "Load more" button to retrieve all items.