### PR TITLE
feat(benefit): ensure tol-code is set for new appl

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1,3 +1,5 @@
+import logging
+
 from datetime import date, timedelta
 from typing import Dict, List, Union
 
@@ -79,6 +81,7 @@ from common.utils import (
 )
 from companies.api.v1.serializers import CompanySearchSerializer, CompanySerializer
 from companies.models import Company
+from companies.services import get_or_create_organisation_with_business_id
 from shared.audit_log import audit_logging
 from shared.audit_log.enums import Operation
 from terms.api.v1.serializers import (
@@ -90,6 +93,8 @@ from terms.enums import TermsType
 from terms.models import ApplicantTermsApproval, Terms
 from users.api.v1.serializers import UserSerializer
 from users.utils import get_company_from_request, get_request_user_from_context
+
+log = logging.getLogger(__name__)
 
 
 def _get_instalment(application, instalment_number):
@@ -1319,6 +1324,9 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
         de_minimis_data = validated_data.pop("de_minimis_aid_set")
         employee_data = validated_data.pop("employee", None)
         validated_data["company"] = self.get_company_for_new_application(validated_data)
+        company = validated_data["company"]
+        if not company.industry_code:
+            self._refresh_company_industry(company)
         validated_data["company_form_code"] = validated_data[
             "company"
         ].company_form_code
@@ -1402,6 +1410,24 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
                 "",
                 Operation.CREATE,
                 de_minimis,
+            )
+
+    @staticmethod
+    def _refresh_company_industry(company: Company) -> None:
+        """
+        If the company is missing the industry_code (TOL-code), fetch the latest
+        data from the service bus and update the company's industry and industry_code.
+        """
+        try:
+            refreshed = get_or_create_organisation_with_business_id(
+                company.business_id
+            )
+            company.industry_code = refreshed.industry_code
+            company.industry = refreshed.industry
+            company.save(update_fields=["industry_code", "industry"])
+        except Exception:
+            log.warning(
+                "Could not refresh industry_code for company %s", company.business_id
             )
 
     def get_logged_in_user(self):

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -600,6 +600,71 @@ def test_application_post_success(api_client, application):
 
 
 @pytest.mark.django_db
+@pytest.mark.freeze_time("2021-06-04")
+def test_application_post_company_with_industry_code_not_refreshed(
+    api_client, application
+):
+    """
+    When a new application is created and the company already has an industry_code,
+    the service bus should NOT be called to refresh it.
+    """
+    company = application.company
+    company.industry_code = "62010"
+    company.save()
+
+    data = ApplicantApplicationSerializer(application).data
+    application.delete()
+    del data["id"]
+
+    with mock.patch(
+        "applications.api.v1.serializers.application.get_or_create_organisation_with_business_id"
+    ) as mock_refresh:
+        response = api_client.post(reverse("v1:applicant-application-list"), data)
+
+    assert response.status_code == 201
+    mock_refresh.assert_not_called()
+    company.refresh_from_db()
+    assert company.industry_code == "62010"
+
+
+@pytest.mark.django_db
+@pytest.mark.freeze_time("2021-06-04")
+def test_application_post_company_without_industry_code_triggers_refresh(
+    api_client, application
+):
+    """
+    When a new application is created and the company is missing the industry_code,
+    the service bus should be called and the company's industry/industry_code updated.
+    """
+    company = application.company
+    company.industry_code = ""
+    company.industry = ""
+    company.save()
+
+    data = ApplicantApplicationSerializer(application).data
+    application.delete()
+    del data["id"]
+
+    refreshed_company = CompanyFactory.build(
+        business_id=company.business_id,
+        industry_code="62010",
+        industry="Ohjelmistot",
+    )
+
+    with mock.patch(
+        "applications.api.v1.serializers.application.get_or_create_organisation_with_business_id",
+        return_value=refreshed_company,
+    ) as mock_refresh:
+        response = api_client.post(reverse("v1:applicant-application-list"), data)
+
+    assert response.status_code == 201
+    mock_refresh.assert_called_once_with(company.business_id)
+    company.refresh_from_db()
+    assert company.industry_code == "62010"
+    assert company.industry == "Ohjelmistot"
+
+
+@pytest.mark.django_db
 def test_application_post_unfinished(api_client, application):
     """
     Create a new application with partial information


### PR DESCRIPTION
## Description :sparkles:
This adds validation to ensure that the TOL-code is set when creating a new application. Application can be connected to a company that is already in database, but does not have TOL-code. 
There is already code to store the industry and industry_code (=TOL-code) for new companies that are added to database.
TOL-code is received from Service Bus company info.


## Motivation and Context
TOL-code (industry code) is needed for de minimis reporting. 

Refs: [HL-1774](https://helsinkisolutionoffice.atlassian.net/browse/HL-1774)

## Issues :bug:

## Testing :alembic:
Tests have been updated to reflect this change.

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[HL-1774]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ