### PR TITLE
YJDH-818 | Shared backend: Add resiliency to OIDC redirect related tests

### DIFF
--- a/backend/shared/shared/azure_adfs/tests/test_adfs_login.py
+++ b/backend/shared/shared/azure_adfs/tests/test_adfs_login.py
@@ -399,6 +399,7 @@ def test_adfs_callback_admin_link(
 )
 @override_settings(
     OIDC_REDIRECT_ALLOWED_HOSTS=["localhost:3200"],
+    OIDC_REDIRECT_REQUIRE_HTTPS=False,
     NEXT_PUBLIC_MOCK_FLAG=False,
 )
 def test_adfs_callback_routing(

--- a/backend/shared/shared/common/tests/test_utils.py
+++ b/backend/shared/shared/common/tests/test_utils.py
@@ -3,6 +3,7 @@ from datetime import date
 import pytest
 import stdnum.exceptions
 from django.db.models import Q
+from django.test import override_settings
 
 from shared.common.tests.utils import (
     create_finnish_social_security_number,
@@ -265,22 +266,27 @@ def test_invalid_social_security_number_birthdate(test_value):
 
 
 class TestIsSafeRedirectUrl:
+    @override_settings(OIDC_REDIRECT_REQUIRE_HTTPS=True)
     def test_safe_internal_url(self, rf):
         request = rf.get("/")
         assert is_safe_redirect_url(request, "/safe/", allowed_hosts=[])
 
+    @override_settings(OIDC_REDIRECT_REQUIRE_HTTPS=False)
     def test_unsafe_external_url(self, rf):
         request = rf.get("/")
         assert not is_safe_redirect_url(request, "http://evil.com", allowed_hosts=[])
 
+    @override_settings(OIDC_REDIRECT_REQUIRE_HTTPS=False)
     def test_allowed_external_url(self, rf):
         request = rf.get("/")
         assert is_safe_redirect_url(
             request, "http://trusted.com", allowed_hosts=["trusted.com"]
         )
 
-    def test_setting_lookup_hosts(self, rf, settings):
-        settings.OIDC_REDIRECT_ALLOWED_HOSTS = ["trusted.com"]
+    @override_settings(
+        OIDC_REDIRECT_ALLOWED_HOSTS=["trusted.com"], OIDC_REDIRECT_REQUIRE_HTTPS=False
+    )
+    def test_setting_lookup_hosts(self, rf):
         request = rf.get("/")
         # Should work by passing setting name
         assert is_safe_redirect_url(
@@ -289,14 +295,15 @@ class TestIsSafeRedirectUrl:
         # Should also work by default (None)
         assert is_safe_redirect_url(request, "http://trusted.com")
 
-    def test_setting_lookup_https(self, rf, settings):
-        settings.OIDC_REDIRECT_REQUIRE_HTTPS = True
+    @override_settings(OIDC_REDIRECT_REQUIRE_HTTPS=True)
+    def test_setting_lookup_https(self, rf):
         request = rf.get("/")  # insecure request
         # Should be unsafe because HTTPS is required but URL is http (or request is insecure)
         assert not is_safe_redirect_url(
             request, "http://example.com", require_https="OIDC_REDIRECT_REQUIRE_HTTPS"
         )
 
+    @override_settings(OIDC_REDIRECT_REQUIRE_HTTPS=False)
     def test_default_request_host_is_allowed(self, rf):
         request = rf.get("/", HTTP_HOST="mysite.com")
         assert is_safe_redirect_url(request, "http://mysite.com/path", allowed_hosts=[])

--- a/backend/shared/shared/oidc/tests/test_eauth_views.py
+++ b/backend/shared/shared/oidc/tests/test_eauth_views.py
@@ -110,6 +110,7 @@ def test_eauth_authentication_init_view(requests_mock, user_client, user):
     LOGIN_REDIRECT_URL="http://example.com/success",
     NEXT_PUBLIC_MOCK_FLAG=False,
     OIDC_REDIRECT_ALLOWED_HOSTS=["example.com"],
+    OIDC_REDIRECT_REQUIRE_HTTPS=False,
 )
 def test_eauth_callback_view(requests_mock, user_client, user):
     token_info = {

--- a/backend/shared/shared/oidc/tests/test_utils.py
+++ b/backend/shared/shared/oidc/tests/test_utils.py
@@ -1,12 +1,13 @@
+import pytest
 from django.conf import settings
 from django.test import RequestFactory, override_settings
 
-import pytest
-
 from shared.oidc.utils import get_eauth_login_success_url
+
 
 @pytest.mark.django_db
 class TestGetEauthLoginSuccessUrl:
+    @override_settings(OIDC_REDIRECT_REQUIRE_HTTPS=True)
     def test_returns_session_url_if_safe(self):
         rf = RequestFactory()
         request = rf.get("/")
@@ -17,6 +18,7 @@ class TestGetEauthLoginSuccessUrl:
         assert url == "/safe-url/"
         assert "eauth_next_url" not in request.session
 
+    @override_settings(OIDC_REDIRECT_REQUIRE_HTTPS=False)
     def test_returns_default_url_if_unsafe(self):
         rf = RequestFactory()
         request = rf.get("/")
@@ -27,7 +29,9 @@ class TestGetEauthLoginSuccessUrl:
         assert url == settings.LOGIN_REDIRECT_URL
         assert "eauth_next_url" not in request.session
 
-    @override_settings(OIDC_REDIRECT_ALLOWED_HOSTS=["trusted.com"])
+    @override_settings(
+        OIDC_REDIRECT_ALLOWED_HOSTS=["trusted.com"], OIDC_REDIRECT_REQUIRE_HTTPS=False
+    )
     def test_returns_allowed_external_url(self):
         rf = RequestFactory()
         request = rf.get("/")
@@ -36,6 +40,7 @@ class TestGetEauthLoginSuccessUrl:
         url = get_eauth_login_success_url(request)
         assert url == "http://trusted.com/callback"
 
+    @override_settings(OIDC_REDIRECT_REQUIRE_HTTPS=False)
     def test_falls_back_to_default_if_no_session_url(self):
         rf = RequestFactory()
         request = rf.get("/")


### PR DESCRIPTION
## Description :sparkles:

## Shared backend: Add resiliency to OIDC redirect related tests

Some of the shared backend tests failed if one didn't have OIDC_REDIRECT_REQUIRE_HTTPS turned off in their env file.

Add resiliency to the tests by overriding OIDC_REDIRECT_REQUIRE_HTTPS to False where needed.

Also override OIDC_REDIRECT_REQUIRE_HTTPS to True where URL is tested to be safe, in these cases being more strict (i.e. requiring HTTPS instead of allowing both HTTP and HTTPS) makes sense.

## Issues :bug:

- [YJDH-818](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-818)
- PR #3930 added some of the related tests

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-818]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ