### PR TITLE
fix: try to parse all kinds of ahjo errors

### DIFF
--- a/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationList.tsx
@@ -109,6 +109,19 @@ export const renderPaymentTagPerStatus = (
   </$TagWrapper>
 );
 
+const parseAhjoError = (ahjoError: AhjoError): JSX.Element[] => {
+  if (Array.isArray(ahjoError.errorFromAhjo))
+    return ahjoError.errorFromAhjo.map(({ message }) => <li>{message}</li>);
+
+  if (
+    typeof ahjoError.errorFromAhjo === 'object' &&
+    ahjoError.errorFromAhjo.message
+  )
+    return [<li>{ahjoError.errorFromAhjo.message}</li>];
+
+  return [<li>{String(ahjoError.errorFromAhjo)}</li>];
+};
+
 const ApplicationList: React.FC<ApplicationListProps> = ({
   heading,
   status,
@@ -177,13 +190,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
                   Ahjo, {convertToUIDateAndTimeFormat(ahjoError?.modifiedAt)}
                 </strong>
               </div>
-              <ul>
-                {ahjoError?.errorFromAhjo?.map
-                  ? ahjoError?.errorFromAhjo?.map(({ message }) => (
-                      <li>{message}</li>
-                    ))
-                  : ahjoError?.errorFromAhjo}
-              </ul>
+              <ul>{parseAhjoError(ahjoError)}</ul>
             </Tooltip>
           </$ActionErrors>
         )}

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -266,13 +266,13 @@ export interface DecisionProposalDraft {
 }
 
 export interface AhjoError {
-  errorFromAhjo: ErrorFromAhjo[];
+  errorFromAhjo: ErrorFromAhjo | ErrorFromAhjo[];
   modifiedAt: string;
   status: string;
 }
 
 export interface AhjoErrorData {
-  error_from_ahjo: ErrorFromAhjo[];
+  error_from_ahjo: ErrorFromAhjo | ErrorFromAhjo[];
   modified_at: string;
   status: string;
 }


### PR DESCRIPTION
## Description :sparkles:

Ahjo error, depending on the case, might be inside an array, object, or string. 

Try mapping as array first:`[{"id": 1234, "message":"Hello ErrorArray}]`

Next, try as object: `{"id": 1234, "message": "Hello ErrorObject"}`

Finally, fallback to string: `"Hello ErrorString"`

All of these 3 cases are possible to store into backend database.