### PR TITLE
feat(ks,handler): handler can handle applications with invalid SSN

### DIFF
--- a/frontend/kesaseteli/handler/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/handler/src/__tests__/index.test.tsx
@@ -203,7 +203,7 @@ describe('frontend/kesaseteli/handler/src/pages/index.tsx', () => {
       }
     });
 
-    it(`shows error when vtjData is not found and disables action buttons`, async () => {
+    it(`shows error when vtjData is not found and enables action buttons`, async () => {
       const social_security_number = fakeYouthTargetGroupAgeSSN();
       const application = fakeActivatedYouthApplication({
         social_security_number,
@@ -222,6 +222,23 @@ describe('frontend/kesaseteli/handler/src/pages/index.tsx', () => {
       await indexPageApi.expectations.vtjErrorMessageIsPresent('notFound', {
         social_security_number,
       });
+      await indexPageApi.expectations.actionButtonsArePresent();
+      indexPageApi.expectations.actionButtonsAreEnabled();
+    });
+
+    it(`disables action buttons when both SSN and non-VTJ birthdate are missing`, async () => {
+      const application = fakeActivatedYouthApplication({
+        social_security_number: undefined,
+        non_vtj_birthdate: undefined,
+        status: 'awaiting_manual_processing',
+      });
+      expectToGetYouthApplication(application);
+      renderPage(HandlerIndex, {
+        query: { id: application.id },
+      });
+      const indexPageApi = await getIndexPageApi(application);
+      await indexPageApi.expectations.pageIsLoaded();
+
       await indexPageApi.expectations.actionButtonsArePresent();
       indexPageApi.expectations.actionButtonsAreDisabled();
     });

--- a/frontend/kesaseteli/handler/src/components/form/ActionButtons.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/ActionButtons.tsx
@@ -58,8 +58,6 @@ const ActionButtons: React.FC<Props> = ({ application, ...gridCellprops }) => {
 
   const isDisabled =
     isLoading ||
-    // Social security number requires VTJ data for processing
-    (social_security_number && vtjDataNotFound) ||
     // Missing social security number requires birthdate for processing
     (!social_security_number && !non_vtj_birthdate);
 

--- a/frontend/kesaseteli/handler/src/components/form/VtjErrorNotification.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/VtjErrorNotification.tsx
@@ -8,16 +8,22 @@ import $VtjException from './VtjErrorNotification.sc';
 type Props = {
   reason: VtjExceptionType;
   type?: NotificationProps['type'];
+  size?: NotificationProps['size'];
   params?: Record<string, string | number>;
 };
-const VtjErrorNotification: React.FC<Props> = ({ reason, type, params }) => {
+const VtjErrorNotification: React.FC<Props> = ({
+  reason,
+  type = 'alert',
+  size = 'small',
+  params,
+}) => {
   const { t } = useTranslation();
   return (
     <$VtjException
       data-testid={`vtj-exception-${reason}`}
       label=" "
-      type={type ?? 'alert'}
-      size="small"
+      type={type}
+      size={size}
     >
       {t(`common:handlerApplication.vtjException.${reason}`, params)}
     </$VtjException>

--- a/frontend/kesaseteli/handler/src/components/form/VtjInfo.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/VtjInfo.tsx
@@ -23,7 +23,9 @@ const VtjInfo: React.FC<Props> = ({ application }) => {
   } = application;
 
   if (!social_security_number) {
-    return <VtjErrorNotification reason="missingSsn" type="error" />;
+    return (
+      <VtjErrorNotification reason="missingSsn" type="error" size="large" />
+    );
   }
 
   if (!vtjData || !('Henkilo' in vtjData)) {
@@ -31,6 +33,7 @@ const VtjInfo: React.FC<Props> = ({ application }) => {
       <VtjErrorNotification
         reason="notFound"
         type="error"
+        size="large"
         params={{ social_security_number }}
       />
     );
@@ -96,6 +99,7 @@ const VtjInfo: React.FC<Props> = ({ application }) => {
         <VtjErrorNotification
           reason="notFound"
           type="error"
+          size="large"
           params={{ social_security_number }}
         />
       )}

--- a/frontend/kesaseteli/handler/src/components/form/__tests__/ActionButtons.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/__tests__/ActionButtons.test.tsx
@@ -1,0 +1,42 @@
+import { screen } from '@testing-library/react';
+import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
+import { fakeActivatedYouthApplication } from 'kesaseteli-shared/__tests__/utils/fake-objects';
+import React from 'react';
+import ActionButtons from '../ActionButtons';
+
+describe('ActionButtons', () => {
+  it('should be enabled when SSN is provided even if VTJ data is not found', () => {
+    const application = fakeActivatedYouthApplication({
+      social_security_number: '010101-123A',
+      encrypted_handler_vtj_json: {
+        Henkilo: { Henkilotunnus: { '@voimassaolokoodi': '0' } },
+      },
+    });
+    renderComponent(<ActionButtons application={application} />);
+
+    expect(screen.getByTestId('accept-button')).toBeEnabled();
+    expect(screen.getByTestId('reject-button')).toBeEnabled();
+  });
+
+  it('should be enabled when non-VTJ birthdate is provided and SSN is missing', () => {
+    const application = fakeActivatedYouthApplication({
+      social_security_number: undefined,
+      non_vtj_birthdate: '2000-01-01',
+    });
+    renderComponent(<ActionButtons application={application} />);
+
+    expect(screen.getByTestId('accept-button')).toBeEnabled();
+    expect(screen.getByTestId('reject-button')).toBeEnabled();
+  });
+
+  it('should be disabled when both SSN and non-VTJ birthdate are missing', () => {
+    const application = fakeActivatedYouthApplication({
+      social_security_number: undefined,
+      non_vtj_birthdate: undefined,
+    });
+    renderComponent(<ActionButtons application={application} />);
+
+    expect(screen.getByTestId('accept-button')).toBeDisabled();
+    expect(screen.getByTestId('reject-button')).toBeDisabled();
+  });
+});

--- a/frontend/kesaseteli/handler/src/components/form/__tests__/VtjErrorNotification.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/__tests__/VtjErrorNotification.test.tsx
@@ -1,0 +1,39 @@
+import { screen } from '@testing-library/react';
+import getHandlerTranslationsApi from 'kesaseteli/handler/__tests__/utils/i18n/get-handler-translations-api';
+import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
+import React from 'react';
+import VtjErrorNotification from '../VtjErrorNotification';
+
+describe('VtjErrorNotification', () => {
+  const {
+    translations: { fi: translations },
+    regexp,
+  } = getHandlerTranslationsApi();
+
+  it('renders with default type and size', () => {
+    renderComponent(<VtjErrorNotification reason="notFound" />);
+    expect(
+      screen.getByText(
+        regexp(translations.handlerApplication.vtjException.notFound)
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders with explicit large size as set in VtjInfo for notFound', () => {
+    renderComponent(<VtjErrorNotification reason="notFound" size="large" />);
+    expect(
+      screen.getByText(
+        regexp(translations.handlerApplication.vtjException.notFound)
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders with error type for missing SSN', () => {
+    renderComponent(<VtjErrorNotification reason="missingSsn" type="error" />);
+    expect(
+      screen.getByText(
+        regexp(translations.handlerApplication.vtjException.missingSsn)
+      )
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
YJDH-848.

Allow handler to accept or reject applications with invalid SSN that cannot be found from VTJ, the same as he can handle the applications without SSN.

<img width="1511" height="809" alt="image" src="https://github.com/user-attachments/assets/0b04448b-4fbc-4627-9f09-7885b9b34e1c" />

<img width="1527" height="780" alt="image" src="https://github.com/user-attachments/assets/1f5ab44c-8054-49e7-9b3c-8561919d7a13" />


<img width="1384" height="713" alt="image" src="https://github.com/user-attachments/assets/857859ea-29bf-4d11-83ef-55c74caaef5e" />
