### PR TITLE
YJDH-820 | Kesäseteli: Audit log access to change/history/delete django admin views

### DIFF
--- a/backend/kesaseteli/applications/admin.py
+++ b/backend/kesaseteli/applications/admin.py
@@ -1,6 +1,7 @@
 import logging
 from itertools import chain
 
+from auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
 from django import forms
 from django.apps import apps
 from django.conf import settings
@@ -59,7 +60,9 @@ class TargetGroupFilter(admin.SimpleListFilter):
         return queryset
 
 
-class SummerVoucherConfigurationAdmin(admin.ModelAdmin):
+class SummerVoucherConfigurationAdmin(
+    AuditlogAdminViewAccessLogMixin, admin.ModelAdmin
+):
     form = SummerVoucherConfigurationAdminForm
     list_display = [
         "year",
@@ -106,7 +109,7 @@ class SummerVoucherConfigurationAdmin(admin.ModelAdmin):
         }
 
 
-class SchoolAdmin(admin.ModelAdmin):
+class SchoolAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
     list_display = [
         "name",
         "created_at",
@@ -187,7 +190,7 @@ class SchoolAdmin(admin.ModelAdmin):
         return render(request, "admin/applications/school/import_form.html", context)
 
 
-class EmailTemplateAdmin(admin.ModelAdmin):
+class EmailTemplateAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
     list_display = ["type", "language", "subject", "modified_at"]
     list_filter = ["type", "language"]
     search_fields = ["subject", "html_body", "text_body"]
@@ -366,7 +369,7 @@ class IsValidSchoolFilter(admin.SimpleListFilter):
         return queryset
 
 
-class YouthApplicationAdmin(admin.ModelAdmin):
+class YouthApplicationAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
     list_display = [
         "id",
         "first_name",
@@ -454,7 +457,7 @@ class YouthApplicationAdmin(admin.ModelAdmin):
         return False
 
 
-class YouthSummerVoucherAdmin(admin.ModelAdmin):
+class YouthSummerVoucherAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
     list_display = [
         "id",
         "summer_voucher_serial_number",
@@ -541,7 +544,7 @@ class YouthSummerVoucherAdmin(admin.ModelAdmin):
             )
 
 
-class EmployerApplicationAdmin(admin.ModelAdmin):
+class EmployerApplicationAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
     list_display = [
         "id",
         "company__name",
@@ -600,7 +603,7 @@ class EmployerApplicationAdmin(admin.ModelAdmin):
         )
 
 
-class EmployerSummerVoucherAdmin(admin.ModelAdmin):
+class EmployerSummerVoucherAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
     list_display = [
         "id",
         "youth_summer_voucher_id",

--- a/backend/kesaseteli/companies/admin.py
+++ b/backend/kesaseteli/companies/admin.py
@@ -1,10 +1,11 @@
+from auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
 from django.apps import apps
 from django.contrib import admin
 
 from companies.models import Company
 
 
-class CompanyAdmin(admin.ModelAdmin):
+class CompanyAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
     list_display = [
         "name",
         "business_id",

--- a/backend/kesaseteli/kesaseteli/admin.py
+++ b/backend/kesaseteli/kesaseteli/admin.py
@@ -1,3 +1,4 @@
+from auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import GroupAdmin, UserAdmin
@@ -23,7 +24,7 @@ class EmailFilter(admin.SimpleListFilter):
         return queryset
 
 
-class KesaseteliUserAdmin(UserAdmin):
+class KesaseteliUserAdmin(AuditlogAdminViewAccessLogMixin, UserAdmin):
     list_display = list(UserAdmin.list_display) + ["date_joined"]
     list_filter = ["date_joined", EmailFilter] + list(UserAdmin.list_filter)
     date_hierarchy = "date_joined"
@@ -35,7 +36,7 @@ class UserInline(admin.StackedInline):
     autocomplete_fields = ("user",)
 
 
-class KesaseteliGroupAdmin(GroupAdmin):
+class KesaseteliGroupAdmin(AuditlogAdminViewAccessLogMixin, GroupAdmin):
     list_display = ("name", "get_user_count")
     inlines = (UserInline,)
 


### PR DESCRIPTION
## Description :sparkles:

Audit log access to change/history/delete django admin views.

**Testable** locally in **django admin** at:
- **"Home > Audit log > Log entries"** (The new django-auditlog managed auditlog i.e. the target of access logs here)

For clarity the old shared backend managed auditlog can be seen at "Home > Audit_Log > Audit log entrys" and is not the target of access logs here.

## Related

[YJDH-820](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-820)

## Testing :alembic:

## Screenshots :camera_flash:

### Local django admin:

<img width="1770" height="1224" alt="image" src="https://github.com/user-attachments/assets/4a41a6dc-27a4-4fba-8cfa-38c9ad25262d" />

## Additional notes :spiral_notepad:


[YJDH-820]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ