### PR TITLE
ci(release-please): count build(deps) as dependencies

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
     {"type": "fix", "section": "Bug Fixes"},
     {"type": "perf", "section": "Performance Improvements"},
     {"type": "deps", "section": "Dependencies"},
+    {"type": "build", "scope": "deps", "section": "Dependencies"},
     {"type": "revert", "section": "Reverts"},
     {"type": "docs", "section": "Documentation"},
     {"type": "style", "section": "Styles", "hidden": true},


### PR DESCRIPTION
For whatever reason, the dependabot commits in this repo are something like this: `build(deps): bump django from 4.2.11 to 4.2.24 in /backend/benefit` (https://github.com/City-of-Helsinki/yjdh/commit/fd00ce6e14c142b5792ca6d95b4eb1842b4c0d35)

Release please doesn't recognize these as dependency type commits but rather as build system type commits, and doesn't create a release for them. This change hopefully fixes the issue. The docs don't mention a scope, but apparently it should be possible: https://github.com/conventional-changelog/conventional-changelog/blob/8076d4666c2a3ea728b95bf1e4e78d4c7189b1dc/packages/conventional-changelog-conventionalcommits/test/test.js#L180-L201