### PR TITLE
Fix Kesäseteli's terms and links related to TOS and a11y statement to match new spec

### DIFF
--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -154,7 +154,7 @@
     "copyrightText": "City of Helsinki",
     "allRightsReservedText": "All rights reserved",
     "accessibilityStatement": "Accessibility statement",
-    "accessibilityStatementLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kesaseteli-saavutettavuusseloste/",
+    "accessibilityStatementLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/summer-job-voucher-accessibility-statement/",
     "information": "Information on the service",
     "informationLink": "https://kesaseteli.fi/en/",
     "backToTop": "Back to top"

--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -118,7 +118,7 @@
         "employment_description": "Employment description",
         "employment_salary_paid": "Salary paid (€)",
         "hired_without_voucher_assessment": "Would you have employed without the Summer Job Voucher?",
-        "termsAndConditions": "I have read and accept the <a>terms of use</a>."
+        "termsAndConditions": "I have read and accept the <a>terms of service</a>."
       },
       "helpers": {
         "date": "Use format D.M.YYYY",
@@ -164,7 +164,7 @@
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/for-employers/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/terms-of-service/",
   "error": {
     "generic": {
       "label": "An unexpected error occurred",

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -164,7 +164,7 @@
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kayttoehdot/",
   "error": {
     "generic": {
       "label": "Tapahtui tuntematon virhe",

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -154,7 +154,7 @@
     "copyrightText": "Helsingfors stad",
     "allRightsReservedText": "Med ensamrätt",
     "accessibilityStatement": "Tillgänglighetsutlåtande",
-    "accessibilityStatementLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kesaseteli-saavutettavuusseloste/",
+    "accessibilityStatementLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/sommarsedelns-tillganglighetsutlatande/",
     "information": "Information om servicen",
     "informationLink": "https://kesaseteli.fi/sv/",
     "backToTop": "Tillbaka till toppen"

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -118,7 +118,7 @@
         "employment_description": "Beskrivning av arbetsuppgifter",
         "employment_salary_paid": "Utbetalt lönebelopp (€)",
         "hired_without_voucher_assessment": "Skulle du ha anställt en ung sommarjobbare utan Sommarsedeln?",
-        "termsAndConditions": "Jag har läst och godkänner <a>villkoren</a>."
+        "termsAndConditions": "Jag har läst och godkänner <a>användningsvillkor</a>."
       },
       "helpers": {
         "date": "Använd ett format D.M.ÅÅÅÅ",
@@ -164,7 +164,7 @@
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/at-arbetsgivaren/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/anvandningsvillkor/",
   "error": {
     "generic": {
       "label": "Ett okänt fel inträffade.",

--- a/frontend/kesaseteli/youth/public/locales/en/common.json
+++ b/frontend/kesaseteli/youth/public/locales/en/common.json
@@ -36,7 +36,7 @@
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://nuorten.hel.fi/en/studies-and-work/for-summer-job-seekers/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/terms-of-service/",
   "error": {
     "generic": {
       "label": "An unexpected error occurred",
@@ -67,8 +67,8 @@
       "unlistedSchoolPlaceholder": "E.g. International School of Helsinki",
       "email": "Email address",
       "phone_number": "Phone number",
-      "termsAndConditions": "I have read and accept the <a>terms of use</a>.",
-      "termsAndConditionsLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/for-summer-job-seekers/",
+      "termsAndConditions": "I have read and accept the <a>terms of service</a>.",
+      "termsAndConditionsLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/terms-of-service/",
       "sendButton": "Submit information",
       "requiredInfo": "All fields marked with * are required",
       "sendItAnyway": "If you think the information is right, you can send in the application for control. we will be in touch with you after we checked your information.",

--- a/frontend/kesaseteli/youth/public/locales/en/common.json
+++ b/frontend/kesaseteli/youth/public/locales/en/common.json
@@ -27,7 +27,7 @@
     "contactUs": "Contact us",
     "contactUsLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/contact-us/",
     "accessibilityStatement": "Accessibility statement",
-    "accessibilityStatementLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kesaseteli-saavutettavuusseloste/",
+    "accessibilityStatementLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/summer-job-voucher-accessibility-statement/",
     "information": "Information on the service",
     "informationLink": "https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/"
   },

--- a/frontend/kesaseteli/youth/public/locales/en/common.json
+++ b/frontend/kesaseteli/youth/public/locales/en/common.json
@@ -20,7 +20,7 @@
     "copyrightText": "City of Helsinki",
     "allRightsReservedText": "All rights reserved",
     "backToTop": "Back to top",
-    "registerInformation": "Privacy policy",
+    "registerInformation": "Privacy notice",
     "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth-services-summer-job-voucher-data-file.pdf",
     "jobOpenings": "Open Summer Jobs (Only in finnish)",
     "jobOpeningsLink": "https://nuorten.hel.fi/avoimet-tyopaikat/",

--- a/frontend/kesaseteli/youth/public/locales/fi/common.json
+++ b/frontend/kesaseteli/youth/public/locales/fi/common.json
@@ -36,7 +36,7 @@
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/nuorelle/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kayttoehdot/",
   "error": {
     "generic": {
       "label": "Tapahtui tuntematon virhe",
@@ -68,7 +68,7 @@
       "email": "Sähköpostiosoite",
       "phone_number": "Puhelinnumero",
       "termsAndConditions": "Olen lukenut palvelun <a>käyttöehdot</a> ja hyväksyn ne.",
-      "termsAndConditionsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/nuorelle/",
+      "termsAndConditionsLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kayttoehdot/",
       "sendButton": "Lähetä tiedot",
       "requiredInfo": "Kaikki * merkityt kentät ovat pakollisia julkaisuun",
       "sendItAnyway": "Mikäli tiedot ovat mielestäsi oikein, voit lähettää ne meille tarkastettavaksi. Palaamme asiaan kun olemme käsitelleet tietosi.",

--- a/frontend/kesaseteli/youth/public/locales/fi/common.json
+++ b/frontend/kesaseteli/youth/public/locales/fi/common.json
@@ -20,7 +20,7 @@
     "copyrightText": "Helsingin kaupunki",
     "allRightsReservedText": "Kaikki oikeudet pidätetään",
     "backToTop": "Takaisin ylös",
-    "registerInformation": "Rekisteriseloste",
+    "registerInformation": "Tietosuojaseloste",
     "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Nuorisopalvelujen-kesatyosetelirekisteri.pdf",
     "jobOpenings": "Avoimet kesätyöpaikat",
     "jobOpeningsLink": "https://nuorten.hel.fi/avoimet-tyopaikat/",

--- a/frontend/kesaseteli/youth/public/locales/sv/common.json
+++ b/frontend/kesaseteli/youth/public/locales/sv/common.json
@@ -27,7 +27,7 @@
     "contactUs": "Ta kontakt",
     "contactUsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/ta-kontakt/",
     "accessibilityStatement": "Tillgänglighetsutlåtande",
-    "accessibilityStatementLink": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/kesaseteli-saavutettavuusseloste/",
+    "accessibilityStatementLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/sommarsedelns-tillganglighetsutlatande/",
     "information": "Information om servicen",
     "informationLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/"
   },

--- a/frontend/kesaseteli/youth/public/locales/sv/common.json
+++ b/frontend/kesaseteli/youth/public/locales/sv/common.json
@@ -20,7 +20,7 @@
     "copyrightText": "Helsingfors stad",
     "allRightsReservedText": "Med ensamrätt",
     "backToTop": "Tillbaka till toppen",
-    "registerInformation": "Dataskyddspolicy",
+    "registerInformation": "Dataskyddsbeskrivning",
     "registerInformationLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Ungdomstjansternas-register-for-sommarjobbssedlar.pdf",
     "jobOpenings": "Öppna arbetsplatser (Endast på finska)",
     "jobOpeningsLink": "https://nuorten.hel.fi/avoimet-tyopaikat/",

--- a/frontend/kesaseteli/youth/public/locales/sv/common.json
+++ b/frontend/kesaseteli/youth/public/locales/sv/common.json
@@ -36,7 +36,7 @@
     "sv": "På svenska",
     "en": "In English"
   },
-  "termsAndConditionsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/kesatyonhakijalle/",
+  "termsAndConditionsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/anvandningsvillkor/",
   "error": {
     "generic": {
       "label": "Ett okänt fel inträffade.",
@@ -67,8 +67,8 @@
       "unlistedSchoolPlaceholder": "Te.x. Grundskolan Norsen",
       "email": "E-postadress",
       "phone_number": "Telefonnummer",
-      "termsAndConditions": "Jag har läst och godkänner <a>villkoren</a>.",
-      "termsAndConditionsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/kesatyonhakijalle/",
+      "termsAndConditions": "Jag har läst och godkänner <a>användningsvillkor</a>.",
+      "termsAndConditionsLink": "https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/anvandningsvillkor/",
       "sendButton": "Skicka informationen",
       "requiredInfo": "Alla fält som är märkta med * är obligatoriska",
       "sendItAnyway": "Om du anser uppgifterna är rätt, kan du skicka in din ansökan för kontroll. Vi återkommer då vi behandlat ditt ärende.",


### PR DESCRIPTION
YJDH-724.

The term for "terms of service" and the target of the link changed after new refinement and specification https://helsinkisolutionoffice.atlassian.net/browse/YJDH-724?focusedCommentId=141405.

The term for "rekisteriseloste" changed to "tietosuojaseloste". Also renamed the links in other languages to
match the title of the related document.

Changed to a new language specific accessibility statement link.