### PR TITLE
Render birthdate instead of SSN in emplyers form and fix summer voucher validation

### DIFF
--- a/backend/kesaseteli/applications/admin.py
+++ b/backend/kesaseteli/applications/admin.py
@@ -10,6 +10,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import path, reverse
 from django.utils import timezone
+from django.utils.formats import date_format
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
@@ -371,6 +372,8 @@ class YouthApplicationAdmin(admin.ModelAdmin):
         "id",
         "first_name",
         "last_name",
+        "target_group_display",
+        "birthdate",
         "masked_social_security_number",
         "status",
         "school",
@@ -381,6 +384,7 @@ class YouthApplicationAdmin(admin.ModelAdmin):
     list_filter = [
         "created_at",
         "modified_at",
+        "target_group",
         "status",
         IsValidSchoolFilter,
         SchoolFilter,
@@ -417,6 +421,21 @@ class YouthApplicationAdmin(admin.ModelAdmin):
     # currently in school list.
     is_valid_school.short_description = _("is in current school list")
 
+    def target_group_display(self, obj):
+        return obj.get_target_group_display()
+
+    target_group_display.short_description = _("target group")
+
+    def birthdate(self, obj):
+        return obj.birthdate
+
+    birthdate.short_description = _("birthdate")
+
+    def birthdate_display(self, obj):
+        return date_format(obj.birthdate, format="DATE_FORMAT", use_l10n=True)
+
+    birthdate_display.short_description = _("birthdate")
+
     def masked_social_security_number(self, obj):
         """Mask social security number for display."""
         return mask_social_security_number(obj.social_security_number)
@@ -425,8 +444,11 @@ class YouthApplicationAdmin(admin.ModelAdmin):
 
     def get_readonly_fields(self, request, obj=None):
         """Make contact info fields readonly."""
+        custom_readonly_fields = [
+            "birthdate_display",
+        ]
         if obj:
-            return [
+            return custom_readonly_fields + [
                 f.name
                 for f in self.model._meta.fields
                 if f.name not in self.exclude and f.name not in self.contact_info_fields
@@ -458,7 +480,8 @@ class YouthSummerVoucherAdmin(admin.ModelAdmin):
     list_display = [
         "id",
         "summer_voucher_serial_number",
-        "target_group",
+        "target_group_display",
+        "birthdate",
         "youth_application_link",
         "masked_social_security_number",
         "youth_application__email",
@@ -487,6 +510,16 @@ class YouthSummerVoucherAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("youth_application")
+
+    def target_group_display(self, obj):
+        return obj.get_target_group_display()
+
+    target_group_display.short_description = _("target group")
+
+    def birthdate(self, obj):
+        return obj.youth_application.birthdate
+
+    birthdate.short_description = _("birthdate")
 
     def masked_social_security_number(self, obj):
         """Mask social security number for display."""

--- a/backend/kesaseteli/applications/api/v1/permissions.py
+++ b/backend/kesaseteli/applications/api/v1/permissions.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from django.http import HttpRequest
+from rest_framework.exceptions import NotFound
 from rest_framework.permissions import BasePermission
 
 from applications.enums import EmployerApplicationStatus
@@ -19,7 +20,10 @@ ALLOWED_APPLICATION_UPDATE_STATUSES = [
 
 
 def get_user_company(request: HttpRequest) -> Optional[Company]:
-    user_company = get_or_create_company_using_organization_roles(request)
+    try:
+        user_company = get_or_create_company_using_organization_roles(request)
+    except NotFound:
+        user_company = None
 
     return user_company
 

--- a/backend/kesaseteli/applications/api/v1/permissions.py
+++ b/backend/kesaseteli/applications/api/v1/permissions.py
@@ -30,12 +30,14 @@ def has_employer_application_permission(
     """
     Allow access only to DRAFT status employer applications of the user's company.
     """
-    return (
-        request.user.is_staff
-        or request.user.is_superuser
-        or (
-            employer_application.company == get_user_company(request)
-            and employer_application.status in ALLOWED_APPLICATION_VIEW_STATUSES
+    user_company = get_user_company(request)
+    return bool(
+        user_company
+        and employer_application.company == user_company
+        and (
+            request.user.is_staff
+            or request.user.is_superuser
+            or employer_application.status in ALLOWED_APPLICATION_VIEW_STATUSES
         )
     )
 

--- a/backend/kesaseteli/applications/api/v1/permissions.py
+++ b/backend/kesaseteli/applications/api/v1/permissions.py
@@ -32,17 +32,22 @@ def has_employer_application_permission(
     request: HttpRequest, employer_application: EmployerApplication
 ) -> bool:
     """
-    Allow access only to DRAFT status employer applications of the user's company.
+    Allow access to employer applications.
+    - Staff and superusers have full access.
+    - Standard users must belong to the same company as the application.
+    - For standard users, only DRAFT and SUBMITTED applications are viewable.
     """
+    if request.user.is_staff or request.user.is_superuser:
+        return True
+
+    # It is important to check the company permission, because
+    # at some point user might also lose the company permission.
+    # User should not be able to access applications of companies they don't belong to.
     user_company = get_user_company(request)
     return bool(
         user_company
         and employer_application.company == user_company
-        and (
-            request.user.is_staff
-            or request.user.is_superuser
-            or employer_application.status in ALLOWED_APPLICATION_VIEW_STATUSES
-        )
+        and employer_application.status in ALLOWED_APPLICATION_VIEW_STATUSES
     )
 
 

--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -17,6 +17,7 @@ from applications.enums import (
     AttachmentType,
     EmployerApplicationStatus,
     get_supported_languages,
+    YouthApplicationStatus,
 )
 from applications.models import (
     Attachment,
@@ -25,11 +26,13 @@ from applications.models import (
     School,
     SummerVoucherConfiguration,
     YouthApplication,
+    YouthSummerVoucher,
 )
 from applications.target_groups import (
     get_target_group_choices,
     get_target_group_data,
 )
+from common.fuzzy_matching import is_last_name_fuzzy_match_in_full_name
 from common.permissions import HandlerPermission
 from companies.api.v1.serializers import CompanySerializer
 from companies.services import get_or_create_company_using_organization_roles
@@ -232,6 +235,11 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
         allow_blank=True,
         required=False,
     )
+    employee_name = serializers.CharField(
+        max_length=256,
+        allow_blank=True,
+        required=False,
+    )
 
     class Meta:
         model = EmployerSummerVoucher
@@ -241,6 +249,7 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
             "employee_name",
             "employee_school",
             "employee_ssn",
+            "employee_birthdate",
             "employee_phone_number",
             "employee_home_city",
             "employee_postcode",
@@ -256,17 +265,18 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = [
             "ordering",
-            "employee_name",
             "employee_school",
             "employee_ssn",
+            "employee_birthdate",
             "employee_home_city",
             "employee_postcode",
         ]
         list_serializer_class = EmployerSummerVoucherListSerializer
 
     def _validate_non_draft_required_fields(self, data):
+        parent = self.parent
         status = (
-            self.parent.parent.initial_data.get("status") if self.parent.parent else ""
+            parent.parent.initial_data.get("status") if parent and parent.parent else ""
         )
 
         if not status or status == EmployerApplicationStatus.DRAFT:
@@ -288,7 +298,114 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
     def validate(self, data):
         data = super().validate(data)
         self._validate_non_draft_required_fields(data)
+        self._validate_summer_voucher_serial_number(data)
+
         return data
+
+    def _validate_summer_voucher_serial_number(self, data):
+        serial_number = data.get("summer_voucher_serial_number")
+        if not serial_number:
+            return
+
+        try:
+            youth_summer_voucher = YouthSummerVoucher.objects.get(
+                summer_voucher_serial_number=int(serial_number)
+            )
+        except (ValueError, TypeError, YouthSummerVoucher.DoesNotExist):
+            return
+
+        # 1. Name validation
+        user_provided_name = data.get("employee_name")
+        if not user_provided_name:
+            raise serializers.ValidationError(
+                {
+                    "employee_name": _(
+                        "Employee name is required when providing a serial number"
+                    )
+                }
+            )
+
+        youth_application = youth_summer_voucher.youth_application
+        if not is_last_name_fuzzy_match_in_full_name(
+            last_name=youth_application.last_name, full_name=user_provided_name
+        ):
+            raise serializers.ValidationError(
+                {
+                    "employee_name": _(
+                        "Provided employee name does not match the voucher owner"
+                    )
+                }
+            )
+
+        # 2. Usage validation
+        #
+        # Each YouthSummerVoucher (identified by its serial number) represents a
+        # unique work contract for a single student. Therefore, it must have a
+        # strict 1-1 relationship with an EmployerApplication.
+        #
+        # A voucher can only be attached to at most ONE EmployerApplication
+        # system-wide. This block ensures that:
+        # 1. A voucher already in a SUBMITTED/ACCEPTED application cannot be reused.
+        # 2. A voucher already in a DRAFT application (even of the same company or user)
+        #    cannot be added to a second draft.
+        #
+        # Hijacking is prevented by making the serial number effectively unique
+        # across all active and draft applications.
+        application = None
+        if self.instance:
+            application = getattr(self.instance, "application", None)
+
+        if not application:
+            application = self.context.get("application")
+
+        if not application:
+            # Try to get it from the root serializer (EmployerApplicationSerializer)
+            # This is often needed during nested validation
+            root = getattr(self, "root", None)
+            if root and hasattr(root, "instance") and root.instance:
+                application = root.instance
+
+        # Check if this voucher is already linked to ANY other application in the DB.
+        # We exclude the current application to allow idempotent updates.
+        used_in_other = EmployerSummerVoucher.objects.filter(
+            youth_summer_voucher=youth_summer_voucher,
+        )
+
+        if application and hasattr(application, "id"):
+            # Match by ID to be safe across different object instances
+            used_in_other = used_in_other.exclude(application_id=application.id)
+
+        # 3. Status validation
+        # Only accepted youth applications can have their vouchers attached.
+        if youth_application.status != YouthApplicationStatus.ACCEPTED:
+            raise serializers.ValidationError(
+                {
+                    "summer_voucher_serial_number": _(
+                        f"This voucher is not yet valid for attachment "
+                        f"(Youth application status: {youth_application.status}). "
+                        "Status must be 'accepted'."
+                    )
+                }
+            )
+
+        if used_in_other.exists():
+            conflicting_app_id = used_in_other.first().application_id
+            request = self.context.get("request")
+            user = getattr(request, "user", "Unknown") if request else "Unknown"
+            LOGGER.warning(
+                "[SECURITY ISSUE] Suspicious voucher usage detected. Voucher serial "
+                f"{youth_summer_voucher.summer_voucher_serial_number} "
+                f"is already linked to application {conflicting_app_id}. "
+                f"Attempted by user {user} (ID: {getattr(user, 'id', 'N/A')}) "
+                f"for application {getattr(application, 'id', 'new draft')}."
+            )
+            raise serializers.ValidationError(
+                {
+                    "summer_voucher_serial_number": _(
+                        "This voucher has already been used in another application"
+                    )
+                }
+            )
 
     REQUIRED_FIELDS_FOR_SUBMITTED_SUMMER_VOUCHERS = [
         "summer_voucher_serial_number",
@@ -376,7 +493,10 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
         self, summer_vouchers_data: list, application: EmployerApplication
     ) -> None:
         serializer = EmployerSummerVoucherSerializer(
-            application.summer_vouchers.all(), data=summer_vouchers_data, many=True
+            application.summer_vouchers.all(),
+            data=summer_vouchers_data,
+            many=True,
+            context={**self.context, "application": application},
         )
 
         if not serializer.is_valid():
@@ -388,6 +508,7 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
             )
 
         for idx, summer_voucher_item in enumerate(serializer.validated_data):
+            summer_voucher_item.pop("employee_name", None)
             summer_voucher_item["application_id"] = application.pk
             summer_voucher_item["ordering"] = (
                 idx  # use the ordering defined in the JSON sent by the client

--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -303,19 +303,52 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
         return data
 
     def _validate_summer_voucher_serial_number(self, data):
+        """
+        Validate the summer voucher serial number and its usage.
+
+        Orchestrates fetching the voucher, validating the employee name match,
+        checking usage across applications, and verifying the youth application
+        status.
+
+        :raises ValidationError: if any validation step fails.
+        """
         serial_number = data.get("summer_voucher_serial_number")
         if not serial_number:
             return
 
+        voucher = self._get_youth_summer_voucher(serial_number)
+        if not voucher:
+            return
+
+        user_provided_name = data.get("employee_name")
+        self._validate_voucher_employee_name(voucher, user_provided_name)
+        self._validate_voucher_status(voucher.youth_application)
+        self._validate_voucher_usage(
+            voucher, application=self._get_application_context()
+        )
+
+    def _get_youth_summer_voucher(
+        self, serial_number: str
+    ) -> Optional[YouthSummerVoucher]:
+        """
+        Safely fetch the YouthSummerVoucher by serial number.
+        """
         try:
-            youth_summer_voucher = YouthSummerVoucher.objects.get(
+            return YouthSummerVoucher.objects.get(
                 summer_voucher_serial_number=int(serial_number)
             )
         except (ValueError, TypeError, YouthSummerVoucher.DoesNotExist):
-            return
+            return None
 
-        # 1. Name validation
-        user_provided_name = data.get("employee_name")
+    def _validate_voucher_employee_name(
+        self, voucher: YouthSummerVoucher, user_provided_name: str
+    ) -> None:
+        """
+        Validate that the provided employee name matches the voucher owner.
+
+        :raises ValidationError: if employee_name is missing or does not match
+            voucher owner.
+        """
         if not user_provided_name:
             raise serializers.ValidationError(
                 {
@@ -325,7 +358,7 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
                 }
             )
 
-        youth_application = youth_summer_voucher.youth_application
+        youth_application = voucher.youth_application
         if not is_last_name_fuzzy_match_in_full_name(
             last_name=youth_application.last_name, full_name=user_provided_name
         ):
@@ -337,46 +370,12 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
                 }
             )
 
-        # 2. Usage validation
-        #
-        # Each YouthSummerVoucher (identified by its serial number) represents a
-        # unique work contract for a single student. Therefore, it must have a
-        # strict 1-1 relationship with an EmployerApplication.
-        #
-        # A voucher can only be attached to at most ONE EmployerApplication
-        # system-wide. This block ensures that:
-        # 1. A voucher already in a SUBMITTED/ACCEPTED application cannot be reused.
-        # 2. A voucher already in a DRAFT application (even of the same company or user)
-        #    cannot be added to a second draft.
-        #
-        # Hijacking is prevented by making the serial number effectively unique
-        # across all active and draft applications.
-        application = None
-        if self.instance:
-            application = getattr(self.instance, "application", None)
+    def _validate_voucher_status(self, youth_application: YouthApplication) -> None:
+        """
+        Ensure the youth application is in the ACCEPTED status.
 
-        if not application:
-            application = self.context.get("application")
-
-        if not application:
-            # Try to get it from the root serializer (EmployerApplicationSerializer)
-            # This is often needed during nested validation
-            root = getattr(self, "root", None)
-            if root and hasattr(root, "instance") and root.instance:
-                application = root.instance
-
-        # Check if this voucher is already linked to ANY other application in the DB.
-        # We exclude the current application to allow idempotent updates.
-        used_in_other = EmployerSummerVoucher.objects.filter(
-            youth_summer_voucher=youth_summer_voucher,
-        )
-
-        if application and hasattr(application, "id"):
-            # Match by ID to be safe across different object instances
-            used_in_other = used_in_other.exclude(application_id=application.id)
-
-        # 3. Status validation
-        # Only accepted youth applications can have their vouchers attached.
+        :raises ValidationError: if the youth application is not in ACCEPTED status.
+        """
         if youth_application.status != YouthApplicationStatus.ACCEPTED:
             raise serializers.ValidationError(
                 {
@@ -388,13 +387,52 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
                 }
             )
 
+    def _get_application_context(self) -> Optional[EmployerApplication]:
+        """
+        Attempt to find the EmployerApplication instance from the serializer
+        context or hierarchy.
+        """
+        application = None
+        if self.instance:
+            application = getattr(self.instance, "application", None)
+
+        if not application:
+            application = self.context.get("application")
+
+        if not application:
+            # Try to get it from the root serializer (EmployerApplicationSerializer)
+            root = getattr(self, "root", None)
+            if root and hasattr(root, "instance") and root.instance:
+                application = root.instance
+
+        return application
+
+    def _validate_voucher_usage(
+        self, voucher: YouthSummerVoucher, application: Optional[EmployerApplication]
+    ) -> None:
+        """
+        Ensure the voucher is not already used in another application.
+
+        :raises ValidationError: if the voucher is already linked to another
+            application.
+        """
+        # Check if this voucher is already linked to ANY other application in the DB.
+        # We exclude the current application to allow idempotent updates.
+        used_in_other = EmployerSummerVoucher.objects.filter(
+            youth_summer_voucher=voucher,
+        )
+
+        if application and hasattr(application, "id"):
+            # Match by ID to be safe across different object instances
+            used_in_other = used_in_other.exclude(application_id=application.id)
+
         if used_in_other.exists():
             conflicting_app_id = used_in_other.first().application_id
             request = self.context.get("request")
             user = getattr(request, "user", "Unknown") if request else "Unknown"
             LOGGER.warning(
                 "[SECURITY ISSUE] Suspicious voucher usage detected. Voucher serial "
-                f"{youth_summer_voucher.summer_voucher_serial_number} "
+                f"{voucher.summer_voucher_serial_number} "
                 f"is already linked to application {conflicting_app_id}. "
                 f"Attempted by user {user} (ID: {getattr(user, 'id', 'N/A')}) "
                 f"for application {getattr(application, 'id', 'new draft')}."

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -720,12 +720,16 @@ class EmployerApplicationFilter(filters.FilterSet):
     def qs(self):
         """
         Queryset property overridden to apply only_mine filter by default
-        when not provided or empty.
+        when not provided or empty, BUT only if the user has no company.
+        If the user has a company, they see all company applications by default.
         """
         parent_qs = super().qs
 
-        # Apply only_mine filter by default when not provided or empty
+        # Apply only_mine filter by default when not provided or empty,
+        # but only if the user has no company context.
         if self.data.get("only_mine") in (None, ""):
+            if get_user_company(self.request):
+                return parent_qs
             return self._filter_by_user(parent_qs)
 
         return parent_qs

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -716,24 +716,6 @@ class EmployerApplicationFilter(filters.FilterSet):
             return self._filter_by_user(queryset)
         return queryset
 
-    @property
-    def qs(self):
-        """
-        Queryset property overridden to apply only_mine filter by default
-        when not provided or empty, BUT only if the user has no company.
-        If the user has a company, they see all company applications by default.
-        """
-        parent_qs = super().qs
-
-        # Apply only_mine filter by default when not provided or empty,
-        # but only if the user has no company context.
-        if self.data.get("only_mine") in (None, ""):
-            if get_user_company(self.request):
-                return parent_qs
-            return self._filter_by_user(parent_qs)
-
-        return parent_qs
-
     class Meta:
         model = EmployerApplication
         _timestamp_field_lookups = [
@@ -769,9 +751,17 @@ class EmployerApplicationViewSet(ModelViewSet):
         )
 
         user = self.request.user
+
         if user.is_anonymous:
             return queryset.none()
 
+        if user.is_staff or user.is_superuser:
+            return queryset
+
+        # Ensure that visibility is strictly tied to the organization the user
+        # currently represents. If the user does not represent an organization
+        # (e.g., lost permissions), they should not see any applications,
+        # even if they were the creator of some.
         user_company = get_user_company(self.request)
 
         if user_company:
@@ -780,10 +770,13 @@ class EmployerApplicationViewSet(ModelViewSet):
                 status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
             )
 
-        return queryset.filter(
-            user=self.request.user,
-            status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
+        # User is not staff, superuser or company user (not representing any company)
+        # Should not be able to see any applications
+        LOGGER.warning(
+            f"User {user.id} is not staff, superuser or company user "
+            "(not representing any company)."
         )
+        return queryset.none()
 
     def create(self, request, *args, **kwargs):
         """
@@ -806,11 +799,12 @@ class EmployerApplicationViewSet(ModelViewSet):
         if instance.status not in ALLOWED_APPLICATION_UPDATE_STATUSES:
             raise ValidationError("Only DRAFT applications can be updated")
 
+        # Ensure that visibility and modification are strictly tied to the
+        # organization the user currently represents. Even the original creator
+        # must have an active organization association to update the application.
         user_company = get_user_company(request)
-        if instance.user != request.user and instance.company != user_company:
-            raise PermissionDenied(
-                "Only application creator or company members can update it"
-            )
+        if not user_company or instance.company != user_company:
+            raise PermissionDenied("Only company members can update it")
 
         return super().update(request, *args, **kwargs)
 
@@ -822,11 +816,12 @@ class EmployerApplicationViewSet(ModelViewSet):
         if instance.status not in ALLOWED_APPLICATION_UPDATE_STATUSES:
             raise ValidationError("Only DRAFT applications can be deleted")
 
+        # Ensure that visibility and modification are strictly tied to the
+        # organization the user currently represents. Even the original creator
+        # must have an active organization association to delete the application.
         user_company = get_user_company(request)
-        if instance.user != request.user and instance.company != user_company:
-            raise PermissionDenied(
-                "Only application creator or company members can delete it"
-            )
+        if not user_company or instance.company != user_company:
+            raise PermissionDenied("Only company members can delete it")
 
         return super().destroy(request, *args, **kwargs)
 
@@ -859,10 +854,15 @@ class EmployerSummerVoucherViewSet(ModelViewSet):
 
         user_company = get_user_company(self.request)
 
-        return queryset.filter(
-            application__company=user_company,
-            application__status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
-        )
+        if user_company:
+            return queryset.filter(
+                application__company=user_company,
+                application__status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
+            )
+
+        # If the user does not represent an organization (e.g. lost permissions),
+        # they should not see any summer vouchers.
+        return queryset.none()
 
     def create(self, request, *args, **kwargs):
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
@@ -896,15 +896,12 @@ class EmployerSummerVoucherViewSet(ModelViewSet):
                 "Attachments can be uploaded only for DRAFT applications"
             )
 
+        # Ensure that visibility and modification are strictly tied to the
+        # organization the user currently represents. Even the original creator
+        # must have an active organization association to post an attachment.
         user_company = get_user_company(request)
-
-        if (
-            obj.application.user != request.user
-            and obj.application.company != user_company
-        ):
-            raise PermissionDenied(
-                "Only application creator or company members can post attachment to it"
-            )
+        if not user_company or obj.application.company != user_company:
+            raise PermissionDenied("Only company members can post attachment to it")
 
         # Validate request data
         serializer = AttachmentSerializer(
@@ -955,17 +952,13 @@ class EmployerSummerVoucherViewSet(ModelViewSet):
             # by get_queryset() and will receive a 404 from self.get_object() above.
 
             # 2. Identity Check (403 Permission Denied):
-            # Deny if the user is NEITHER the application creator NOR a member of the
-            # same company. This check remains critical for Staff/Handlers who pass the
-            # get_queryset visibility.
+            # Deny if the user is not representing the organization associated
+            # with the application. This ensures that even the original creator
+            # cannot delete attachments if they no longer represent the company.
             user_company = get_user_company(request)
-
-            if (
-                obj.application.user != request.user
-                and obj.application.company != user_company
-            ):
+            if not user_company or obj.application.company != user_company:
                 raise PermissionDenied(
-                    "Only application creator or company members can delete attachment from it"  # noqa: E501
+                    "Only company members can delete attachment from it"  # noqa: E501
                 )
 
             # 3. Status Check (403 Permission Denied):

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -19,7 +19,7 @@ from django.views.decorators.csrf import csrf_protect
 from django_filters import rest_framework as filters
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.parsers import MultiPartParser
@@ -320,6 +320,7 @@ class YouthApplicationViewSet(ModelViewSet):
                 "employer_summer_voucher_id": str(employer_summer_voucher_id),
                 "employee_name": youth_application.name,
                 "employee_ssn": youth_application.social_security_number,
+                "employee_birthdate": youth_application.birthdate,
                 "employee_phone_number": youth_application.phone_number,
                 "employee_home_city": youth_application.home_municipality,
                 "employee_postcode": youth_application.postcode,
@@ -769,8 +770,14 @@ class EmployerApplicationViewSet(ModelViewSet):
 
         user_company = get_user_company(self.request)
 
+        if user_company:
+            return queryset.filter(
+                company=user_company,
+                status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
+            )
+
         return queryset.filter(
-            company=user_company,
+            user=self.request.user,
             status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
         )
 
@@ -794,8 +801,12 @@ class EmployerApplicationViewSet(ModelViewSet):
         instance = self.get_object()
         if instance.status not in ALLOWED_APPLICATION_UPDATE_STATUSES:
             raise ValidationError("Only DRAFT applications can be updated")
-        if request.user != instance.user:
-            raise PermissionDenied("Only application creator can update it")
+
+        user_company = get_user_company(request)
+        if instance.user != request.user and instance.company != user_company:
+            raise PermissionDenied(
+                "Only application creator or company members can update it"
+            )
 
         return super().update(request, *args, **kwargs)
 
@@ -806,8 +817,12 @@ class EmployerApplicationViewSet(ModelViewSet):
         instance = self.get_object()
         if instance.status not in ALLOWED_APPLICATION_UPDATE_STATUSES:
             raise ValidationError("Only DRAFT applications can be deleted")
-        if request.user != instance.user:
-            raise PermissionDenied("Only application creator can delete it")
+
+        user_company = get_user_company(request)
+        if instance.user != request.user and instance.company != user_company:
+            raise PermissionDenied(
+                "Only application creator or company members can delete it"
+            )
 
         return super().destroy(request, *args, **kwargs)
 
@@ -876,8 +891,19 @@ class EmployerSummerVoucherViewSet(ModelViewSet):
             raise ValidationError(
                 "Attachments can be uploaded only for DRAFT applications"
             )
-        if obj.application.user != request.user:
-            raise PermissionDenied("Only application creator can post attachment to it")
+
+        try:
+            user_company = get_user_company(request)
+        except NotFound:
+            user_company = None
+
+        if (
+            obj.application.user != request.user
+            and obj.application.company != user_company
+        ):
+            raise PermissionDenied(
+                "Only application creator or company members can post attachment to it"
+            )
 
         # Validate request data
         serializer = AttachmentSerializer(
@@ -923,15 +949,31 @@ class EmployerSummerVoucherViewSet(ModelViewSet):
             """
             Delete a single attachment as file.
             """
-            if obj.application.status not in ALLOWED_APPLICATION_UPDATE_STATUSES:
-                raise ValidationError(
-                    "Attachments can be deleted only for DRAFT applications"
-                )
-            if obj.application.user != request.user:
+            # 1. Visibility Check (404 Not Found):
+            # Unauthorized users from different companies are already filtered out
+            # by get_queryset() and will receive a 404 from self.get_object() above.
+
+            # 2. Identity Check (403 Permission Denied):
+            # Deny if the user is NEITHER the application creator NOR a member of the
+            # same company. This check remains critical for Staff/Handlers who pass the
+            # get_queryset visibility.
+            try:
+                user_company = get_user_company(request)
+            except NotFound:
+                user_company = None
+
+            if (
+                obj.application.user != request.user
+                and obj.application.company != user_company
+            ):
                 raise PermissionDenied(
-                    "Only application creator can delete attachment from it"
+                    "Only application creator or company members can delete attachment from it"  # noqa: E501
                 )
 
+            # 3. Status Check (403 Permission Denied):
+            # Deny if the application is NOT in a modifiable state (must be DRAFT or
+            # requested for info). Consolidates both identity and status under 403 for
+            # consistent security testing.
             if (
                 obj.application.status
                 not in AttachmentSerializer.ATTACHMENT_MODIFICATION_ALLOWED_STATUSES

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -19,7 +19,7 @@ from django.views.decorators.csrf import csrf_protect
 from django_filters import rest_framework as filters
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.parsers import MultiPartParser
@@ -892,10 +892,7 @@ class EmployerSummerVoucherViewSet(ModelViewSet):
                 "Attachments can be uploaded only for DRAFT applications"
             )
 
-        try:
-            user_company = get_user_company(request)
-        except NotFound:
-            user_company = None
+        user_company = get_user_company(request)
 
         if (
             obj.application.user != request.user
@@ -957,10 +954,7 @@ class EmployerSummerVoucherViewSet(ModelViewSet):
             # Deny if the user is NEITHER the application creator NOR a member of the
             # same company. This check remains critical for Staff/Handlers who pass the
             # get_queryset visibility.
-            try:
-                user_company = get_user_company(request)
-            except NotFound:
-                user_company = None
+            user_company = get_user_company(request)
 
             if (
                 obj.application.user != request.user

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -1314,6 +1314,14 @@ class EmployerSummerVoucher(TimeStampedModel, UUIDModel):
         )
 
     @property
+    def employee_birthdate(self):
+        return (
+            self.youth_summer_voucher.youth_application.birthdate
+            if self.youth_summer_voucher
+            else None
+        )
+
+    @property
     def employee_home_city(self) -> str:
         return (
             self.youth_summer_voucher.youth_application.home_municipality

--- a/backend/kesaseteli/applications/tests/test_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_applications_api.py
@@ -174,6 +174,9 @@ def test_update_summer_voucher(api_client, application, summer_voucher):
     data["summer_vouchers"][0]["summer_voucher_serial_number"] = str(
         new_youth_summer_voucher.summer_voucher_serial_number
     )
+    data["summer_vouchers"][0]["employee_name"] = (
+        new_youth_summer_voucher.youth_application.name
+    )
 
     response = api_client.put(
         get_detail_url(application),

--- a/backend/kesaseteli/applications/tests/test_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_applications_api.py
@@ -553,14 +553,23 @@ def test_application_create_double(api_client, company):
 def test_applications_list_only_finds_own_application(
     api_client, application, company, user
 ):
-    EmployerApplicationFactory()
-    EmployerApplicationFactory(company=company)
-    EmployerApplicationFactory(user=user)
+    EmployerApplicationFactory()  # Not seen (different company)
+    app2 = EmployerApplicationFactory(company=company)  # Seen (same company, diff user)
+    EmployerApplicationFactory(user=user)  # Not seen (same user, diff company)
 
     assert EmployerApplication.objects.count() == 4
 
+    # Default: finds all company applications (own + colleague's)
     response = api_client.get(get_list_url())
+    assert response.status_code == 200
+    assert len(response.data) == 2
+    assert {str(app["id"]) for app in response.data} == {
+        str(application.id),
+        str(app2.id),
+    }
 
+    # With only_mine=true: finds only own applications in current company
+    response = api_client.get(get_list_url() + "?only_mine=true")
     assert response.status_code == 200
     assert len(response.data) == 1
     assert str(response.data[0]["id"]) == str(application.id)
@@ -576,11 +585,20 @@ def test_application_get_only_finds_own_application(
 
     assert EmployerApplication.objects.count() == 4
 
-    applications_404 = [app1, app2, app3]
-    for app in applications_404:
-        response = api_client.get(get_detail_url(app))
-        assert response.status_code == 404
+    # app1 is random company -> 404
+    response = api_client.get(get_detail_url(app1))
+    assert response.status_code == 404
 
+    # app2 is colleague's application in same company -> 200
+    response = api_client.get(get_detail_url(app2))
+    assert response.status_code == 200
+
+    # app3 is own application in random company -> 404
+    # (because queryset is filtered by the session's company)
+    response = api_client.get(get_detail_url(app3))
+    assert response.status_code == 404
+
+    # original application -> 200
     response = api_client.get(get_detail_url(application))
     assert response.status_code == 200
     assert str(response.data["id"]) == str(application.id)

--- a/backend/kesaseteli/applications/tests/test_attachments_api.py
+++ b/backend/kesaseteli/applications/tests/test_attachments_api.py
@@ -297,8 +297,8 @@ def test_delete_attachment_for_submitted_application(
 
     response = api_client.delete(attachment_delete_url)
 
-    assert response.status_code == 400
-    assert "Attachments can be deleted only for DRAFT applications" in response.data
+    assert response.status_code == 403
+    assert "Operation not allowed for this application status." in str(response.data)
     submitted_summer_voucher.refresh_from_db()
     assert submitted_summer_voucher.attachments.count() == 1
 

--- a/backend/kesaseteli/applications/tests/test_employer_summer_voucher_validation.py
+++ b/backend/kesaseteli/applications/tests/test_employer_summer_voucher_validation.py
@@ -1,0 +1,170 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from applications.api.v1.serializers import (
+    EmployerApplicationSerializer,
+)
+from applications.api.v1.views import EmployerApplicationViewSet
+from applications.enums import EmployerApplicationStatus, YouthApplicationStatus
+from applications.models import (
+    EmployerApplication,
+    EmployerSummerVoucher,
+    YouthSummerVoucher,
+)
+from common.tests.factories import EmployerApplicationFactory
+from shared.common.tests.factories import UserFactory
+
+"""
+This test suite verifies the validation and permission logic for Employer Applications.
+It ensures that:
+- Vouchers are correctly linked only when student data matches.
+- Vouchers cannot be reused across different applications.
+- Users within the same company have visibility and update access to company applications.
+- Vouchers can only be linked if the source Youth Application is in ACCEPTED status.
+"""
+
+
+def get_detail_url(application):
+    return reverse("v1:employerapplication-detail", kwargs={"pk": str(application.id)})
+
+
+@pytest.fixture
+def active_voucher(accepted_youth_application):
+    """A voucher derived from the global accepted_youth_application fixture."""
+    return accepted_youth_application.youth_summer_voucher
+
+
+@pytest.fixture(autouse=True)
+def disable_mock_flag(settings):
+    """Disable mock flag to ensure real company logic is tested."""
+    settings.NEXT_PUBLIC_MOCK_FLAG = False
+
+
+@pytest.mark.django_db
+class TestEmployerApplicationValidation:
+    def test_update_permission_allowed_for_company_colleague(self, api_client, company):
+        """
+        Verify that a company colleague CAN update a draft application belonging to their company.
+        """
+        # 1. Create a draft application for a specific company.
+        application = EmployerApplicationFactory(
+            company=company, status=EmployerApplicationStatus.DRAFT
+        )
+
+        # 2. Authenticate as a completely different user (the "colleague").
+        # Note: In this system, company access isn't tied to the User model itself.
+        # Instead, it's tied to the "organization_roles" stored in the active SESSION.
+        # The api_client fixture already has the 'company' in its session via `store_company_in_session`.
+        api_client.force_authenticate(user=UserFactory())
+
+        # 3. Even though the User changed, the 'api_client' fixture preserves its session.
+        # That session already contains 'company.business_id' (set by store_company_in_session).
+        # This simulates a different person logged into the same organizational context.
+        data = EmployerApplicationSerializer(application).data
+        data["street_address"] = "New Company Address"
+
+        # 4. Attempt to update the application via the API.
+        # The backend's permission logic will fetch the company from the session,
+        # find that it matches the application's company, and allow the update.
+        response = api_client.put(get_detail_url(application), data)
+
+        assert response.status_code == status.HTTP_200_OK, response.data
+        application.refresh_from_db()
+        assert application.street_address == "New Company Address"
+
+    def test_link_voucher_success(self, api_client, application, active_voucher):
+        """
+        Verify that a voucher is correctly linked via Application PUT.
+        """
+        data = EmployerApplicationSerializer(application).data
+        youth_app = active_voucher.youth_application
+
+        new_voucher_data = {
+            "summer_voucher_serial_number": str(
+                active_voucher.summer_voucher_serial_number
+            ),
+            "employee_name": f"{youth_app.first_name} {youth_app.last_name}",
+            "employee_phone_number": "0401234567",
+            "employment_postcode": "00100",
+        }
+
+        if not data.get("summer_vouchers"):
+            data["summer_vouchers"] = [new_voucher_data]
+        else:
+            data["summer_vouchers"][0].update(new_voucher_data)
+
+        response = api_client.put(get_detail_url(application), data)
+        assert response.status_code == status.HTTP_200_OK, response.data
+        assert EmployerSummerVoucher.objects.filter(
+            application=application, youth_summer_voucher=active_voucher
+        ).exists()
+
+    def test_link_voucher_failure_youth_application_not_accepted(
+        self, api_client, application, youth_application
+    ):
+        """
+        Verify that a voucher CANNOT be linked if the associated YouthApplication is NOT in ACCEPTED status.
+        """
+        youth_application.status = YouthApplicationStatus.SUBMITTED
+        youth_application.save()
+
+        # Ensure a voucher exists
+        voucher, _ = YouthSummerVoucher.objects.get_or_create(
+            youth_application=youth_application,
+            defaults={
+                "summer_voucher_serial_number": YouthSummerVoucher.get_next_serial_number()
+            },
+        )
+
+        data = EmployerApplicationSerializer(application).data
+        new_voucher_data = {
+            "summer_voucher_serial_number": str(voucher.summer_voucher_serial_number),
+            "employee_name": f"{youth_application.first_name} {youth_application.last_name}",
+            "employee_phone_number": "0401234567",
+            "employment_postcode": "00100",
+        }
+
+        if not data.get("summer_vouchers"):
+            data["summer_vouchers"] = [new_voucher_data]
+        else:
+            data["summer_vouchers"][0].update(new_voucher_data)
+
+        response = api_client.put(get_detail_url(application), data)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "not yet valid for attachment" in str(response.data).lower()
+
+    def test_voucher_reuse_prevention(self, api_client, application, active_voucher):
+        """
+        Verify that a voucher cannot be used in two different applications.
+        """
+        # First linkage
+        EmployerSummerVoucher.objects.create(
+            application=application, youth_summer_voucher=active_voucher
+        )
+
+        # Attempt to link to a second application.
+        # Ensure it belongs to the same company/user so it's visible in get_queryset.
+        application2 = EmployerApplicationFactory(
+            company=application.company, user=application.user
+        )
+        data = EmployerApplicationSerializer(application2).data
+        youth_app = active_voucher.youth_application
+
+        new_voucher_data = {
+            "summer_voucher_serial_number": str(
+                active_voucher.summer_voucher_serial_number
+            ),
+            "employee_name": f"{youth_app.first_name} {youth_app.last_name}",
+            "employee_phone_number": "0401234567",
+            "employment_postcode": "00100",
+        }
+
+        if not data.get("summer_vouchers"):
+            data["summer_vouchers"] = [new_voucher_data]
+        else:
+            data["summer_vouchers"][0].update(new_voucher_data)
+
+        response = api_client.put(get_detail_url(application2), data)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "already been used" in str(response.data).lower()

--- a/backend/kesaseteli/applications/tests/test_employer_summer_voucher_validation.py
+++ b/backend/kesaseteli/applications/tests/test_employer_summer_voucher_validation.py
@@ -5,10 +5,8 @@ from rest_framework import status
 from applications.api.v1.serializers import (
     EmployerApplicationSerializer,
 )
-from applications.api.v1.views import EmployerApplicationViewSet
 from applications.enums import EmployerApplicationStatus, YouthApplicationStatus
 from applications.models import (
-    EmployerApplication,
     EmployerSummerVoucher,
     YouthSummerVoucher,
 )

--- a/backend/kesaseteli/applications/tests/test_models.py
+++ b/backend/kesaseteli/applications/tests/test_models.py
@@ -208,7 +208,7 @@ def test_employer_summer_voucher_summer_voucher_serial_number_setter_exception(
         employer_voucher.summer_voucher_serial_number = serial_number
 
 
-@pytest.mark.django_db(transaction=True, reset_sequences=True)
+@pytest.mark.django_db()
 def test_youth_summer_voucher_get_last_used_serial_number():
     assert YouthSummerVoucher.objects.count() == 0
     assert YouthSummerVoucher.get_last_used_serial_number() is None
@@ -221,7 +221,7 @@ def test_youth_summer_voucher_get_last_used_serial_number():
         )
 
 
-@pytest.mark.django_db(transaction=True, reset_sequences=True)
+@pytest.mark.django_db()
 def test_youth_summer_voucher_first_serial_number():
     assert YouthSummerVoucher.objects.count() == 0
     summer_voucher = (
@@ -233,7 +233,7 @@ def test_youth_summer_voucher_first_serial_number():
     )
 
 
-@pytest.mark.django_db(transaction=True, reset_sequences=True)
+@pytest.mark.django_db()
 def test_youth_summer_voucher_sequentiality():
     assert YouthSummerVoucher.objects.count() == 0
     for ordinal_number in range(1, 10):
@@ -243,7 +243,7 @@ def test_youth_summer_voucher_sequentiality():
         assert summer_voucher.summer_voucher_serial_number == ordinal_number
 
 
-@pytest.mark.django_db(transaction=True, reset_sequences=True)
+@pytest.mark.django_db()
 def test_youth_summer_voucher_sequentiality_duplicate_create():
     assert YouthSummerVoucher.objects.count() == 0
 
@@ -268,7 +268,7 @@ def test_youth_summer_voucher_sequentiality_duplicate_create():
     ) == list(range(1, 3))
 
 
-@pytest.mark.django_db(transaction=True, reset_sequences=True)
+@pytest.mark.django_db()
 def test_youth_summer_voucher_sequentiality_failing_transaction():
     assert YouthSummerVoucher.objects.count() == 0
 
@@ -295,7 +295,7 @@ def test_youth_summer_voucher_sequentiality_failing_transaction():
     ) == list(range(1, 3))
 
 
-@pytest.mark.django_db(transaction=True, reset_sequences=True)
+@pytest.mark.django_db()
 def test_youth_summer_voucher_sequentiality_failing_nested_transaction():
     assert YouthSummerVoucher.objects.count() == 0
 
@@ -324,7 +324,7 @@ def test_youth_summer_voucher_sequentiality_failing_nested_transaction():
     ) == list(range(1, 4))
 
 
-@pytest.mark.django_db(transaction=True, reset_sequences=True)
+@pytest.mark.django_db()
 def test_youth_summer_voucher_sequentiality_failing_nested_transactions():
     assert YouthSummerVoucher.objects.count() == 0
 
@@ -354,7 +354,7 @@ def test_youth_summer_voucher_sequentiality_failing_nested_transactions():
     ) == list(range(1, 3))
 
 
-@pytest.mark.django_db(transaction=True, reset_sequences=True)
+@pytest.mark.django_db()
 def test_youth_summer_voucher_sequentiality_complex_transaction_nesting():
     assert YouthSummerVoucher.objects.count() == 0
 

--- a/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
+++ b/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
@@ -1,3 +1,4 @@
+from datetime import date
 from unittest import mock
 
 import pytest
@@ -377,126 +378,138 @@ def test_employer_summer_voucher_handle_attachment_non_viewable_statuses(
 
 
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+@pytest.mark.parametrize(
+    "client_type, context_type, owner_type, app_company_type, expected_status",
+    [
+        pytest.param(
+            "user1", "company1", "user1", "company1", 204, id="creator_own_context"
+        ),  # Creator in own company
+        pytest.param(
+            "user2", "company1", "user1", "company1", 204, id="colleague_same_context"
+        ),  # Colleague in same company
+        pytest.param(
+            "user1", "company2", "user1", "company1", 404, id="creator_wrong_context"
+        ),  # Same user but wrong company context
+        pytest.param(
+            "user1", "company1", "user2", "company2", 404, id="other_company_access"
+        ),  # Targeting other company's application
+        pytest.param(
+            "staff", "none", "user1", "company1", 403, id="staff_access"
+        ),  # Staff/Handler (No company)
+    ],
+)
 @pytest.mark.django_db
-def test_employer_summer_voucher_handle_attachment_delete_draft():
+def test_employer_summer_voucher_handle_attachment_delete_draft(
+    staff_client,
+    client_type,
+    context_type,
+    owner_type,
+    app_company_type,
+    expected_status,
+):
     """
     Test that the employer summer voucher's handle attachment endpoint can be
     used to delete draft employer applications' attachments but only those that
-    are the user's and use the user's company.
+    are the user's or use the user's company.
     """
-    application_status = EmployerApplicationStatus.DRAFT
     user1, user2 = UserFactory.create_batch(size=2)
-    user1_client = force_login_user(user1)
-    user2_client = force_login_user(user2)
-
     company1, company2 = CompanyFactory.create_batch(size=2)
 
-    user1_company1_attachment = create_attachment(user1, company1, application_status)
-    user1_company2_attachment = create_attachment(user1, company2, application_status)
-    user2_company1_attachment = create_attachment(user2, company1, application_status)
-    user2_company2_attachment = create_attachment(user2, company2, application_status)
+    # Map types to objects
+    users = {"user1": user1, "user2": user2, "staff": None}
+    companies = {"company1": company1, "company2": company2, "none": None}
 
-    def del_attachment(client: Client, attachment: Attachment):
-        return client.delete(
-            reverse(
-                "v1:employersummervoucher-handle-attachment",
-                kwargs={
-                    "pk": attachment.summer_voucher.id,
-                    "attachment_pk": attachment.id,
-                },
-            )
+    client_user = users[client_type]
+    client_company = companies[context_type]
+    app_owner = users[owner_type]
+    app_company = companies[app_company_type]
+
+    # Setup application and attachment
+    attachment = create_attachment(
+        app_owner, app_company, EmployerApplicationStatus.DRAFT
+    )
+
+    # Setup client
+    if client_type == "staff":
+        client = staff_client
+    else:
+        client = force_login_user(client_user)
+        if client_company:
+            set_company_business_id_to_client(client_company, client)
+
+    response = client.delete(
+        reverse(
+            "v1:employersummervoucher-handle-attachment",
+            kwargs={
+                "pk": attachment.summer_voucher.id,
+                "attachment_pk": attachment.id,
+            },
         )
+    )
 
-    # Seen but unallowed deletions (=403), and not seen cases (=404):
-    set_company_business_id_to_client(company1, user1_client)
-    assert del_attachment(user1_client, user1_company2_attachment).status_code == 404
-    assert del_attachment(user1_client, user2_company1_attachment).status_code == 403
-    assert del_attachment(user1_client, user2_company2_attachment).status_code == 404
-
-    set_company_business_id_to_client(company1, user2_client)
-    assert del_attachment(user2_client, user1_company1_attachment).status_code == 403
-    assert del_attachment(user2_client, user1_company2_attachment).status_code == 404
-    assert del_attachment(user2_client, user2_company2_attachment).status_code == 404
-
-    set_company_business_id_to_client(company2, user1_client)
-    assert del_attachment(user1_client, user1_company1_attachment).status_code == 404
-    assert del_attachment(user1_client, user2_company1_attachment).status_code == 404
-    assert del_attachment(user1_client, user2_company2_attachment).status_code == 403
-
-    set_company_business_id_to_client(company2, user2_client)
-    assert del_attachment(user2_client, user1_company1_attachment).status_code == 404
-    assert del_attachment(user2_client, user1_company2_attachment).status_code == 403
-    assert del_attachment(user2_client, user2_company1_attachment).status_code == 404
-
-    # Allowed deletions
-    set_company_business_id_to_client(company1, user1_client)
-    assert del_attachment(user1_client, user1_company1_attachment).status_code == 204
-
-    set_company_business_id_to_client(company1, user2_client)
-    assert del_attachment(user2_client, user2_company1_attachment).status_code == 204
-
-    set_company_business_id_to_client(company2, user1_client)
-    assert del_attachment(user1_client, user1_company2_attachment).status_code == 204
-
-    set_company_business_id_to_client(company2, user2_client)
-    assert del_attachment(user2_client, user2_company2_attachment).status_code == 204
+    assert response.status_code == expected_status
 
 
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+@pytest.mark.parametrize(
+    "client_type, context_type, owner_type, app_company_type, expected_status",
+    [
+        pytest.param(
+            "user1", "company1", "user1", "company1", 403, id="own_submitted"
+        ),  # Own app (Blocked by SUBMITTED status)
+        pytest.param(
+            "user2", "company1", "user1", "company1", 403, id="colleague_submitted"
+        ),  # Colleague's app (Blocked by SUBMITTED status)
+        pytest.param(
+            "user1", "company2", "user1", "company1", 404, id="wrong_context_submitted"
+        ),  # Wrong company context
+        pytest.param(
+            "user1", "company1", "user2", "company2", 404, id="other_company_submitted"
+        ),  # Other company context
+    ],
+)
 @pytest.mark.django_db
-def test_employer_summer_voucher_handle_attachment_delete_submitted():
+def test_employer_summer_voucher_handle_attachment_delete_submitted(
+    client_type, context_type, owner_type, app_company_type, expected_status
+):
     """
     Test that the employer summer voucher's handle attachment endpoint can not
     be used to delete submitted employer applications' attachments at all, not
     the user's and the user's company's nor anyone else's.
     """
-    application_status = EmployerApplicationStatus.SUBMITTED
     user1, user2 = UserFactory.create_batch(size=2)
-    user1_client = force_login_user(user1)
-    user2_client = force_login_user(user2)
-
     company1, company2 = CompanyFactory.create_batch(size=2)
 
-    user1_company1_attachment = create_attachment(user1, company1, application_status)
-    user1_company2_attachment = create_attachment(user1, company2, application_status)
-    user2_company1_attachment = create_attachment(user2, company1, application_status)
-    user2_company2_attachment = create_attachment(user2, company2, application_status)
+    # Map types to objects
+    users = {"user1": user1, "user2": user2}
+    companies = {"company1": company1, "company2": company2}
 
-    def del_attachment(client: Client, attachment: Attachment):
-        return client.delete(
-            reverse(
-                "v1:employersummervoucher-handle-attachment",
-                kwargs={
-                    "pk": attachment.summer_voucher.id,
-                    "attachment_pk": attachment.id,
-                },
-            )
+    client_user = users[client_type]
+    client_company = companies[context_type]
+    app_owner = users[owner_type]
+    app_company = companies[app_company_type]
+
+    # Setup application and attachment
+    attachment = create_attachment(
+        app_owner, app_company, EmployerApplicationStatus.SUBMITTED
+    )
+
+    # Setup client
+    client = force_login_user(client_user)
+    if client_company:
+        set_company_business_id_to_client(client_company, client)
+
+    response = client.delete(
+        reverse(
+            "v1:employersummervoucher-handle-attachment",
+            kwargs={
+                "pk": attachment.summer_voucher.id,
+                "attachment_pk": attachment.id,
+            },
         )
+    )
 
-    # The status code 400s are the ones that match the user's company:
-    set_company_business_id_to_client(company1, user1_client)
-    assert del_attachment(user1_client, user1_company1_attachment).status_code == 400
-    assert del_attachment(user1_client, user1_company2_attachment).status_code == 404
-    assert del_attachment(user1_client, user2_company1_attachment).status_code == 400
-    assert del_attachment(user1_client, user2_company2_attachment).status_code == 404
-
-    set_company_business_id_to_client(company1, user2_client)
-    assert del_attachment(user2_client, user1_company1_attachment).status_code == 400
-    assert del_attachment(user2_client, user1_company2_attachment).status_code == 404
-    assert del_attachment(user2_client, user2_company1_attachment).status_code == 400
-    assert del_attachment(user2_client, user2_company2_attachment).status_code == 404
-
-    set_company_business_id_to_client(company2, user1_client)
-    assert del_attachment(user1_client, user1_company1_attachment).status_code == 404
-    assert del_attachment(user1_client, user1_company2_attachment).status_code == 400
-    assert del_attachment(user1_client, user2_company1_attachment).status_code == 404
-    assert del_attachment(user1_client, user2_company2_attachment).status_code == 400
-
-    set_company_business_id_to_client(company2, user2_client)
-    assert del_attachment(user2_client, user1_company1_attachment).status_code == 404
-    assert del_attachment(user2_client, user1_company2_attachment).status_code == 400
-    assert del_attachment(user2_client, user2_company1_attachment).status_code == 404
-    assert del_attachment(user2_client, user2_company2_attachment).status_code == 400
+    assert response.status_code == expected_status
 
 
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
@@ -1283,6 +1296,7 @@ def test_youth_application_fetch_employee_data(user_client):
             "employer_summer_voucher_id": str(employer_summer_voucher.id),
             "employee_name": "John Doe",
             "employee_ssn": "111111-111C",
+            "employee_birthdate": date(1911, 11, 11),
             "employee_phone_number": "123456789",
             "employee_home_city": "Helsinki",
             "employee_postcode": "00100",

--- a/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
+++ b/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
@@ -77,8 +77,7 @@ def test_employer_application_list_viewable_statuses(
 ):
     """
     Test that the employer application list endpoint returns draft and
-    submitted employer applications but only those that are the user's and use
-    the user's company by default.
+    submitted employer applications but only those that use the user's company.
     """
     user1, user2 = UserFactory.create_batch(size=2)
     user1_client = force_login_user(user1)
@@ -91,19 +90,30 @@ def test_employer_application_list_viewable_statuses(
     user2_company1_attachment = create_attachment(user2, company1, application_status)
     user2_company2_attachment = create_attachment(user2, company2, application_status)
 
-    for user, client, company, attachment in [
-        (user1, user1_client, company1, user1_company1_attachment),
-        (user1, user1_client, company2, user1_company2_attachment),
-        (user2, user2_client, company1, user2_company1_attachment),
-        (user2, user2_client, company2, user2_company2_attachment),
+    company1_application_ids = {
+        str(user1_company1_attachment.summer_voucher.application.id),
+        str(user2_company1_attachment.summer_voucher.application.id),
+    }
+    company2_application_ids = {
+        str(user1_company2_attachment.summer_voucher.application.id),
+        str(user2_company2_attachment.summer_voucher.application.id),
+    }
+    for client, company, expected_application_ids in [
+        (user1_client, company1, company1_application_ids),
+        (user1_client, company2, company2_application_ids),
+        (user2_client, company1, company1_application_ids),
+        (user2_client, company2, company2_application_ids),
     ]:
         set_company_business_id_to_client(company, client)
         response = client.get(reverse("v1:employerapplication-list"))
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == str(attachment.summer_voucher.application.id)
-        assert response.data[0]["user"] == user.id
-        assert response.data[0]["company"]["id"] == str(company.id)
+        # In the company-wide visibility model, the user should see all applications
+        # belonging to the company they currently represent.
+        # Here we expect 2 applications for the company:
+        # 1. The one created by the current user
+        # 2. The one created by the other user for the same company
+        assert len(response.data) == 2
+        assert {x["id"] for x in response.data} == expected_application_ids
 
 
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
@@ -177,8 +187,7 @@ def test_employer_application_detail_viewable_statuses(
 ):
     """
     Test that the employer application detail endpoint returns draft and
-    submitted employer applications but only those that are the user's and use
-    the user's company.
+    submitted employer applications but only those that use the user's company.
     """
     user1, user2 = UserFactory.create_batch(size=2)
     user1_client = force_login_user(user1)
@@ -197,15 +206,16 @@ def test_employer_application_detail_viewable_statuses(
             reverse("v1:employerapplication-detail", kwargs={"pk": application.id})
         )
 
-    # The status code 200s are the ones that match both the user and the company:
+    # In the company-wide visibility model, colleagues are able to see each other's
+    # applications within the same company context.
     set_company_business_id_to_client(company1, user1_client)
     assert get_app(user1_client, user1_company1_attachment).status_code == 200
     assert get_app(user1_client, user1_company2_attachment).status_code == 404
-    assert get_app(user1_client, user2_company1_attachment).status_code == 404
+    assert get_app(user1_client, user2_company1_attachment).status_code == 200
     assert get_app(user1_client, user2_company2_attachment).status_code == 404
 
     set_company_business_id_to_client(company1, user2_client)
-    assert get_app(user2_client, user1_company1_attachment).status_code == 404
+    assert get_app(user2_client, user1_company1_attachment).status_code == 200
     assert get_app(user2_client, user1_company2_attachment).status_code == 404
     assert get_app(user2_client, user2_company1_attachment).status_code == 200
     assert get_app(user2_client, user2_company2_attachment).status_code == 404
@@ -214,11 +224,11 @@ def test_employer_application_detail_viewable_statuses(
     assert get_app(user1_client, user1_company1_attachment).status_code == 404
     assert get_app(user1_client, user1_company2_attachment).status_code == 200
     assert get_app(user1_client, user2_company1_attachment).status_code == 404
-    assert get_app(user1_client, user2_company2_attachment).status_code == 404
+    assert get_app(user1_client, user2_company2_attachment).status_code == 200
 
     set_company_business_id_to_client(company2, user2_client)
     assert get_app(user2_client, user1_company1_attachment).status_code == 404
-    assert get_app(user2_client, user1_company2_attachment).status_code == 404
+    assert get_app(user2_client, user1_company2_attachment).status_code == 200
     assert get_app(user2_client, user2_company1_attachment).status_code == 404
     assert get_app(user2_client, user2_company2_attachment).status_code == 200
 
@@ -1428,3 +1438,53 @@ def test_youth_application_fetch_employee_data_unallowed_methods(user_client):
     assert user_client.get(url).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
     assert user_client.patch(url).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
     assert user_client.put(url).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+
+@pytest.mark.django_db
+def test_employer_application_list_no_company_lost_permission(api_client):
+    """
+    Test that applications are NOT returned if the user has no company association,
+    even if they are the creator of the applications. This covers the case where
+    a user might have lost the permission to represent the company.
+    """
+    user = UserFactory()
+    # Create an application for this user
+    EmployerApplicationFactory(user=user)
+
+    api_client = force_login_user(user)
+
+    # Mock get_user_company to return None (simulating lost permission or no association)
+    with mock.patch("applications.api.v1.views.get_user_company", return_value=None):
+        response = api_client.get(reverse("v1:employerapplication-list"))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 0
+
+
+@pytest.mark.django_db
+def test_employer_application_modification_no_company_lost_permission(api_client):
+    """
+    Test that applications CANNOT be modified or deleted if the user has no company
+    association, even if they are the original creator of the applications.
+    """
+    user = UserFactory()
+    # Create a draft application for this user
+    application = EmployerApplicationFactory(
+        user=user, status=EmployerApplicationStatus.DRAFT
+    )
+
+    api_client = force_login_user(user)
+
+    # Mock get_user_company to return None (simulating lost permission)
+    with mock.patch("applications.api.v1.views.get_user_company", return_value=None):
+        url = reverse("v1:employerapplication-detail", kwargs={"pk": application.id})
+
+        # 1. Try to Update
+        response = api_client.put(
+            url, {"status": EmployerApplicationStatus.DRAFT}, format="json"
+        )
+        # should fail with 404 Not Found (because it's filtered out from queryset)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        # 2. Try to Delete
+        response = api_client.delete(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/frontend/kesaseteli/employer/browser-tests/actions/application.actions.ts
+++ b/frontend/kesaseteli/employer/browser-tests/actions/application.actions.ts
@@ -5,6 +5,7 @@ import Application from '@frontend/shared/src/types/application';
 import Employment from '@frontend/shared/src/types/employment';
 import { convertToUIDateFormat } from '@frontend/shared/src/utils/date.utils';
 
+import TestController from 'testcafe';
 import { getStep1Components } from '../application-page/step1.components';
 import { getStep2Components } from '../application-page/step2.components';
 import { getWizardComponents } from '../application-page/wizard.components';
@@ -22,25 +23,25 @@ export const fillEmployerDetails = async (
 ): Promise<void> => {
   const step1 = getStep1Components(t);
   const step1Form = await step1.form();
-  const {
-    contact_person_name,
-    contact_person_email,
-    street_address,
-    bank_account_number,
-    contact_person_phone_number,
-  } = application;
 
-  await step1Form.actions.fillContactPersonName(contact_person_name);
-  await step1Form.actions.fillContactPersonEmail(contact_person_email);
-  await step1Form.actions.fillContactPersonPhone(contact_person_phone_number);
-  await step1Form.actions.fillStreetAddress(street_address);
-  await step1Form.actions.fillBankAccountNumber(bank_account_number);
+  const contactPersonName = application.contact_person_name;
+  await step1Form.actions.fillContactPersonName(contactPersonName);
+  await step1Form.actions.fillContactPersonEmail(
+    application.contact_person_email
+  );
+  await step1Form.actions.fillContactPersonPhone(
+    application.contact_person_phone_number
+  );
+  await step1Form.actions.fillStreetAddress(application.street_address);
+  await step1Form.actions.fillBankAccountNumber(
+    application.bank_account_number
+  );
 };
 
 export const fillEmploymentDetails = async (
   t: TestController,
   application: Application,
-  expectedPreFill?: Partial<Employment>
+  _expectedPreFill?: Partial<Employment>
   // eslint-disable-next-line sonarjs/cognitive-complexity
 ): Promise<void> => {
   const step1 = getStep1Components(t);
@@ -48,22 +49,18 @@ export const fillEmploymentDetails = async (
   const { summer_vouchers } = application;
 
   if (summer_vouchers.length > 0) {
-    const employment = summer_vouchers[0];
-
-    await step1Form.actions.fillEmployeeName(employment.employee_name ?? '');
+    const voucher = summer_vouchers[0];
+    await step1Form.actions.fillEmployeeName(voucher.employee_name ?? '');
     await step1Form.actions.fillSerialNumber(
-      employment.summer_voucher_serial_number ?? ''
+      voucher.summer_voucher_serial_number ?? ''
     );
     await step1Form.actions.clickFetchEmployeeDataButton();
     await step1Form.expectations.isEmploymentFieldsEnabled();
-    await step1Form.expectations.isSsnFieldReadOnly();
+    await step1Form.expectations.isBirthdateFieldReadOnly();
 
-    if (expectedPreFill) {
-      await step1Form.expectations.isEmploymentFulfilledWith(expectedPreFill);
-    }
+    await step1Form.expectations.isEmploymentFulfilledWith(voucher);
 
     const {
-      employee_ssn,
       employee_phone_number,
       employment_postcode,
       employment_start_date,
@@ -72,11 +69,7 @@ export const fillEmploymentDetails = async (
       employment_description,
       employment_salary_paid,
       hired_without_voucher_assessment,
-    } = employment;
-
-    if (!expectedPreFill?.employee_ssn) {
-      await step1Form.actions.fillSsn(employee_ssn ?? '');
-    }
+    } = voucher;
     await step1Form.actions.fillPhoneNumber(employee_phone_number ?? '');
     await step1Form.actions.fillEmploymentPostcode(
       String(employment_postcode ?? '')
@@ -151,9 +144,8 @@ export const loginAndfillApplication = async (
 
   if (toStep >= 1) {
     if (isRealIntegrationsEnabled()) {
-      const companyTable = await getStep1Components(t).companyTable(
-        application.company
-      );
+      const step1 = getStep1Components(t);
+      const companyTable = await step1.companyTable(application.company);
       await companyTable.expectations.isCompanyDataPresent();
     }
     await fillStep1Form(t, application, expectedPreFill);

--- a/frontend/kesaseteli/employer/browser-tests/application-page/application.mocks.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/application.mocks.ts
@@ -25,11 +25,11 @@ const httpsAgent = fs.existsSync(certPath)
   : new https.Agent({ rejectUnauthorized: false }); // CodeQL: test-only fallback for CI
 
 export const MOCKED_EMPLOYEE_DATA = {
-  employee_ssn: '010101-123U',
   employee_phone_number: '040 1234567',
   employee_home_city: 'Helsinki',
   employee_postcode: '00100', // using string for postcode to preserve padding
   employee_school: 'Testikoulu',
+  employee_birthdate: '2000-01-01',
 } as unknown as Partial<Employment>;
 
 export const FULLY_MOCKED_FORM_DATA = {

--- a/frontend/kesaseteli/employer/browser-tests/application-page/step1.components.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/step1.components.ts
@@ -9,6 +9,8 @@ import ContactInfo from '@frontend/shared/src/types/contact-info';
 import { friendlyFormatIBAN } from 'ibantools';
 import TestController, { Selector } from 'testcafe';
 
+import { convertToUIDateFormat } from '@frontend/shared/src/utils/date.utils';
+
 const formSelector = () => Selector('form#employer-application-form');
 
 export const getStep1Components = (t: TestController) => {
@@ -102,9 +104,9 @@ export const getStep1Components = (t: TestController) => {
         name: /hae tiedot työntekijän nimen ja kesäsetelin sarjanumeron avulla/i,
       });
     },
-    ssnInput() {
+    birthdateInput() {
       return withinForm().findByRole('textbox', {
-        name: /^henkilötunnus/i,
+        name: /^syntymäaika/i,
       });
     },
     phoneNumberInput() {
@@ -113,7 +115,7 @@ export const getStep1Components = (t: TestController) => {
       });
     },
     employmentPostcodeInput() {
-      return withinForm().findByRole('spinbutton', {
+      return withinForm().findByRole('textbox', {
         name: /^työn suorituspaikan postinumero/i,
       });
     },
@@ -167,12 +169,12 @@ export const getStep1Components = (t: TestController) => {
     },
     async isEmploymentFieldsEnabled() {
       await t
-        .expect(selectors.ssnInput().hasAttribute('disabled'))
+        .expect(selectors.birthdateInput().hasAttribute('disabled'))
         .notOk(await getErrorMessage(t));
     },
-    async isSsnFieldReadOnly() {
+    async isBirthdateFieldReadOnly() {
       await t
-        .expect(selectors.ssnInput().hasAttribute('readonly'))
+        .expect(selectors.birthdateInput().hasAttribute('readonly'))
         .ok(await getErrorMessage(t));
     },
     async isFulFilledWith({
@@ -185,7 +187,7 @@ export const getStep1Components = (t: TestController) => {
       await t.expect(formSelector().exists).ok(await getErrorMessage(t));
       await t
         .expect(selectors.contactPersonNameInput().value)
-        .eql(contact_person_name, await getErrorMessage(t));
+        .eql(contact_person_name?.trim(), await getErrorMessage(t));
       await t
         .expect(selectors.contactPersonEmailInput().value)
         .eql(contact_person_email, await getErrorMessage(t));
@@ -203,17 +205,27 @@ export const getStep1Components = (t: TestController) => {
         .eql(contact_person_phone_number, await getErrorMessage(t));
     },
     async isEmploymentFulfilledWith({
-      employee_ssn,
+      employee_birthdate,
       employee_phone_number,
+      employee_name,
     }: {
-      employee_ssn?: string;
+      employee_birthdate?: string;
       employee_phone_number?: string;
+      employee_name?: string;
     }) {
       await t.expect(formSelector().exists).ok(await getErrorMessage(t));
-      if (employee_ssn) {
+      if (employee_name) {
         await t
-          .expect(selectors.ssnInput().value)
-          .eql(employee_ssn, await getErrorMessage(t));
+          .expect(selectors.employeeNameInput().value)
+          .eql(employee_name, await getErrorMessage(t));
+      }
+      if (employee_birthdate) {
+        await t
+          .expect(selectors.birthdateInput().value)
+          .eql(
+            convertToUIDateFormat(employee_birthdate),
+            await getErrorMessage(t)
+          );
       }
       if (employee_phone_number) {
         await t
@@ -330,14 +342,6 @@ export const getStep1Components = (t: TestController) => {
     },
     async clickFetchEmployeeDataButton() {
       await t.click(selectors.fetchEmployeeDataButton());
-    },
-    fillSsn(ssn: string) {
-      return fillInput(
-        t,
-        'summer_vouchers.0.employee_ssn',
-        selectors.ssnInput(),
-        ssn
-      );
     },
     fillPhoneNumber(phone: string) {
       return fillInput(

--- a/frontend/kesaseteli/employer/browser-tests/application-page/summary.components.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/summary.components.ts
@@ -156,9 +156,11 @@ export const getSummaryComponents = async (t: TestController) => {
         const header = selectors.employmentHeading();
         await t
           .expect(header.textContent)
-          .contains(employment.employee_name ?? '', await getErrorMessage(t))
-          .expect(header.textContent)
-          .contains(employment.employee_ssn ?? '', await getErrorMessage(t));
+          .contains(employment.employee_name ?? '', await getErrorMessage(t));
+        await expectEmploymentFieldhasValue(
+          'employee_birthdate',
+          convertToUIDateFormat(employment.employee_birthdate)
+        );
         await expectEmploymentFieldhasValue('employee_phone_number');
         await expectEmploymentFieldhasValue('employment_postcode');
         await expectAttachments('employment_contract');

--- a/frontend/kesaseteli/employer/browser-tests/types.ts
+++ b/frontend/kesaseteli/employer/browser-tests/types.ts
@@ -34,6 +34,7 @@ export type VoucherData = {
   summer_voucher_serial_number?: string;
   employee_name?: string;
   employee_ssn: string;
+  employee_birthdate?: string;
   employee_phone_number: string;
   employee_home_city: string;
   employee_postcode: string;

--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -150,6 +150,7 @@
         "contact_person_phone_number": "Telephone number",
         "employee_name": "Name of the employee",
         "employee_ssn": "Social security number",
+        "employee_birthdate": "Date of birth",
         "employee_home_city": "Domicile",
         "employee_postcode": "Postal code of the workplace",
         "employee_phone_number": "Phone number",

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -150,6 +150,7 @@
         "contact_person_phone_number": "Yhteyshenkilön puhelinnumero",
         "employee_name": "Työntekijän nimi",
         "employee_ssn": "Henkilötunnus",
+        "employee_birthdate": "Syntymäaika",
         "employee_home_city": "Kotipaikka",
         "employee_postcode": "Postinumero",
         "employee_phone_number": "Puhelinnumero",

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -150,6 +150,7 @@
         "contact_person_phone_number": "Telefonnummer",
         "employee_name": "Arbetstagarens namn",
         "employee_ssn": "Personnummer",
+        "employee_birthdate": "Födelsedatum",
         "employee_home_city": "Hemort",
         "employee_postcode": "Post nummer",
         "employee_phone_number": "Telefonnummer",

--- a/frontend/kesaseteli/employer/src/components/application/ApplicationForm.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/ApplicationForm.tsx
@@ -1,4 +1,5 @@
 import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
+import usePersistFormValuesEffect from 'kesaseteli/employer/hooks/application/usePersistFormValuesEffect';
 import useResetApplicationFormValuesEffect from 'kesaseteli/employer/hooks/application/useResetApplicationFormValuesEffect';
 import useSaveCurrentStepEffect from 'kesaseteli/employer/hooks/wizard/useSaveCurrentStepEffect';
 import { useTranslation } from 'next-i18next';
@@ -35,6 +36,7 @@ const ApplicationForm: React.FC<Props> = ({ title, step, children }: Props) => {
   );
 
   useResetApplicationFormValuesEffect(methods);
+  usePersistFormValuesEffect(methods);
 
   useSaveCurrentStepEffect(step);
 

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
@@ -1,4 +1,4 @@
-import { Button } from 'hds-react';
+import { Button, TextInput as HdsTextInput } from 'hds-react';
 import AttachmentInput from 'kesaseteli/employer/components/application/form/AttachmentInput';
 import DateInput from 'kesaseteli/employer/components/application/form/DateInput';
 import SelectionGroup from 'kesaseteli/employer/components/application/form/SelectionGroup';
@@ -13,12 +13,14 @@ import FormSection from 'shared/components/forms/section/FormSection';
 import FormSectionDivider from 'shared/components/forms/section/FormSectionDivider';
 import FormSectionHeading from 'shared/components/forms/section/FormSectionHeading';
 import LinkText from 'shared/components/link-text/LinkText';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { POSTAL_CODE_REGEX } from 'shared/constants';
 import { EMPLOYEE_HIRED_WITHOUT_VOUCHER_ASSESSMENT } from 'shared/constants/employee-constants';
 import Application from 'shared/types/application';
 import DraftApplication from 'shared/types/draft-application';
 import Employment from 'shared/types/employment';
 import { getFormApplication } from 'shared/utils/application.utils';
+import { convertToUIDateFormat } from 'shared/utils/date.utils';
 import { getDecimalNumberRegex } from 'shared/utils/regex.utils';
 
 /**
@@ -43,8 +45,8 @@ const useFetchEmployeeDataButtonState = (
     const integerStringRegex = /^\s*\d+\s*$/; // Allow leading and trailing whitespace
     setIsFetchEmployeeDataEnabled(
       (formDataVoucher.employee_name?.length ?? 0) > 0 &&
-        typeof formDataVoucher.summer_voucher_serial_number === 'string' &&
-        integerStringRegex.test(formDataVoucher.summer_voucher_serial_number)
+      typeof formDataVoucher.summer_voucher_serial_number === 'string' &&
+      integerStringRegex.test(formDataVoucher.summer_voucher_serial_number)
     );
   }, [getValues, index]);
 
@@ -76,21 +78,29 @@ const useFetchEmployeeData = (
   const [isEmployeeDataFetched, setIsEmployeeDataFetched] =
     useState<boolean>(false);
 
-  const [employeeSsn, employeePhoneNumber, employmentPostcode] = useWatch({
+  const [employeePhoneNumber, employmentPostcode, employeeBirthdate] = useWatch({
     control,
     name: [
-      `summer_vouchers.${index}.employee_ssn`,
       `summer_vouchers.${index}.employee_phone_number`,
       `summer_vouchers.${index}.employment_postcode`,
+      `summer_vouchers.${index}.employee_birthdate`,
     ],
   });
 
-  // Set fetched state when SSN, phone number or postcode is populated
+  // Set fetched state when phone number, postcode or birthdate is populated
   useEffect(() => {
-    if (employeeSsn || employeePhoneNumber || employmentPostcode) {
+    if (
+      employeePhoneNumber ||
+      employmentPostcode ||
+      employeeBirthdate
+    ) {
       setIsEmployeeDataFetched(true);
     }
-  }, [employeeSsn, employeePhoneNumber, employmentPostcode]);
+  }, [
+    employeePhoneNumber,
+    employmentPostcode,
+    employeeBirthdate,
+  ]);
 
   const handleGetEmployeeData = useCallback((): void => {
     const currentValues = getValues();
@@ -98,11 +108,18 @@ const useFetchEmployeeData = (
 
     const handleReset = (app: Application): void => {
       // Don't reset the fetched state during form reset
-      reset(getFormApplication(app));
+      reset(getFormApplication(app), { keepDirty: true });
     };
 
-    const performFetch = (appData: Application | DraftApplication): void => {
-      void fetchEmployment(appData, index, (app) => {
+    const performFetch = (appData: DraftApplication | Application): void => {
+      const currentValues = getValues();
+      // Ensure the voucher we are processing has the ID from the server (if it was just created)
+      const serverVoucherId = appData.summer_vouchers?.[index]?.id;
+      if (serverVoucherId) {
+        currentValues.summer_vouchers[index].id = serverVoucherId;
+      }
+
+      void fetchEmployment(currentValues, index, (app) => {
         handleReset(app);
         setIsEmployeeDataFetched(true);
       });
@@ -137,6 +154,11 @@ const EmploymentForm: React.FC<Props> = ({ index }) => {
 
   const getId = (field: keyof Employment): TextInputProps['id'] =>
     `summer_vouchers.${index}.${field}`;
+
+  const [employeeBirthdate] = useWatch({
+    control: useFormContext<Application>().control,
+    name: [`summer_vouchers.${index}.employee_birthdate`],
+  });
 
   const disableEmploymentFields = !isEmployeeDataFetched;
 
@@ -174,16 +196,19 @@ const EmploymentForm: React.FC<Props> = ({ index }) => {
       </FormSection>
       <FormSectionDivider $colSpan={2} />
       <FormSection columns={2} withoutDivider>
-        <TextInput
-          id={getId('employee_ssn')}
-          validation={{
-            required: true,
-            maxLength: 32,
-          }}
-          autoComplete="off"
-          disabled={disableEmploymentFields}
-          readOnly={isEmployeeDataFetched}
-        />
+        <$GridCell>
+          {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+          {/* @ts-ignore: HDS types are overly strict in this environment, bypassing for read-only field */}
+          <HdsTextInput
+            id="employee_birthdate_readonly"
+            name="employee_birthdate_readonly"
+            label={t('common:application.form.inputs.employee_birthdate')}
+            value={convertToUIDateFormat(employeeBirthdate)}
+            readOnly
+            disabled={disableEmploymentFields}
+            onChange={() => undefined}
+          />
+        </$GridCell>
 
         <TextInput
           id={getId('employee_phone_number')}
@@ -193,11 +218,10 @@ const EmploymentForm: React.FC<Props> = ({ index }) => {
         />
         <TextInput
           id={getId('employment_postcode')}
-          type="number"
           validation={{
             required: true,
             pattern: POSTAL_CODE_REGEX,
-            maxLength: 256,
+            maxLength: 5,
           }}
           disabled={disableEmploymentFields}
         />

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/__tests__/EmploymentForm.test.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/__tests__/EmploymentForm.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import EmploymentForm from '../EmploymentForm';
@@ -25,6 +26,7 @@ const renderWithProviders = (index: number, initialValues?: any) => {
       defaultValues: {
         summer_vouchers: [initialValues],
       },
+      mode: 'onBlur',
     });
     return (
       <BackendAPIProvider baseURL={getBackendDomain()}>
@@ -57,10 +59,6 @@ describe('EmploymentForm', () => {
       summer_voucher_serial_number: '123',
     });
 
-    // The SSN field should be disabled
-    expect(
-      screen.getByLabelText(/common:application.form.inputs.employee_ssn/i)
-    ).toBeDisabled();
     // The phone number field should be disabled
     expect(
       screen.getByLabelText(
@@ -69,33 +67,83 @@ describe('EmploymentForm', () => {
     ).toBeDisabled();
   });
 
-  it('activates the second part of the form when employee_ssn is present', () => {
+  it('activates the second part of the form and shows birthdate when employee_birthdate is present', () => {
     renderWithProviders(0, {
       employee_name: 'Test',
       summer_voucher_serial_number: '123',
-      employee_ssn: '010101-123A',
+      employee_birthdate: '2000-01-01',
     });
 
-    expect(
-      screen.getByLabelText(/common:application.form.inputs.employee_ssn/i)
-    ).not.toBeDisabled();
     expect(
       screen.getByLabelText(
         /common:application.form.inputs.employee_phone_number/i
       )
     ).not.toBeDisabled();
+
+    const birthdateInput = screen.getByLabelText(
+      /common:application.form.inputs.employee_birthdate/i
+    );
+    expect(birthdateInput).toHaveValue('1.1.2000');
+    expect(birthdateInput).toHaveAttribute('readOnly');
   });
 
-  it('activates the second part of the form when employee_phone_number is present (even if SSN is missing)', () => {
+  describe('employment_postcode', () => {
+    it.each(['00100', '01200', '20100', '33100'])(
+      'preserves leading zeros and accepts valid postcode "%s"',
+      async (postcode) => {
+        renderWithProviders(0, {
+          employee_name: 'Test',
+          summer_voucher_serial_number: '123',
+          employee_birthdate: '2000-01-01',
+        });
+
+        const input = screen.getByLabelText(
+          /common:application.form.inputs.employment_postcode/i
+        );
+        await userEvent.clear(input);
+        await userEvent.type(input, postcode);
+        input.blur();
+
+        expect(input).toHaveValue(postcode);
+        await waitFor(() => {
+          expect(
+            screen.queryByText(/common:application.form.errors.pattern/i)
+          ).not.toBeInTheDocument();
+          expect(
+            screen.queryByText(/common:application.form.errors.maxLength/i)
+          ).not.toBeInTheDocument();
+        });
+      }
+    );
+
+    it('shows error for too long postcode "123456"', async () => {
+      renderWithProviders(0, {
+        employee_name: 'Test',
+        summer_voucher_serial_number: '123',
+        employee_birthdate: '2000-01-01',
+      });
+
+      const input = screen.getByLabelText(
+        /common:application.form.inputs.employment_postcode/i
+      );
+      await userEvent.clear(input);
+      await userEvent.type(input, '123456');
+      input.blur();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/common:application.form.errors.maxLength/i)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('activates the second part of the form when employee_phone_number is present', () => {
     renderWithProviders(0, {
       employee_name: 'Test',
       summer_voucher_serial_number: '123',
       employee_phone_number: '0401234567',
     });
-
-    expect(
-      screen.getByLabelText(/common:application.form.inputs.employee_ssn/i)
-    ).not.toBeDisabled();
     expect(
       screen.getByLabelText(
         /common:application.form.inputs.employee_phone_number/i
@@ -108,16 +156,12 @@ describe('EmploymentForm', () => {
     ).not.toBeDisabled();
   });
 
-  it('activates the second part of the form when employment_postcode is present (even if SSN is missing)', () => {
+  it('activates the second part of the form when employment_postcode is present', () => {
     renderWithProviders(0, {
       employee_name: 'Test',
       summer_voucher_serial_number: '123',
       employment_postcode: '00100',
     });
-
-    expect(
-      screen.getByLabelText(/common:application.form.inputs.employee_ssn/i)
-    ).not.toBeDisabled();
     expect(
       screen.getByLabelText(
         /common:application.form.inputs.employee_phone_number/i

--- a/frontend/kesaseteli/employer/src/components/application/summary/EmploymentSummary.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/summary/EmploymentSummary.tsx
@@ -23,7 +23,7 @@ const EmploymentSummary: React.FC<Props> = ({ index }) => {
   if (applicationQuery.isSuccess) {
     const {
       employee_name,
-      employee_ssn,
+      employee_birthdate,
       employment_contract,
       payslip,
       employment_start_date,
@@ -35,11 +35,19 @@ const EmploymentSummary: React.FC<Props> = ({ index }) => {
     return (
       <>
         <FormSectionHeading
-          header={`${employee_name ?? ''} ${employee_ssn ?? ''}`}
+          header={employee_name ?? ''}
           size="s"
           as="h3"
           data-testid={`employee-heading-${index}`}
         />
+
+        <EmploymentFieldSummary fieldName="employee_birthdate" index={index}>
+          {t(
+            'common:application.form.inputs.employee_birthdate'
+          )}
+          : {convertToUIDateFormat(employee_birthdate)}
+        </EmploymentFieldSummary>
+
         <EmploymentFieldSummary
           fieldName="employee_phone_number"
           index={index}
@@ -82,8 +90,7 @@ const EmploymentSummary: React.FC<Props> = ({ index }) => {
         >
           {getLabel(t, 'hired_without_voucher_assessment')}:{' '}
           {t(
-            `common:application.form.selectionGroups.hired_without_voucher_assessment.${
-              hired_without_voucher_assessment ?? ''
+            `common:application.form.selectionGroups.hired_without_voucher_assessment.${hired_without_voucher_assessment ?? ''
             }`
           )}
         </EmploymentFieldSummary>

--- a/frontend/kesaseteli/employer/src/hooks/application/useApplicationFormField.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useApplicationFormField.ts
@@ -73,7 +73,7 @@ const useApplicationFormField = <V extends Value>(
       }
       return value as V;
     },
-    setValue: (value: V) => setValue(id, value),
+    setValue: (value: V) => setValue(id, value, { shouldDirty: true, shouldTouch: true }),
     watch: () => watch(id) as V,
     getError,
     hasError: () => Boolean(getError()),
@@ -99,7 +99,7 @@ const useApplicationFormField = <V extends Value>(
       }
     },
     setError: (error: ErrorOption) => setErrorF(id, error),
-    clearValue: () => setValue(id, ''),
+    clearValue: () => setValue(id, '', { shouldDirty: true, shouldTouch: true }),
     trigger: () => trigger(id, { shouldFocus: true }),
     clearErrors: () => clearErrors(id),
     setFocus: () => {

--- a/frontend/kesaseteli/employer/src/hooks/application/usePersistFormValuesEffect.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/usePersistFormValuesEffect.ts
@@ -1,0 +1,43 @@
+import ApplicationPersistenceService from 'kesaseteli/employer/services/ApplicationPersistenceService';
+import React from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import Application from 'shared/types/application';
+
+/**
+ * Hook to automatically persist form values to SessionStorage as the user types.
+ * This ensures data survives page reloads even before a backend save occurs.
+ */
+const usePersistFormValuesEffect = ({
+  watch,
+  formState: { isDirty },
+}: UseFormReturn<Application>): void => {
+  const values = watch();
+
+  React.useEffect(() => {
+    if (!isDirty) return;
+
+    // Persist Employer fields (Step 1)
+    ApplicationPersistenceService.storeEmployerData(values);
+
+    // Persist Voucher fields (especially search fields and manual inputs)
+    // IMPORTANT: We sanitize the voucher to exclude derived fields (birthdate, SSN, etc.)
+    // to prevent "zombie" results from leaking across search attempts.
+    (values.summer_vouchers ?? []).forEach((voucher) => {
+      const {
+        employee_birthdate,
+        employee_ssn,
+        employee_school,
+        employee_home_city,
+        ...safeVoucher
+      } = voucher;
+
+      // Use serial number or ID as key to ensure we can retrieve it correctly
+      const key = safeVoucher.id || safeVoucher.summer_voucher_serial_number;
+      if (key) {
+        ApplicationPersistenceService.storeVoucherSupplement(key, safeVoucher);
+      }
+    });
+  }, [values, isDirty]);
+};
+
+export default usePersistFormValuesEffect;

--- a/frontend/kesaseteli/employer/src/hooks/application/useResetApplicationFormValuesEffect.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useResetApplicationFormValuesEffect.ts
@@ -3,6 +3,7 @@ import ApplicationPersistenceService from 'kesaseteli/employer/services/Applicat
 import React from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import Application from 'shared/types/application';
+import ContactInfo from 'shared/types/contact-info';
 import Employment from 'shared/types/employment';
 import { getFormApplication } from 'shared/utils/application.utils';
 
@@ -35,34 +36,85 @@ const mergeVoucherSupplements = (vouchers: Employment[]): Employment[] =>
 const mergeEmployerData = (application: Application): void => {
   const employerData = ApplicationPersistenceService.getEmployerData();
   if (!employerData) return;
-  Object.assign(application, {
-    contact_person_name:
-      application.contact_person_name || employerData.contact_person_name,
-    contact_person_email:
-      application.contact_person_email || employerData.contact_person_email,
-    contact_person_phone_number:
-      application.contact_person_phone_number ||
-      employerData.contact_person_phone_number,
-    street_address: application.street_address || employerData.street_address,
-    bank_account_number:
-      application.bank_account_number || employerData.bank_account_number,
+  CONTACT_INFO_KEYS.forEach((key) => {
+    if (!application[key]) {
+      // eslint-disable-next-line no-param-reassign
+      application[key] = employerData[key] as string;
+    }
   });
 };
 
+const mergeUserValues = <T>(
+  target: T,
+  source: T | undefined,
+  keys: (keyof T)[]
+): void => {
+  if (!source) return;
+  keys.forEach((key) => {
+    if (source[key] !== undefined && source[key] !== null) {
+      // eslint-disable-next-line no-param-reassign
+      target[key] = source[key];
+    }
+  });
+};
+
+const CONTACT_INFO_KEYS: (keyof ContactInfo)[] = [
+  'contact_person_name',
+  'contact_person_email',
+  'contact_person_phone_number',
+  'street_address',
+  'bank_account_number',
+];
+
+const EMPLOYMENT_KEYS: (keyof Employment)[] = [
+  'employee_name',
+  'summer_voucher_serial_number',
+  'employee_phone_number',
+  'employment_postcode',
+  'employment_start_date',
+  'employment_end_date',
+  'employment_work_hours',
+  'employment_salary_paid',
+  'employment_description',
+  'hired_without_voucher_assessment',
+];
+
 const useResetApplicationFormValuesEffect = ({
   reset,
+  getValues,
+  formState: { isDirty },
 }: UseFormReturn<Application>): void => {
   const { applicationQuery } = useApplicationApi();
   React.useEffect(() => {
     if (!applicationQuery.isSuccess || !applicationQuery.data) return;
 
+    const currentValues = getValues();
     const application = getFormApplication(applicationQuery.data);
     const vouchers = ensureVoucherExists(application.summer_vouchers ?? []);
     application.summer_vouchers = mergeVoucherSupplements(vouchers);
+
+    // Clever Fix: Because search inputs and date fields are often NOT immediately
+    // persisted to the backend (read-only or draft state), we manually preserve
+    // the user's current typed/selected values for these fields.
+    //
+    // Comparison Hierarchy:
+    // 1. On Initial Load (isDirty === false): We trust (Server Data + SessionStorage Data).
+    // 2. During Active Edit (isDirty === true): We trust (User Typed Value) over Server Data.
+    if (currentValues && isDirty) {
+      mergeUserValues(application, currentValues, CONTACT_INFO_KEYS);
+
+      application.summer_vouchers = application.summer_vouchers.map((v, i) => {
+        const current = currentValues.summer_vouchers?.[i];
+        const updatedVoucher = { ...v };
+        mergeUserValues(updatedVoucher, current, EMPLOYMENT_KEYS);
+        return updatedVoucher;
+      });
+    }
+
     mergeEmployerData(application);
 
-    reset(application, { keepDirty: false });
-  }, [reset, applicationQuery.isSuccess, applicationQuery.data]);
+    reset(application, { keepDirty: isDirty });
+  }, [reset, applicationQuery.isSuccess, applicationQuery.data, getValues]);
 };
 
 export default useResetApplicationFormValuesEffect;

--- a/frontend/kesaseteli/handler/src/components/form/CreateApplicationWithoutSsnForm.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/CreateApplicationWithoutSsnForm.tsx
@@ -96,7 +96,6 @@ const CreateApplicationWithoutSsnForm: React.FC = () => {
       <DateInput id="nonVtjBirthdate" validation={{ required: true }} />
       <TextInput
         id="postcode"
-        type="number"
         validation={{
           required: true,
           pattern: POSTAL_CODE_REGEX,

--- a/frontend/kesaseteli/shared/src/__tests__/utils/fake-objects.ts
+++ b/frontend/kesaseteli/shared/src/__tests__/utils/fake-objects.ts
@@ -209,7 +209,7 @@ export const fakeValidVtjAddress = (
   merge(
     {
       LahiosoiteS: faker.address.streetAddress(),
-      Postinumero: faker.helpers.replaceSymbols('#####'),
+      Postinumero: faker.address.zipCode('#####'),
       PostitoimipaikkaS: faker.address.cityName(),
       AsuminenAlkupvm: convertDateFormat(faker.date.past(), DATE_FORMATS.VTJ),
       AsuminenLoppupvm: convertDateFormat(

--- a/frontend/kesaseteli/shared/src/__tests__/utils/fake-objects.ts
+++ b/frontend/kesaseteli/shared/src/__tests__/utils/fake-objects.ts
@@ -160,7 +160,7 @@ export const fakeYouthApplication = (
     first_name: faker.name.firstName(),
     last_name: faker.name.lastName(),
     social_security_number,
-    postcode: faker.datatype.number({ min: 10_000, max: 99_999 }).toString(),
+    postcode: faker.address.zipCode('#####'),
     school: is_unlisted_school
       ? faker.commerce.department()
       : faker.random.arrayElement(fakeSchools),
@@ -209,7 +209,7 @@ export const fakeValidVtjAddress = (
   merge(
     {
       LahiosoiteS: faker.address.streetAddress(),
-      Postinumero: String(faker.datatype.number(99_999)),
+      Postinumero: faker.helpers.replaceSymbols('#####'),
       PostitoimipaikkaS: faker.address.cityName(),
       AsuminenAlkupvm: convertDateFormat(faker.date.past(), DATE_FORMATS.VTJ),
       AsuminenLoppupvm: convertDateFormat(
@@ -302,8 +302,8 @@ export const fakeActivatedYouthApplication = (
       additional_info_provided_at:
         override?.status === 'additional_information_provided'
           ? convertToBackendDateFormat(
-            override?.additional_info_provided_at ?? faker.date.past()
-          )
+              override?.additional_info_provided_at ?? faker.date.past()
+            )
           : undefined,
       encrypted_handler_vtj_json: fakeVtjData(application),
     },

--- a/frontend/kesaseteli/shared/tsconfig.json
+++ b/frontend/kesaseteli/shared/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
     "baseUrl": "../../",
     "paths": {
       "kesaseteli-shared/*": [
@@ -12,6 +13,9 @@
         "shared/browser-tests/*"
       ]
     }
-  }
-}
+  },
+  "include": [
+    "src",
+    "../../shared/src/types/styled-components.d.ts"
+  ]
 }

--- a/frontend/shared/browser-tests/utils/input.utils.ts
+++ b/frontend/shared/browser-tests/utils/input.utils.ts
@@ -30,10 +30,7 @@ export const fillInput = async <T>(
     }
   }
 
-  await t
-    .click(inputSelector)
-    .pressKey('ctrl+a delete')
-    .typeText(inputSelector, value ?? '');
+  await t.typeText(inputSelector, value ?? '', { replace: true });
 };
 
 /**

--- a/frontend/shared/src/__tests__/utils/FakeObjectFactory.ts
+++ b/frontend/shared/src/__tests__/utils/FakeObjectFactory.ts
@@ -10,7 +10,6 @@ import {
   ATTACHMENT_CONTENT_TYPES,
   ATTACHMENT_TYPES,
 } from '../../constants/attachment-constants';
-import { EMPLOYEE_EXCEPTION_REASON } from '../../constants/employee-constants';
 import { DEFAULT_LANGUAGE, Language } from '../../i18n/i18n';
 import type Application from '../../types/application';
 import { AttachmentType, KesaseteliAttachment } from '../../types/attachment';
@@ -113,17 +112,14 @@ class FakeObjectFactory {
       employee_name: faker.name.findName(),
       employee_school: faker.commerce.department(),
       employee_ssn: '111111-111C',
+      employee_birthdate: '2000-01-01',
       employee_phone_number: faker.phone.phoneNumber(),
       // for example dots are not allowed in city name, so let's remove them (St. Louis -> St Louis)
       employee_home_city: faker.address
         .cityName()
         .replace(/[^ A-Za-zÄÅÖäåö-]/g, ''),
-      employee_postcode: faker.datatype
-        .number({ min: 10_000, max: 99_999 })
-        .toString(),
-      employment_postcode: faker.datatype
-        .number({ min: 10_000, max: 99_999 })
-        .toString(),
+      employee_postcode: faker.address.zipCode('#####'),
+      employment_postcode: faker.address.zipCode('#####'),
       employment_start_date: convertToBackendDateFormat(faker.date.past()),
       employment_end_date: convertToBackendDateFormat(faker.date.future()),
       employment_work_hours: faker.datatype.number({

--- a/frontend/shared/src/__tests__/utils/test-utils.tsx
+++ b/frontend/shared/src/__tests__/utils/test-utils.tsx
@@ -7,7 +7,6 @@ import {
 import * as router from 'next/router';
 import { NextRouter } from 'next/router';
 import React from 'react';
-import JEST_TIMEOUT from 'shared/__tests__/utils/jest-timeout';
 
 const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   // eslint-disable-next-line react/jsx-no-useless-fragment
@@ -35,7 +34,7 @@ export const waitFor = (
 ): Promise<void> => {
   // Overwrite default options
   const mergedOptions = {
-    timeout: 5_000,
+    timeout: 5000,
     ...options,
   };
   return _waitFor(callback, mergedOptions);

--- a/frontend/shared/src/backend-api/BackendAPIProvider.tsx
+++ b/frontend/shared/src/backend-api/BackendAPIProvider.tsx
@@ -29,6 +29,7 @@ const BackendAPIProvider: React.FC<BackendAPIProviderProps> = ({
       ...headers,
     },
     withCredentials: true,
+    timeout: 10 * 1000, // 10 seconds
   };
 
   // Force http adapter in test environment for nock compatibility

--- a/frontend/shared/src/components/forms/inputs/Dropdown.sc.ts
+++ b/frontend/shared/src/components/forms/inputs/Dropdown.sc.ts
@@ -1,6 +1,11 @@
-import styled from 'styled-components';
+import styled, { DefaultTheme } from 'styled-components';
 
-export const $DropdownWrapper = styled.div<{ errorText?: string }>`
-  ${(props) =>
+type $DropdownWrapperProps = {
+  errorText?: string;
+  theme: DefaultTheme;
+};
+
+export const $DropdownWrapper = styled.div<$DropdownWrapperProps>`
+  ${(props: $DropdownWrapperProps) =>
     !props.errorText ? `margin-bottom: ${props.theme.spacing.m};` : ''}
 `;

--- a/frontend/shared/src/components/forms/inputs/Dropdown.tsx
+++ b/frontend/shared/src/components/forms/inputs/Dropdown.tsx
@@ -7,8 +7,8 @@ import {
 } from 'shared/components/forms/section/FormSection.sc';
 import InputProps from 'shared/types/input-props';
 
-import { $DropdownWrapper } from './Dropdown.sc';
 import FieldErrorMessage from '../fields/fieldErrorMessage/FieldErrorMessage';
+import { $DropdownWrapper } from './Dropdown.sc';
 
 type Option = {
   name: string;
@@ -74,11 +74,7 @@ const Dropdown = <T extends FieldValues, O extends Option>({
                 toggleButtonAriaLabel={toggleButtonAriaLabel || ''}
               />
             ) : (
-              <Select<O>
-                {...field}
-                {...sharedProps}
-                value={value as O}
-              />
+              <Select<O> {...field} {...sharedProps} value={value as O} />
             )
           }
         />

--- a/frontend/shared/src/components/forms/inputs/MultiSelectDropdown.tsx
+++ b/frontend/shared/src/components/forms/inputs/MultiSelectDropdown.tsx
@@ -8,8 +8,8 @@ import {
 } from 'shared/components/forms/section/FormSection.sc';
 import InputProps from 'shared/types/input-props';
 
-import { $DropdownWrapper } from './Dropdown.sc';
 import FieldErrorMessage from '../fields/fieldErrorMessage/FieldErrorMessage';
+import { $DropdownWrapper } from './Dropdown.sc';
 
 type Option = {
   name: string;
@@ -76,11 +76,7 @@ const MultiSelectDropdown = <T extends FieldValues, O extends Option>({
                 toggleButtonAriaLabel={t('common:assistive.openDropdown')}
               />
             ) : (
-              <Select<O>
-                {...field}
-                {...sharedProps}
-                value={value as O[]}
-              />
+              <Select<O> {...field} {...sharedProps} value={value as O[]} />
             )
           }
         />

--- a/frontend/shared/src/hooks/__tests__/useLeaveConfirm.test.ts
+++ b/frontend/shared/src/hooks/__tests__/useLeaveConfirm.test.ts
@@ -85,11 +85,9 @@ describe('useLeaveConfirm', () => {
     const originalLocation = window.location;
 
     beforeAll(() => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       delete (window as { location?: Location }).location;
+
       // eslint-disable-next-line scanjs-rules/assign_to_location
-      // @ts-ignore
       (window as { location: Location }).location = {
         ...originalLocation,
         pathname: '/application',
@@ -101,7 +99,6 @@ describe('useLeaveConfirm', () => {
 
     afterAll(() => {
       // eslint-disable-next-line scanjs-rules/assign_to_location
-      // @ts-ignore
       (window as { location: Location }).location = originalLocation;
     });
 

--- a/frontend/shared/src/types/employment.d.ts
+++ b/frontend/shared/src/types/employment.d.ts
@@ -13,6 +13,7 @@ export type EmployeeHiredWithoutVoucherAssessment =
 export type EmploymentBase = {
   employee_name?: string;
   employee_ssn?: string;
+  employee_birthdate?: string;
   employee_phone_number?: string;
   employee_home_city?: string;
   employee_postcode?: string;

--- a/frontend/shared/src/utils/__tests__/mask-gdpr-data.test.ts
+++ b/frontend/shared/src/utils/__tests__/mask-gdpr-data.test.ts
@@ -18,7 +18,7 @@ describe('frontend/shared/src/utils/masked-gdpr-data.ts', () => {
       social_security_number: FinnishSSN.createWithAge(
         faker.datatype.number({ min: 16, max: 17 })
       ),
-      postcode: faker.datatype.number({ min: 10_000, max: 99_999 }).toString(),
+      postcode: faker.address.zipCode('#####'),
       unlistedSchool: faker.commerce.department(),
       is_unlisted_school: true,
       phone_number: faker.phone.phoneNumber('+358#########'),


### PR DESCRIPTION
YJDH-841.

# Backend

1. Improved serializer validation and linking of employer summer voucher
into employer application. An employer user and his colleagues should be
able to edit company's applications, sumemr vouchers and application
attachments.
2. Added a birthdate field into employer application endpoint's
response.
3. Improvements to admin site views.
4. Employer application filter now defaults showing companys applications without explicitly defining `only_mine` -parameter
5. Fix integrity errors with audit logging in some tests.

# Frontend

Replace SSN with a birthdate field. Social security number should not be
visible anywhere in employers UI anymore. When employee data is fetched,
a birthdate is shown instead of SSN.

Other misc updates:
1. Added timeout to API requests
2. Handle and postcode fields as texts of 5 chars length and mock the
values in tests with postcode mocker.
3. Fixes to reset form values method and loading the values from session
storage.

# Shared

1. Fix input filling and improve post code mocking.