### PR TITLE
fix: Application status is already change to HANDLING when showing no…

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/PageContent.tsx
@@ -149,11 +149,11 @@ const PageContent: React.FC = () => {
       />
     );
   }
-
+// Different confirmation messages for sending update (HANDLING) and sending new application
   if (isSubmittedApplication) {
     return (
       <>
-      {application.status === APPLICATION_STATUSES.INFO_REQUIRED ? (
+      {application.status === APPLICATION_STATUSES.HANDLING ? (
         <NotificationView
           applicationId={application.id}
           title={t('common:notifications.applicationReSubmitted.label')}


### PR DESCRIPTION

 Application status is already change to HANDLING when showing notification. 
 Not anymore INFO_REQUIRED
 New application status is RECEIVED
## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
