### PR TITLE
fix: 403 errors on language change HL-1777

### DIFF
--- a/frontend/benefit/applicant/src/components/header/useHeader.ts
+++ b/frontend/benefit/applicant/src/components/header/useHeader.ts
@@ -99,11 +99,7 @@ const useHeader = (): ExtendedComponentProps => {
     hasCorrectStatus && !application?.archived_for_applicant;
 
   useEffect(() => {
-    if (application?.unread_messages_count) {
-      setUnredMessagesCount(application?.unread_messages_count);
-    } else {
-      setUnredMessagesCount(null);
-    }
+    setUnredMessagesCount(application?.unread_messages_count || null);
   }, [application]);
 
   useEffect(() => {
@@ -144,7 +140,7 @@ const useHeader = (): ExtendedComponentProps => {
 
   const handleLanguageChange = (newLanguage: SUPPORTED_LANGUAGES): void => {
     // Persist the language preference in the backend session.
-    // Skip the call when unauthenticated to avoid spamming sentry with 403.
+    // Skip the call when unauthenticated to avoid spamming Sentry with 403.
     if (isAuthenticated) {
       void axios.get(BackendEndpoint.USER_OPTIONS, {
         params: { lang: newLanguage },

--- a/frontend/benefit/applicant/src/components/header/useHeader.ts
+++ b/frontend/benefit/applicant/src/components/header/useHeader.ts
@@ -8,6 +8,7 @@ import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { useRouter } from 'next/router';
 import { TFunction } from 'next-i18next';
 import React, { useEffect, useMemo, useState } from 'react';
+import AuthContext from 'shared/auth/AuthContext';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 import useGetLanguage from 'shared/hooks/useGetLanguage';
 import isServerSide from 'shared/server/is-server-side';
@@ -66,6 +67,7 @@ const useHeader = (): ExtendedComponentProps => {
   const id = router?.query?.id?.toString() ?? '';
   const openDrawer = Boolean(router?.query?.openDrawer);
   const { axios } = useBackendAPI();
+  const { isAuthenticated } = React.useContext(AuthContext);
   const { isNavigationVisible } = React.useContext(AppContext);
   const getLanguage = useGetLanguage();
   const navigationUriBase =
@@ -141,10 +143,15 @@ const useHeader = (): ExtendedComponentProps => {
   }, [status, setHasMessenger]);
 
   const handleLanguageChange = (newLanguage: SUPPORTED_LANGUAGES): void => {
-    void axios.get(BackendEndpoint.USER_OPTIONS, {
-      params: { lang: newLanguage },
-    });
+    // Persist the language preference in the backend session.
+    // Skip the call when unauthenticated to avoid spamming sentry with 403.
+    if (isAuthenticated) {
+      void axios.get(BackendEndpoint.USER_OPTIONS, {
+        params: { lang: newLanguage },
+      });
+    }
 
+    // Switch the Next.js client-side locale immediately, regardless of auth state.
     void router.push({ pathname, query }, asPath, {
       locale: newLanguage,
     });

--- a/frontend/benefit/handler/src/components/header/useHeader.tsx
+++ b/frontend/benefit/handler/src/components/header/useHeader.tsx
@@ -43,7 +43,7 @@ const useHeader = (): ExtendedComponentProps => {
         params: { lang: SUPPORTED_LANGUAGES.FI },
       });
     }
-  }, [isAuthenticated]);
+  }, [axios, isAuthenticated]);
 
   const { data: alterationData, isLoading: isAlterationListLoading } =
     useApplicationAlterationsQuery();

--- a/frontend/benefit/handler/src/components/header/useHeader.tsx
+++ b/frontend/benefit/handler/src/components/header/useHeader.tsx
@@ -1,27 +1,16 @@
-import axios from 'axios';
 import NumberTag from 'benefit/handler/components/header/NumberTag';
 import { ROUTES, SUPPORTED_LANGUAGES } from 'benefit/handler/constants';
 import AppContext from 'benefit/handler/context/AppContext';
 import useApplicationAlterationsQuery from 'benefit/handler/hooks/useApplicationAlterationsQuery';
 import { useDetermineAhjoMode } from 'benefit/handler/hooks/useDetermineAhjoMode';
-import {
-  BackendEndpoint,
-  getBackendDomain,
-} from 'benefit-shared/backend-api/backend-api';
+import { BackendEndpoint } from 'benefit-shared/backend-api/backend-api';
 import { useRouter } from 'next/router';
 import { TFunction, useTranslation } from 'next-i18next';
 import React, { useEffect } from 'react';
+import AuthContext from 'shared/auth/AuthContext';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
 import { NavigationItem, OptionType } from 'shared/types/common';
 import { getLanguageOptions } from 'shared/utils/common';
-
-const setLanguageToFinnish = (): void => {
-  const optionsEndpoint = `${getBackendDomain()}/${
-    BackendEndpoint.USER_OPTIONS
-  }`;
-  void axios.get(optionsEndpoint, {
-    params: { lang: SUPPORTED_LANGUAGES.FI },
-  });
-};
 
 type ExtendedComponentProps = {
   t: TFunction;
@@ -38,13 +27,23 @@ const useHeader = (): ExtendedComponentProps => {
   const router = useRouter();
   const { isNavigationVisible } = React.useContext(AppContext);
   const isNewAhjoMode = useDetermineAhjoMode();
+  const { axios } = useBackendAPI();
+  const { isAuthenticated } = React.useContext(AuthContext);
 
   const languageOptions = React.useMemo(
     (): OptionType<string>[] => getLanguageOptions(t, 'supportedLanguages'),
     [t]
   );
 
-  useEffect(setLanguageToFinnish, []);
+  useEffect(() => {
+    // The handler UI is currently Finnish-only so it's set here.
+    // Only when authenticated so there is no 403 error.
+    if (isAuthenticated) {
+      void axios.get(BackendEndpoint.USER_OPTIONS, {
+        params: { lang: SUPPORTED_LANGUAGES.FI },
+      });
+    }
+  }, [isAuthenticated]);
 
   const { data: alterationData, isLoading: isAlterationListLoading } =
     useApplicationAlterationsQuery();


### PR DESCRIPTION


There are 403 errors on Sentry that seem to come from language change when user is not logged in.
This changes it so that language change is sent to backend only if the user is authenticated. 

Handler side has only Finnish language, so it's not any use to change it or send it to backend, but I left that logic as it is.


https://helsinkisolutionoffice.atlassian.net/browse/HL-1777


Refs: HL-1777

