### PR TITLE
feat: Hl 1575 instalment to accepted

### DIFF
--- a/backend/benefit/calculator/api/v1/validators.py
+++ b/backend/benefit/calculator/api/v1/validators.py
@@ -16,6 +16,7 @@ class InstalmentStatusValidator(StatusTransitionValidator):
         ),
         InstalmentStatus.ERROR_IN_TALPA: (
             InstalmentStatus.WAITING,
+            InstalmentStatus.ACCEPTED,
             InstalmentStatus.PAID,
         ),
         InstalmentStatus.PAID: (InstalmentStatus.COMPLETED,),

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -225,7 +225,8 @@
           "accepted": "Hyväksytty",
           "waiting": "Odottaa",
           "completed": "Maksettu",
-          "error_in_talpa": "Virhe maksussa"
+          "error_in_talpa": "Virhe maksussa",
+          "paid": "Merkitty maksetuksi manuaalisesti"
         },
         "calculationEndDate": "Viim. tukipäivä",
         "calculatedBenefitAmount": "Tukisumma",
@@ -282,7 +283,10 @@
         "return": "Palauta",
         "confirm": "Hyväksy",
         "cancel": "Peru",
-        "finish": "Siirrä arkistoon"
+        "finish": "Siirrä arkistoon",
+        "return_as_waiting": "Palauta odottamaan",
+        "return_as_accepted": "Palauta hyväksytyksi",
+        "mark_as_paid": "Merkitse maksetuksi"
       }
     },
     "pageHeaders": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -225,7 +225,8 @@
           "accepted": "Hyväksytty",
           "waiting": "Odottaa",
           "completed": "Maksettu",
-          "error_in_talpa": "Virhe maksussa"
+          "error_in_talpa": "Virhe maksussa",
+          "paid": "Merkitty maksetuksi manuaalisesti"
         },
         "calculationEndDate": "Viim. tukipäivä",
         "calculatedBenefitAmount": "Tukisumma",
@@ -282,7 +283,10 @@
         "return": "Palauta",
         "confirm": "Hyväksy",
         "cancel": "Peru",
-        "finish": "Siirrä arkistoon"
+        "finish": "Siirrä arkistoon",
+        "return_as_waiting": "Palauta odottamaan",
+        "return_as_accepted": "Palauta hyväksytyksi",
+        "mark_as_paid": "Merkitse maksetuksi"
       }
     },
     "pageHeaders": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -225,7 +225,8 @@
           "accepted": "Hyväksytty",
           "waiting": "Odottaa",
           "completed": "Maksettu",
-          "error_in_talpa": "Virhe maksussa"
+          "error_in_talpa": "Virhe maksussa",
+          "paid": "Merkitty maksetuksi manuaalisesti"
         },
         "calculationEndDate": "Viim. tukipäivä",
         "calculatedBenefitAmount": "Tukisumma",
@@ -282,7 +283,10 @@
         "return": "Palauta",
         "confirm": "Hyväksy",
         "cancel": "Peru",
-        "finish": "Siirrä arkistoon"
+        "finish": "Siirrä arkistoon",
+        "return_as_waiting": "Palauta odottamaan",
+        "return_as_accepted": "Palauta hyväksytyksi",
+        "mark_as_paid": "Merkitse maksetuksi"
       }
     },
     "pageHeaders": {

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
@@ -12,10 +12,6 @@ import {
 } from 'benefit-shared/constants';
 import { ApplicationListItemData } from 'benefit-shared/types/application';
 import {
-  Button,
-  IconArrowUndo,
-  IconCheck,
-  IconCross,
   IconErrorFill,
   Table,
   Tag,
@@ -38,7 +34,6 @@ import {
   $Column,
   $Wrapper,
 } from '../applicationReview/actions/handlingApplicationActions/HandlingApplicationActions.sc';
-import { $HintText, $TableFooter } from '../table/TableExtras.sc';
 import {
   $AlterationBadge,
   $EmptyHeading,
@@ -46,6 +41,7 @@ import {
   $InstalmentList,
   $TagWrapper,
 } from './ApplicationList.sc';
+import ApplicationTableFooter from './ApplicationTableFooter';
 import { useApplicationList } from './useApplicationList';
 
 export interface ApplicationListProps {
@@ -241,71 +237,17 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
             setSelectedRows={setSelectedRows}
             zebra
           />
-          <$TableFooter>
-            <$Wrapper>
-              <$Column>
-                {(selectedRows.length === 0 || selectedRows.length > 1) && (
-                  <$HintText>Valitse yksi hakemus</$HintText>
-                )}
-
-                {selectedApplication &&
-                  selectedRows.length === 1 &&
-                  selectedInstalment && (
-                    <>
-                      {selectedInstalment.status ===
-                        INSTALMENT_STATUSES.WAITING && (
-                        <Button
-                          disabled={isLoading || isLoadingStatusChange}
-                          theme="coat"
-                          iconLeft={<IconCheck />}
-                          onClick={() =>
-                            changeInstalmentStatus({
-                              id: selectedInstalment.id,
-                              status: INSTALMENT_STATUSES.ACCEPTED,
-                            })
-                          }
-                        >
-                          {t(`${translationsBase}.actions.confirm`)}
-                        </Button>
-                      )}
-
-                      {selectedInstalment.status ===
-                        INSTALMENT_STATUSES.WAITING && (
-                        <Button
-                          disabled={isLoading || isLoadingStatusChange}
-                          theme="coat"
-                          iconLeft={<IconCross />}
-                          onClick={() => setIsInstalmentCancelModalShown(true)}
-                        >
-                          {t(`${translationsBase}.actions.cancel`)}
-                        </Button>
-                      )}
-
-                      {[
-                        INSTALMENT_STATUSES.ACCEPTED,
-                        INSTALMENT_STATUSES.CANCELLED,
-                      ].includes(
-                        selectedInstalment?.status as INSTALMENT_STATUSES
-                      ) && (
-                        <Button
-                          disabled={isLoading || isLoadingStatusChange}
-                          theme="coat"
-                          iconLeft={<IconArrowUndo />}
-                          onClick={() =>
-                            changeInstalmentStatus({
-                              id: selectedInstalment.id,
-                              status: INSTALMENT_STATUSES.WAITING,
-                            })
-                          }
-                        >
-                          {t(`${translationsBase}.actions.return`)}
-                        </Button>
-                      )}
-                    </>
-                  )}
-              </$Column>
-            </$Wrapper>
-          </$TableFooter>
+        {selectedRows.length > 0 && (
+          <ApplicationTableFooter
+            selectedRows={selectedRows}
+            list={list}
+            isLoading={isLoading}
+            isLoadingStatusChange={isLoadingStatusChange}
+            translationsBase={translationsBase}
+            changeInstalmentStatus={changeInstalmentStatus}
+            setIsInstalmentCancelModalShown={setIsInstalmentCancelModalShown}
+          />
+        )}
           <Modal
             id="instalment-cancel-confirm"
             isOpen={isInstalmentCancelModalShown}

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationTableFooter.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationTableFooter.tsx
@@ -1,0 +1,133 @@
+import { INSTALMENT_STATUSES } from 'benefit-shared/constants';
+import { ApplicationListItemData } from 'benefit-shared/types/application';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+
+import {
+    $Column,
+    $Wrapper,
+  } from '../applicationReview/actions/handlingApplicationActions/HandlingApplicationActions.sc';
+import { $HintText, $TableFooter } from '../table/TableExtras.sc';
+import InstalmentButton from "./InstalmentButton";
+
+interface TableFooterProps {
+  selectedRows: string[];
+  list: ApplicationListItemData[];
+  isLoading: boolean;
+  isLoadingStatusChange: boolean;
+  translationsBase: string;
+  changeInstalmentStatus: (params: { 
+    id?: string; 
+    status: INSTALMENT_STATUSES 
+  }) => void;
+  setIsInstalmentCancelModalShown: (show: boolean) => void;
+}
+
+const ApplicationTableFooter: React.FC<TableFooterProps> = ({
+  selectedRows,
+  list,
+  isLoading,
+  isLoadingStatusChange,
+  translationsBase,
+  changeInstalmentStatus,
+  setIsInstalmentCancelModalShown
+}) => {
+  const { t } = useTranslation();
+
+
+  const selectedApplication = list.find((app) => app.id === selectedRows[0]);
+  const selectedInstalment =
+    list.find(
+      (app: ApplicationListItemData) =>
+        app.id === String(selectedApplication?.id)
+    )?.pendingInstalment || null;
+
+  const handleStatusChange = (status: INSTALMENT_STATUSES): void => {
+      changeInstalmentStatus({
+          id: selectedInstalment.id,
+          status,
+      });
+  };
+
+  // If no rows or multiple rows selected, show hint
+  if (selectedRows.length !== 1) {
+    return (
+      <$TableFooter>
+        <$Wrapper>
+          <$Column>
+            <$HintText>Valitse yksi hakemus</$HintText>
+          </$Column>
+        </$Wrapper>
+      </$TableFooter>
+    );
+  }
+
+  // If no selected application or instalment, return null
+  if (!selectedApplication || !selectedInstalment) {
+    return null;
+  }
+
+  return (
+    <$TableFooter>
+      <$Wrapper>
+        <$Column>
+          {/* Waiting Status Buttons */}
+          {selectedInstalment.status === INSTALMENT_STATUSES.WAITING && (
+            <>
+              <InstalmentButton
+                isLoading={isLoading}
+                isLoadingStatusChange={isLoadingStatusChange}
+                onClick={() => handleStatusChange(INSTALMENT_STATUSES.ACCEPTED)}
+              >
+                {t(`${translationsBase}.actions.confirm`)}
+              </InstalmentButton>
+              <InstalmentButton
+                isLoading={isLoading}
+                isLoadingStatusChange={isLoadingStatusChange}
+                onClick={() => setIsInstalmentCancelModalShown(true)}
+              >
+                {t(`${translationsBase}.actions.cancel`)}
+              </InstalmentButton>
+            </>
+          )}
+
+          {/* Error in Talpa Buttons */}
+          {selectedInstalment.status === INSTALMENT_STATUSES.ERROR_IN_TALPA && (
+            <>
+              <InstalmentButton
+                isLoading={isLoading}
+                isLoadingStatusChange={isLoadingStatusChange}
+                onClick={() => handleStatusChange(INSTALMENT_STATUSES.ACCEPTED)}
+              >
+                {t(`${translationsBase}.actions.return_as_accepted`)}
+              </InstalmentButton>
+              <InstalmentButton
+                isLoading={isLoading}
+                isLoadingStatusChange={isLoadingStatusChange}
+                onClick={() => handleStatusChange(INSTALMENT_STATUSES.PAID)}
+              >
+                {t(`${translationsBase}.actions.mark_as_paid`)}
+              </InstalmentButton>
+            </>
+          )}
+
+          {/* Return Button for Accepted/Cancelled Statuses */}
+          {[
+            INSTALMENT_STATUSES.ACCEPTED,
+            INSTALMENT_STATUSES.CANCELLED,
+          ].includes(selectedInstalment?.status as INSTALMENT_STATUSES) && (
+            <InstalmentButton
+                isLoading={isLoading}
+                isLoadingStatusChange={isLoadingStatusChange}
+                onClick={() => handleStatusChange(INSTALMENT_STATUSES.WAITING)}
+            >
+              {t(`${translationsBase}.actions.return`)}
+            </InstalmentButton>
+          )}
+        </$Column>
+      </$Wrapper>
+    </$TableFooter>
+  );
+};
+
+export default ApplicationTableFooter;

--- a/frontend/benefit/handler/src/components/applicationList/InstalmentButton.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/InstalmentButton.tsx
@@ -1,0 +1,31 @@
+import { 
+    Button, 
+    IconCheck, 
+  } from 'hds-react';
+import React from "react";
+
+
+interface InstalmentButtonProps {
+  isLoading: boolean;
+  isLoadingStatusChange: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+  
+const InstalmentButton: React.FC<InstalmentButtonProps> = ({
+  isLoading,
+  isLoadingStatusChange,
+  onClick,
+  children 
+}) => (
+    <Button
+      disabled={isLoading || isLoadingStatusChange}
+      theme="coat"
+      iconLeft={<IconCheck />}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+
+export default InstalmentButton;


### PR DESCRIPTION
## Description :sparkles:
[HL-1575](https://helsinkisolutionoffice.atlassian.net/browse/HL-1575)
Enable the returning of an instalment from error_in_talpa status to accepted or paid status via  handlerUI.
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
<img width="1466" alt="Screenshot 2024-12-10 at 12 03 58" src="https://github.com/user-attachments/assets/5170f712-84ce-41f1-8370-552bb259acf0">
<img width="1459" alt="Screenshot 2024-12-10 at 12 04 07" src="https://github.com/user-attachments/assets/7e8ae2d7-6993-4368-9669-db8d3f2ef87a">
<img width="1422" alt="Screenshot 2024-12-10 at 12 04 36" src="https://github.com/user-attachments/assets/7ba12f6b-913e-47db-8a9d-0e5a1e99aabd">

## Additional notes :spiral_notepad:


[HL-1575]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ