### PR TITLE
fix: restore required setting TUNNISTAMO_API_TOKENS_ENDPOINT

### DIFF
--- a/backend/tet/tet/settings.py
+++ b/backend/tet/tet/settings.py
@@ -295,6 +295,7 @@ OIDC_OP_USER_ENDPOINT = f"{OIDC_OP_BASE_URL}/protocol/openid-connect/userinfo"
 OIDC_OP_JWKS_ENDPOINT = f"{OIDC_OP_BASE_URL}/protocol/openid-connect/certs"
 OIDC_OP_LOGOUT_ENDPOINT = f"{OIDC_OP_BASE_URL}/protocol/openid-connect/logout"
 OIDC_OP_LOGOUT_CALLBACK_URL = django_env.str("OIDC_OP_LOGOUT_CALLBACK_URL")
+TUNNISTAMO_API_TOKENS_ENDPOINT = None  # settings value must exist in hp_client
 TUNNISTUS_API_TOKENS_ENDPOINT = django_env("TUNNISTUS_API_TOKENS_ENDPOINT")
 HELSINKI_PROFILE_API_URL = django_env.str("HELSINKI_PROFILE_API_URL")
 LOGOUT_REDIRECT_URL = django_env.str("LOGOUT_REDIRECT_URL")


### PR DESCRIPTION
hp_client requires that the setting exists even if it is not going to be used.

refs: TETP-310, TETP-314
