### PR TITLE
fix: round alteration recovery amount down

### DIFF
--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from datetime import date
+from decimal import Decimal, ROUND_DOWN
 from typing import List
 
 from dateutil.relativedelta import relativedelta
@@ -500,7 +501,11 @@ class HandlerApplicationAlterationViewSet(BaseApplicationAlterationViewSet):
         )
 
         alteration.recovery_justification = request.data.get("recovery_justification")
-        alteration.recovery_amount = request.data.get("recovery_amount")
+        recovery_amount = Decimal(request.data.get("recovery_amount"))
+        alteration.recovery_amount = recovery_amount.quantize(
+            Decimal("1"), rounding=ROUND_DOWN
+        )
+
         alteration.recovery_end_date = request.data.get("recovery_end_date")
         alteration.recovery_start_date = request.data.get("recovery_start_date")
 

--- a/backend/benefit/applications/api/v1/serializers/application_alteration.py
+++ b/backend/benefit/applications/api/v1/serializers/application_alteration.py
@@ -1,4 +1,5 @@
 from datetime import date
+from decimal import Decimal, ROUND_DOWN
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -94,6 +95,12 @@ class BaseApplicationAlterationSerializer(DynamicFieldsModelSerializer):
         read_only=True,
         help_text="The handler responsible for the cancellation of this alteration, if any",
     )
+
+    def validate_recovery_amount(self, value):
+        if value is not None:
+            # Round down the recovery_amount to the nearest integer while keeping it as Decimal
+            return value.quantize(Decimal("1"), rounding=ROUND_DOWN)
+        return value
 
     def get_application_company_name(self, obj):
         return obj.application.company.name

--- a/backend/benefit/applications/services/applications_csv_report.py
+++ b/backend/benefit/applications/services/applications_csv_report.py
@@ -5,7 +5,7 @@ from typing import List
 
 from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
-from django.utils import timezone, translation
+from django.utils import translation
 
 from applications.enums import ApplicationBatchStatus, ApplicationOrigin, BenefitType
 from applications.models import Application
@@ -115,7 +115,6 @@ class ApplicationsCsvService(CsvExportBase):
         """Return the actual payable amount of the currently accepted and due instalment"""
         try:
             instalment = application.calculation.instalments.get(
-                due_date__lte=timezone.now().date(),
                 instalment_number=number,
             )
             return instalment
@@ -375,7 +374,8 @@ class ApplicationsCsvService(CsvExportBase):
             )
             columns.append(
                 csv_default_column(
-                    "Maksettu maksuerä 2", self.get_instalment_2_amount_after_recoveries
+                    "Maksettava maksuerä 2",
+                    self.get_instalment_2_amount_after_recoveries,
                 ),
             )
             columns.append(

--- a/backend/benefit/applications/services/applications_power_bi_csv_report.py
+++ b/backend/benefit/applications/services/applications_power_bi_csv_report.py
@@ -128,7 +128,8 @@ class ApplicationsPowerBiCsvService(ApplicationsCsvService):
             )
             columns.append(
                 csv_default_column(
-                    "Maksettu maksuerä 2", self.get_instalment_2_amount_after_recoveries
+                    "Maksettava maksuerä 2",
+                    self.get_instalment_2_amount_after_recoveries,
                 ),
             )
             columns.append(

--- a/backend/benefit/applications/tests/test_alteration_api.py
+++ b/backend/benefit/applications/tests/test_alteration_api.py
@@ -439,7 +439,7 @@ def test_application_alteration_create_ignored_fields_handler(
             "use_invoice": False,
             "recovery_start_date": application.start_date + relativedelta(days=7),
             "recovery_end_date": application.end_date,
-            "recovery_amount": 4000,
+            "recovery_amount": 4000.97,
             "contact_person_name": "Ella Esimerkki",
         },
     )
@@ -504,7 +504,7 @@ def test_application_alteration_patch_handler(handler_api_client, application):
         ),
         {
             "end_date": application.start_date + relativedelta(days=12),
-            "recovery_amount": 4000,
+            "recovery_amount": 4000.45,
         },
     )
     assert response.status_code == 200


### PR DESCRIPTION
## Description :sparkles:
[HL-1490](https://helsinkisolutionoffice.atlassian.net/browse/HL-1490?atlOrigin=eyJpIjoiYmMxNzY5OWU0ZGEyNGJkMGEyMTJhZGE2OWQwZmJkZDEiLCJwIjoiaiJ9)

Round alteration.recovery_amount down when it is saved or updated.

[HL-1502](https://helsinkisolutionoffice.atlassian.net/browse/HL-1502)
Show both instalments in the csv reports, even if they are not due yet.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1490]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HL-1502]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ