### PR TITLE
YJDH-820 | Renew audit logging

### DIFF
--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -3,6 +3,7 @@ import uuid
 from functools import cached_property
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.core import exceptions
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
@@ -24,6 +25,7 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet
 
 from applications.api.v1.permissions import (
     ALLOWED_APPLICATION_UPDATE_STATUSES,
@@ -59,6 +61,7 @@ from applications.models import (
     YouthApplication,
     YouthSummerVoucher,
 )
+from applications.services import AuditAccessLogService
 from applications.target_groups import (
     AbstractTargetGroup,
     get_target_group_data,
@@ -66,7 +69,6 @@ from applications.target_groups import (
 from common.decorators import enforce_handler_view_adfs_login
 from common.fuzzy_matching import is_last_name_fuzzy_match_in_full_name
 from common.permissions import HandlerPermission
-from shared.audit_log.viewsets import AuditLoggingModelViewSet
 from shared.vtj.vtj_client import VTJClient
 
 LOGGER = logging.getLogger(__name__)
@@ -145,7 +147,7 @@ class TargetGroupListView(ListAPIView):
         return Response(queryset)
 
 
-class YouthApplicationViewSet(AuditLoggingModelViewSet):
+class YouthApplicationViewSet(ModelViewSet):
     permission_classes = [AllowAny]  # Permissions are handled per function
     queryset = YouthApplication.objects.all()
     serializer_class = YouthApplicationSerializer
@@ -164,12 +166,15 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
 
     @action(methods=["get"], detail=True)
     def status(self, request, *args, **kwargs) -> HttpResponse:
-        with self.record_action(additional_information="status"):
-            serializer = YouthApplicationStatusSerializer(
-                self.get_object(),
-                context=self.get_serializer_context(),
-            )
-            return Response(serializer.data)
+        # Not audit logging anything here as this is open to everyone,
+        # also to anonymous users. The returned data is relatively
+        # innocuous and only accessible if the youth application's
+        # random generated UUID v4 ID is known.
+        serializer = YouthApplicationStatusSerializer(
+            self.get_object(),
+            context=self.get_serializer_context(),
+        )
+        return Response(serializer.data)
 
     @transaction.atomic
     @enforce_handler_view_adfs_login
@@ -279,43 +284,49 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
         else:
             youth_application = youth_summer_voucher.youth_application
 
-        if not youth_application or not is_last_name_fuzzy_match_in_full_name(
+        found_match = youth_application and is_last_name_fuzzy_match_in_full_name(
             last_name=youth_application.last_name, full_name=employee_name
-        ):
-            with self.record_action(
-                target=YouthApplication,
-                additional_information=(
-                    "YouthApplicationViewSet.fetch_employee_data called with "
-                    f'employer_summer_voucher_id="{employer_summer_voucher_id}", '
-                    f'employee_name="{employee_name}" and '
-                    f"summer_voucher_serial_number={voucher_number} "
-                    "(POST used with CSRF as a GET). Found no matches."
-                ),
-            ):
-                return Response(status=status.HTTP_404_NOT_FOUND)
+        )
 
-        with self.record_action(
-            target=youth_application,
-            additional_information=(
-                "YouthApplicationViewSet.fetch_employee_data called with "
-                f'employer_summer_voucher_id="{employer_summer_voucher_id}", '
-                f'employee_name="{employee_name}" and '
-                f"summer_voucher_serial_number={voucher_number} "
-                "(POST used with CSRF as a GET). Found 1 match."
-            ),
-        ):
-            return Response(
-                data={
-                    "employer_summer_voucher_id": str(employer_summer_voucher_id),
-                    "employee_name": youth_application.name,
-                    "employee_ssn": youth_application.social_security_number,
-                    "employee_phone_number": youth_application.phone_number,
-                    "employee_home_city": youth_application.home_municipality,
-                    "employee_postcode": youth_application.postcode,
-                    "employee_school": youth_application.school,
-                },
-                status=status.HTTP_200_OK,
+        additional_data_for_access_audit_log = {
+            "method": f"{self.__class__.__name__}.fetch_employee_data",
+            "parameters": {
+                "employer_summer_voucher_id": str(employer_summer_voucher_id),
+                "employee_name": employee_name,
+                "summer_voucher_serial_number": voucher_number,
+            },
+        }
+
+        if not found_match:
+            # Manually log access because of access to sensitive information:
+            AuditAccessLogService.create_access_log_entry_with_no_related_object_instance(
+                actor=request.user,
+                actor_email=request.user.email,
+                content_type=ContentType.objects.get_for_model(YouthApplication),
+                additional_data=additional_data_for_access_audit_log,
             )
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        # Manually log access because of access to sensitive information:
+        AuditAccessLogService.create_access_log_entry_with_related_object_and_additional_data(
+            accessed_instance=youth_application,
+            actor=request.user,
+            actor_email=request.user.email,
+            additional_data=additional_data_for_access_audit_log,
+        )
+
+        return Response(
+            data={
+                "employer_summer_voucher_id": str(employer_summer_voucher_id),
+                "employee_name": youth_application.name,
+                "employee_ssn": youth_application.social_security_number,
+                "employee_phone_number": youth_application.phone_number,
+                "employee_home_city": youth_application.home_municipality,
+                "employee_postcode": youth_application.postcode,
+                "employee_school": youth_application.school,
+            },
+            status=status.HTTP_200_OK,
+        )
 
     @transaction.atomic
     @action(methods=["patch"], detail=True)
@@ -360,8 +371,7 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
                         _("Failed to send youth summer voucher email"),
                         status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     )
-            with self.record_action(additional_information="accept"):
-                return HttpResponse(status=status.HTTP_200_OK)
+            return HttpResponse(status=status.HTTP_200_OK)
         else:
             return HttpResponse(status=status.HTTP_400_BAD_REQUEST)
 
@@ -396,8 +406,7 @@ class YouthApplicationViewSet(AuditLoggingModelViewSet):
         if not youth_application.is_rejected and youth_application.reject(
             handler=request.user, encrypted_handler_vtj_json=encrypted_handler_vtj_json
         ):
-            with self.record_action(additional_information="reject"):
-                return HttpResponse(status=status.HTTP_200_OK)
+            return HttpResponse(status=status.HTTP_200_OK)
         else:
             return HttpResponse(status=status.HTTP_400_BAD_REQUEST)
 
@@ -737,7 +746,7 @@ class EmployerApplicationFilter(filters.FilterSet):
         }
 
 
-class EmployerApplicationViewSet(AuditLoggingModelViewSet):
+class EmployerApplicationViewSet(ModelViewSet):
     queryset = EmployerApplication.objects.all()
     serializer_class = EmployerApplicationSerializer
     permission_classes = [IsAuthenticated, EmployerApplicationPermission]
@@ -803,7 +812,7 @@ class EmployerApplicationViewSet(AuditLoggingModelViewSet):
         return super().destroy(request, *args, **kwargs)
 
 
-class EmployerSummerVoucherViewSet(AuditLoggingModelViewSet):
+class EmployerSummerVoucherViewSet(ModelViewSet):
     queryset = EmployerSummerVoucher.objects.all()
     serializer_class = EmployerSummerVoucherSerializer
     permission_classes = [

--- a/backend/kesaseteli/applications/migrations/0049_remove_employersummervoucher_employee_home_city_and_more.py
+++ b/backend/kesaseteli/applications/migrations/0049_remove_employersummervoucher_employee_home_city_and_more.py
@@ -4,50 +4,49 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('applications', '0048_employerapplication_add_timestamp_and_status_indexes'),
+        ("applications", "0048_employerapplication_add_timestamp_and_status_indexes"),
     ]
 
     operations = [
         migrations.RemoveField(
-            model_name='employersummervoucher',
-            name='employee_home_city',
+            model_name="employersummervoucher",
+            name="employee_home_city",
         ),
         migrations.RemoveField(
-            model_name='employersummervoucher',
-            name='employee_name',
+            model_name="employersummervoucher",
+            name="employee_name",
         ),
         migrations.RemoveField(
-            model_name='employersummervoucher',
-            name='employee_postcode',
+            model_name="employersummervoucher",
+            name="employee_postcode",
         ),
         migrations.RemoveField(
-            model_name='employersummervoucher',
-            name='employee_school',
+            model_name="employersummervoucher",
+            name="employee_school",
         ),
         migrations.RemoveField(
-            model_name='employersummervoucher',
-            name='employee_ssn',
+            model_name="employersummervoucher",
+            name="employee_ssn",
         ),
         migrations.RemoveField(
-            model_name='historicalemployersummervoucher',
-            name='employee_home_city',
+            model_name="historicalemployersummervoucher",
+            name="employee_home_city",
         ),
         migrations.RemoveField(
-            model_name='historicalemployersummervoucher',
-            name='employee_name',
+            model_name="historicalemployersummervoucher",
+            name="employee_name",
         ),
         migrations.RemoveField(
-            model_name='historicalemployersummervoucher',
-            name='employee_postcode',
+            model_name="historicalemployersummervoucher",
+            name="employee_postcode",
         ),
         migrations.RemoveField(
-            model_name='historicalemployersummervoucher',
-            name='employee_school',
+            model_name="historicalemployersummervoucher",
+            name="employee_school",
         ),
         migrations.RemoveField(
-            model_name='historicalemployersummervoucher',
-            name='employee_ssn',
+            model_name="historicalemployersummervoucher",
+            name="employee_ssn",
         ),
     ]

--- a/backend/kesaseteli/applications/migrations/0050_add_target_group_to_youth_application.py
+++ b/backend/kesaseteli/applications/migrations/0050_add_target_group_to_youth_application.py
@@ -4,15 +4,30 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('applications', '0049_remove_employersummervoucher_employee_home_city_and_more'),
+        (
+            "applications",
+            "0049_remove_employersummervoucher_employee_home_city_and_more",
+        ),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='youthapplication',
-            name='target_group',
-            field=models.CharField(blank=True, choices=[('hki_15', '8. luokkalainen'), ('primary_target_group', '9. luokkalainen'), ('secondary_target_group', 'Toisen asteen ensimmäisen vuoden opiskelija'), ('hki_18', 'Toisen asteen toisen vuoden opiskelija')], max_length=256, verbose_name='target group'),
+            model_name="youthapplication",
+            name="target_group",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("hki_15", "8. luokkalainen"),
+                    ("primary_target_group", "9. luokkalainen"),
+                    (
+                        "secondary_target_group",
+                        "Toisen asteen ensimmäisen vuoden opiskelija",
+                    ),
+                    ("hki_18", "Toisen asteen toisen vuoden opiskelija"),
+                ],
+                max_length=256,
+                verbose_name="target group",
+            ),
         ),
     ]

--- a/backend/kesaseteli/applications/migrations/0052_remove_target_group_from_youth_summer_voucher.py
+++ b/backend/kesaseteli/applications/migrations/0052_remove_target_group_from_youth_summer_voucher.py
@@ -4,18 +4,17 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('applications', '0051_populate_youth_application_target_group'),
+        ("applications", "0051_populate_youth_application_target_group"),
     ]
 
     operations = [
         migrations.RemoveField(
-            model_name='historicalyouthsummervoucher',
-            name='target_group',
+            model_name="historicalyouthsummervoucher",
+            name="target_group",
         ),
         migrations.RemoveField(
-            model_name='youthsummervoucher',
-            name='target_group',
+            model_name="youthsummervoucher",
+            name="target_group",
         ),
     ]

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -886,6 +886,7 @@ class YouthApplication(LockForUpdateMixin, TimeStampedModel, UUIDModel):
         ]
         ordering = ["-created_at"]
 
+
 class YouthSummerVoucherQuerySet(models.QuerySet):
     def select_youth_application(self):
         return self.select_related("youth_application")

--- a/backend/kesaseteli/applications/services.py
+++ b/backend/kesaseteli/applications/services.py
@@ -1,7 +1,9 @@
 import logging
 from typing import TYPE_CHECKING
 
+from auditlog.models import LogEntry
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.template import Context, Template
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import get_template
@@ -13,10 +15,14 @@ from applications.models import EmailTemplate, School, SummerVoucherConfiguratio
 from common.utils import send_mail_with_error_logging
 
 if TYPE_CHECKING:
+    from django.contrib.contenttypes.models import ContentType
+
     from applications.models import YouthApplication
 
 
 LOGGER = logging.getLogger(__name__)
+
+User = get_user_model()
 
 
 class TargetGroupValidationService:
@@ -211,3 +217,51 @@ class SchoolService:
                 else:
                     existing_count += 1
         return created_count, existing_count
+
+
+class AuditAccessLogService:
+    """
+    Service for creating ACCESS audit log entries with additional_data.
+    """
+
+    @staticmethod
+    def create_access_log_entry_with_no_related_object_instance(
+        *,
+        actor: User,
+        actor_email: str,
+        content_type: "ContentType",
+        additional_data: dict,
+    ) -> LogEntry:
+        """
+        Create an ACCESS audit log entry with no related object instance,
+        but with additional data.
+        """
+        return LogEntry.objects.create(
+            action=LogEntry.Action.ACCESS,
+            actor=actor,
+            actor_email=actor_email,
+            content_type=content_type,
+            additional_data=additional_data,
+        )
+
+    @staticmethod
+    def create_access_log_entry_with_related_object_and_additional_data(
+        *,
+        accessed_instance,
+        actor: User,
+        actor_email: str,
+        additional_data: dict,
+    ) -> LogEntry:
+        """
+        Create an ACCESS audit log entry with related object instance and
+        additional data into which "is_sent" and "request_path" info
+        can be set later.
+        """
+        return LogEntry.objects.log_create(
+            accessed_instance,
+            force_log=True,
+            action=LogEntry.Action.ACCESS,
+            actor=actor,
+            actor_email=actor_email,
+            additional_data=additional_data,
+        )

--- a/backend/kesaseteli/applications/target_groups.py
+++ b/backend/kesaseteli/applications/target_groups.py
@@ -263,6 +263,3 @@ def get_target_group_data(identifiers: List[str]) -> List[dict]:
                 }
             )
     return target_groups
-
-
-

--- a/backend/kesaseteli/applications/tests/test_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_applications_api.py
@@ -1,4 +1,6 @@
 import pytest
+from auditlog.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 from freezegun import freeze_time
 from rest_framework.reverse import reverse
@@ -14,7 +16,6 @@ from common.tests.factories import (
     EmployerSummerVoucherFactory,
     YouthSummerVoucherFactory,
 )
-from shared.audit_log.models import AuditLogEntry
 
 
 def get_list_url():
@@ -288,7 +289,7 @@ def test_application_delete_other_user_not_allowed(api_client, application):
 @override_settings(
     AUDIT_LOG_ORIGIN="TEST_SERVICE",
 )
-def test_application_create_writes_audit_log(api_client, user, company):
+def test_application_create_writes_audit_log(api_client, company):
     response = api_client.post(
         get_list_url(),
         {},
@@ -296,26 +297,22 @@ def test_application_create_writes_audit_log(api_client, user, company):
 
     assert response.status_code == 201
 
-    audit_event = AuditLogEntry.objects.first().message["audit_event"]
-    assert audit_event["actor"] == {
-        "ip_address": "127.0.0.1",
-        "role": "USER",
-        "user_id": str(user.pk),
-        "provider": "",
-    }
-    assert audit_event["operation"] == "CREATE"
-    assert audit_event["target"] == {
-        "id": response.data["id"],
-        "type": "EmployerApplication",
-    }
-    assert audit_event["status"] == "SUCCESS"
+    audit_event = LogEntry.objects.first()
+    assert audit_event.remote_addr == "127.0.0.1"
+    assert audit_event.actor_id == response.wsgi_request.user.id
+    assert audit_event.actor_email == response.wsgi_request.user.email
+    assert audit_event.action == LogEntry.Action.CREATE
+    assert audit_event.object_pk == response.data["id"]
+    assert audit_event.content_type == ContentType.objects.get_for_model(
+        EmployerApplication
+    )
 
 
 @pytest.mark.django_db
 @override_settings(
     AUDIT_LOG_ORIGIN="TEST_SERVICE",
 )
-def test_application_update_writes_audit_log(api_client, user, application):
+def test_application_update_writes_audit_log(api_client, application):
     application.invoicer_name = "test1"
     application.save()
 
@@ -329,70 +326,36 @@ def test_application_update_writes_audit_log(api_client, user, application):
     assert response.status_code == 200
     assert response.data["invoicer_name"] == "test2"
 
-    audit_event = AuditLogEntry.objects.first().message["audit_event"]
-    assert audit_event["actor"] == {
-        "ip_address": "127.0.0.1",
-        "role": "USER",
-        "user_id": str(user.pk),
-        "provider": "",
-    }
-    assert audit_event["operation"] == "UPDATE"
-    assert audit_event["target"] == {
-        "id": response.data["id"],
-        "type": "EmployerApplication",
-        "changes": ["invoicer_name changed from test1 to test2"],
-    }
-    assert audit_event["status"] == "SUCCESS"
+    audit_event = LogEntry.objects.first()
+    assert audit_event.remote_addr == "127.0.0.1"
+    assert audit_event.actor_id == response.wsgi_request.user.id
+    assert audit_event.actor_email == response.wsgi_request.user.email
+    assert audit_event.action == LogEntry.Action.UPDATE
+    assert audit_event.object_pk == response.data["id"]
+    assert audit_event.content_type == ContentType.objects.get_for_model(
+        EmployerApplication
+    )
+    assert audit_event.changes == {"invoicer_name": ["test1", "test2"]}
 
 
 @pytest.mark.django_db
 @override_settings(
     AUDIT_LOG_ORIGIN="TEST_SERVICE",
 )
-def test_application_delete_writes_audit_log(api_client, user, application):
+def test_application_delete_writes_audit_log(api_client, application):
     response = api_client.delete(get_detail_url(application))
 
     assert response.status_code == 204
 
-    audit_event = AuditLogEntry.objects.first().message["audit_event"]
-    assert audit_event["actor"] == {
-        "ip_address": "127.0.0.1",
-        "role": "USER",
-        "user_id": str(user.pk),
-        "provider": "",
-    }
-    assert audit_event["operation"] == "DELETE"
-    assert audit_event["target"] == {
-        "id": str(application.id),
-        "type": "EmployerApplication",
-    }
-    assert audit_event["status"] == "SUCCESS"
-
-
-@pytest.mark.django_db
-@override_settings(
-    AUDIT_LOG_ORIGIN="TEST_SERVICE",
-)
-def test_application_create_writes_audit_log_if_not_authenticated(
-    unauthenticated_api_client,
-):
-    response = unauthenticated_api_client.post(
-        get_list_url(),
-        {},
+    audit_event = LogEntry.objects.first()
+    assert audit_event.remote_addr == "127.0.0.1"
+    assert audit_event.actor_id == response.wsgi_request.user.id
+    assert audit_event.actor_email == response.wsgi_request.user.email
+    assert audit_event.action == LogEntry.Action.DELETE
+    assert audit_event.object_pk == str(application.id)
+    assert audit_event.content_type == ContentType.objects.get_for_model(
+        EmployerApplication
     )
-
-    assert response.status_code == 403
-
-    audit_event = AuditLogEntry.objects.first().message["audit_event"]
-    assert audit_event["actor"] == {
-        "ip_address": "127.0.0.1",
-        "role": "ANONYMOUS",
-        "user_id": "",
-        "provider": "",
-    }
-    assert audit_event["operation"] == "CREATE"
-    assert audit_event["target"]["type"] == "EmployerApplication"
-    assert audit_event["status"] == "FORBIDDEN"
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/applications/tests/test_attachments_api.py
+++ b/backend/kesaseteli/applications/tests/test_attachments_api.py
@@ -5,7 +5,9 @@ import tempfile
 import uuid
 
 import pytest
+from auditlog.models import LogEntry
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from PIL import Image
 from rest_framework.reverse import reverse
 
@@ -52,6 +54,10 @@ def _upload_file(
 @pytest.mark.django_db
 @pytest.mark.parametrize("extension", ["pdf", "jpg"])
 def test_attachment_upload(request, api_client, summer_voucher, extension):
+    """
+    Test that uploading an attachment to an employer summer voucher works.
+    """
+    assert not summer_voucher.attachments.exists()
     response = _upload_file(
         request,
         api_client,
@@ -63,6 +69,49 @@ def test_attachment_upload(request, api_client, summer_voucher, extension):
     assert len(summer_voucher.attachments.all()) == 1
     attachment = summer_voucher.attachments.all().first()
     assert attachment.attachment_file.name.endswith(f".{extension}")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "extension, expected_content_type",
+    [
+        ("pdf", "application/pdf"),
+        ("jpg", "image/jpeg"),
+    ],
+)
+def test_attachment_upload_writes_audit_log(
+    request, api_client, summer_voucher, extension, expected_content_type
+):
+    """
+    Test that uploading an attachment to an employer summer voucher
+    writes an audit log entry.
+    """
+    response = _upload_file(
+        request,
+        api_client,
+        summer_voucher,
+        extension,
+        AttachmentType.EMPLOYMENT_CONTRACT,
+    )
+
+    audit_event = LogEntry.objects.first()
+    assert audit_event.action == LogEntry.Action.CREATE
+    assert audit_event.object_pk == response.data["id"]
+    assert audit_event.content_type == ContentType.objects.get_for_model(Attachment)
+    assert audit_event.actor_id == response.wsgi_request.user.id
+    assert audit_event.actor_email == response.wsgi_request.user.email
+    assert audit_event.changes["attachment_file"] == [
+        "None",
+        response.data["attachment_file_name"],
+    ]
+    assert audit_event.changes["content_type"] == [
+        "None",
+        response.data["content_type"],
+    ]
+    assert audit_event.changes["attachment_type"] == [
+        "None",
+        response.data["attachment_type"],
+    ]
 
 
 @pytest.mark.django_db
@@ -185,6 +234,9 @@ def test_get_attachment_with_invalid_uuid(
     "attachment_type", [attachment_type for attachment_type in AttachmentType.values]
 )
 def test_delete_attachment(request, api_client, summer_voucher, attachment_type):
+    """
+    Test that deleting an attachment from an employer summer voucher works.
+    """
     _upload_file(request, api_client, summer_voucher, "pdf", attachment_type)
     attachment = Attachment.objects.first()
     attachment_delete_url = handle_attachment_url(summer_voucher, attachment.pk)
@@ -192,6 +244,35 @@ def test_delete_attachment(request, api_client, summer_voucher, attachment_type)
     response = api_client.delete(attachment_delete_url)
 
     assert response.status_code == 204
+
+    with pytest.raises(Attachment.DoesNotExist):
+        attachment.refresh_from_db()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "attachment_type",
+    [attachment_type for attachment_type in AttachmentType.values],
+)
+def test_delete_attachment_writes_audit_log(
+    request, api_client, summer_voucher, attachment_type
+):
+    """
+    Test that deleting an attachment from an employer summer voucher
+    writes an audit log entry.
+    """
+    _upload_file(request, api_client, summer_voucher, "pdf", attachment_type)
+    attachment = Attachment.objects.first()
+    attachment_delete_url = handle_attachment_url(summer_voucher, attachment.pk)
+
+    response = api_client.delete(attachment_delete_url)
+
+    audit_event = LogEntry.objects.first()
+    assert audit_event.action == LogEntry.Action.DELETE
+    assert audit_event.object_pk == str(attachment.id)
+    assert audit_event.content_type == ContentType.objects.get_for_model(Attachment)
+    assert audit_event.actor_id == response.wsgi_request.user.id
+    assert audit_event.actor_email == response.wsgi_request.user.email
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/applications/tests/test_employer_summer_voucher_admin.py
+++ b/backend/kesaseteli/applications/tests/test_employer_summer_voucher_admin.py
@@ -63,6 +63,7 @@ def test_field_configuration(employer_summer_voucher_admin):
     assert "masked_employee_ssn" in config_readonly
     assert "employee_ssn" not in config_readonly
 
+
 @pytest.mark.django_db
 def test_get_queryset(employer_summer_voucher_admin):
     voucher = EmployerSummerVoucherFactory()

--- a/backend/kesaseteli/applications/tests/test_excel_export.py
+++ b/backend/kesaseteli/applications/tests/test_excel_export.py
@@ -6,6 +6,8 @@ from typing import List
 
 import openpyxl
 import pytest
+from auditlog.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
 from django.http import StreamingHttpResponse
 from django.shortcuts import reverse
 from django.test import override_settings
@@ -57,7 +59,7 @@ from common.tests.factories import (
 )
 from common.urls import handler_403_url
 from common.utils import getattr_nested
-from shared.audit_log.models import AuditLogEntry
+from shared.common.tests.utils import utc_datetime
 
 
 def excel_download_url():
@@ -157,67 +159,70 @@ def test_youth_excel_download_no_youth_applications(staff_client):
 
 @pytest.mark.django_db
 def test_youth_excel_download_writes_audit_log(staff_client, youth_application):
-    old_audit_log_entry_count = AuditLogEntry.objects.count()
-    response = staff_client.get(youth_excel_download_url())
+    old_audit_log_entry_count = LogEntry.objects.count()
+    frozen_datetime = utc_datetime(2025, 10, 15)
+    with freeze_time(frozen_datetime):
+        response = staff_client.get(youth_excel_download_url())
 
-    assert AuditLogEntry.objects.count() == old_audit_log_entry_count + 1
-    audit_event = AuditLogEntry.objects.first().message["audit_event"]
-    assert audit_event["actor"]["role"] == "USER"
-    assert audit_event["actor"]["user_id"] == str(response.wsgi_request.user.pk)
-    assert audit_event["status"] == "SUCCESS"
-    assert audit_event["operation"] == "READ"
-    assert audit_event["target"]["id"] == ""
-    assert audit_event["target"]["type"] == "YouthApplication"
-    assert (
-        audit_event["additional_information"]
-        == "YouthApplicationExcelExportViewSet.list"
+    assert LogEntry.objects.count() == old_audit_log_entry_count + 1
+    audit_event = LogEntry.objects.filter(
+        action=LogEntry.Action.ACCESS,
+        timestamp=frozen_datetime,
+    ).first()
+    assert audit_event.actor_id == response.wsgi_request.user.pk
+    assert audit_event.actor_email == response.wsgi_request.user.email
+    assert audit_event.action == LogEntry.Action.ACCESS
+    assert audit_event.object_pk == ""
+    assert audit_event.content_type == ContentType.objects.get_for_model(
+        YouthApplication
     )
+    assert audit_event.additional_data == {
+        "is_sent": False,
+        "request_path": youth_excel_download_url(),
+        "method": "YouthApplicationExcelExportViewSet.list",
+    }
+    assert audit_event.timestamp == frozen_datetime
 
 
 @pytest.mark.django_db
-@pytest.mark.xfail(reason="Audit log writing should be added to this endpoint")
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
-@pytest.mark.parametrize(
-    "download_url,expected_audit_log_additional_information",
-    [
-        (
-            f"{excel_download_url()}?download=unhandled",
-            "EmployerApplicationExcelDownloadView.get unhandled",
-        ),
-        (
-            f"{excel_download_url()}?download=annual",
-            "EmployerApplicationExcelDownloadView.get annual",
-        ),
-    ],
-)
-def test_excel_download_writes_audit_log(
-    staff_client, download_url, expected_audit_log_additional_information
-):
+@pytest.mark.parametrize("columns", ExcelColumns.values)
+@pytest.mark.parametrize("download_type", ["unhandled", "annual", "annual-previous"])
+def test_excel_download_writes_audit_log(staff_client, columns, download_type):
     """
     Test that audit log is written when downloading employer summer voucher
     Excel files.
-
-    NOTE:
-        Tested values MAY NEED UPDATING when audit logging is added to the endpoint!
     """
     create_test_employer_summer_vouchers(year=2021)
+    download_url = f"{excel_download_url()}?download={download_type}&columns={columns}"
 
-    old_audit_log_entry_count = AuditLogEntry.objects.count()
-    with freeze_time(datetime(2021, 12, 31)):
+    old_audit_log_entry_count = LogEntry.objects.count()
+    frozen_datetime = utc_datetime(2021, 12, 31)
+    with freeze_time(frozen_datetime):
         response = staff_client.get(download_url)
 
-    assert AuditLogEntry.objects.count() == old_audit_log_entry_count + 1
-    audit_event = AuditLogEntry.objects.first().message["audit_event"]
-    assert audit_event["actor"]["role"] == "USER"
-    assert audit_event["actor"]["user_id"] == str(response.wsgi_request.user.pk)
-    assert audit_event["status"] == "SUCCESS"
-    assert audit_event["operation"] == "READ"
-    assert audit_event["target"]["id"] == ""
-    assert audit_event["target"]["type"] == "EmployerSummerVoucher"
-    assert (
-        audit_event["additional_information"]
-        == expected_audit_log_additional_information
+    assert LogEntry.objects.count() == old_audit_log_entry_count + 1
+    audit_event = LogEntry.objects.filter(
+        action=LogEntry.Action.ACCESS,
+        timestamp=frozen_datetime,
+    ).first()
+    assert audit_event.action == LogEntry.Action.ACCESS
+    assert audit_event.object_pk == ""  # Not a single object, but a list
+    assert audit_event.content_type == ContentType.objects.get_for_model(
+        EmployerSummerVoucher
     )
+    assert audit_event.additional_data == {
+        "is_sent": False,
+        "request_path": excel_download_url(),
+        "method": "EmployerApplicationExcelDownloadView.get",
+        "parameters": {
+            "columns": columns,
+            "download": download_type,
+        },
+    }
+    assert audit_event.timestamp == frozen_datetime
+    assert audit_event.actor_id == response.wsgi_request.user.id
+    assert audit_event.actor_email == response.wsgi_request.user.email
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/applications/tests/test_security_with_anonymous_user.py
+++ b/backend/kesaseteli/applications/tests/test_security_with_anonymous_user.py
@@ -258,3 +258,24 @@ def test_not_acceptable_response_to_anonymous_user_requesting_html_from_endpoint
     }
     assert isinstance(response.accepted_renderer, JSONRenderer)
     assert response.wsgi_request.user.is_anonymous
+
+
+@pytest.mark.django_db
+def test_employer_application_list_post_forbidden_to_anonymous_user(
+    client,
+):
+    """
+    Test that using POST on employer application list endpoint
+    returns forbidden to anonymous users.
+    """
+    response = client.post(reverse("v1:employerapplication-list"), data={})
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.data == {
+        "detail": ErrorDetail(
+            string=_("Authentication credentials were not provided."),
+            code=NotAuthenticated.default_code,
+        )
+    }
+    assert isinstance(response.accepted_renderer, JSONRenderer)
+    assert response.wsgi_request.user.is_anonymous

--- a/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
+++ b/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
@@ -1,7 +1,9 @@
 from unittest import mock
 
 import pytest
+from auditlog.models import LogEntry
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.test import Client, override_settings
 from freezegun import freeze_time
 from rest_framework import status
@@ -24,7 +26,6 @@ from common.tests.factories import (
 )
 from common.tests.utils import set_company_business_id_to_client
 from common.urls import handler_403_url
-from shared.audit_log.models import AuditLogEntry
 from shared.common.tests.conftest import force_login_user
 from shared.common.tests.factories import UserFactory
 
@@ -1338,7 +1339,7 @@ def test_youth_application_fetch_employee_data_success_writes_audit_log(user_cli
         youth_summer_voucher__summer_voucher_serial_number=123,
     )
     url = reverse("v1:youthapplication-fetch-employee-data")
-    audit_log_entries_before = AuditLogEntry.objects.count()
+    log_entry_count_before = LogEntry.objects.count()
     response = user_client.post(
         url,
         data={
@@ -1347,20 +1348,25 @@ def test_youth_application_fetch_employee_data_success_writes_audit_log(user_cli
             "summer_voucher_serial_number": 123,
         },
     )
-    assert AuditLogEntry.objects.count() == audit_log_entries_before + 1
-    audit_event = AuditLogEntry.objects.first().message["audit_event"]
-    assert audit_event["actor"]["role"] == "USER"
-    assert audit_event["actor"]["user_id"] == str(response.wsgi_request.user.pk)
-    assert audit_event["status"] == "SUCCESS"
-    assert audit_event["operation"] == "CREATE"
-    assert audit_event["target"]["id"] == str(youth_application.id)
-    assert audit_event["target"]["type"] == "YouthApplication"
-    assert audit_event["additional_information"] == (
-        "YouthApplicationViewSet.fetch_employee_data called with "
-        f'employer_summer_voucher_id="{employer_summer_voucher.id}", '
-        'employee_name="Peter Doe" and summer_voucher_serial_number=123 '
-        "(POST used with CSRF as a GET). Found 1 match."
+    assert LogEntry.objects.count() == log_entry_count_before + 1
+    audit_event = LogEntry.objects.first()
+    assert audit_event.actor_id == response.wsgi_request.user.pk
+    assert audit_event.actor_email == response.wsgi_request.user.email
+    assert audit_event.action == LogEntry.Action.ACCESS
+    assert audit_event.object_pk == str(youth_application.id)
+    assert audit_event.content_type == ContentType.objects.get_for_model(
+        YouthApplication
     )
+    assert audit_event.additional_data == {
+        "is_sent": False,
+        "request_path": url,
+        "method": "YouthApplicationViewSet.fetch_employee_data",
+        "parameters": {
+            "employer_summer_voucher_id": str(employer_summer_voucher.id),
+            "employee_name": "Peter Doe",
+            "summer_voucher_serial_number": 123,
+        },
+    }
 
 
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
@@ -1370,7 +1376,7 @@ def test_youth_application_fetch_employee_data_not_found_writes_audit_log(user_c
         application=EmployerApplicationFactory()
     )
     url = reverse("v1:youthapplication-fetch-employee-data")
-    audit_log_entries_before = AuditLogEntry.objects.count()
+    log_entry_count_before = LogEntry.objects.count()
     response = user_client.post(
         url,
         data={
@@ -1379,20 +1385,25 @@ def test_youth_application_fetch_employee_data_not_found_writes_audit_log(user_c
             "summer_voucher_serial_number": 123456789,
         },
     )
-    assert AuditLogEntry.objects.count() == audit_log_entries_before + 1
-    audit_event = AuditLogEntry.objects.first().message["audit_event"]
-    assert audit_event["actor"]["role"] == "USER"
-    assert audit_event["actor"]["user_id"] == str(response.wsgi_request.user.pk)
-    assert audit_event["status"] == "SUCCESS"
-    assert audit_event["operation"] == "CREATE"
-    assert audit_event["target"]["id"] == ""
-    assert audit_event["target"]["type"] == "YouthApplication"
-    assert audit_event["additional_information"] == (
-        "YouthApplicationViewSet.fetch_employee_data called with "
-        f'employer_summer_voucher_id="{employer_summer_voucher.id}", '
-        'employee_name="Teppo Testaaja" and summer_voucher_serial_number=123456789 '
-        "(POST used with CSRF as a GET). Found no matches."
+    assert LogEntry.objects.count() == log_entry_count_before + 1
+    audit_event = LogEntry.objects.first()
+    assert audit_event.actor_id == response.wsgi_request.user.pk
+    assert audit_event.actor_email == response.wsgi_request.user.email
+    assert audit_event.action == LogEntry.Action.ACCESS
+    assert audit_event.object_pk == ""
+    assert audit_event.content_type == ContentType.objects.get_for_model(
+        YouthApplication
     )
+    assert audit_event.additional_data == {
+        "is_sent": False,
+        "request_path": url,
+        "method": "YouthApplicationViewSet.fetch_employee_data",
+        "parameters": {
+            "employer_summer_voucher_id": str(employer_summer_voucher.id),
+            "employee_name": "Teppo Testaaja",
+            "summer_voucher_serial_number": 123456789,
+        },
+    }
 
 
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)

--- a/backend/kesaseteli/applications/tests/test_target_group_validation_api.py
+++ b/backend/kesaseteli/applications/tests/test_target_group_validation_api.py
@@ -25,7 +25,9 @@ from common.urls import get_create_without_ssn_url, get_list_url
         "primary_target_group_suffix",
     ],
 )
-def test_youth_application_creation_invalid_target_group(api_client, invalid_target_group):
+def test_youth_application_creation_invalid_target_group(
+    api_client, invalid_target_group
+):
     """
     Test that creating a youth application with an invalid target group returns 400 Bad Request.
     """
@@ -51,7 +53,9 @@ def test_youth_application_creation_invalid_target_group(api_client, invalid_tar
         "999",
     ],
 )
-def test_non_vtj_youth_application_creation_invalid_target_group(staff_client, invalid_target_group):
+def test_non_vtj_youth_application_creation_invalid_target_group(
+    staff_client, invalid_target_group
+):
     """
     Test that creating a non-VTJ youth application with an invalid target group returns 400 Bad Request.
     """

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -10,8 +10,10 @@ from urllib.parse import urlparse
 
 import factory.random
 import pytest
+from auditlog.models import LogEntry
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.template import Context, Template
 from django.test import override_settings
@@ -71,7 +73,6 @@ from common.urls import (
     RedirectTo,
     reverse_youth_application_action,
 )
-from shared.audit_log.models import AuditLogEntry
 from shared.common.lang_test_utils import (
     assert_email_body_language,
     assert_email_subject_language,
@@ -358,7 +359,6 @@ def test_youth_applications_not_allowed_methods(
     http_method,
     action,
 ):
-    old_audit_log_entry_count = AuditLogEntry.objects.count()
     settings.NEXT_PUBLIC_MOCK_FLAG = mock_flag
     client_fixture = request.getfixturevalue(client_fixture_func.__name__)
     client_http_method_func = getattr(client_fixture, http_method)
@@ -370,9 +370,10 @@ def test_youth_applications_not_allowed_methods(
     else:
         endpoint_url = reverse_youth_application_action(action, pk=youth_application.pk)
 
+    log_entry_count_before_method_call = LogEntry.objects.count()
     response = client_http_method_func(endpoint_url)
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
-    assert AuditLogEntry.objects.count() == old_audit_log_entry_count
+    assert LogEntry.objects.count() == log_entry_count_before_method_call
 
 
 @pytest.mark.django_db
@@ -1341,11 +1342,12 @@ def test_youth_application_post_valid_audit_log(api_client):
     assert "id" in response.data
     assert response.data["id"]
     assert YouthApplication.objects.filter(pk=response.data["id"]).exists()
-    audit_event = AuditLogEntry.objects.first().message["audit_event"]
-    assert audit_event["status"] == "SUCCESS"
-    assert audit_event["operation"] == "CREATE"
-    assert audit_event["target"]["id"] == str(response.data["id"])
-    assert audit_event["target"]["type"] == "YouthApplication"
+    audit_event = LogEntry.objects.first()
+    assert audit_event.action == LogEntry.Action.CREATE
+    assert audit_event.object_pk == response.data["id"]
+    assert audit_event.content_type == ContentType.objects.get_for_model(
+        YouthApplication
+    )
 
 
 @pytest.mark.django_db
@@ -2209,6 +2211,7 @@ def test_youth_applications_accept_acceptable(
     old_modified_at = acceptable_youth_application.modified_at
     old_youth_summer_voucher_count = YouthSummerVoucher.objects.count()
     assert not acceptable_youth_application.has_youth_summer_voucher
+    log_entry_count_before_accepting = LogEntry.objects.count()
     response = client_fixture.patch(
         reverse_youth_application_action("accept", acceptable_youth_application.pk),
         data=json.dumps(get_test_handling_data()),
@@ -2230,31 +2233,45 @@ def test_youth_applications_accept_acceptable(
             acceptable_youth_application.youth_summer_voucher.summer_voucher_serial_number
             == YouthSummerVoucher.get_last_used_serial_number()
         )
-        audit_event = AuditLogEntry.objects.first().message["audit_event"]
-        assert audit_event["status"] == "SUCCESS"
-        assert audit_event["operation"] == "UPDATE"
-        assert audit_event["target"]["id"] == str(acceptable_youth_application.pk)
-        assert audit_event["target"]["type"] == "YouthApplication"
-        assert audit_event["additional_information"] == "accept"
+        youth_voucher_audit_event, youth_app_audit_event = LogEntry.objects.all()[:2]
+        # Created the youth summer voucher:
+        assert youth_voucher_audit_event.action == LogEntry.Action.CREATE
+        assert youth_voucher_audit_event.object_pk == str(
+            acceptable_youth_application.youth_summer_voucher.pk
+        )
+        assert (
+            youth_voucher_audit_event.content_type
+            == ContentType.objects.get_for_model(YouthSummerVoucher)
+        )
+        # Updated the youth application to accepted status:
+        assert youth_app_audit_event.action == LogEntry.Action.UPDATE
+        assert youth_app_audit_event.object_pk == str(acceptable_youth_application.pk)
+        assert youth_app_audit_event.content_type == ContentType.objects.get_for_model(
+            YouthApplication
+        )
+        assert youth_app_audit_event.changes["status"] == [
+            str(old_status),
+            str(YouthApplicationStatus.ACCEPTED),
+        ]
         handler = response.wsgi_request.user
         assert handler is not None
         if handler == AnonymousUser():
             assert HandlerPermission.allow_empty_handler()
             assert handler.pk is None
             assert acceptable_youth_application.handler is None
-            assert audit_event["actor"]["role"] == "ANONYMOUS"
-            assert audit_event["actor"]["user_id"] == ""
+            assert youth_voucher_audit_event.actor_id is None
+            assert youth_app_audit_event.actor_id is None
         else:
             assert handler.pk is not None
             assert acceptable_youth_application.handler == handler
-            assert audit_event["actor"]["role"] == "USER"
-            assert audit_event["actor"]["user_id"] == str(handler.pk)
+            assert youth_voucher_audit_event.actor_id == handler.pk
+            assert youth_app_audit_event.actor_id == handler.pk
     else:
         assert acceptable_youth_application.status == old_status
         assert acceptable_youth_application.modified_at == old_modified_at
         assert not acceptable_youth_application.has_youth_summer_voucher
         assert YouthSummerVoucher.objects.count() == old_youth_summer_voucher_count
-        assert not AuditLogEntry.objects.exists()
+        assert LogEntry.objects.count() == log_entry_count_before_accepting
 
     if response.status_code == status.HTTP_302_FOUND:
         assert response.url == RedirectTo.get_redirect_url(
@@ -2345,6 +2362,7 @@ def test_youth_applications_handle_handled(
     assert handled_youth_application.is_handled
     old_status = handled_youth_application.status
     old_modified_at = handled_youth_application.modified_at
+    log_entry_count_before_handling = LogEntry.objects.count()
     response = client_fixture.patch(
         reverse_youth_application_action(handling_action, handled_youth_application.pk),
         data=json.dumps(get_test_handling_data()),
@@ -2355,7 +2373,7 @@ def test_youth_applications_handle_handled(
     handled_youth_application.refresh_from_db()
     assert handled_youth_application.status == old_status
     assert handled_youth_application.modified_at == old_modified_at
-    assert not AuditLogEntry.objects.exists()
+    assert LogEntry.objects.count() == log_entry_count_before_handling
 
     if response.status_code == status.HTTP_302_FOUND:
         assert response.url == RedirectTo.get_redirect_url(
@@ -2397,6 +2415,7 @@ def test_youth_applications_reject_rejectable(
     old_status = rejectable_youth_application.status
     old_modified_at = rejectable_youth_application.modified_at
     assert not rejectable_youth_application.has_youth_summer_voucher
+    log_entry_count_before_rejecting = LogEntry.objects.count()
     response = client_fixture.patch(
         reverse_youth_application_action("reject", rejectable_youth_application.pk),
         data=json.dumps(get_test_handling_data()),
@@ -2412,29 +2431,31 @@ def test_youth_applications_reject_rejectable(
         assert rejectable_youth_application.encrypted_handler_vtj_json == json.dumps(
             get_test_handling_data()["encrypted_handler_vtj_json"]
         )
-        audit_event = AuditLogEntry.objects.first().message["audit_event"]
-        assert audit_event["status"] == "SUCCESS"
-        assert audit_event["operation"] == "UPDATE"
-        assert audit_event["target"]["id"] == str(rejectable_youth_application.pk)
-        assert audit_event["target"]["type"] == "YouthApplication"
-        assert audit_event["additional_information"] == "reject"
+        audit_event = LogEntry.objects.first()
+        assert audit_event.action == LogEntry.Action.UPDATE
+        assert audit_event.object_pk == str(rejectable_youth_application.pk)
+        assert audit_event.content_type == ContentType.objects.get_for_model(
+            YouthApplication
+        )
+        assert audit_event.changes["status"] == [
+            str(old_status),
+            str(YouthApplicationStatus.REJECTED),
+        ]
         handler = response.wsgi_request.user
         assert handler is not None
         if handler == AnonymousUser():
             assert HandlerPermission.allow_empty_handler()
             assert handler.pk is None
             assert rejectable_youth_application.handler is None
-            assert audit_event["actor"]["role"] == "ANONYMOUS"
-            assert audit_event["actor"]["user_id"] == ""
+            assert audit_event.actor_id is None
         else:
             assert handler.pk is not None
             assert rejectable_youth_application.handler == handler
-            assert audit_event["actor"]["role"] == "USER"
-            assert audit_event["actor"]["user_id"] == str(handler.pk)
+            assert audit_event.actor_id == handler.pk
     else:
         assert rejectable_youth_application.status == old_status
         assert rejectable_youth_application.modified_at == old_modified_at
-        assert not AuditLogEntry.objects.exists()
+        assert LogEntry.objects.count() == log_entry_count_before_rejecting
 
     if response.status_code == status.HTTP_302_FOUND:
         assert response.url == RedirectTo.get_redirect_url(

--- a/backend/kesaseteli/applications/views.py
+++ b/backend/kesaseteli/applications/views.py
@@ -7,6 +7,7 @@ from typing import List, Union
 
 import xlsx_streaming
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import F, OuterRef, QuerySet, Subquery, Window
 from django.db.models.functions import RowNumber
 from django.http import HttpResponse, HttpResponseRedirect, StreamingHttpResponse
@@ -16,6 +17,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import TemplateView
 from rest_framework import status
 from rest_framework.permissions import AllowAny
+from rest_framework.viewsets import ModelViewSet
 from xlsxwriter import Workbook
 from xlsxwriter.worksheet import Format, Worksheet
 
@@ -28,9 +30,9 @@ from applications.exporters.excel_exporter import (
     get_xlsx_filename,
 )
 from applications.models import EmployerSummerVoucher, YouthApplication
+from applications.services import AuditAccessLogService
 from common.decorators import enforce_handler_view_adfs_login
 from common.urls import handler_create_application_without_ssn_url
-from shared.audit_log.viewsets import AuditLoggingModelViewSet
 
 
 class EmployerApplicationExcelDownloadView(TemplateView):
@@ -56,7 +58,7 @@ class EmployerApplicationExcelDownloadView(TemplateView):
         ).order_by("-modified_at")
         base_queryset = EmployerSummerVoucher.objects
         if filter_pks:
-            base_queryset.filter(pk__in=filter_pks)
+            base_queryset = base_queryset.filter(pk__in=filter_pks)
         return (
             base_queryset.select_related(
                 "application", "application__company", "application__user"
@@ -78,19 +80,32 @@ class EmployerApplicationExcelDownloadView(TemplateView):
     @enforce_handler_view_adfs_login
     def get(self, request, *args, **kwargs):
         columns = request.GET.get("columns", ExcelColumns.REPORTING.value)
+        download_type = request.GET.get("download")
         if columns not in ExcelColumns.values:
             raise ValueError(
                 f"Invalid columns {columns} for Excel download, "
                 f"acceptable values are {ExcelColumns.values}"
             )
-
-        if request.GET.get("download") == "unhandled":
+        # Manually log access because of mass access to sensitive information:
+        AuditAccessLogService.create_access_log_entry_with_no_related_object_instance(
+            actor=request.user,
+            actor_email=request.user.email,
+            content_type=ContentType.objects.get_for_model(EmployerSummerVoucher),
+            additional_data={
+                "method": f"{self.__class__.__name__}.get",
+                "parameters": {
+                    "columns": columns,
+                    "download": download_type,
+                },
+            },
+        )
+        if download_type == "unhandled":
             return self.export_and_download_unhandled_applications(columns)
-        elif request.GET.get("download") == "annual":
+        elif download_type == "annual":
             return self.export_and_download_annual_applications(
                 columns, year=date.today().year
             )
-        elif request.GET.get("download") == "annual-previous":
+        elif download_type == "annual-previous":
             return self.export_and_download_annual_applications(
                 columns, year=date.today().year - 1
             )
@@ -194,7 +209,7 @@ class EmployerApplicationExcelDownloadView(TemplateView):
         return self.get_xlsx_response(queryset, columns)
 
 
-class YouthApplicationExcelExportViewSet(AuditLoggingModelViewSet):
+class YouthApplicationExcelExportViewSet(ModelViewSet):
     permission_classes = [AllowAny]  # Permissions are handled per function
     serializer_class = YouthApplicationExcelExportSerializer
 
@@ -261,28 +276,31 @@ class YouthApplicationExcelExportViewSet(AuditLoggingModelViewSet):
     def list(
         self, request, *args, **kwargs
     ) -> Union[HttpResponse, HttpResponseRedirect, StreamingHttpResponse]:
-        with self.record_action(
-            additional_information=f"{self.__class__.__name__}.list"
-        ):
-            queryset = self.get_queryset()
-            if not queryset.exists():
-                return HttpResponse(_("Hakemuksia ei löytynyt."))
+        # Manually log access because of mass access to sensitive information:
+        AuditAccessLogService.create_access_log_entry_with_no_related_object_instance(
+            actor=request.user,
+            actor_email=request.user.email,
+            content_type=ContentType.objects.get_for_model(YouthApplication),
+            additional_data={"method": f"{self.__class__.__name__}.list"},
+        )
 
-            response = StreamingHttpResponse(
-                xlsx_streaming.stream_queryset_as_xlsx(
-                    qs=queryset,
-                    xlsx_template=self.xlsx_template(queryset),
-                    serializer=self.serializer,
-                    batch_size=settings.EXCEL_DOWNLOAD_BATCH_SIZE,
-                ),
-                content_type=(
-                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-                ),
-            )
-            response["Content-Disposition"] = (
-                f"attachment; filename={self.xlsx_filename}"
-            )
-            return response
+        queryset = self.get_queryset()
+        if not queryset.exists():
+            return HttpResponse(_("Hakemuksia ei löytynyt."))
+
+        response = StreamingHttpResponse(
+            xlsx_streaming.stream_queryset_as_xlsx(
+                qs=queryset,
+                xlsx_template=self.xlsx_template(queryset),
+                serializer=self.serializer,
+                batch_size=settings.EXCEL_DOWNLOAD_BATCH_SIZE,
+            ),
+            content_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        )
+        response["Content-Disposition"] = f"attachment; filename={self.xlsx_filename}"
+        return response
 
     @property
     def worksheet_name(self) -> str:

--- a/backend/kesaseteli/common/decorators.py
+++ b/backend/kesaseteli/common/decorators.py
@@ -61,8 +61,9 @@ enforce_handler_view_adfs_login = partial(
     permit_view_if_permissions_or_redirect(
         permission_classes=[HandlerPermission],
         login_url=reverse_lazy("django_auth_adfs:login"),
-        redirect_only_if_func=lambda r: is_request_user_unauthenticated(r)
-        and not is_api_request(r),
+        redirect_only_if_func=lambda r: (
+            is_request_user_unauthenticated(r) and not is_api_request(r)
+        ),
         run_before_redirect_func=set_use_original_redirect_url_into_session,
         forbidden_response_func=forbidden_handler_view_response,
     )

--- a/backend/kesaseteli/companies/tests/test_company_services.py
+++ b/backend/kesaseteli/companies/tests/test_company_services.py
@@ -51,6 +51,7 @@ def test_get_or_create_company_via_organization_roles_fallback_uses_defaults(
 
     assert Company.objects.count() == 1
 
+
 @pytest.mark.django_db
 def test_get_or_create_company_via_ytj_data_uses_defaults():
     """
@@ -77,5 +78,3 @@ def test_get_or_create_company_via_ytj_data_uses_defaults():
     assert company.postcode == ""
     assert company.city == ""
     assert company.ytj_json == ytj_data
-
-

--- a/backend/kesaseteli/kesaseteli/apps.py
+++ b/backend/kesaseteli/kesaseteli/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class KesaseteliProjectConfig(AppConfig):
+    name = "kesaseteli"
+
+    def ready(self):
+        from auditlog_extra.utils import AuditLogConfigurationHelper
+
+        AuditLogConfigurationHelper.raise_error_if_unconfigured_models()

--- a/backend/kesaseteli/kesaseteli/auditlog_settings.py
+++ b/backend/kesaseteli/kesaseteli/auditlog_settings.py
@@ -1,0 +1,56 @@
+# ADD any AUDIT LOGGING SETTINGS you want to use in your project HERE.
+# Only the settings listed in __all__ will be imported
+# in kesaseteli/settings.py:
+__all__ = [
+    "AUDITLOG_INCLUDE_ALL_MODELS",
+    "AUDITLOG_DISABLE_REMOTE_ADDR",
+    "AUDITLOG_DISABLE_ON_RAW_SAVE",
+    "AUDITLOG_EXCLUDE_TRACKING_MODELS",
+    "AUDITLOG_INCLUDE_TRACKING_MODELS",
+]
+
+# Register all models by default
+AUDITLOG_INCLUDE_ALL_MODELS = True
+
+# Exclude the IP address from logging?
+# When using AuditlogMiddleware, the IP address is logged by default
+AUDITLOG_DISABLE_REMOTE_ADDR = False
+
+# Disables logging during raw save. (I.e. for instance using loaddata)
+# M2M operations will still be logged, since they’re never considered raw.
+AUDITLOG_DISABLE_ON_RAW_SAVE = True
+
+# Exclude models in registration process.
+# This setting will only be considered when AUDITLOG_INCLUDE_ALL_MODELS is True.
+AUDITLOG_EXCLUDE_TRACKING_MODELS = (
+    "auditlog.logentry",  # excluded by default, here to show it exists
+    "admin.logentry",  # excluded by default, here to show it exists
+    "applications.historicalemployerapplication",  # to be removed completely
+    "applications.historicalemployersummervoucher",  # to be removed completely
+    "applications.historicalyouthsummervoucher",  # to be removed completely
+    "audit_log.auditlogentry",  # no double audit logging
+    "contenttypes.contenttype",  # system model
+    "sequences.sequence",  # system model
+    "sessions.session",  # auth model
+)
+
+AUDITLOG_INCLUDE_TRACKING_MODELS = (
+    "applications.attachment",
+    "applications.emailtemplate",
+    "applications.employerapplication",
+    "applications.employersummervoucher",
+    "applications.school",
+    "applications.summervoucherconfiguration",
+    "applications.youthapplication",
+    "applications.youthsummervoucher",
+    "auth.group",
+    "auth.group_permissions",
+    "auth.permission",
+    {
+        "model": "auth.user",
+        "exclude_fields": ["last_login"],  # To reduce excessive logging
+    },
+    "auth.user_groups",
+    "auth.user_user_permissions",
+    "companies.company",
+)

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -259,6 +259,8 @@ INSTALLED_APPS = [
     "django_extensions",
     "django_auth_adfs",
     "sequences.apps.SequencesConfig",
+    "auditlog",
+    "auditlog_extra",
     # shared apps
     "shared.audit_log",
     "shared.oidc",
@@ -267,6 +269,7 @@ INSTALLED_APPS = [
     "companies",
     "staff_admin_permissions.apps.StaffAdminPermissionsConfig",
     "django.contrib.postgres",
+    "kesaseteli",  # MUST BE LAST for AUDIT LOGGING enforcement! See app's apps.py
 ]
 
 if NEXT_PUBLIC_ENABLE_SUOMIFI:
@@ -284,6 +287,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
+    "auditlog_extra.middleware.AuditlogMiddleware",
 ]
 
 if NEXT_PUBLIC_ENABLE_SUOMIFI:
@@ -748,3 +752,6 @@ SUMMER_VOUCHER_DEFAULT_TARGET_GROUPS = [
 SUMMER_VOUCHER_DEFAULT_VOUCHER_VALUE = 350
 SUMMER_VOUCHER_DEFAULT_MIN_WORK_COMPENSATION = 500
 SUMMER_VOUCHER_DEFAULT_MIN_WORK_HOURS = 60
+
+# Load auditlog settings
+from kesaseteli.auditlog_settings import *  # noqa: E402, F403

--- a/backend/kesaseteli/requirements.in
+++ b/backend/kesaseteli/requirements.in
@@ -1,4 +1,6 @@
 -e file:../shared
+django-auditlog
+django-auditlog-extra@https://github.com/City-of-Helsinki/django-auditlog-extra/archive/24978fc884355e8d210016dac2e58b8c7d4b701a.zip
 django-auth-adfs
 django-cors-headers
 django-environ

--- a/backend/kesaseteli/requirements.txt
+++ b/backend/kesaseteli/requirements.txt
@@ -43,6 +43,8 @@ defusedxml==0.7.1
 django==5.2.13
     # via
     #   -r requirements.in
+    #   django-auditlog
+    #   django-auditlog-extra
     #   django-auth-adfs
     #   django-cors-headers
     #   django-extensions
@@ -56,6 +58,12 @@ django==5.2.13
     #   djangosaml2
     #   mozilla-django-oidc
     #   yjdh-backend-shared
+django-auditlog==3.4.1
+    # via
+    #   -r requirements.in
+    #   django-auditlog-extra
+django-auditlog-extra @ https://github.com/City-of-Helsinki/django-auditlog-extra/archive/24978fc884355e8d210016dac2e58b8c7d4b701a.zip
+    # via -r requirements.in
 django-auth-adfs==1.16.0
     # via
     #   -r requirements.in
@@ -149,7 +157,9 @@ pyopenssl==24.2.1
 pysaml2==7.5.4
     # via djangosaml2
 python-dateutil==2.9.0.post0
-    # via pysaml2
+    # via
+    #   django-auditlog
+    #   pysaml2
 python-stdnum==2.2
     # via
     #   -r requirements.in


### PR DESCRIPTION
## Description :sparkles:

- Add audit logging using `django-auditlog` & `django-auditlog-extra`.
- Remove collection of audit log using the old audit logging solution i.e. `AuditLoggingModelViewSet` from `shared.audit_log`.

TODO (Not in this PR):
- Use django-resilient-logger to send new audit logs to Elasticsearch
  - Not possible at the moment as the Elasticsearch we're using in production is Elasticsearch v7, and django-resilient-logger requires Elasticsearch v8, which is incompatible with Elasticsearch v7.
- Specific audit logging concerns related to Django admin
  - These were not handled by the previous audit logging solution in use, so no use case / support has been removed for these in this PR. The only thing related to Django admin in the previous audit logging solution is that there is a `AuditLogEntryAdmin` that is used for e.g. showing the previous audit logging solution's audit log entries in Django admin. This has been left intact.

## Related

[YJDH-820](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-820)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-820]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ