### PR TITLE
chore: modify commitlint config to allow more types

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,27 @@
-module.exports = {extends: ['@commitlint/config-conventional']}
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => message.includes('Signed-off-by: dependabot[bot]')],
+  rules: {
+    'header-max-length': [2, 'always', 72],
+    'body-max-line-length': [2, 'always', 72],
+    'body-leading-blank': [2, 'always'],
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'deps',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+      ],
+    ],
+  },
+};


### PR DESCRIPTION
## Description :sparkles:

Allow more types than in config-conventional
