### PR TITLE
fix: In application cloning force origin to be applicant

### DIFF
--- a/backend/benefit/applications/services/clone_application.py
+++ b/backend/benefit/applications/services/clone_application.py
@@ -8,7 +8,7 @@ from applications.enums import (
     ApplicationStatus,
     ApplicationStep,
     AttachmentType,
-    ApplicationOrigin
+    ApplicationOrigin,
 )
 from applications.models import (
     AhjoStatus,

--- a/backend/benefit/applications/services/clone_application.py
+++ b/backend/benefit/applications/services/clone_application.py
@@ -8,6 +8,7 @@ from applications.enums import (
     ApplicationStatus,
     ApplicationStep,
     AttachmentType,
+    ApplicationOrigin
 )
 from applications.models import (
     AhjoStatus,
@@ -42,7 +43,7 @@ def clone_application_based_on_other(
             "alternative_company_postcode": application_base.alternative_company_postcode,
             "alternative_company_street_address": application_base.alternative_company_street_address,
             "applicant_language": "fi",
-            "application_origin": application_base.application_origin,
+            "application_origin": ApplicationOrigin.applicant,
             "application_step": ApplicationStep.STEP_1,
             "archived": False,
             "association_has_business_activities": application_base.association_has_business_activities

--- a/backend/benefit/applications/services/clone_application.py
+++ b/backend/benefit/applications/services/clone_application.py
@@ -5,10 +5,10 @@ from PIL import Image
 
 from applications.enums import (
     AhjoStatus as AhjoStatusEnum,
+    ApplicationOrigin,
     ApplicationStatus,
     ApplicationStep,
     AttachmentType,
-    ApplicationOrigin,
 )
 from applications.models import (
     AhjoStatus,

--- a/backend/benefit/applications/services/clone_application.py
+++ b/backend/benefit/applications/services/clone_application.py
@@ -43,7 +43,7 @@ def clone_application_based_on_other(
             "alternative_company_postcode": application_base.alternative_company_postcode,
             "alternative_company_street_address": application_base.alternative_company_street_address,
             "applicant_language": "fi",
-            "application_origin": ApplicationOrigin.applicant,
+            "application_origin": ApplicationOrigin.APPLICANT,
             "application_step": ApplicationStep.STEP_1,
             "archived": False,
             "association_has_business_activities": application_base.association_has_business_activities

--- a/backend/benefit/applications/tests/test_application_clone.py
+++ b/backend/benefit/applications/tests/test_application_clone.py
@@ -241,7 +241,7 @@ def _set_up_decided_application():
         co_operation_negotiations_description="Very co-operation. Much contract.",
         paper_application_date="2024-10-23",
         pay_subsidy_granted=PaySubsidyGranted.GRANTED,
-        application_origin=ApplicationOrigin.HANDLER,
+        application_origin=ApplicationOrigin.APPLICANT,
         application_step=ApplicationStep.STEP_6,
         batch=ApplicationBatchFactory(
             proposal_for_decision=ApplicationStatus.ACCEPTED,


### PR DESCRIPTION
## Description :sparkles:
Force application origin to be applicant

[hl-1547](https://helsinkisolutionoffice.atlassian.net/browse/HL-1547)
## Issues :bug:
In application cloning it was possible to clone paper application and have new paper application that had problem with full application attachment

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
