### PR TITLE
Fix commitlint config path in github actions

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -20,4 +20,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v6
         with:
-          configFile: ./commitlint.config.mjs
+          configFile: ./frontend/commitlint.config.mjs


### PR DESCRIPTION
## Description :sparkles:

### Fix commitlint config path in github actions

This fixes running commitlint in github actions with the wanted
commitlint.config.mjs, and thus allows "deps" type and does not break
on dependabot PRs anymore.

Refs: PR #3978 (moved commitlint.config.mjs from root to /frontend/)

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
