### PR TITLE
Fixes to links and translations

### DIFF
--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -164,7 +164,7 @@
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://kesaseteli.fi/en/the-summer-job-voucher/for-employers/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/for-employers/",
   "error": {
     "generic": {
       "label": "An unexpected error occurred",

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -164,7 +164,7 @@
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://kesaseteli.fi/etusivu/tyonantajalle/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/",
   "error": {
     "generic": {
       "label": "Tapahtui tuntematon virhe",

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -164,7 +164,7 @@
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://kesaseteli.fi/sv/med-sommarsedeln-i-handen-ar-du-ett-steg-narmare-dina-drommars-sommarjobb/at-arbetsgivaren/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/at-arbetsgivaren/",
   "error": {
     "generic": {
       "label": "Ett okänt fel inträffade.",

--- a/frontend/kesaseteli/youth/public/locales/en/common.json
+++ b/frontend/kesaseteli/youth/public/locales/en/common.json
@@ -23,20 +23,20 @@
     "registerInformation": "Privacy policy",
     "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth%20services%20summer%20job%20voucher%20data%20file.pdf",
     "jobOpenings": "Open Summer Jobs (Only in finnish)",
-    "jobOpeningsLink": "https://nuorten.helsinki/avoimet-tyopaikat/",
+    "jobOpeningsLink": "https://nuorten.hel.fi/avoimet-tyopaikat/",
     "contactUs": "Contact us",
-    "contactUsLink": "https://nuorten.helsinki/en/studies-and-work/the-summer-job-voucher/contact-us/",
+    "contactUsLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/contact-us/",
     "accessibilityStatement": "Accessibility statement",
     "accessibilityStatementLink": "https://www.hel.fi/helsinki/en/administration/information/information/accessibility",
     "information": "Information on the service",
-    "informationLink": "https://nuorten.helsinki/en/studies-and-work/the-summer-job-voucher/"
+    "informationLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/"
   },
   "languages": {
     "fi": "Suomeksi",
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://nuorten.helsinki/en/studies-and-work/for-summer-job-seekers/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/en/studies-and-work/for-summer-job-seekers/",
   "error": {
     "generic": {
       "label": "An unexpected error occurred",
@@ -51,11 +51,11 @@
   "youthApplication": {
     "title": "Sign up to receive your personal Summer Job Voucher",
     "paragraph_1": "Earning your own money is fun and easy! The Summer Job Voucher is personal and worth 350€ for the employer.",
-    "form" : {
+    "form": {
       "title": "Summer Job Voucher information",
       "info": "Please fill in the information as it appears on your Kela card",
       "button": "Submit information",
-      "first_name" : "First name",
+      "first_name": "First name",
       "last_name": "Last name",
       "social_security_number": "Personal identity code",
       "postcode": "Postal code",
@@ -68,29 +68,29 @@
       "email": "Email address",
       "phone_number": "Phone number",
       "termsAndConditions": "I have read and accept the <a>terms of use</a>.",
-      "termsAndConditionsLink": "https://nuorten.helsinki/en/studies-and-work/the-summer-job-voucher/for-summer-job-seekers/",
+      "termsAndConditionsLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/for-summer-job-seekers/",
       "sendButton": "Submit information",
       "requiredInfo": "All fields marked with * are required",
       "sendItAnyway": "If you think the information is right, you can send in the application for control. we will be in touch with you after we checked your information.",
       "forceSubmitLink": "Send"
     },
-    "checkNotification" : {
-      "label" : "Oops! Some information is not correct.",
-      "recheck" : "Check, that you have written your name and personal number as it is on your KELA-card.",
+    "checkNotification": {
+      "label": "Oops! Some information is not correct.",
+      "recheck": "Check, that you have written your name and personal number as it is on your KELA-card.",
       "validation": "Check following form fields: {{ fields}}"
     }
   },
   "additionalInfo": {
     "title": "Please, check your application",
-    "notification" : {
+    "notification": {
       "confirmed": " Your e-mail address is confirmed",
       "confirmedDescription": "",
-      "sent" : "Thanks! Your specified information has been sent!",
+      "sent": "Thanks! Your specified information has been sent!",
       "notFound": "Your application is not found"
     },
     "paragraph_1": "Your application needs more information. Choose from the options below and write your explanation.",
     "paragraph_2": "",
-    "form" : {
+    "form": {
       "reasons": "Title",
       "reasonsPlaceholder": "Choose from following options",
       "additional_info_description": "More information",
@@ -119,42 +119,42 @@
     "clearAllChoices": "Clear all selected"
   },
   "notificationPages": {
-    "thankyou" : {
+    "thankyou": {
       "title": "Excellent! You sent your information to the Summer Job Vouchers´ digital system.",
       "message": "You have received an email with an activation link for your Summer Job Voucher, which must be activated within {{ expirationHours }} hours.",
       "goToFrontendPage": "Go to the Summer Job Voucher front page"
     },
-    "emailInUse" : {
+    "emailInUse": {
       "title": "Oops! The email is already in use.",
       "message": " If you made a mistake, please wait {{ expirationHours }} hours and try again.",
       "goToFrontendPage": "Check your information and send the application for the Summer Job Voucher again."
     },
-    "alreadyAssigned" : {
+    "alreadyAssigned": {
       "title": "Oops! You already sent a Summer Job Voucher application, which is being processed now.",
       "message": "",
       "goToFrontendPage": ""
     },
-    "activated" : {
+    "activated": {
       "title": "Confirmation succeeded",
       "message": "Great! You have submitted your information to the system and your application will be processed as soon as possible - within one month at the latest. You will receive the Summer Voucher and instructions for use by e-mail once your application has been checked!",
       "goToFrontendPage": ""
     },
-    "accepted" : {
+    "accepted": {
       "title": "EN Hienoa! Olet lähettänyt tietosi järjestelmään",
       "message": "EN Saat pian kesäsetelin ohjeineen sähköpostiisi",
       "goToFrontendPage": ""
     },
-    "expired" : {
+    "expired": {
       "title": "Oops! The confirmation link has expired",
       "message": "Unfortunately, it has been more than {{ expirationHours }} hours since your registration was confirmed. Please fill in the registration form again.",
       "goToFrontendPage": "Register yourself and send the Summer Job Voucher again"
     },
-    "alreadyActivated" : {
+    "alreadyActivated": {
       "title": "Oops! You already sent a Summer Job Voucher application, which is being processed now.",
       "message": "",
       "goToFrontendPage": ""
     },
-    "inadmissibleData" : {
+    "inadmissibleData": {
       "title": "Oops! Based on the given information it is not possible to get the Summer Job Voucher",
       "message": "Check your information and send the registration form again.",
       "goToFrontendPage": "Check your information and send the application for the Summer Job Voucher again."

--- a/frontend/kesaseteli/youth/public/locales/en/common.json
+++ b/frontend/kesaseteli/youth/public/locales/en/common.json
@@ -21,7 +21,7 @@
     "allRightsReservedText": "All rights reserved",
     "backToTop": "Back to top",
     "registerInformation": "Privacy policy",
-    "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth%20services%20summer%20job%20voucher%20data%20file.pdf",
+    "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth-services-summer-job-voucher-data-file.pdf",
     "jobOpenings": "Open Summer Jobs (Only in finnish)",
     "jobOpeningsLink": "https://nuorten.hel.fi/avoimet-tyopaikat/",
     "contactUs": "Contact us",

--- a/frontend/kesaseteli/youth/public/locales/fi/common.json
+++ b/frontend/kesaseteli/youth/public/locales/fi/common.json
@@ -21,7 +21,7 @@
     "allRightsReservedText": "Kaikki oikeudet pidätetään",
     "backToTop": "Takaisin ylös",
     "registerInformation": "Rekisteriseloste",
-    "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Nuorisopalvelujen%20kesatyosetelirekisteri.pdf",
+    "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Nuorisopalvelujen-kesatyosetelirekisteri.pdf",
     "jobOpenings": "Avoimet kesätyöpaikat",
     "jobOpeningsLink": "https://nuorten.hel.fi/avoimet-tyopaikat/",
     "contactUs": "Ota yhteyttä",

--- a/frontend/kesaseteli/youth/public/locales/fi/common.json
+++ b/frontend/kesaseteli/youth/public/locales/fi/common.json
@@ -23,20 +23,20 @@
     "registerInformation": "Rekisteriseloste",
     "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Nuorisopalvelujen%20kesatyosetelirekisteri.pdf",
     "jobOpenings": "Avoimet kesätyöpaikat",
-    "jobOpeningsLink": "https://nuorten.helsinki/avoimet-tyopaikat/",
+    "jobOpeningsLink": "https://nuorten.hel.fi/avoimet-tyopaikat/",
     "contactUs": "Ota yhteyttä",
-    "contactUsLink": "https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/ota-yhteytta/",
+    "contactUsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/ota-yhteytta/",
     "accessibilityStatement": "Saavutettavuusseloste",
     "accessibilityStatementLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietoa-hel-fista/saavutettavuus/saavutettavuusselosteet",
     "information": "Tietoa palvelusta",
-    "informationLink": "https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/"
+    "informationLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/"
   },
   "languages": {
     "fi": "Suomeksi",
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://nuorten.helsinki/kesaseteli/nuorelle/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/nuorelle/",
   "error": {
     "generic": {
       "label": "Tapahtui tuntematon virhe",
@@ -51,11 +51,11 @@
   "youthApplication": {
     "title": "Rekisteröidy ja saat henkilökohtaisen Kesäsetelin käyttöösi",
     "paragraph_1": "Oman rahan tienaaminen on hauskaa ja helppoa! Kesäseteli on henkilökohtainen ja sen arvo on työnantajalle 350 euroa.",
-    "form" : {
+    "form": {
       "title": "Kesäsetelin tiedot",
       "info": "Täytäthän tiedot samalla tavalla kuin kelakortissasi",
       "button": "Lähetä tiedot",
-      "first_name" : "Etunimi",
+      "first_name": "Etunimi",
       "last_name": "Sukunimi",
       "social_security_number": "Henkilötunnus",
       "postcode": "Postinumero",
@@ -68,29 +68,29 @@
       "email": "Sähköpostiosoite",
       "phone_number": "Puhelinnumero",
       "termsAndConditions": "Olen lukenut palvelun <a>käyttöehdot</a> ja hyväksyn ne.",
-      "termsAndConditionsLink": "https://kesasethttps://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/nuorelle/",
+      "termsAndConditionsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/nuorelle/",
       "sendButton": "Lähetä tiedot",
       "requiredInfo": "Kaikki * merkityt kentät ovat pakollisia julkaisuun",
       "sendItAnyway": "Mikäli tiedot ovat mielestäsi oikein, voit lähettää ne meille tarkastettavaksi. Palaamme asiaan kun olemme käsitelleet tietosi.",
       "forceSubmitLink": "Lähetä"
     },
-    "checkNotification" : {
-      "label" : "Hups! Jokin tiedoista ei ole oikein",
-      "recheck" : "Tarkistathan, että olet kirjoittanut nimesi ja henkilötunnuksesi kuten ne ovat Kela-kortissasi.",
+    "checkNotification": {
+      "label": "Hups! Jokin tiedoista ei ole oikein",
+      "recheck": "Tarkistathan, että olet kirjoittanut nimesi ja henkilötunnuksesi kuten ne ovat Kela-kortissasi.",
       "validation": "Tarkista seuraavat kentät: {{ fields}}"
     }
   },
   "additionalInfo": {
     "title": "Tarkenna hakemustasi",
-    "notification" : {
-      "confirmed" : "Sähköpostiosoite on vahvistettu",
-      "confirmedDescription" : "",
-      "sent" : "Kiitos! Tarkennus on nyt lähetetty.",
-      "notFound":  "Hakemusta ei löytynyt"
+    "notification": {
+      "confirmed": "Sähköpostiosoite on vahvistettu",
+      "confirmedDescription": "",
+      "sent": "Kiitos! Tarkennus on nyt lähetetty.",
+      "notFound": "Hakemusta ei löytynyt"
     },
     "paragraph_1": "Hakemuksesi tarvitsee lisätietoja. Valitse alla olevista vaihtoehdoista ja kirjoita sille perustelu.",
     "paragraph_2": "",
-    "form" : {
+    "form": {
       "reasons": "Otsikko",
       "reasonsPlaceholder": "Valitse seuraavista vaihtoehdoista",
       "additional_info_description": "Lisätiedot",
@@ -119,42 +119,42 @@
     "clearAllChoices": "Tyhjennä kaikki valinnat"
   },
   "notificationPages": {
-    "thankyou" : {
+    "thankyou": {
       "title": "Hienoa! Olet lähettänyt tietosi kesäsetelijärjestelmään",
       "message": "Sait sähköpostiin Kesäsetelin aktivointi-linkin, joka täytyy aktivoida {{ expirationHours }} tunnin kuluessa.",
       "goToFrontendPage": "Siirry kesäsetelin etusivulle"
     },
-    "emailInUse" : {
+    "emailInUse": {
       "title": "Hups! Sähköposti on jo käytössä.",
       "message": "Jos kyseessä on virhe, odota {{ expirationHours }} tuntia ja yritä uudelleen.",
       "goToFrontendPage": "Tarkista tiedot ja lähetä kesäsetelihakemus uudelleen"
     },
-    "alreadyAssigned" : {
+    "alreadyAssigned": {
       "title": "Hups! Olet jo aikaisemmin lähettänyt Kesäsetelihakemuksen ja se on nyt käsittelyssä.",
       "message": "",
       "goToFrontendPage": ""
     },
-    "activated" : {
+    "activated": {
       "title": "Vahvistus onnistui",
       "message": "Hienoa! Olet lähettänyt tietosi järjestelmään ja hakemuksesi käsitellään mahdollisimman pian - viimeistään kuukauden kuluessa. Saat Kesäsetelin ja käyttöohjeet sähköpostiisi kun hakemuksesi on tarkastettu!",
       "goToFrontendPage": ""
     },
-    "accepted" : {
+    "accepted": {
       "title": "Hienoa! Olet lähettänyt tietosi järjestelmään",
       "message": " Saat pian kesäsetelin ohjeineen sähköpostiisi",
       "goToFrontendPage": ""
     },
-    "expired" : {
+    "expired": {
       "title": "Hups! Vahvistuslinkki on vanhentunut.",
       "message": "Ikävä kyllä rekisteröinnin vahvistukseen on kulunut yli {{ expirationHours }} tuntia. Täytäthän rekisteröintikomakkeen uudelleen.",
       "goToFrontendPage": "Rekisteröidy ja lähetä kesäseteli uudelleen"
     },
-    "alreadyActivated" : {
+    "alreadyActivated": {
       "title": "Hups! Olet jo aikaisemmin lähettänyt Kesäsetelihakemuksen ja se on nyt käsittelyssä.",
       "message": "",
       "goToFrontendPage": ""
     },
-    "inadmissibleData" : {
+    "inadmissibleData": {
       "title": "Hups! Antamillasi tiedoilla ei voi hakea Kesäseteliä.",
       "message": "Tarkistahan tietosi ja lähetä rekisteröitymislomake uudestaan.",
       "goToFrontendPage": "Tarkista tiedot ja lähetä kesäsetelihakemus uudelleen"

--- a/frontend/kesaseteli/youth/public/locales/sv/common.json
+++ b/frontend/kesaseteli/youth/public/locales/sv/common.json
@@ -21,7 +21,7 @@
     "allRightsReservedText": "Med ensamrätt",
     "backToTop": "Tillbaka till toppen",
     "registerInformation": "Dataskyddspolicy",
-    "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Ungdomstjansternas%20register%20for%20sommarjobbssedlar.pdf",
+    "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Ungdomstjansternas-register-for-sommarjobbssedlar.pdf",
     "jobOpenings": "Öppna arbetsplatser (Endast på finska)",
     "jobOpeningsLink": "https://nuorten.hel.fi/avoimet-tyopaikat/",
     "contactUs": "Ta kontakt",

--- a/frontend/kesaseteli/youth/public/locales/sv/common.json
+++ b/frontend/kesaseteli/youth/public/locales/sv/common.json
@@ -94,8 +94,8 @@
       "reasons": "Rubrik",
       "reasonsPlaceholder": "Välj av följande alternativ",
       "additional_info_description": "Tilläggsuppgifter",
-      "additional_info_attachments": "SWE Liitetiedostot",
-      "additional_info_attachmentsHelper": "SWE Voit lisätä korkeintaan 5 liitetiedostoa. Sallitut tiedostomuodot: pdf, jpg ja png. Maksimikoko 10MB",
+      "additional_info_attachments": "Bilagor",
+      "additional_info_attachmentsHelper": "Du kan lägga till högst 5 bilagor. Godkända filformat: pdf, jpg ja png. Maximistorleken 10MB.",
       "sendButton": "Skicka uppgifterna"
     },
     "reasons": {
@@ -127,7 +127,7 @@
     "emailInUse": {
       "title": "Hoppsan! E-postadressen används redan.",
       "message": "Om det handlar om ett fel, vänta i {{ expirationHours }} timmar och försöka igen.",
-      "goToFrontendPage": "SV Tarkista tiedot ja lähetä uudelleen"
+      "goToFrontendPage": "Kontrollera uppgifterna och skicka på nytt"
     },
     "alreadyAssigned": {
       "title": "Hoppsan! Du har redan ansökt om en Sommarsedel, som behandlats som bäst.",
@@ -136,7 +136,7 @@
     },
     "activated": {
       "title": "Bekräftelsen lyckades",
-      "message": "Bra! Du har lämnat in dina uppgifter till systemet och din ansökan kommer att behandlas så snart som möjligt – senast inom en månad. Du får sommarsedeln och bruksanvisningar via e-post när din ansökan har kontrollerats!",
+      "message": "Bra! Du har lämnat in dina uppgifter till systemet och din ansökan kommer att behandlas så snart som möjligt - senast inom en månad. Du får sommarsedeln och bruksanvisningar via e-post när din ansökan har kontrollerats!",
       "goToFrontendPage": ""
     },
     "expired": {
@@ -145,8 +145,8 @@
       "goToFrontendPage": "Registrera dig och skicka Sommarsedeln på nytt"
     },
     "accepted": {
-      "title": "SV Hienoa! Olet lähettänyt tietosi järjestelmään",
-      "message": "SV Saat pian kesäsetelin ohjeineen sähköpostiisi",
+      "title": "Fint! Du har skickat dina uppgifter till det elekrtorniska systemet",
+      "message": "Du får snart sommarsedeln med anvisningar till din epost",
       "goToFrontendPage": ""
     },
     "alreadyActivated": {
@@ -155,9 +155,9 @@
       "goToFrontendPage": ""
     },
     "inadmissibleData": {
-      "title": "SV Hups! Antamillasi tiedoilla ei voi hakea Kesäseteliä.",
-      "message": "SV Tarkistahan tietosi ja lähetä rekisteröitymislomake uudestaan.",
-      "goToFrontendPage": "SV Tarkista tiedot ja lähetä kesäseteli uudelleen"
+      "title": "Hups! Med de uppgifter du angivit kan du inte ansöka en Sommarsedel.",
+      "message": "Kontrollera dina uppgifter och skicka registreringsblanketten på nytt.",
+      "goToFrontendPage": "Kontrollera dina uppgifter och skicka registreringsblanketten på nytt"
     }
   }
 }

--- a/frontend/kesaseteli/youth/public/locales/sv/common.json
+++ b/frontend/kesaseteli/youth/public/locales/sv/common.json
@@ -23,20 +23,20 @@
     "registerInformation": "Dataskyddspolicy",
     "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Ungdomstjansternas%20register%20for%20sommarjobbssedlar.pdf",
     "jobOpenings": "Öppna arbetsplatser (Endast på finska)",
-    "jobOpeningsLink": "https://nuorten.helsinki/avoimet-tyopaikat/",
+    "jobOpeningsLink": "https://nuorten.hel.fi/avoimet-tyopaikat/",
     "contactUs": "Ta kontakt",
-    "contactUsLink": "https://nuorten.helsinki/sv/studier-och-jobb/sommarsedeln/ta-kontakt/",
+    "contactUsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/ta-kontakt/",
     "accessibilityStatement": "Tillgänglighetsutlåtande",
     "accessibilityStatementLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/information/tillganglighet",
     "information": "Information om servicen",
-    "informationLink": "https://nuorten.helsinki/sv/studier-och-jobb/sommarsedeln/"
+    "informationLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/"
   },
   "languages": {
     "fi": "Suomeksi",
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://nuorten.helsinki/sv/studier-och-jobb/kesatyonhakijalle/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/kesatyonhakijalle/",
   "error": {
     "generic": {
       "label": "Ett okänt fel inträffade.",
@@ -51,11 +51,11 @@
   "youthApplication": {
     "title": "Registrera dig och få din personlig Sommarsedel",
     "paragraph_1": "Det är roligt och enkelt att tjäna egna pengar!\nSommarsedeln är personlig och värd 350 euro för arbetsgivaren.",
-    "form" : {
+    "form": {
       "title": "Information om Sommarsedeln",
       "info": "Fyll i uppgifterna på samma sätt som på ditt FPA-kort",
       "button": "Skicka informationen",
-      "first_name" : "Förnamn",
+      "first_name": "Förnamn",
       "last_name": "Efternamn",
       "social_security_number": "Personbeteckning",
       "postcode": "Post nummer",
@@ -68,15 +68,15 @@
       "email": "E-postadress",
       "phone_number": "Telefonnummer",
       "termsAndConditions": "Jag har läst och godkänner <a>villkoren</a>.",
-      "termsAndConditionsLink": "https://nuorten.helsinki/sv/studier-och-jobb/sommarsedeln/kesatyonhakijalle/",
+      "termsAndConditionsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/kesatyonhakijalle/",
       "sendButton": "Skicka informationen",
       "requiredInfo": "Alla fält som är märkta med * är obligatoriska",
       "sendItAnyway": "Om du anser uppgifterna är rätt, kan du skicka in din ansökan för kontroll. Vi återkommer då vi behandlat ditt ärende.",
       "forceSubmitLink": "Skicka"
     },
-    "checkNotification" : {
-      "label" : "Ops! Någon av uppgifterna ör inte rätt.",
-      "recheck" : "Kontrollera att du skrivit ditt nan och personnumret, som de är på ditt FPA-kort.",
+    "checkNotification": {
+      "label": "Ops! Någon av uppgifterna ör inte rätt.",
+      "recheck": "Kontrollera att du skrivit ditt nan och personnumret, som de är på ditt FPA-kort.",
       "validation": "Kontrollera följande fält: {{ fields}}"
     }
   },
@@ -85,12 +85,12 @@
     "notification": {
       "confirmed": "E-post adressen är begräftad",
       "confirmedDescription": "",
-      "sent" : "Tack! din tilläggsinformation har skickats!",
+      "sent": "Tack! din tilläggsinformation har skickats!",
       "notFound": "Din ansökan hittas inte!"
     },
     "paragraph_1": "Din ansökan behöver mer information. Välj bland alternativen nedan och skriv din förklaring.",
     "paragraph_2": "",
-    "form" : {
+    "form": {
       "reasons": "Rubrik",
       "reasonsPlaceholder": "Välj av följande alternativ",
       "additional_info_description": "Tilläggsuppgifter",
@@ -119,42 +119,42 @@
     "clearAllChoices": "Töm alla val"
   },
   "notificationPages": {
-    "thankyou" : {
+    "thankyou": {
       "title": "Fint! Du har skickat dina uppgifter till Sommarsedelns digitala system.",
       "message": "Du fick en aktiveringslänk för Sommarsedeln per e-post. Den måste aktiveras inom {{ expirationHours }} timmar.",
       "goToFrontendPage": "Gå till Sommarsedelns förstasida"
     },
-    "emailInUse" : {
+    "emailInUse": {
       "title": "Hoppsan! E-postadressen används redan.",
       "message": "Om det handlar om ett fel, vänta i {{ expirationHours }} timmar och försöka igen.",
       "goToFrontendPage": "SV Tarkista tiedot ja lähetä uudelleen"
     },
-    "alreadyAssigned" : {
+    "alreadyAssigned": {
       "title": "Hoppsan! Du har redan ansökt om en Sommarsedel, som behandlats som bäst.",
       "message": "",
       "goToFrontendPage": ""
     },
-    "activated" : {
+    "activated": {
       "title": "Bekräftelsen lyckades",
       "message": "Bra! Du har lämnat in dina uppgifter till systemet och din ansökan kommer att behandlas så snart som möjligt – senast inom en månad. Du får sommarsedeln och bruksanvisningar via e-post när din ansökan har kontrollerats!",
       "goToFrontendPage": ""
     },
-    "expired" : {
+    "expired": {
       "title": "Hoppsan! Bekräftelselänken har gått ut.",
       "message": " Det har tyvärr gått mer än {{ expirationHours }} timmar sedan registreringsbekräftelsen. Fyll i registreringsblanketten igen.",
       "goToFrontendPage": "Registrera dig och skicka Sommarsedeln på nytt"
     },
-    "accepted" : {
+    "accepted": {
       "title": "SV Hienoa! Olet lähettänyt tietosi järjestelmään",
       "message": "SV Saat pian kesäsetelin ohjeineen sähköpostiisi",
       "goToFrontendPage": ""
     },
-    "alreadyActivated" : {
+    "alreadyActivated": {
       "title": "Hoppsan! Du har redan ansökt om en Sommarsedel, som behandlats som bäst.",
       "message": "",
       "goToFrontendPage": ""
     },
-    "inadmissibleData" : {
+    "inadmissibleData": {
       "title": "SV Hups! Antamillasi tiedoilla ei voi hakea Kesäseteliä.",
       "message": "SV Tarkistahan tietosi ja lähetä rekisteröitymislomake uudestaan.",
       "goToFrontendPage": "SV Tarkista tiedot ja lähetä kesäseteli uudelleen"


### PR DESCRIPTION
YJDH-724.

In Youth frontend app:
1. Fix footer links for privacy notes.
2. Change "nuorten.helsinki" domain in links to "nuorten.hel.fi".
3. Add some Swedish translations.