### PR TITLE
fix(benefit): due date changing label fixed

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1911,7 +1911,8 @@
       },
       "changeInstalmentDate": {
         "heading": "Eräpäivän muutos",
-        "helperText": "Kirjoita päivämäärä muodossa PP.KK.VVVV",
+        "label": "Uusi eräpäivä",
+        "helperText": "Kirjoita päivämäärä muodossa PP.KK.VVVV. Eräpäivän on oltava ensimmäisen maksuerän eräpäivän jälkeen ja enintään nykyinen eräpäivä.",
         "buttons": {
           "cancel": "Peruuta",
           "confirm": "Vahvista"

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1910,7 +1910,8 @@
       },
       "changeInstalmentDate": {
         "heading": "Eräpäivän muutos",
-        "helperText": "Kirjoita päivämäärä muodossa PP.KK.VVVV",
+        "label": "Uusi eräpäivä",
+        "helperText": "Kirjoita päivämäärä muodossa PP.KK.VVVV. Eräpäivän on oltava ensimmäisen maksuerän eräpäivän jälkeen ja enintään nykyinen eräpäivä.",
         "buttons": {
           "cancel": "Peruuta",
           "confirm": "Vahvista"

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1911,7 +1911,8 @@
       },
       "changeInstalmentDate": {
         "heading": "Eräpäivän muutos",
-        "helperText": "Kirjoita päivämäärä muodossa PP.KK.VVVV",
+        "label": "Uusi eräpäivä",
+        "helperText": "Kirjoita päivämäärä muodossa PP.KK.VVVV. Eräpäivän on oltava ensimmäisen maksuerän eräpäivän jälkeen ja enintään nykyinen eräpäivä.",
         "buttons": {
           "cancel": "Peruuta",
           "confirm": "Vahvista"

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
@@ -329,7 +329,7 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
               {/* @ts-expect-error -- HDS DateInput types are overly strict with TS 5.9 */}
               <DateInput
                 id="instalment-change-date-dateinput"
-                label="Viimeinen työpäivä"
+                label={t('common:instalments.dialog.changeInstalmentDate.label')}
                 helperText={t(
                   'common:instalments.dialog.changeInstalmentDate.helperText'
                 )}


### PR DESCRIPTION
## Description

Fixed the label for changing due date of 2nd instalment. Also, instruction
text has been made more clear.

## Motivation and Context

There was a wrong label in date changing dialog.

[HL-1756](https://helsinkisolutionoffice.atlassian.net/browse/HL-1756)

## Testing

No special testing needed.

[HL-1756]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ