### PR TITLE
Normal user should always represent some company 

### DIFF
--- a/backend/kesaseteli/applications/api/v1/permissions.py
+++ b/backend/kesaseteli/applications/api/v1/permissions.py
@@ -32,17 +32,22 @@ def has_employer_application_permission(
     request: HttpRequest, employer_application: EmployerApplication
 ) -> bool:
     """
-    Allow access only to DRAFT status employer applications of the user's company.
+    Allow access to employer applications.
+    - Staff and superusers have full access.
+    - Standard users must belong to the same company as the application.
+    - For standard users, only DRAFT and SUBMITTED applications are viewable.
     """
+    if request.user.is_staff or request.user.is_superuser:
+        return True
+
+    # It is important to check the company permission, because
+    # at some point user might also lose the company permission.
+    # User should not be able to access applications of companies they don't belong to.
     user_company = get_user_company(request)
     return bool(
         user_company
         and employer_application.company == user_company
-        and (
-            request.user.is_staff
-            or request.user.is_superuser
-            or employer_application.status in ALLOWED_APPLICATION_VIEW_STATUSES
-        )
+        and employer_application.status in ALLOWED_APPLICATION_VIEW_STATUSES
     )
 
 

--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -303,19 +303,52 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
         return data
 
     def _validate_summer_voucher_serial_number(self, data):
+        """
+        Validate the summer voucher serial number and its usage.
+
+        Orchestrates fetching the voucher, validating the employee name match,
+        checking usage across applications, and verifying the youth application
+        status.
+
+        :raises ValidationError: if any validation step fails.
+        """
         serial_number = data.get("summer_voucher_serial_number")
         if not serial_number:
             return
 
+        voucher = self._get_youth_summer_voucher(serial_number)
+        if not voucher:
+            return
+
+        user_provided_name = data.get("employee_name")
+        self._validate_voucher_employee_name(voucher, user_provided_name)
+        self._validate_voucher_status(voucher.youth_application)
+        self._validate_voucher_usage(
+            voucher, application=self._get_application_context()
+        )
+
+    def _get_youth_summer_voucher(
+        self, serial_number: str
+    ) -> Optional[YouthSummerVoucher]:
+        """
+        Safely fetch the YouthSummerVoucher by serial number.
+        """
         try:
-            youth_summer_voucher = YouthSummerVoucher.objects.get(
+            return YouthSummerVoucher.objects.get(
                 summer_voucher_serial_number=int(serial_number)
             )
         except (ValueError, TypeError, YouthSummerVoucher.DoesNotExist):
-            return
+            return None
 
-        # 1. Name validation
-        user_provided_name = data.get("employee_name")
+    def _validate_voucher_employee_name(
+        self, voucher: YouthSummerVoucher, user_provided_name: str
+    ) -> None:
+        """
+        Validate that the provided employee name matches the voucher owner.
+
+        :raises ValidationError: if employee_name is missing or does not match
+            voucher owner.
+        """
         if not user_provided_name:
             raise serializers.ValidationError(
                 {
@@ -325,7 +358,7 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
                 }
             )
 
-        youth_application = youth_summer_voucher.youth_application
+        youth_application = voucher.youth_application
         if not is_last_name_fuzzy_match_in_full_name(
             last_name=youth_application.last_name, full_name=user_provided_name
         ):
@@ -337,46 +370,12 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
                 }
             )
 
-        # 2. Usage validation
-        #
-        # Each YouthSummerVoucher (identified by its serial number) represents a
-        # unique work contract for a single student. Therefore, it must have a
-        # strict 1-1 relationship with an EmployerApplication.
-        #
-        # A voucher can only be attached to at most ONE EmployerApplication
-        # system-wide. This block ensures that:
-        # 1. A voucher already in a SUBMITTED/ACCEPTED application cannot be reused.
-        # 2. A voucher already in a DRAFT application (even of the same company or user)
-        #    cannot be added to a second draft.
-        #
-        # Hijacking is prevented by making the serial number effectively unique
-        # across all active and draft applications.
-        application = None
-        if self.instance:
-            application = getattr(self.instance, "application", None)
+    def _validate_voucher_status(self, youth_application: YouthApplication) -> None:
+        """
+        Ensure the youth application is in the ACCEPTED status.
 
-        if not application:
-            application = self.context.get("application")
-
-        if not application:
-            # Try to get it from the root serializer (EmployerApplicationSerializer)
-            # This is often needed during nested validation
-            root = getattr(self, "root", None)
-            if root and hasattr(root, "instance") and root.instance:
-                application = root.instance
-
-        # Check if this voucher is already linked to ANY other application in the DB.
-        # We exclude the current application to allow idempotent updates.
-        used_in_other = EmployerSummerVoucher.objects.filter(
-            youth_summer_voucher=youth_summer_voucher,
-        )
-
-        if application and hasattr(application, "id"):
-            # Match by ID to be safe across different object instances
-            used_in_other = used_in_other.exclude(application_id=application.id)
-
-        # 3. Status validation
-        # Only accepted youth applications can have their vouchers attached.
+        :raises ValidationError: if the youth application is not in ACCEPTED status.
+        """
         if youth_application.status != YouthApplicationStatus.ACCEPTED:
             raise serializers.ValidationError(
                 {
@@ -388,13 +387,52 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
                 }
             )
 
+    def _get_application_context(self) -> Optional[EmployerApplication]:
+        """
+        Attempt to find the EmployerApplication instance from the serializer
+        context or hierarchy.
+        """
+        application = None
+        if self.instance:
+            application = getattr(self.instance, "application", None)
+
+        if not application:
+            application = self.context.get("application")
+
+        if not application:
+            # Try to get it from the root serializer (EmployerApplicationSerializer)
+            root = getattr(self, "root", None)
+            if root and hasattr(root, "instance") and root.instance:
+                application = root.instance
+
+        return application
+
+    def _validate_voucher_usage(
+        self, voucher: YouthSummerVoucher, application: Optional[EmployerApplication]
+    ) -> None:
+        """
+        Ensure the voucher is not already used in another application.
+
+        :raises ValidationError: if the voucher is already linked to another
+            application.
+        """
+        # Check if this voucher is already linked to ANY other application in the DB.
+        # We exclude the current application to allow idempotent updates.
+        used_in_other = EmployerSummerVoucher.objects.filter(
+            youth_summer_voucher=voucher,
+        )
+
+        if application and hasattr(application, "id"):
+            # Match by ID to be safe across different object instances
+            used_in_other = used_in_other.exclude(application_id=application.id)
+
         if used_in_other.exists():
             conflicting_app_id = used_in_other.first().application_id
             request = self.context.get("request")
             user = getattr(request, "user", "Unknown") if request else "Unknown"
             LOGGER.warning(
                 "[SECURITY ISSUE] Suspicious voucher usage detected. Voucher serial "
-                f"{youth_summer_voucher.summer_voucher_serial_number} "
+                f"{voucher.summer_voucher_serial_number} "
                 f"is already linked to application {conflicting_app_id}. "
                 f"Attempted by user {user} (ID: {getattr(user, 'id', 'N/A')}) "
                 f"for application {getattr(application, 'id', 'new draft')}."

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -716,24 +716,6 @@ class EmployerApplicationFilter(filters.FilterSet):
             return self._filter_by_user(queryset)
         return queryset
 
-    @property
-    def qs(self):
-        """
-        Queryset property overridden to apply only_mine filter by default
-        when not provided or empty, BUT only if the user has no company.
-        If the user has a company, they see all company applications by default.
-        """
-        parent_qs = super().qs
-
-        # Apply only_mine filter by default when not provided or empty,
-        # but only if the user has no company context.
-        if self.data.get("only_mine") in (None, ""):
-            if get_user_company(self.request):
-                return parent_qs
-            return self._filter_by_user(parent_qs)
-
-        return parent_qs
-
     class Meta:
         model = EmployerApplication
         _timestamp_field_lookups = [
@@ -769,9 +751,17 @@ class EmployerApplicationViewSet(ModelViewSet):
         )
 
         user = self.request.user
+
         if user.is_anonymous:
             return queryset.none()
 
+        if user.is_staff or user.is_superuser:
+            return queryset
+
+        # Ensure that visibility is strictly tied to the organization the user
+        # currently represents. If the user does not represent an organization
+        # (e.g., lost permissions), they should not see any applications,
+        # even if they were the creator of some.
         user_company = get_user_company(self.request)
 
         if user_company:
@@ -780,10 +770,13 @@ class EmployerApplicationViewSet(ModelViewSet):
                 status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
             )
 
-        return queryset.filter(
-            user=self.request.user,
-            status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
+        # User is not staff, superuser or company user (not representing any company)
+        # Should not be able to see any applications
+        LOGGER.warning(
+            f"User {user.id} is not staff, superuser or company user "
+            "(not representing any company)."
         )
+        return queryset.none()
 
     def create(self, request, *args, **kwargs):
         """
@@ -806,11 +799,12 @@ class EmployerApplicationViewSet(ModelViewSet):
         if instance.status not in ALLOWED_APPLICATION_UPDATE_STATUSES:
             raise ValidationError("Only DRAFT applications can be updated")
 
+        # Ensure that visibility and modification are strictly tied to the
+        # organization the user currently represents. Even the original creator
+        # must have an active organization association to update the application.
         user_company = get_user_company(request)
-        if instance.user != request.user and instance.company != user_company:
-            raise PermissionDenied(
-                "Only application creator or company members can update it"
-            )
+        if not user_company or instance.company != user_company:
+            raise PermissionDenied("Only company members can update it")
 
         return super().update(request, *args, **kwargs)
 
@@ -822,11 +816,12 @@ class EmployerApplicationViewSet(ModelViewSet):
         if instance.status not in ALLOWED_APPLICATION_UPDATE_STATUSES:
             raise ValidationError("Only DRAFT applications can be deleted")
 
+        # Ensure that visibility and modification are strictly tied to the
+        # organization the user currently represents. Even the original creator
+        # must have an active organization association to delete the application.
         user_company = get_user_company(request)
-        if instance.user != request.user and instance.company != user_company:
-            raise PermissionDenied(
-                "Only application creator or company members can delete it"
-            )
+        if not user_company or instance.company != user_company:
+            raise PermissionDenied("Only company members can delete it")
 
         return super().destroy(request, *args, **kwargs)
 
@@ -859,10 +854,15 @@ class EmployerSummerVoucherViewSet(ModelViewSet):
 
         user_company = get_user_company(self.request)
 
-        return queryset.filter(
-            application__company=user_company,
-            application__status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
-        )
+        if user_company:
+            return queryset.filter(
+                application__company=user_company,
+                application__status__in=ALLOWED_APPLICATION_VIEW_STATUSES,
+            )
+
+        # If the user does not represent an organization (e.g. lost permissions),
+        # they should not see any summer vouchers.
+        return queryset.none()
 
     def create(self, request, *args, **kwargs):
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
@@ -896,15 +896,12 @@ class EmployerSummerVoucherViewSet(ModelViewSet):
                 "Attachments can be uploaded only for DRAFT applications"
             )
 
+        # Ensure that visibility and modification are strictly tied to the
+        # organization the user currently represents. Even the original creator
+        # must have an active organization association to post an attachment.
         user_company = get_user_company(request)
-
-        if (
-            obj.application.user != request.user
-            and obj.application.company != user_company
-        ):
-            raise PermissionDenied(
-                "Only application creator or company members can post attachment to it"
-            )
+        if not user_company or obj.application.company != user_company:
+            raise PermissionDenied("Only company members can post attachment to it")
 
         # Validate request data
         serializer = AttachmentSerializer(
@@ -955,17 +952,13 @@ class EmployerSummerVoucherViewSet(ModelViewSet):
             # by get_queryset() and will receive a 404 from self.get_object() above.
 
             # 2. Identity Check (403 Permission Denied):
-            # Deny if the user is NEITHER the application creator NOR a member of the
-            # same company. This check remains critical for Staff/Handlers who pass the
-            # get_queryset visibility.
+            # Deny if the user is not representing the organization associated
+            # with the application. This ensures that even the original creator
+            # cannot delete attachments if they no longer represent the company.
             user_company = get_user_company(request)
-
-            if (
-                obj.application.user != request.user
-                and obj.application.company != user_company
-            ):
+            if not user_company or obj.application.company != user_company:
                 raise PermissionDenied(
-                    "Only application creator or company members can delete attachment from it"  # noqa: E501
+                    "Only company members can delete attachment from it"  # noqa: E501
                 )
 
             # 3. Status Check (403 Permission Denied):

--- a/backend/kesaseteli/applications/tests/test_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_applications_api.py
@@ -553,14 +553,23 @@ def test_application_create_double(api_client, company):
 def test_applications_list_only_finds_own_application(
     api_client, application, company, user
 ):
-    EmployerApplicationFactory()
-    EmployerApplicationFactory(company=company)
-    EmployerApplicationFactory(user=user)
+    EmployerApplicationFactory()  # Not seen (different company)
+    app2 = EmployerApplicationFactory(company=company)  # Seen (same company, diff user)
+    EmployerApplicationFactory(user=user)  # Not seen (same user, diff company)
 
     assert EmployerApplication.objects.count() == 4
 
+    # Default: finds all company applications (own + colleague's)
     response = api_client.get(get_list_url())
+    assert response.status_code == 200
+    assert len(response.data) == 2
+    assert {str(app["id"]) for app in response.data} == {
+        str(application.id),
+        str(app2.id),
+    }
 
+    # With only_mine=true: finds only own applications in current company
+    response = api_client.get(get_list_url() + "?only_mine=true")
     assert response.status_code == 200
     assert len(response.data) == 1
     assert str(response.data[0]["id"]) == str(application.id)
@@ -576,11 +585,20 @@ def test_application_get_only_finds_own_application(
 
     assert EmployerApplication.objects.count() == 4
 
-    applications_404 = [app1, app2, app3]
-    for app in applications_404:
-        response = api_client.get(get_detail_url(app))
-        assert response.status_code == 404
+    # app1 is random company -> 404
+    response = api_client.get(get_detail_url(app1))
+    assert response.status_code == 404
 
+    # app2 is colleague's application in same company -> 200
+    response = api_client.get(get_detail_url(app2))
+    assert response.status_code == 200
+
+    # app3 is own application in random company -> 404
+    # (because queryset is filtered by the session's company)
+    response = api_client.get(get_detail_url(app3))
+    assert response.status_code == 404
+
+    # original application -> 200
     response = api_client.get(get_detail_url(application))
     assert response.status_code == 200
     assert str(response.data["id"]) == str(application.id)

--- a/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
+++ b/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
@@ -77,8 +77,7 @@ def test_employer_application_list_viewable_statuses(
 ):
     """
     Test that the employer application list endpoint returns draft and
-    submitted employer applications but only those that are the user's and use
-    the user's company by default.
+    submitted employer applications but only those that use the user's company.
     """
     user1, user2 = UserFactory.create_batch(size=2)
     user1_client = force_login_user(user1)
@@ -91,19 +90,30 @@ def test_employer_application_list_viewable_statuses(
     user2_company1_attachment = create_attachment(user2, company1, application_status)
     user2_company2_attachment = create_attachment(user2, company2, application_status)
 
-    for user, client, company, attachment in [
-        (user1, user1_client, company1, user1_company1_attachment),
-        (user1, user1_client, company2, user1_company2_attachment),
-        (user2, user2_client, company1, user2_company1_attachment),
-        (user2, user2_client, company2, user2_company2_attachment),
+    company1_application_ids = {
+        str(user1_company1_attachment.summer_voucher.application.id),
+        str(user2_company1_attachment.summer_voucher.application.id),
+    }
+    company2_application_ids = {
+        str(user1_company2_attachment.summer_voucher.application.id),
+        str(user2_company2_attachment.summer_voucher.application.id),
+    }
+    for client, company, expected_application_ids in [
+        (user1_client, company1, company1_application_ids),
+        (user1_client, company2, company2_application_ids),
+        (user2_client, company1, company1_application_ids),
+        (user2_client, company2, company2_application_ids),
     ]:
         set_company_business_id_to_client(company, client)
         response = client.get(reverse("v1:employerapplication-list"))
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == str(attachment.summer_voucher.application.id)
-        assert response.data[0]["user"] == user.id
-        assert response.data[0]["company"]["id"] == str(company.id)
+        # In the company-wide visibility model, the user should see all applications
+        # belonging to the company they currently represent.
+        # Here we expect 2 applications for the company:
+        # 1. The one created by the current user
+        # 2. The one created by the other user for the same company
+        assert len(response.data) == 2
+        assert {x["id"] for x in response.data} == expected_application_ids
 
 
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
@@ -177,8 +187,7 @@ def test_employer_application_detail_viewable_statuses(
 ):
     """
     Test that the employer application detail endpoint returns draft and
-    submitted employer applications but only those that are the user's and use
-    the user's company.
+    submitted employer applications but only those that use the user's company.
     """
     user1, user2 = UserFactory.create_batch(size=2)
     user1_client = force_login_user(user1)
@@ -197,15 +206,16 @@ def test_employer_application_detail_viewable_statuses(
             reverse("v1:employerapplication-detail", kwargs={"pk": application.id})
         )
 
-    # The status code 200s are the ones that match both the user and the company:
+    # In the company-wide visibility model, colleagues are able to see each other's
+    # applications within the same company context.
     set_company_business_id_to_client(company1, user1_client)
     assert get_app(user1_client, user1_company1_attachment).status_code == 200
     assert get_app(user1_client, user1_company2_attachment).status_code == 404
-    assert get_app(user1_client, user2_company1_attachment).status_code == 404
+    assert get_app(user1_client, user2_company1_attachment).status_code == 200
     assert get_app(user1_client, user2_company2_attachment).status_code == 404
 
     set_company_business_id_to_client(company1, user2_client)
-    assert get_app(user2_client, user1_company1_attachment).status_code == 404
+    assert get_app(user2_client, user1_company1_attachment).status_code == 200
     assert get_app(user2_client, user1_company2_attachment).status_code == 404
     assert get_app(user2_client, user2_company1_attachment).status_code == 200
     assert get_app(user2_client, user2_company2_attachment).status_code == 404
@@ -214,11 +224,11 @@ def test_employer_application_detail_viewable_statuses(
     assert get_app(user1_client, user1_company1_attachment).status_code == 404
     assert get_app(user1_client, user1_company2_attachment).status_code == 200
     assert get_app(user1_client, user2_company1_attachment).status_code == 404
-    assert get_app(user1_client, user2_company2_attachment).status_code == 404
+    assert get_app(user1_client, user2_company2_attachment).status_code == 200
 
     set_company_business_id_to_client(company2, user2_client)
     assert get_app(user2_client, user1_company1_attachment).status_code == 404
-    assert get_app(user2_client, user1_company2_attachment).status_code == 404
+    assert get_app(user2_client, user1_company2_attachment).status_code == 200
     assert get_app(user2_client, user2_company1_attachment).status_code == 404
     assert get_app(user2_client, user2_company2_attachment).status_code == 200
 
@@ -1428,3 +1438,53 @@ def test_youth_application_fetch_employee_data_unallowed_methods(user_client):
     assert user_client.get(url).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
     assert user_client.patch(url).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
     assert user_client.put(url).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+
+@pytest.mark.django_db
+def test_employer_application_list_no_company_lost_permission(api_client):
+    """
+    Test that applications are NOT returned if the user has no company association,
+    even if they are the creator of the applications. This covers the case where
+    a user might have lost the permission to represent the company.
+    """
+    user = UserFactory()
+    # Create an application for this user
+    EmployerApplicationFactory(user=user)
+
+    api_client = force_login_user(user)
+
+    # Mock get_user_company to return None (simulating lost permission or no association)
+    with mock.patch("applications.api.v1.views.get_user_company", return_value=None):
+        response = api_client.get(reverse("v1:employerapplication-list"))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 0
+
+
+@pytest.mark.django_db
+def test_employer_application_modification_no_company_lost_permission(api_client):
+    """
+    Test that applications CANNOT be modified or deleted if the user has no company
+    association, even if they are the original creator of the applications.
+    """
+    user = UserFactory()
+    # Create a draft application for this user
+    application = EmployerApplicationFactory(
+        user=user, status=EmployerApplicationStatus.DRAFT
+    )
+
+    api_client = force_login_user(user)
+
+    # Mock get_user_company to return None (simulating lost permission)
+    with mock.patch("applications.api.v1.views.get_user_company", return_value=None):
+        url = reverse("v1:employerapplication-detail", kwargs={"pk": application.id})
+
+        # 1. Try to Update
+        response = api_client.put(
+            url, {"status": EmployerApplicationStatus.DRAFT}, format="json"
+        )
+        # should fail with 404 Not Found (because it's filtered out from queryset)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        # 2. Try to Delete
+        response = api_client.delete(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
Additions to #4004

YJDH-841.

User should not be able to access or modify the applications he has
created, if he is not representing a company that owns the application.
He might have lost his permissions and he should not be able to access
the applications anymore.

API view queryset and permission handling should be consistent: staff
members, superusers and company representators should see the
applications of 1 company.