### PR TITLE
chore: remove tet from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,4 @@
 
 # Ratkaisutoimisto
 /backend/benefit/ @City-of-Helsinki/ratkaisutoimiston-backend
-/backend/tet/ @City-of-Helsinki/ratkaisutoimiston-backend
 /frontend/benefit/ @City-of-Helsinki/ratkaisutoimiston-frontend
-/frontend/tet/ @City-of-Helsinki/ratkaisutoimiston-frontend


### PR DESCRIPTION
TET doesn't exist anymore, remove it. Only concerns Ratkaisutoimisto.