### PR TITLE
Hl 1548

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -595,6 +595,10 @@
       "label": "The Helsinki benefit application has been submitted",
       "message": "We have received your Helsinki benefit application with application number {{applicationNumber}}.\n\nNext, the application will be sent for processing. You can follow the progress of your application in the Helsinki benefit service.\n\nIf you have questions about your application, you can use the Helsinki benefit e-service to send messages or send an email to helsinkilisa@hel.fi."
     },
+    "applicationReSubmitted": {
+      "label": "The modification to the Helsinki benefit application has been submitted",
+      "message": "We have received the modification to your Helsinki benefit application, with the application number {{applicationNumber}}."
+    },
     "applicationSaved": {
       "label": "Application saved",
       "message": "Helsinki-benefit application {{applicationNumber}} {{applicantName}} has been saved."

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -593,7 +593,7 @@
   "notifications": {
     "applicationSubmitted": {
       "label": "The Helsinki benefit application has been submitted",
-      "message": "We have received your Helsinki benefit application with application number {{applicationNumber}}.\n\nNext, the application will be sent for processing. The designated contact person for the application will receive an email notification when it has been processed. You can follow the progress of your application in the Helsinki benefit service.\n\nIf you have questions about your application, you can use the Helsinki benefit e-service to send messages or send an email to helsinkilisa@hel.fi."
+      "message": "We have received your Helsinki benefit application with application number {{applicationNumber}}.\n\nNext, the application will be sent for processing. You can follow the progress of your application in the Helsinki benefit service.\n\nIf you have questions about your application, you can use the Helsinki benefit e-service to send messages or send an email to helsinkilisa@hel.fi."
     },
     "applicationSaved": {
       "label": "Application saved",

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -593,7 +593,7 @@
   "notifications": {
     "applicationSubmitted": {
       "label": "Helsinki-lisä -hakemus on lähetetty",
-      "message": "Olemme vastaanottaneet Helsinki-lisä -hakemuksesi, jonka hakemusnumero on  {{applicationNumber}}.\n\nSeuraavaksi hakemus siirtyy käsiteltäväksi. Saat ilmoituksen sähköpostiisi, kun hakemus on käsitelty. Voit seurata käsittelyn etenemistä Helsinki-lisän asiointipalvelussa.\n\nHakemukseen liittyvissä kysymyksissä voit lähettää viestejä Helsinki-lisän asiointipalvelussa tai lähettää sähköpostia osoitteeseen helsinkilisa@hel.fi."
+      "message": "Olemme vastaanottaneet Helsinki-lisä -hakemuksesi, jonka hakemusnumero on  {{applicationNumber}}.\n\nSeuraavaksi hakemus siirtyy käsiteltäväksi. Voit seurata käsittelyn etenemistä Helsinki-lisän asiointipalvelussa.\n\nHakemukseen liittyvissä kysymyksissä voit lähettää viestejä Helsinki-lisän asiointipalvelussa tai lähettää sähköpostia osoitteeseen helsinkilisa@hel.fi."
     },
     "applicationSaved": {
       "label": "Hakemus tallennettu",

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -595,6 +595,10 @@
       "label": "Helsinki-lisä -hakemus on lähetetty",
       "message": "Olemme vastaanottaneet Helsinki-lisä -hakemuksesi, jonka hakemusnumero on  {{applicationNumber}}.\n\nSeuraavaksi hakemus siirtyy käsiteltäväksi. Voit seurata käsittelyn etenemistä Helsinki-lisän asiointipalvelussa.\n\nHakemukseen liittyvissä kysymyksissä voit lähettää viestejä Helsinki-lisän asiointipalvelussa tai lähettää sähköpostia osoitteeseen helsinkilisa@hel.fi."
     },
+    "applicationReSubmitted": {
+      "label": "Helsinki-lisä -hakemuksen muutos on lähetetty",
+      "message": "Olemme vastaanottaneet muutoksen Helsinki-lisä hakemukseesi, jonka hakemusnumero on {{applicationNumber}}."
+    },
     "applicationSaved": {
       "label": "Hakemus tallennettu",
       "message": "Helsinki-lisä hakemus {{applicationNumber}} {{applicantName}} on tallennettu."

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -593,7 +593,7 @@
   "notifications": {
     "applicationSubmitted": {
       "label": "Ansökan om Helsingforstillägget har skickats",
-      "message": "Vi har mottagit din ansökan om Helsingforstillägg med ansökningsnummer {{applicationNumber}}\n\nAnsökningen överförs till handläggning. Den kontaktperson som utsetts för ansökningen får ett meddelande per e-post när ansökningen har behandlats. Du kan följa upp med hur handläggningen framskrider i e-tjänsten för sysselsättning Helsingforstillägg.\n\nOm du har frågor om ansökningen, kan du skicka meddelanden i e-tjänsten för sysselsättning Helsingforstillägg eller skicka e-post till adressen helsinkilisa@hel.fi."
+      "message": "Vi har mottagit din ansökan om Helsingforstillägg med ansökningsnummer {{applicationNumber}}\n\nAnsökningen överförs till handläggning. Du kan följa upp med hur handläggningen framskrider i e-tjänsten för sysselsättning Helsingforstillägg.\n\nOm du har frågor om ansökningen, kan du skicka meddelanden i e-tjänsten för sysselsättning Helsingforstillägg eller skicka e-post till adressen helsinkilisa@hel.fi."
     },
     "applicationSaved": {
       "label": "Applikationen sparas",

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -595,6 +595,10 @@
       "label": "Ansökan om Helsingforstillägget har skickats",
       "message": "Vi har mottagit din ansökan om Helsingforstillägg med ansökningsnummer {{applicationNumber}}\n\nAnsökningen överförs till handläggning. Du kan följa upp med hur handläggningen framskrider i e-tjänsten för sysselsättning Helsingforstillägg.\n\nOm du har frågor om ansökningen, kan du skicka meddelanden i e-tjänsten för sysselsättning Helsingforstillägg eller skicka e-post till adressen helsinkilisa@hel.fi."
     },
+    "applicationReSubmitted": {
+      "label": " Ändringen av Helsingforstillägget ansökan har skickats.",
+      "message": "Vi har mottagit ändringen i din Helsingforstillägget med ansökningsnummer{{applicationNumber}}."
+    },
     "applicationSaved": {
       "label": "Applikationen sparas",
       "message": "Helsingforstillägg applikationen {{applicationNumber}} {{applicantName}} sparas."

--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -166,7 +166,7 @@ const PageContent: React.FC = () => {
           })}
         />
         ):
-        <NotificationView
+        (<NotificationView
           applicationId={application.id}
           title={t('common:notifications.applicationSubmitted.label')}
           message={t('common:notifications.applicationSubmitted.message', {
@@ -177,6 +177,7 @@ const PageContent: React.FC = () => {
             ),
           })}
         />
+        )
 
         {router.locale === SUPPORTED_LANGUAGES.FI && (
           <Container>

--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -153,7 +153,7 @@ const PageContent: React.FC = () => {
   if (isSubmittedApplication) {
     return (
       <>
-      application.status === && APPLICATION_STATUSES.INFO_REQUIRED ? (
+      {application.status === && APPLICATION_STATUSES.INFO_REQUIRED ? (
         <NotificationView
           applicationId={application.id}
           title={t('common:notifications.applicationReSubmitted.label')}
@@ -178,6 +178,7 @@ const PageContent: React.FC = () => {
           })}
         />
         )
+      }
 
         {router.locale === SUPPORTED_LANGUAGES.FI && (
           <Container>

--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -153,6 +153,19 @@ const PageContent: React.FC = () => {
   if (isSubmittedApplication) {
     return (
       <>
+      application.status === && APPLICATION_STATUSES.INFO_REQUIRED ? (
+        <NotificationView
+          applicationId={application.id}
+          title={t('common:notifications.applicationReSubmitted.label')}
+          message={t('common:notifications.applicationReSubmitted.message', {
+            applicationNumber: application?.applicationNumber,
+            applicantName: getFullName(
+              application?.employee?.firstName,
+              application?.employee?.lastName
+            ),
+          })}
+        />
+        ):
         <NotificationView
           applicationId={application.id}
           title={t('common:notifications.applicationSubmitted.label')}
@@ -164,6 +177,7 @@ const PageContent: React.FC = () => {
             ),
           })}
         />
+
         {router.locale === SUPPORTED_LANGUAGES.FI && (
           <Container>
             <$Hr />

--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -153,7 +153,7 @@ const PageContent: React.FC = () => {
   if (isSubmittedApplication) {
     return (
       <>
-      {application.status === && APPLICATION_STATUSES.INFO_REQUIRED ? (
+      {application.status === APPLICATION_STATUSES.INFO_REQUIRED ? (
         <NotificationView
           applicationId={application.id}
           title={t('common:notifications.applicationReSubmitted.label')}


### PR DESCRIPTION
## Description :sparkles:
[HL-1548](https://helsinkisolutionoffice.atlassian.net/browse/HL-1548)
Removed text about sending email notification of decision in application send confirmation box.
Added own text for resending application confirmation.



[HL-1548]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ