### PR TITLE
fix(kesaseteli): accessibility statement link

### DIFF
--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -154,7 +154,7 @@
     "copyrightText": "City of Helsinki",
     "allRightsReservedText": "All rights reserved",
     "accessibilityStatement": "Accessibility statement",
-    "accessibilityStatementLink": "https://www.hel.fi/helsinki/en/administration/information/information/accessibility",
+    "accessibilityStatementLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kesaseteli-saavutettavuusseloste/",
     "information": "Information on the service",
     "informationLink": "https://kesaseteli.fi/en/",
     "backToTop": "Back to top"

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -154,7 +154,7 @@
     "copyrightText": "Helsingin kaupunki",
     "allRightsReservedText": "Kaikki oikeudet pidätetään",
     "accessibilityStatement": "Saavutettavuusseloste",
-    "accessibilityStatementLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietoa-hel-fista/saavutettavuus/saavutettavuusselosteet",
+    "accessibilityStatementLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kesaseteli-saavutettavuusseloste/",
     "information": "Tietoa palvelusta",
     "informationLink": "https://kesaseteli.fi/",
     "backToTop": "Takaisin ylös"

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -154,7 +154,7 @@
     "copyrightText": "Helsingfors stad",
     "allRightsReservedText": "Med ensamrätt",
     "accessibilityStatement": "Tillgänglighetsutlåtande",
-    "accessibilityStatementLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/information/tillganglighet",
+    "accessibilityStatementLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kesaseteli-saavutettavuusseloste/",
     "information": "Information om servicen",
     "informationLink": "https://kesaseteli.fi/sv/",
     "backToTop": "Tillbaka till toppen"

--- a/frontend/kesaseteli/youth/public/locales/en/common.json
+++ b/frontend/kesaseteli/youth/public/locales/en/common.json
@@ -27,7 +27,7 @@
     "contactUs": "Contact us",
     "contactUsLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/contact-us/",
     "accessibilityStatement": "Accessibility statement",
-    "accessibilityStatementLink": "https://www.hel.fi/helsinki/en/administration/information/information/accessibility",
+    "accessibilityStatementLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kesaseteli-saavutettavuusseloste/",
     "information": "Information on the service",
     "informationLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/"
   },

--- a/frontend/kesaseteli/youth/public/locales/fi/common.json
+++ b/frontend/kesaseteli/youth/public/locales/fi/common.json
@@ -27,7 +27,7 @@
     "contactUs": "Ota yhteyttä",
     "contactUsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/ota-yhteytta/",
     "accessibilityStatement": "Saavutettavuusseloste",
-    "accessibilityStatementLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietoa-hel-fista/saavutettavuus/saavutettavuusselosteet",
+    "accessibilityStatementLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kesaseteli-saavutettavuusseloste/",
     "information": "Tietoa palvelusta",
     "informationLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/"
   },

--- a/frontend/kesaseteli/youth/public/locales/sv/common.json
+++ b/frontend/kesaseteli/youth/public/locales/sv/common.json
@@ -27,7 +27,7 @@
     "contactUs": "Ta kontakt",
     "contactUsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/ta-kontakt/",
     "accessibilityStatement": "Tillgänglighetsutlåtande",
-    "accessibilityStatementLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/information/tillganglighet",
+    "accessibilityStatementLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kesaseteli-saavutettavuusseloste/",
     "information": "Information om servicen",
     "informationLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/"
   },


### PR DESCRIPTION
YJDH-724.

Fix the accessibility statement link in footer of Kesäseteli's Youth and Employer apps. The link is now targeting to nuorten.hel.fi -page, which can be dynamically updated.

NOTE: The link is purposely the same in every language and in both the apps. It was requested so by the product owner.
