### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/CODEOWNERES
+++ b/CODEOWNERES
@@ -1,1 +1,0 @@
-* @City-of-Helsinki/ratkaisutoimiston-frontend

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+* @City-of-Helsinki/ratkaisutoimiston-backend @City-of-Helsinki/ratkaisutoimiston-frontend
+/backend/ @City-of-Helsinki/ratkaisutoimiston-backend
+/frontend/ @City-of-Helsinki/ratkaisutoimiston-frontend


### PR DESCRIPTION
Filename had a typo. Added more atomic ownership due to the repo being a monorepo.