### PR TITLE
fix: include CSRF token in tet userinfo endpoint response

### DIFF
--- a/backend/tet/tet/views.py
+++ b/backend/tet/tet/views.py
@@ -4,6 +4,7 @@ from typing import Optional
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.http import HttpResponse, JsonResponse
+from django.middleware.csrf import get_token
 from django.shortcuts import redirect
 from django.views import View
 
@@ -53,6 +54,12 @@ class UserInfoView(View):
 
             if not userinfo["name"]:
                 userinfo["name"] = userinfo["organization_name"]
+
+            # We want to ensure the client has some kind of CSRF token available
+            # Calling get_token ensures Django includes CSRF token in the response
+            # CSRF token does not normally get included into APIView's because
+            # DRF calls csrf_exempt by default
+            _ = get_token(request)
 
             return JsonResponse(userinfo)
         else:


### PR DESCRIPTION
Currently CSRF token is provided only once during the end of authentication. If the user loses the CSRF token, there is no way to retrieve it without logging out and logging back in.

- APIView does not set CSRF token because it defaults to csrf_exempt
- CsrfViewMiddleware does not set a new token if cookie is missing

CSRF token can be forced into the response by calling get_token, so it is added to the userinfo endpoint to improve the chances of it being delivered to the browser.

Refs: TETP-306

https://helsinkisolutionoffice.atlassian.net/browse/TETP-306
