### PR TITLE
[DRAFT] fix: upgrade vulnerable Next.js version

### DIFF
--- a/frontend/benefit/applicant/package.json
+++ b/frontend/benefit/applicant/package.json
@@ -30,7 +30,7 @@
     "hds-design-tokens": "^3.11.0",
     "hds-react": "^3.11.0",
     "lodash": "^4.17.21",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-router-mock": "0.9.12",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",

--- a/frontend/benefit/handler/package.json
+++ b/frontend/benefit/handler/package.json
@@ -39,7 +39,7 @@
     "hds-react": "^3.11.0",
     "ibantools": "^4.3.4",
     "lodash": "^4.17.21",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
     "next-router-mock": "0.9.12",

--- a/frontend/benefit/shared/package.json
+++ b/frontend/benefit/shared/package.json
@@ -20,7 +20,7 @@
     "formik": "^2.2.9",
     "hds-react": "^3.11.0",
     "ibantools": "^4.1.5",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-i18next": "^13.0.3",
     "next-router-mock": "0.9.12",
     "react": "^18.2.0",

--- a/frontend/kesaseteli/employer/package.json
+++ b/frontend/kesaseteli/employer/package.json
@@ -28,7 +28,7 @@
     "hds-react": "^3.11.0",
     "ibantools": "^4.1.5",
     "lodash": "^4.17.21",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
     "next-router-mock": "0.9.12",

--- a/frontend/kesaseteli/handler/package.json
+++ b/frontend/kesaseteli/handler/package.json
@@ -28,7 +28,7 @@
     "hds-design-tokens": "^3.11.0",
     "hds-react": "^3.11.0",
     "lodash": "^4.17.21",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
     "react": "^18.2.0",

--- a/frontend/kesaseteli/youth/package.json
+++ b/frontend/kesaseteli/youth/package.json
@@ -29,7 +29,7 @@
     "hds-design-tokens": "^3.11.0",
     "hds-react": "^3.11.0",
     "lodash": "^4.17.21",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
     "next-router-mock": "0.9.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -143,7 +143,7 @@
     "lerna-audit": "^1.3.3",
     "lint-staged": "^12.3.1",
     "lodash": "^4.17.21",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-router-mock": "0.9.12",
     "nock": "^13.5.0",
     "picocolors": "1.0.0",

--- a/frontend/shared/package.json
+++ b/frontend/shared/package.json
@@ -25,7 +25,7 @@
     "hds-react": "^3.11.0",
     "js-file-download": "^0.4.12",
     "lodash": "^4.17.21",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-i18next": "^13.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/tet/admin/package.json
+++ b/frontend/tet/admin/package.json
@@ -27,7 +27,7 @@
     "hds-design-tokens": "^3.11.0",
     "hds-react": "^3.11.0",
     "leaflet": "^1.7.1",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
     "react": "^18.2.0",

--- a/frontend/tet/shared/package.json
+++ b/frontend/tet/shared/package.json
@@ -17,7 +17,7 @@
     "@frontend/shared": "*",
     "axios": "^0.27.2",
     "hds-react": "^3.11.0",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-i18next": "^13.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/tet/youth/package.json
+++ b/frontend/tet/youth/package.json
@@ -28,7 +28,7 @@
     "hds-react": "^3.11.0",
     "leaflet": "^1.7.1",
     "leaflet.markercluster": "^1.5.3",
-    "next": "14.2.12",
+    "next": "14.2.25",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^13.0.3",
     "react": "^18.2.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2314,10 +2314,10 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@next/env@14.2.12":
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-14.2.12.tgz#15f1d1065a420416e92f177fc8c94ee4ecc2669d"
-  integrity sha512-3fP29GIetdwVIfIRyLKM7KrvJaqepv+6pVodEbx0P5CaMLYBtx+7eEg8JYO5L9sveJO87z9eCReceZLi0hxO1Q==
+"@next/env@14.2.25":
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-14.2.25.tgz#936d10b967e103e49a4bcea1e97292d5605278dd"
+  integrity sha512-JnzQ2cExDeG7FxJwqAksZ3aqVJrHjFwZQAEJ9gQZSoEhIow7SNoKZzju/AwQ+PLIR4NY8V0rhcVozx/2izDO0w==
 
 "@next/eslint-plugin-next@14.1.1":
   version "14.1.1"
@@ -2333,50 +2333,50 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-darwin-arm64@14.2.12":
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.12.tgz#263c68fd55538624a6236552d153a3487d601a33"
-  integrity sha512-crHJ9UoinXeFbHYNok6VZqjKnd8rTd7K3Z2zpyzF1ch7vVNKmhjv/V7EHxep3ILoN8JB9AdRn/EtVVyG9AkCXw==
+"@next/swc-darwin-arm64@14.2.25":
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.25.tgz#7bcccfda0c0ff045c45fbe34c491b7368e373e3d"
+  integrity sha512-09clWInF1YRd6le00vt750s3m7SEYNehz9C4PUcSu3bAdCTpjIV4aTYQZ25Ehrr83VR1rZeqtKUPWSI7GfuKZQ==
 
-"@next/swc-darwin-x64@14.2.12":
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.12.tgz#0fc05a99094ac531692d552743f62f7dbbcb5bc8"
-  integrity sha512-JbEaGbWq18BuNBO+lCtKfxl563Uw9oy2TodnN2ioX00u7V1uzrsSUcg3Ep9ce+P0Z9es+JmsvL2/rLphz+Frcw==
+"@next/swc-darwin-x64@14.2.25":
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.25.tgz#b489e209d7b405260b73f69a38186ed150fb7a08"
+  integrity sha512-V+iYM/QR+aYeJl3/FWWU/7Ix4b07ovsQ5IbkwgUK29pTHmq+5UxeDr7/dphvtXEq5pLB/PucfcBNh9KZ8vWbug==
 
-"@next/swc-linux-arm64-gnu@14.2.12":
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.12.tgz#56214b10cdb1c47d6f26ae2dd00bc9b32fd2a694"
-  integrity sha512-qBy7OiXOqZrdp88QEl2H4fWalMGnSCrr1agT/AVDndlyw2YJQA89f3ttR/AkEIP9EkBXXeGl6cC72/EZT5r6rw==
+"@next/swc-linux-arm64-gnu@14.2.25":
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.25.tgz#ba064fabfdce0190d9859493d8232fffa84ef2e2"
+  integrity sha512-LFnV2899PJZAIEHQ4IMmZIgL0FBieh5keMnriMY1cK7ompR+JUd24xeTtKkcaw8QmxmEdhoE5Mu9dPSuDBgtTg==
 
-"@next/swc-linux-arm64-musl@14.2.12":
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.12.tgz#017ccb35e94dd5336f38bdab90ccc7163467e0d1"
-  integrity sha512-EfD9L7o9biaQxjwP1uWXnk3vYZi64NVcKUN83hpVkKocB7ogJfyH2r7o1pPnMtir6gHZiGCeHKagJ0yrNSLNHw==
+"@next/swc-linux-arm64-musl@14.2.25":
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.25.tgz#bf0018267e4e0fbfa1524750321f8cae855144a3"
+  integrity sha512-QC5y5PPTmtqFExcKWKYgUNkHeHE/z3lUsu83di488nyP0ZzQ3Yse2G6TCxz6nNsQwgAx1BehAJTZez+UQxzLfw==
 
-"@next/swc-linux-x64-gnu@14.2.12":
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.12.tgz#b5df80780eceef6b44a0cedfe7234d34a60af1f9"
-  integrity sha512-iQ+n2pxklJew9IpE47hE/VgjmljlHqtcD5UhZVeHICTPbLyrgPehaKf2wLRNjYH75udroBNCgrSSVSVpAbNoYw==
+"@next/swc-linux-x64-gnu@14.2.25":
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.25.tgz#64f5a6016a7148297ee80542e0fd788418a32472"
+  integrity sha512-y6/ML4b9eQ2D/56wqatTJN5/JR8/xdObU2Fb1RBidnrr450HLCKr6IJZbPqbv7NXmje61UyxjF5kvSajvjye5w==
 
-"@next/swc-linux-x64-musl@14.2.12":
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.12.tgz#553ad8dd26e8fce343f2b01d741dffc8bb909e37"
-  integrity sha512-rFkUkNwcQ0ODn7cxvcVdpHlcOpYxMeyMfkJuzaT74xjAa5v4fxP4xDk5OoYmPi8QNLDs3UgZPMSBmpBuv9zKWA==
+"@next/swc-linux-x64-musl@14.2.25":
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.25.tgz#58dc636d7c55828478159546f7b95ab1e902301c"
+  integrity sha512-sPX0TSXHGUOZFvv96GoBXpB3w4emMqKeMgemrSxI7A6l55VBJp/RKYLwZIB9JxSqYPApqiREaIIap+wWq0RU8w==
 
-"@next/swc-win32-arm64-msvc@14.2.12":
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.12.tgz#cf9c3907f43b9a0cbe2f10a46f6c9f5de05ba9dc"
-  integrity sha512-PQFYUvwtHs/u0K85SG4sAdDXYIPXpETf9mcEjWc0R4JmjgMKSDwIU/qfZdavtP6MPNiMjuKGXHCtyhR/M5zo8g==
+"@next/swc-win32-arm64-msvc@14.2.25":
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.25.tgz#93562d447c799bded1e89c1a62d5195a2a8c6c0d"
+  integrity sha512-ReO9S5hkA1DU2cFCsGoOEp7WJkhFzNbU/3VUF6XxNGUCQChyug6hZdYL/istQgfT/GWE6PNIg9cm784OI4ddxQ==
 
-"@next/swc-win32-ia32-msvc@14.2.12":
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.12.tgz#cad79313b383e95e6d53bdb631b47a26e63146e0"
-  integrity sha512-FAj2hMlcbeCV546eU2tEv41dcJb4NeqFlSXU/xL/0ehXywHnNpaYajOUvn3P8wru5WyQe6cTZ8fvckj/2XN4Vw==
+"@next/swc-win32-ia32-msvc@14.2.25":
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.25.tgz#ad85a33466be1f41d083211ea21adc0d2c6e6554"
+  integrity sha512-DZ/gc0o9neuCDyD5IumyTGHVun2dCox5TfPQI/BJTYwpSNYM3CZDI4i6TOdjeq1JMo+Ug4kPSMuZdwsycwFbAw==
 
-"@next/swc-win32-x64-msvc@14.2.12":
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.12.tgz#9d5b2f2733221ae85c3e5c6d4b6f8f1da32d5cae"
-  integrity sha512-yu8QvV53sBzoIVRHsxCHqeuS8jYq6Lrmdh0briivuh+Brsp6xjg80MAozUsBTAV9KNmY08KlX0KYTWz1lbPzEg==
+"@next/swc-win32-x64-msvc@14.2.25":
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.25.tgz#3969c66609e683ec63a6a9f320a855f7be686a08"
+  integrity sha512-KSznmS6eFjQ9RJ1nEc66kJvtGIL1iZMYmGEXsZPh2YtnLtqrgdVvKXJY2ScjjoFnG6nGLyPFR0UiEvDwVah4Tw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -11995,12 +11995,12 @@ next-router-mock@0.9.12:
   resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.12.tgz#a64934c9c86f60f6b3c6a7e37e72e51ed5feeea0"
   integrity sha512-PzKn70RSqO50GHyYyhd4WJb9I526Abfq2VDP+YPV8yqlaR38OKtQAcWr3njR75UG+Ik6HououZHm7ucxl6LSnA==
 
-next@14.2.12:
-  version "14.2.12"
-  resolved "https://registry.yarnpkg.com/next/-/next-14.2.12.tgz#39d52c090c40980f4ae56f485ad234b777ebc955"
-  integrity sha512-cDOtUSIeoOvt1skKNihdExWMTybx3exnvbFbb9ecZDIxlvIbREQzt9A5Km3Zn3PfU+IFjyYGsHS+lN9VInAGKA==
+next@14.2.25:
+  version "14.2.25"
+  resolved "https://registry.yarnpkg.com/next/-/next-14.2.25.tgz#0657551fde6a97f697cf9870e9ccbdaa465c6008"
+  integrity sha512-N5M7xMc4wSb4IkPvEV5X2BRRXUmhVHNyaXwEM86+voXthSZz8ZiRyQW4p9mwAoAPIm6OzuVZtn7idgEJeAJN3Q==
   dependencies:
-    "@next/env" "14.2.12"
+    "@next/env" "14.2.25"
     "@swc/helpers" "0.5.5"
     busboy "1.6.0"
     caniuse-lite "^1.0.30001579"
@@ -12008,15 +12008,15 @@ next@14.2.12:
     postcss "8.4.31"
     styled-jsx "5.1.1"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "14.2.12"
-    "@next/swc-darwin-x64" "14.2.12"
-    "@next/swc-linux-arm64-gnu" "14.2.12"
-    "@next/swc-linux-arm64-musl" "14.2.12"
-    "@next/swc-linux-x64-gnu" "14.2.12"
-    "@next/swc-linux-x64-musl" "14.2.12"
-    "@next/swc-win32-arm64-msvc" "14.2.12"
-    "@next/swc-win32-ia32-msvc" "14.2.12"
-    "@next/swc-win32-x64-msvc" "14.2.12"
+    "@next/swc-darwin-arm64" "14.2.25"
+    "@next/swc-darwin-x64" "14.2.25"
+    "@next/swc-linux-arm64-gnu" "14.2.25"
+    "@next/swc-linux-arm64-musl" "14.2.25"
+    "@next/swc-linux-x64-gnu" "14.2.25"
+    "@next/swc-linux-x64-musl" "14.2.25"
+    "@next/swc-win32-arm64-msvc" "14.2.25"
+    "@next/swc-win32-ia32-msvc" "14.2.25"
+    "@next/swc-win32-x64-msvc" "14.2.25"
 
 no-case@^2.2.0:
   version "2.3.2"


### PR DESCRIPTION
## Description :sparkles:
Upgrading vulnerable Next.js version
## Issues :bug:
https://github.com/City-of-Helsinki/yjdh/security/dependabot/534
https://github.com/City-of-Helsinki/yjdh/security/dependabot/532
https://github.com/City-of-Helsinki/yjdh/security/dependabot/530
https://github.com/City-of-Helsinki/yjdh/security/dependabot/528
https://github.com/City-of-Helsinki/yjdh/security/dependabot/526
https://github.com/City-of-Helsinki/yjdh/security/dependabot/523
https://github.com/City-of-Helsinki/yjdh/security/dependabot/521
https://github.com/City-of-Helsinki/yjdh/security/dependabot/520
https://github.com/City-of-Helsinki/yjdh/security/dependabot/519
https://github.com/City-of-Helsinki/yjdh/security/dependabot/518

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
