### PR TITLE
YJDH-822 | Kesäseteli: Remove historical models as unnecessary

### DIFF
--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -313,7 +313,6 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
         help_text=_("Status of the application, visible to the applicant"),
         required=False,
     )
-    submitted_at = serializers.SerializerMethodField("get_submitted_at")
     is_mine = serializers.SerializerMethodField("get_is_mine")
 
     class Meta:
@@ -339,7 +338,7 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
             "submitted_at",
             "is_mine",
         ]
-        read_only_fields = ["created_at", "modified_at", "user"]
+        read_only_fields = ["created_at", "modified_at", "submitted_at", "user"]
 
     @transaction.atomic
     def update(self, instance, validated_data):
@@ -347,6 +346,13 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
         summer_vouchers_data = validated_data.pop("summer_vouchers", []) or []
         if request and request.method == "PUT":
             self._update_summer_vouchers(summer_vouchers_data, instance)
+
+        new_status = validated_data.get("status")
+        if (
+            new_status == EmployerApplicationStatus.SUBMITTED
+            and instance.status == EmployerApplicationStatus.DRAFT
+        ):
+            validated_data["submitted_at"] = timezone.now()
 
         return super().update(instance, validated_data)
 
@@ -359,18 +365,6 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
         validated_data["user"] = user
 
         return super().create(validated_data)
-
-    def get_submitted_at(self, obj):
-        if (
-            hisory_entry := obj.history.filter(
-                status=EmployerApplicationStatus.SUBMITTED
-            )
-            .order_by("modified_at")
-            .first()
-        ):
-            return hisory_entry.modified_at
-        else:
-            return None
 
     def get_is_mine(self, obj):
         request = self.context.get("request")

--- a/backend/kesaseteli/applications/migrations/0053_remove_all_remaining_historical_models.py
+++ b/backend/kesaseteli/applications/migrations/0053_remove_all_remaining_historical_models.py
@@ -1,0 +1,42 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "applications",
+            "0052_remove_target_group_from_youth_summer_voucher",
+        ),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="historicalemployersummervoucher",
+            name="application",
+        ),
+        migrations.RemoveField(
+            model_name="historicalemployersummervoucher",
+            name="history_user",
+        ),
+        migrations.RemoveField(
+            model_name="historicalemployersummervoucher",
+            name="youth_summer_voucher",
+        ),
+        migrations.RemoveField(
+            model_name="historicalyouthsummervoucher",
+            name="history_user",
+        ),
+        migrations.RemoveField(
+            model_name="historicalyouthsummervoucher",
+            name="youth_application",
+        ),
+        migrations.DeleteModel(
+            name="HistoricalEmployerApplication",
+        ),
+        migrations.DeleteModel(
+            name="HistoricalEmployerSummerVoucher",
+        ),
+        migrations.DeleteModel(
+            name="HistoricalYouthSummerVoucher",
+        ),
+    ]

--- a/backend/kesaseteli/applications/migrations/0054_employerapplication_submitted_at.py
+++ b/backend/kesaseteli/applications/migrations/0054_employerapplication_submitted_at.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+from django.db.models import F
+
+from applications.enums import EmployerApplicationStatus
+
+
+def fill_submitted_at(apps, schema_editor):
+    """
+    Clear EmployerApplication submitted_at for DRAFT status, and
+    set it to modified_at for all others (i.e. SUBMITTED in production in early 2026).
+
+    Why this should work for production data when going to production during spring 2026?
+     - Because there are no other states used in production except DRAFT and SUBMITTED.
+    """
+    employer_app_model = apps.get_model("applications", "EmployerApplication")
+    employer_app_model.objects.filter(status=EmployerApplicationStatus.DRAFT).update(
+        submitted_at=None
+    )
+    employer_app_model.objects.exclude(status=EmployerApplicationStatus.DRAFT).update(
+        submitted_at=F("modified_at")
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("applications", "0053_remove_all_remaining_historical_models"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="employerapplication",
+            name="submitted_at",
+            field=models.DateTimeField(
+                blank=True,
+                null=True,
+                verbose_name="timestamp when employer application was submitted",
+            ),
+        ),
+        migrations.RunPython(fill_submitted_at, migrations.RunPython.noop),
+    ]

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -57,7 +57,7 @@ from shared.common.validators import (
     validate_phone_number,
     validate_postcode,
 )
-from shared.models.abstract_models import HistoricalModel, TimeStampedModel, UUIDModel
+from shared.models.abstract_models import TimeStampedModel, UUIDModel
 from shared.models.mixins import LockForUpdateMixin
 from shared.vtj.vtj_client import VTJClient
 
@@ -899,7 +899,7 @@ class YouthSummerVoucherManager(models.Manager):
         ).select_youth_application()
 
 
-class YouthSummerVoucher(HistoricalModel, TimeStampedModel, UUIDModel):
+class YouthSummerVoucher(TimeStampedModel, UUIDModel):
     objects = YouthSummerVoucherManager()
 
     _SERIAL_NUMBER_SEQUENCE_NAME = "youth_summer_voucher_serial_numbers"
@@ -1151,7 +1151,7 @@ class YouthSummerVoucher(HistoricalModel, TimeStampedModel, UUIDModel):
         ordering = ["summer_voucher_serial_number"]
 
 
-class EmployerApplication(HistoricalModel, TimeStampedModel, UUIDModel):
+class EmployerApplication(TimeStampedModel, UUIDModel):
     company = models.ForeignKey(
         Company,
         on_delete=models.CASCADE,
@@ -1169,6 +1169,11 @@ class EmployerApplication(HistoricalModel, TimeStampedModel, UUIDModel):
         verbose_name=_("status"),
         choices=EmployerApplicationStatus.choices,
         default=EmployerApplicationStatus.DRAFT,
+    )
+    submitted_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name=_("timestamp when employer application was submitted"),
     )
     street_address = models.CharField(
         max_length=256,
@@ -1243,7 +1248,7 @@ class EmployerSummerVoucherManager(models.Manager):
         ).select_youth_voucher()
 
 
-class EmployerSummerVoucher(HistoricalModel, TimeStampedModel, UUIDModel):
+class EmployerSummerVoucher(TimeStampedModel, UUIDModel):
     objects = EmployerSummerVoucherManager()
 
     application = models.ForeignKey(
@@ -1455,21 +1460,8 @@ class EmployerSummerVoucher(HistoricalModel, TimeStampedModel, UUIDModel):
             return YouthSummerVoucher.voucher_value_in_euros_in_year(year)
 
     @property
-    def last_submitted_at(self) -> Optional[datetime]:
-        if (
-            last_submitted_history_entry := self.history.filter(
-                pk=self.pk, application__status=EmployerApplicationStatus.SUBMITTED
-            )
-            .order_by("-modified_at")
-            .first()
-        ):
-            return last_submitted_history_entry.modified_at
-        else:
-            return (
-                self.modified_at
-                if self.application.status == EmployerApplicationStatus.SUBMITTED
-                else None
-            )
+    def submitted_at(self) -> Optional[datetime]:
+        return self.application.submitted_at
 
     class Meta:
         verbose_name = _("employer summer voucher")

--- a/backend/kesaseteli/applications/tests/test_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_applications_api.py
@@ -2,6 +2,7 @@ import pytest
 from auditlog.models import LogEntry
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
+from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework.reverse import reverse
 
@@ -16,6 +17,7 @@ from common.tests.factories import (
     EmployerSummerVoucherFactory,
     YouthSummerVoucherFactory,
 )
+from shared.common.tests.utils import utc_datetime
 
 
 def get_list_url():
@@ -91,6 +93,27 @@ def test_application_patch(api_client, application):
 
     application.refresh_from_db()
     assert application.status == EmployerApplicationStatus.SUBMITTED
+
+
+@pytest.mark.django_db
+def test_submitted_at_is_set_on_draft_to_submitted_transition(api_client, application):
+    """
+    Test that application's submitted_at is set on DRAFT → SUBMITTED status transition.
+    """
+    application.refresh_from_db()
+    assert application.status == EmployerApplicationStatus.DRAFT
+    assert application.submitted_at is None
+
+    submission_time = timezone.now()
+    with freeze_time(submission_time):
+        data = {"status": EmployerApplicationStatus.SUBMITTED.value}
+        response = api_client.patch(get_detail_url(application), data)
+
+    assert response.status_code == 200
+    application.refresh_from_db()
+    assert application.status == EmployerApplicationStatus.SUBMITTED
+    assert application.submitted_at is not None
+    assert application.submitted_at == submission_time
 
 
 @pytest.mark.django_db
@@ -339,6 +362,123 @@ def test_application_update_writes_audit_log(api_client, application):
 
 
 @pytest.mark.django_db
+@override_settings(AUDIT_LOG_ORIGIN="TEST_SERVICE")
+def test_application_update_writes_multichange_audit_log(api_client, application):
+    application.invoicer_name = "old name"
+    application.is_separate_invoicer = True
+    application.contact_person_email = "old@example.org"
+    application.save()
+
+    data = EmployerApplicationSerializer(application).data
+    data["invoicer_name"] = "new name"
+    data["is_separate_invoicer"] = False
+    data["contact_person_email"] = "new@example.org"
+    response = api_client.put(
+        get_detail_url(application),
+        data,
+    )
+
+    assert response.status_code == 200
+    assert response.data["invoicer_name"] == "new name"
+    assert response.data["is_separate_invoicer"] is False
+    assert response.data["contact_person_email"] == "new@example.org"
+
+    audit_event = LogEntry.objects.first()
+    assert audit_event.remote_addr == "127.0.0.1"
+    assert audit_event.actor_id == response.wsgi_request.user.id
+    assert audit_event.actor_email == response.wsgi_request.user.email
+    assert audit_event.action == LogEntry.Action.UPDATE
+    assert audit_event.object_pk == response.data["id"]
+    assert audit_event.content_type == ContentType.objects.get(
+        app_label="applications", model="employerapplication"
+    )
+    assert audit_event.changes == {
+        "contact_person_email": ["old@example.org", "new@example.org"],
+        "invoicer_name": ["old name", "new name"],
+        "is_separate_invoicer": ["True", "False"],
+    }
+
+
+@pytest.mark.django_db
+@override_settings(AUDIT_LOG_ORIGIN="TEST_SERVICE")
+def test_application_update_audit_log_excludes_summer_vouchers(api_client, application):
+    """
+    The summer_vouchers list does not appear in the audit log changes.
+
+    NOTE!
+        This is DOCUMENTING the BEHAVIOR of how EmployerApplication audit logging works.
+        CHANGE IF NEEDED (e.g. if summer vouchers are started to be logged here)!
+    """
+    application.invoicer_name = "old name"
+    application.save()
+
+    data = EmployerApplicationSerializer(application).data
+    orig_summer_voucher_count = len(data["summer_vouchers"])
+    data["invoicer_name"] = "new name"
+    data["summer_vouchers"].append(
+        {
+            "summer_voucher_serial_number": "",
+            "employment_postcode": "00100",
+            "employment_start_date": "2026-06-01",
+            "employment_end_date": "2026-08-31",
+            "employment_work_hours": "37.5",
+            "employment_salary_paid": "1000.00",
+            "employment_description": "",
+            "hired_without_voucher_assessment": None,
+            "employee_phone_number": "+358 50 1234567890",
+        }
+    )
+    response = api_client.put(get_detail_url(application), data)
+
+    assert response.status_code == 200
+    assert len(response.data["summer_vouchers"]) == orig_summer_voucher_count + 1
+
+    audit_event = LogEntry.objects.first()
+
+    # Only the invoicer_name change is shown, no summer_vouchers changes:
+    assert audit_event.changes == {
+        "invoicer_name": ["old name", "new name"],
+    }
+
+
+@pytest.mark.django_db
+@override_settings(AUDIT_LOG_ORIGIN="TEST_SERVICE")
+def test_application_submitting_audit_logs_status_and_submitted_at_changes(
+    api_client, application
+):
+    """
+    Test that submitting application with DRAFT → SUBMITTED status change
+    audit logs the "status" and "submitted_at" field changes.
+    """
+    application.refresh_from_db()
+    assert application.status == EmployerApplicationStatus.DRAFT
+    assert application.submitted_at is None
+
+    old_audit_log_entry_count = LogEntry.objects.count()
+    frozen_datetime = utc_datetime(2025, 6, 20, 12, 0, 0)
+    with freeze_time(frozen_datetime):
+        response = api_client.patch(
+            get_detail_url(application), {"status": EmployerApplicationStatus.SUBMITTED}
+        )
+
+    assert response.status_code == 200
+    application.refresh_from_db()
+    assert application.submitted_at == frozen_datetime
+
+    assert LogEntry.objects.count() == old_audit_log_entry_count + 1
+    audit_event = LogEntry.objects.filter(
+        object_pk=application.id,
+        action=LogEntry.Action.UPDATE,
+        timestamp=frozen_datetime,
+    ).first()
+
+    assert audit_event.changes == {
+        "status": ["draft", "submitted"],
+        "submitted_at": ["None", "2025-06-20 12:00:00"],
+    }
+
+
+@pytest.mark.django_db
 @override_settings(
     AUDIT_LOG_ORIGIN="TEST_SERVICE",
 )
@@ -356,6 +496,36 @@ def test_application_delete_writes_audit_log(api_client, application):
     assert audit_event.content_type == ContentType.objects.get_for_model(
         EmployerApplication
     )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status",
+    [
+        status
+        for status in EmployerApplicationStatus.values
+        if status != EmployerApplicationStatus.DRAFT
+    ],
+)
+def test_application_non_draft_creation_failure(api_client, company, status):
+    """
+    EmployerApplication should not be creatable with non-DRAFT status.
+    """
+    response = api_client.post(get_list_url(), {"status": status})
+    # WARNING! DO NOT CHANGE without adding code to set submitted_at on non-DRAFT creation!
+    assert response.status_code == 400
+    assert "Initial status of application must be draft" in str(response.data)
+
+
+@pytest.mark.django_db
+def test_application_draft_creation_success(api_client, company):
+    """
+    EmployerApplication should be creatable with DRAFT status.
+    """
+    response = api_client.post(
+        get_list_url(), {"status": EmployerApplicationStatus.DRAFT}
+    )
+    assert response.status_code == 201
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/applications/tests/test_excel_export.py
+++ b/backend/kesaseteli/applications/tests/test_excel_export.py
@@ -269,7 +269,7 @@ def test_excel_view_download_content(  # noqa: C901
     def employer_summer_voucher_sorting_key(voucher: EmployerSummerVoucher):
         # Sorting key should be the same as what is used to order by queryset results
         # in Excel download, see EmployerApplicationExcelDownloadView
-        return voucher.last_submitted_at, voucher.created_at, voucher.pk
+        return voucher.submitted_at, voucher.created_at, voucher.pk
 
     vouchers: List[EmployerSummerVoucher] = sorted(
         create_test_employer_summer_vouchers(year=2021),
@@ -307,7 +307,7 @@ def test_excel_view_download_content(  # noqa: C901
             elif excel_field.title == RECEIVED_DATE_FIELD_TITLE:
                 assert (
                     output_column.value
-                    == voucher.last_submitted_at.astimezone().strftime("%d/%m/%Y")
+                    == voucher.submitted_at.astimezone().strftime("%d/%m/%Y")
                 )
             elif excel_field.title == APPLICATION_LANGUAGE_FIELD_TITLE:
                 assert output_column.value == voucher.application.get_language_display()

--- a/backend/kesaseteli/applications/tests/test_models.py
+++ b/backend/kesaseteli/applications/tests/test_models.py
@@ -33,75 +33,61 @@ def _get_email_template_image_file(image_name: str) -> bytes:
 
 def create_test_employer_summer_vouchers(year) -> List[EmployerSummerVoucher]:
     """
-    Create EmployerSummerVouchers for given year sorted by last_submitted_at.
+    Create EmployerSummerVouchers for given year sorted by submitted_at.
     """
     vouchers: List[EmployerSummerVoucher] = []
-    for created_at, last_submitted_at_list, attachment_count in [
-        (utc_datetime(year, 1, 13), [utc_datetime(year, 1, 18)], 0),
-        (utc_datetime(year, 2, 1), [], 0),
-        (utc_datetime(year, 1, 1), [utc_datetime(year, 2, 9)], 1),
-        (utc_datetime(year, 2, 21), [], 3),
-        (utc_datetime(year, 2, 20), [utc_datetime(year, 2, 22)], 10),
-        (utc_datetime(year, 3, 2), [], 5),
-        (utc_datetime(year, 3, 8), [utc_datetime(year, 3, 10)], 4),
-        (
-            utc_datetime(year, 1, 3),
-            [
-                utc_datetime(year, 3, 3),
-                utc_datetime(year, 3, 5),
-                utc_datetime(year, 3, 11),
-            ],
-            0,
-        ),
-        (utc_datetime(year, 1, 1), [utc_datetime(year, 3, 12)], 1),
-        (
-            utc_datetime(year, 3, 10),
-            [utc_datetime(year, 3, 11), utc_datetime(year, 9, 1)],
-            0,
-        ),
-        (utc_datetime(year, 2, 1), [utc_datetime(year, 9, 2)], 1),
-        (utc_datetime(year, 2, 5), [utc_datetime(year, 9, 2)], 1),
-        (utc_datetime(year, 2, 2), [utc_datetime(year, 9, 2)], 1),
+    for created_at, submitted_at, attachment_count in [
+        (utc_datetime(year, 1, 13), utc_datetime(year, 1, 18), 0),
+        (utc_datetime(year, 2, 1), utc_datetime(year, 2, 1), 0),
+        (utc_datetime(year, 1, 1), utc_datetime(year, 2, 9), 1),
+        (utc_datetime(year, 2, 21), utc_datetime(year, 2, 21), 3),
+        (utc_datetime(year, 2, 20), utc_datetime(year, 2, 22), 10),
+        (utc_datetime(year, 3, 2), utc_datetime(year, 3, 2), 5),
+        (utc_datetime(year, 3, 8), utc_datetime(year, 3, 10), 4),
+        (utc_datetime(year, 1, 3), utc_datetime(year, 3, 11), 0),
+        (utc_datetime(year, 1, 1), utc_datetime(year, 3, 12), 1),
+        (utc_datetime(year, 3, 10), utc_datetime(year, 9, 1), 0),
+        (utc_datetime(year, 2, 1), utc_datetime(year, 9, 2), 1),
+        (utc_datetime(year, 2, 5), utc_datetime(year, 9, 2), 1),
+        (utc_datetime(year, 2, 2), utc_datetime(year, 9, 2), 1),
     ]:
         with freeze_time(created_at):
             voucher = EmployerSummerVoucherFactory(
                 application=EmployerApplicationFactory(
-                    status=EmployerApplicationStatus.SUBMITTED
+                    status=EmployerApplicationStatus.SUBMITTED,
+                    submitted_at=submitted_at,
                 )
             )
             AttachmentFactory.create_batch(
                 size=attachment_count, summer_voucher=voucher
             )
-            for last_submitted_at in last_submitted_at_list:
-                with freeze_time(last_submitted_at):
-                    voucher.save()
             vouchers.append(voucher)
 
-    return sorted(vouchers, key=operator.attrgetter("last_submitted_at"))
+    return sorted(vouchers, key=operator.attrgetter("submitted_at"))
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("year", [2021, 2022])
-def test_employer_summer_voucher_last_submitted_at(year):
+def test_employer_summer_voucher_submitted_at(year):
     """
-    Test EmployerSummerVoucher instances' last_submitted_at property.
+    Test EmployerSummerVoucher instances' submitted_at property.
     """
     vouchers = create_test_employer_summer_vouchers(year=year)
 
     assert len(vouchers) == 13
-    assert vouchers[0].last_submitted_at == utc_datetime(year, 1, 18)
-    assert vouchers[1].last_submitted_at == utc_datetime(year, 2, 1)
-    assert vouchers[2].last_submitted_at == utc_datetime(year, 2, 9)
-    assert vouchers[3].last_submitted_at == utc_datetime(year, 2, 21)
-    assert vouchers[4].last_submitted_at == utc_datetime(year, 2, 22)
-    assert vouchers[5].last_submitted_at == utc_datetime(year, 3, 2)
-    assert vouchers[6].last_submitted_at == utc_datetime(year, 3, 10)
-    assert vouchers[7].last_submitted_at == utc_datetime(year, 3, 11)
-    assert vouchers[8].last_submitted_at == utc_datetime(year, 3, 12)
-    assert vouchers[9].last_submitted_at == utc_datetime(year, 9, 1)
-    assert vouchers[10].last_submitted_at == utc_datetime(year, 9, 2)
-    assert vouchers[11].last_submitted_at == utc_datetime(year, 9, 2)
-    assert vouchers[12].last_submitted_at == utc_datetime(year, 9, 2)
+    assert vouchers[0].submitted_at == utc_datetime(year, 1, 18)
+    assert vouchers[1].submitted_at == utc_datetime(year, 2, 1)
+    assert vouchers[2].submitted_at == utc_datetime(year, 2, 9)
+    assert vouchers[3].submitted_at == utc_datetime(year, 2, 21)
+    assert vouchers[4].submitted_at == utc_datetime(year, 2, 22)
+    assert vouchers[5].submitted_at == utc_datetime(year, 3, 2)
+    assert vouchers[6].submitted_at == utc_datetime(year, 3, 10)
+    assert vouchers[7].submitted_at == utc_datetime(year, 3, 11)
+    assert vouchers[8].submitted_at == utc_datetime(year, 3, 12)
+    assert vouchers[9].submitted_at == utc_datetime(year, 9, 1)
+    assert vouchers[10].submitted_at == utc_datetime(year, 9, 2)
+    assert vouchers[11].submitted_at == utc_datetime(year, 9, 2)
+    assert vouchers[12].submitted_at == utc_datetime(year, 9, 2)
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/applications/tests/test_serial_number_migration_functions.py
+++ b/backend/kesaseteli/applications/tests/test_serial_number_migration_functions.py
@@ -1,6 +1,5 @@
 """
-Tests for set_current_valid_serial_number_based_foreign_keys and
-set_historical_serial_number_based_foreign_keys migration functions
+Tests for set_current_valid_serial_number_based_foreign_keys migration function
 used in migration "0042_migrate_youth_summer_voucher_foreign_keys".
 
 These tests use the current data models. These tests CAN BE REMOVED
@@ -12,7 +11,6 @@ import pytest
 
 from applications.migrations.helpers.serial_number_foreign_keys import (
     set_current_valid_serial_number_based_foreign_keys,
-    set_historical_serial_number_based_foreign_keys,
 )
 from applications.models import (
     EmployerApplication,
@@ -92,60 +90,3 @@ def test_match_by_numeric_serial_number(employer_app):
     assert employer_voucher.youth_summer_voucher is not None
     assert employer_voucher.youth_summer_voucher.id == youth_voucher.id
     assert employer_voucher.youth_summer_voucher.summer_voucher_serial_number == 12345
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "obsolete_serial,expected_id",
-    [
-        # Successful conversions
-        ("0", 0),
-        ("12345", 12345),
-        ("987654321987654321", 987654321987654321),
-        ("  00250   ", 250),
-        # Invalid conversions
-        ("ABC123", None),  # Non-numeric string
-        ("Korhonen", None),  # Most common Finnish surname
-        ("", None),  # Empty string
-        ("-123", None),  # Negative numbers are invalid
-    ],
-)
-def test_set_historical_serial_number_based_foreign_keys(
-    obsolete_serial, expected_id, employer_app
-):
-    """
-    Test set_historical_serial_number_based_foreign_keys with various
-    valid and invalid serial numbers.
-    """
-    # Create an EmployerSummerVoucher to generate history
-    employer_voucher = create_employer_summer_voucher(
-        application=employer_app,
-        _obsolete_unclean_serial_number=obsolete_serial,
-    )
-
-    # HistoricalEmployerSummerVoucher does exist, not all IDEs (e.g. PyCharm)
-    # might find it possibly because the model is created dynamically by simple_history.
-    # Disabling possible F401 (unused-import) warning as false positive.
-    from applications.models import HistoricalEmployerSummerVoucher  # noqa: F401
-
-    assert HistoricalEmployerSummerVoucher
-    assert HistoricalEmployerSummerVoucher.__name__ == "HistoricalEmployerSummerVoucher"
-
-    # Clear the history to ensure a clean state
-    HistoricalEmployerSummerVoucher.objects.all().delete()
-    assert HistoricalEmployerSummerVoucher.objects.count() == 0
-
-    # Update the object to create historical record
-    employer_voucher.employment_postcode = "00300"
-    employer_voucher.save()
-
-    assert HistoricalEmployerSummerVoucher.objects.count() == 1
-    historical = HistoricalEmployerSummerVoucher.objects.first()
-    assert historical.youth_summer_voucher_id is None
-
-    # Run the migration function
-    set_historical_serial_number_based_foreign_keys(HistoricalEmployerSummerVoucher)
-
-    # Verify the result
-    historical.refresh_from_db()
-    assert historical.youth_summer_voucher_id == expected_id

--- a/backend/kesaseteli/applications/views.py
+++ b/backend/kesaseteli/applications/views.py
@@ -8,7 +8,7 @@ from typing import List, Union
 import xlsx_streaming
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import F, OuterRef, QuerySet, Subquery, Window
+from django.db.models import F, QuerySet, Window
 from django.db.models.functions import RowNumber
 from django.http import HttpResponse, HttpResponseRedirect, StreamingHttpResponse
 from django.shortcuts import render
@@ -53,9 +53,6 @@ class EmployerApplicationExcelDownloadView(TemplateView):
 
     @staticmethod
     def base_queryset(filter_pks=None) -> QuerySet[EmployerSummerVoucher]:
-        newest_submitted = EmployerSummerVoucher.history.filter(
-            id=OuterRef("id"), application__status=EmployerApplicationStatus.SUBMITTED
-        ).order_by("-modified_at")
         base_queryset = EmployerSummerVoucher.objects
         if filter_pks:
             base_queryset = base_queryset.filter(pk__in=filter_pks)
@@ -64,15 +61,14 @@ class EmployerApplicationExcelDownloadView(TemplateView):
                 "application", "application__company", "application__user"
             )
             .prefetch_related("attachments")
-            .annotate(submitted_at=Subquery(newest_submitted.values("modified_at")[:1]))
             # Use created_at and primary key as the secondary and tertiary ordering
             # parameters to force a predictable although slightly arbitrary ordering for
-            # queryset rows with identical submitted_at values.
-            .order_by("submitted_at", "created_at", "pk")
+            # queryset rows with identical application__submitted_at values.
+            .order_by("application__submitted_at", "created_at", "pk")
             .annotate(
                 row_number=Window(
                     expression=RowNumber(),
-                    order_by=[F("submitted_at"), F("created_at"), F("pk")],
+                    order_by=[F("application__submitted_at"), F("created_at"), F("pk")],
                 )
             )
         )

--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -114,12 +114,19 @@ class EmployerSummerVoucherFactory(
         model = EmployerSummerVoucher
 
 
+def determine_submitted_at(employer_application):
+    if employer_application.status != EmployerApplicationStatus.DRAFT:
+        return get_faker().date_time(tzinfo=get_current_timezone())
+    return None
+
+
 class EmployerApplicationFactory(
     SaveAfterPostGenerationMixin, factory.django.DjangoModelFactory
 ):
     company = factory.SubFactory(CompanyFactory)
     user = factory.SubFactory(DuplicateAllowingUserFactory)
     status = factory.Faker("random_element", elements=EmployerApplicationStatus.values)
+    submitted_at = factory.LazyAttribute(determine_submitted_at)
     street_address = factory.Faker("street_address")
     bank_account_number = factory.Faker("iban")
     contact_person_name = factory.Faker("name")

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -286,15 +286,11 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "simple_history.middleware.HistoryRequestMiddleware",
     "auditlog_extra.middleware.AuditlogMiddleware",
 ]
 
 if NEXT_PUBLIC_ENABLE_SUOMIFI:
-    MIDDLEWARE.insert(
-        MIDDLEWARE.index("simple_history.middleware.HistoryRequestMiddleware"),
-        "djangosaml2.middleware.SamlSessionMiddleware",
-    )
+    MIDDLEWARE.append("djangosaml2.middleware.SamlSessionMiddleware")
 
 TEMPLATES = [
     {

--- a/backend/kesaseteli/pyproject.toml
+++ b/backend/kesaseteli/pyproject.toml
@@ -19,8 +19,16 @@ select = [
     # flake8-print
     "T20",
 ]
+
+# E501 = line-too-long / https://docs.astral.sh/ruff/rules/line-too-long/
 extend-per-file-ignores = { "*/migrations/*" = ["E501"], "*/tests/*" = ["E501"] }
 
 [tool.ruff.lint.isort]
 known-first-party = ["shared"]
+known-third-party = [
+  # Removed django-simple-history package that's been locally stubbed
+  # at /backend/kesaseteli/simple_history/ directory.
+  # Only here to make ruff not change old migrations containing imports from it:
+  "simple_history",
+]
 order-by-type = false

--- a/backend/kesaseteli/requirements.in
+++ b/backend/kesaseteli/requirements.in
@@ -9,7 +9,6 @@ django-filter
 django-localflavor
 django-searchable-encrypted-fields
 django-sequences
-django-simple-history
 django-storages[azure]
 django~=5.2
 djangorestframework

--- a/backend/kesaseteli/requirements.txt
+++ b/backend/kesaseteli/requirements.txt
@@ -52,7 +52,6 @@ django==5.2.13
     #   django-localflavor
     #   django-searchable-encrypted-fields
     #   django-sequences
-    #   django-simple-history
     #   django-storages
     #   djangorestframework
     #   djangosaml2
@@ -83,8 +82,6 @@ django-localflavor==5.0
 django-searchable-encrypted-fields==0.2.1
     # via -r requirements.in
 django-sequences==3.0
-    # via -r requirements.in
-django-simple-history==3.11.0
     # via -r requirements.in
 django-storages[azure]==1.14.6
     # via -r requirements.in

--- a/backend/kesaseteli/simple_history/models.py
+++ b/backend/kesaseteli/simple_history/models.py
@@ -1,0 +1,24 @@
+class HistoricalChanges:
+    """
+    Stub replacing HistoricalChanges class from django-simple-history package
+    i.e. https://pypi.org/project/django-simple-history/
+
+    This stub exists solely to satisfy the import in legacy migrations
+    0001 and 0012, which reference this class in their bases= tuples.
+    The Historical* models were all removed by migration 0050 during year 2026.
+
+    Uses in legacy migrations:
+    ```
+        import simple_history.models
+        bases=(simple_history.models.HistoricalChanges, models.Model),
+    ```
+    """
+
+
+class HistoricalRecords:
+    """
+    Temporary stub replacing HistoricalRecords class from django-simple-history package.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass

--- a/backend/kesaseteli/simple_history/models.py
+++ b/backend/kesaseteli/simple_history/models.py
@@ -13,12 +13,3 @@ class HistoricalChanges:
         bases=(simple_history.models.HistoricalChanges, models.Model),
     ```
     """
-
-
-class HistoricalRecords:
-    """
-    Temporary stub replacing HistoricalRecords class from django-simple-history package.
-    """
-
-    def __init__(self, *args, **kwargs):
-        pass

--- a/backend/shared/shared/models/abstract_models.py
+++ b/backend/shared/shared/models/abstract_models.py
@@ -2,7 +2,6 @@ import uuid
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from simple_history.models import HistoricalRecords
 
 
 class TimeStampedModel(models.Model):
@@ -15,17 +14,6 @@ class TimeStampedModel(models.Model):
 
 class UUIDModel(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-
-    class Meta:
-        abstract = True
-
-
-class HistoricalModel(models.Model):
-    """
-    Keeps a simple history of the changes for the model.
-    """
-
-    history = HistoricalRecords(inherit=True)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
## Description :sparkles:

### Kesäseteli backend changes

- Remove historical models as unnecessary
- Add submitted_at to EmployerApplication
- Migrate EmployerApplication.modified_at to SUBMITTED status EmployerApplications' submitted_at field (set others' submitted_at to null)
- Use submitted_at in Excel export and other places now instead of using the data from HistoricalModel

### Shared backend changes

- Remove `HistoricalModel` as unused (was used only by Kesäseteli previously)

## Related

[YJDH-822](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-822)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-822]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ