### PR TITLE
Instructions to act behalf of an organisation if authorization has failed

### DIFF
--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -274,6 +274,6 @@
     "content": "You do not have the authorization to represent any organization in the Summer Job Voucher service. To process applications, you must have a valid authorization to act on behalf of the employer.",
     "instructions": "Request your organization to grant you the necessary authorizations in the Suomi.fi service.",
     "linkText": "Read more about authorizations <lnk href=\"https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/\" target=\"_blank\">here</lnk>.",
-    "loginButton": "Sign in again"
+    "logoutButton": "Logout"
   }
 }

--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -29,7 +29,7 @@
     "sessionExpiredLabel": "User session expired. Sign in again",
     "infoLabel": "Using the service requires strong authentication",
     "logoutInfoContent": "You have been logged out. If you want to continue to use the service, you have to log in again click the button here below.",
-    "infoContent": "You should identify yourself to be able to advance to the service. You can choose yourself which identification method you want to use. Click on the bottom below to identify yourself."
+    "infoContent": "You should identify yourself to be able to advance to the service. Click on the bottom below to identify yourself."
   },
   "thankyouPage": {
     "thankyouMessageLabel": "The application has been submitted.",

--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -267,5 +267,13 @@
       "rejected": "Rejected",
       "deleted_by_customer": "Deleted"
     }
+  },
+  "noOrganisationPage": {
+    "title": "No authorization",
+    "header": "Not authorized to represent any organization",
+    "content": "You do not have the authorization to represent any organization in the Summer Job Voucher service. To process applications, you must have a valid authorization to act on behalf of the employer.",
+    "instructions": "Request your organization to grant you the necessary authorizations in the Suomi.fi service.",
+    "linkText": "Read more about authorizations <lnk href=\"https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/\" target=\"_blank\">here</lnk>.",
+    "loginButton": "Sign in again"
   }
 }

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -274,6 +274,6 @@
     "content": "Sinulla ei ole valtuuksia edustaa mitään organisaatiota Kesäseteli-palvelussa. Jotta voit käsitellä hakemuksia, sinulla on oltava voimassa oleva valtuutus edustaa työnantajaa.",
     "instructions": "Pyydä organisaatiotasi myöntämään sinulle tarvittavat valtuudet Suomi.fi-palvelussa.",
     "linkText": "Lue lisää valtuuksista <lnk href=\"https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/\" target=\"_blank\">täältä</lnk>.",
-    "loginButton": "Kirjaudu uudelleen sisään"
+    "logoutButton": "Kirjaudu ulos"
   }
 }

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -267,5 +267,13 @@
       "rejected": "Hylätty",
       "deleted_by_customer": "Poistettu"
     }
+  },
+  "noOrganisationPage": {
+    "title": "Ei valtuutusta",
+    "header": "Ei valtuutusta asioida organisaation puolesta",
+    "content": "Sinulla ei ole valtuuksia edustaa mitään organisaatiota Kesäseteli-palvelussa. Jotta voit käsitellä hakemuksia, sinulla on oltava voimassa oleva valtuutus edustaa työnantajaa.",
+    "instructions": "Pyydä organisaatiotasi myöntämään sinulle tarvittavat valtuudet Suomi.fi-palvelussa.",
+    "linkText": "Lue lisää valtuuksista <lnk href=\"https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/\" target=\"_blank\">täältä</lnk>.",
+    "loginButton": "Kirjaudu uudelleen sisään"
   }
 }

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -29,7 +29,7 @@
     "sessionExpiredLabel": "Käyttäjäsessio vanhentui. Kirjaudu uudelleen sisään",
     "infoLabel": "Palvelun käyttäminen edellyttää vahvaa tunnistautumista",
     "logoutInfoContent": "Sinut on kirjattu ulos. Jos haluat jatkaa asiointia palvelussa, kirjaudu uudelleen sisään klikkaamalla alla olevasta painikkeesta.",
-    "infoContent": "Jotta voit edetä palvelussa, sinun täytyy tunnistautua. Voit valita itse, mitä tunnistustapaa haluat käyttää. Tunnistustietosi kulkevat suojatussa yhteydessä. Klikkaa alla olevasta painikkeesta tunnistautuaksesi."
+    "infoContent": "Jotta voit edetä palvelussa, sinun täytyy tunnistautua. Tunnistustietosi kulkevat suojatussa yhteydessä. Klikkaa alla olevasta painikkeesta tunnistautuaksesi."
   },
   "thankyouPage": {
     "thankyouMessageLabel": "Hakemus on lähetetty.",

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -267,5 +267,13 @@
       "rejected": "Avvisad",
       "deleted_by_customer": "Raderad"
     }
+  },
+  "noOrganisationPage": {
+    "title": "Behörighet saknas",
+    "header": "Ingen behörighet att företräda en organisation",
+    "content": "Du har inte behörighet att företräda någon organisation i tjänsten Sommarsedeln. För att kunna hantera ansökningar måste du ha en giltig fullmakt att företräda arbetsgivaren.",
+    "instructions": "Be din organisation bevilja dig nödvändiga fullmakter i tjänsten Suomi.fi.",
+    "linkText": "Läs mer om fullmakter <lnk href=\"https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/\" target=\"_blank\">här</lnk>.",
+    "loginButton": "Logga in på nytt"
   }
 }

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -274,6 +274,6 @@
     "content": "Du har inte behörighet att företräda någon organisation i tjänsten Sommarsedeln. För att kunna hantera ansökningar måste du ha en giltig fullmakt att företräda arbetsgivaren.",
     "instructions": "Be din organisation bevilja dig nödvändiga fullmakter i tjänsten Suomi.fi.",
     "linkText": "Läs mer om fullmakter <lnk href=\"https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/\" target=\"_blank\">här</lnk>.",
-    "loginButton": "Logga in på nytt"
+    "logoutButton": "Logga ut"
   }
 }

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -29,7 +29,7 @@
     "sessionExpiredLabel": "Användarsessionen föråldrades. Logga in på nytt.",
     "infoLabel": "Att använda tjänsten kräver stark autentisering",
     "logoutInfoContent": "Du har nu loggats ut. Om du vill fortsätta använda tjänsten, logga in på nytt genom att klicka på knappen nedan.",
-    "infoContent": "Du bör identifiera dig för att kunna avancera till tjänsten. Du kan själv välja det identifieringssätt du vill använda. Identifieringsuppgifterna rör sig i en säker anslutning. Klicka på nedanstående knapp för att identifiera dig. "
+    "infoContent": "Du bör identifiera dig för att kunna avancera till tjänsten. Identifieringsuppgifterna rör sig i en säker anslutning. Klicka på nedanstående knapp för att identifiera dig. "
   },
   "thankyouPage": {
     "thankyouMessageLabel": "Ansökan har lämnats in.",

--- a/frontend/kesaseteli/employer/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/employer/src/__tests__/index.test.tsx
@@ -52,7 +52,7 @@ describe('frontend/kesaseteli/employer/src/pages/index.tsx', () => {
       await waitFor(
         () =>
           expect(spyPush).toHaveBeenCalledWith(
-            `/${DEFAULT_LANGUAGE}/500`,
+            `${DEFAULT_LANGUAGE}/500`,
             undefined,
             { shallow: false }
           ),

--- a/frontend/kesaseteli/employer/src/hocs/withEmployerAuth.tsx
+++ b/frontend/kesaseteli/employer/src/hocs/withEmployerAuth.tsx
@@ -1,0 +1,12 @@
+import withAuth from 'shared/components/hocs/withAuth';
+import withOrganisation from './withOrganisation';
+
+/**
+ * Combined HOC for the Employer UI.
+ * Ensures the user is both authenticated and has organization authorization.
+ */
+const withEmployerAuth = <P extends JSX.IntrinsicAttributes>(
+  WrappedComponent: React.FC<P>
+): React.FC<P> => withAuth(withOrganisation(WrappedComponent));
+
+export default withEmployerAuth;

--- a/frontend/kesaseteli/employer/src/hocs/withOrganisation.tsx
+++ b/frontend/kesaseteli/employer/src/hocs/withOrganisation.tsx
@@ -1,0 +1,63 @@
+import useCompanyQuery from 'kesaseteli/employer/hooks/backend/useCompanyQuery';
+import React from 'react';
+import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
+import useAuth from 'shared/hooks/useAuth';
+import useGoToPage from 'shared/hooks/useGoToPage';
+import { isError } from 'shared/utils/type-guards';
+
+/**
+ * HOC that ensures the user has organization authorization.
+ * Redirects to /no-organisation if the user is authenticated but lacks organization info or receives a 403.
+ */
+const withOrganisation = <P extends JSX.IntrinsicAttributes>(
+  WrappedComponent: React.FC<P>
+): React.FC<P> =>
+  function Wrapped(props: P) {
+    const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
+    const goToPage = useGoToPage();
+
+    const {
+      data: company,
+      isLoading: isCompanyLoading,
+      isSuccess: isCompanySuccess,
+      error: companyError,
+    } = useCompanyQuery();
+
+    const isForbidden = (err: unknown): boolean =>
+      isError(err) &&
+      (err.message.includes('403') || err.message.includes('Forbidden'));
+
+    const isNoOrganisation = isCompanySuccess && !company?.name;
+    const isAuthError = isForbidden(companyError);
+
+    React.useEffect(() => {
+      // Redirect to no-organisation only if authenticated but unauthorized for organizations
+      if (
+        isAuthenticated &&
+        !isCompanyLoading &&
+        (isNoOrganisation || isAuthError)
+      ) {
+        void goToPage('/no-organisation');
+      }
+    }, [
+      isAuthenticated,
+      isCompanyLoading,
+      isNoOrganisation,
+      isAuthError,
+      goToPage,
+    ]);
+
+    // Show loading spinner while determining status
+    if (isAuthLoading || (isAuthenticated && isCompanyLoading)) {
+      return <PageLoadingSpinner />;
+    }
+
+    // Prevent rendering the wrapped component if we're about to redirect
+    if (isAuthenticated && (isNoOrganisation || isAuthError)) {
+      return <PageLoadingSpinner />;
+    }
+
+    return <WrappedComponent {...props} />;
+  };
+
+export default withOrganisation;

--- a/frontend/kesaseteli/employer/src/hooks/backend/useApplicationsQuery.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useApplicationsQuery.ts
@@ -10,6 +10,7 @@ const useApplicationsQuery = <T = Application[]>(
   onError?: (error: Error | unknown) => void
 ): UseQueryResult<T> => {
   const { axios, handleResponse } = useBackendAPI();
+  const defaultErrorHandler = useErrorHandler();
 
   return useQuery(
     [BackendEndpoint.EMPLOYER_APPLICATIONS, { onlyMine }],
@@ -27,7 +28,7 @@ const useApplicationsQuery = <T = Application[]>(
         : undefined,
       staleTime: Infinity,
       retryDelay: 3000,
-      onError: onError ?? useErrorHandler(),
+      onError: onError ?? defaultErrorHandler,
     }
   );
 };

--- a/frontend/kesaseteli/employer/src/hooks/backend/useApplicationsQuery.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useApplicationsQuery.ts
@@ -6,7 +6,8 @@ import Application from 'shared/types/application';
 
 const useApplicationsQuery = <T = Application[]>(
   onlyMine?: boolean,
-  select?: (applications: Application[]) => T
+  select?: (applications: Application[]) => T,
+  onError?: (error: Error | unknown) => void
 ): UseQueryResult<T> => {
   const { axios, handleResponse } = useBackendAPI();
 
@@ -26,7 +27,7 @@ const useApplicationsQuery = <T = Application[]>(
         : undefined,
       staleTime: Infinity,
       retryDelay: 3000,
-      onError: useErrorHandler(),
+      onError: onError ?? useErrorHandler(),
     }
   );
 };

--- a/frontend/kesaseteli/employer/src/hooks/backend/useCompanyQuery.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useCompanyQuery.ts
@@ -10,6 +10,7 @@ const useCompanyQuery = (): UseQueryResult<Company> =>
     // The dashboard renders fine without it; organisationName will be undefined.
     onError: useErrorHandler({
       onServerError: () => {},
+      onAuthError: () => {},
     }),
   });
 

--- a/frontend/kesaseteli/employer/src/hooks/backend/useCompanyQuery.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useCompanyQuery.ts
@@ -9,7 +9,6 @@ const useCompanyQuery = (): UseQueryResult<Company> =>
     // Company name is supplemental — don't redirect to /500 or /login if it fails.
     // The dashboard renders fine without it; organisationName will be undefined.
     onError: useErrorHandler({
-      onAuthError: () => {},
       onServerError: () => {},
     }),
   });

--- a/frontend/kesaseteli/employer/src/hooks/backend/useLogout.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useLogout.ts
@@ -2,16 +2,28 @@ import ApplicationPersistenceService from 'kesaseteli/employer/services/Applicat
 import {
   BackendEndpoint,
   getBackendUrl,
+  REDIRECT_FIELD_NAME,
 } from 'kesaseteli-shared/backend-api/backend-api';
 import { useRouter } from 'next/router';
 import React from 'react';
 
-const useLogout = (): (() => Promise<boolean>) => {
+const useLogout = (): ((logoutRedirectPath?: string) => Promise<boolean>) => {
   const router = useRouter();
-  return React.useCallback(async () => {
-    ApplicationPersistenceService.clearAll();
-    return router.push(getBackendUrl(BackendEndpoint.LOGOUT));
-  }, [router]);
+  return React.useCallback(
+    async (logoutRedirectPath?: string) => {
+      ApplicationPersistenceService.clearAll();
+      const logoutUrl = getBackendUrl(BackendEndpoint.LOGOUT);
+      if (logoutRedirectPath) {
+        return router.push(
+          `${logoutUrl}?${REDIRECT_FIELD_NAME}=${encodeURIComponent(
+            logoutRedirectPath
+          )}`
+        );
+      }
+      return router.push(logoutUrl);
+    },
+    [router]
+  );
 };
 
 export default useLogout;

--- a/frontend/kesaseteli/employer/src/pages/application.tsx
+++ b/frontend/kesaseteli/employer/src/pages/application.tsx
@@ -2,10 +2,10 @@ import Step1EmployerAndEmployment from 'kesaseteli/employer/components/applicati
 import Step2Summary from 'kesaseteli/employer/components/application/steps/step2/Step2Summary';
 import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
 import useStepStorage from 'kesaseteli/employer/hooks/wizard/useStepStorage';
+import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
 import { GetStaticProps, NextPage } from 'next';
 import * as React from 'react';
 import ApplicationWizard from 'shared/components/application-wizard/ApplicationWizard';
-import withAuth from 'shared/components/hocs/withAuth';
 import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
 import useGoToPage from 'shared/hooks/useGoToPage';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
@@ -39,4 +39,4 @@ const ApplicationPage: NextPage = () => {
 export const getStaticProps: GetStaticProps =
   getServerSideTranslations('common');
 
-export default withAuth(ApplicationPage);
+export default withEmployerAuth(ApplicationPage);

--- a/frontend/kesaseteli/employer/src/pages/index.tsx
+++ b/frontend/kesaseteli/employer/src/pages/index.tsx
@@ -1,49 +1,23 @@
 import Dashboard from 'kesaseteli/employer/components/dashboard/Dashboard';
 import useApplicationsQuery from 'kesaseteli/employer/hooks/backend/useApplicationsQuery';
 import useCompanyQuery from 'kesaseteli/employer/hooks/backend/useCompanyQuery';
-import useLogout from 'kesaseteli/employer/hooks/backend/useLogout';
+import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
 import { DashboardVoucher } from 'kesaseteli/employer/types/types';
 import { GetStaticProps, NextPage } from 'next';
-import { useRouter } from 'next/router';
 import React from 'react';
-import withAuth from 'shared/components/hocs/withAuth';
 import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
-import useLocale from 'shared/hooks/useLocale';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
-import { isError } from 'shared/utils/type-guards';
 
 const EmployerIndex: NextPage = () => {
   const [showOnlyMine, setShowOnlyMine] = React.useState(false);
-  const router = useRouter();
-  const locale = useLocale();
-  const logout = useLogout();
 
   const {
     data: applications,
     isLoading,
     error,
-  } = useApplicationsQuery(showOnlyMine, undefined, () => {});
+  } = useApplicationsQuery(showOnlyMine);
 
-  const {
-    data: company,
-    isSuccess: isCompanySuccess,
-    error: companyError,
-  } = useCompanyQuery();
-
-  React.useEffect(() => {
-    const isForbidden = (err: unknown): boolean =>
-      isError(err) &&
-      (err.message.includes('403') || err.message.includes('Forbidden'));
-
-    // If user is logged in but company data has no name, they are not authorized to act on behalf of any organization.
-    if (isCompanySuccess && !company?.name) {
-      void logout(`/${locale}/no-organisation`);
-    } else if (isForbidden(error) || isForbidden(companyError)) {
-      void logout(`/${locale}/no-organisation`);
-    } else if (error || companyError) {
-      void router.push(`/${locale}/500`, undefined, { shallow: false });
-    }
-  }, [company, isCompanySuccess, error, companyError, logout, locale, router]);
+  const { data: company } = useCompanyQuery();
 
   if (isLoading || error || !applications) {
     return <PageLoadingSpinner />;
@@ -85,4 +59,4 @@ const EmployerIndex: NextPage = () => {
 export const getStaticProps: GetStaticProps =
   getServerSideTranslations('common');
 
-export default withAuth(EmployerIndex);
+export default withEmployerAuth(EmployerIndex);

--- a/frontend/kesaseteli/employer/src/pages/index.tsx
+++ b/frontend/kesaseteli/employer/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import Dashboard from 'kesaseteli/employer/components/dashboard/Dashboard';
 import useApplicationsQuery from 'kesaseteli/employer/hooks/backend/useApplicationsQuery';
 import useCompanyQuery from 'kesaseteli/employer/hooks/backend/useCompanyQuery';
+import useLogout from 'kesaseteli/employer/hooks/backend/useLogout';
 import { DashboardVoucher } from 'kesaseteli/employer/types/types';
 import { GetStaticProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
@@ -9,23 +10,40 @@ import withAuth from 'shared/components/hocs/withAuth';
 import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
 import useLocale from 'shared/hooks/useLocale';
 import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+import { isError } from 'shared/utils/type-guards';
 
 const EmployerIndex: NextPage = () => {
   const [showOnlyMine, setShowOnlyMine] = React.useState(false);
+  const router = useRouter();
+  const locale = useLocale();
+  const logout = useLogout();
+
   const {
     data: applications,
     isLoading,
     error,
-  } = useApplicationsQuery(showOnlyMine);
-  const { data: company } = useCompanyQuery();
-  const router = useRouter();
-  const locale = useLocale();
+  } = useApplicationsQuery(showOnlyMine, undefined, () => {});
+
+  const {
+    data: company,
+    isSuccess: isCompanySuccess,
+    error: companyError,
+  } = useCompanyQuery();
 
   React.useEffect(() => {
-    if (error) {
+    const isForbidden = (err: unknown): boolean =>
+      isError(err) &&
+      (err.message.includes('403') || err.message.includes('Forbidden'));
+
+    // If user is logged in but company data has no name, they are not authorized to act on behalf of any organization.
+    if (isCompanySuccess && !company?.name) {
+      void logout(`/${locale}/no-organisation`);
+    } else if (isForbidden(error) || isForbidden(companyError)) {
+      void logout(`/${locale}/no-organisation`);
+    } else if (error || companyError) {
       void router.push(`/${locale}/500`, undefined, { shallow: false });
     }
-  }, [error, router, locale]);
+  }, [company, isCompanySuccess, error, companyError, logout, locale, router]);
 
   if (isLoading || error || !applications) {
     return <PageLoadingSpinner />;

--- a/frontend/kesaseteli/employer/src/pages/no-organisation.tsx
+++ b/frontend/kesaseteli/employer/src/pages/no-organisation.tsx
@@ -1,5 +1,5 @@
-import { Button, IconSignin } from 'hds-react';
-import useLogin from 'kesaseteli/employer/hooks/backend/useLogin';
+import { Button, IconSignout } from 'hds-react';
+import useLogout from 'kesaseteli/employer/hooks/backend/useLogout';
 import { GetStaticProps, NextPage } from 'next';
 import Head from 'next/head';
 import { Trans, useTranslation } from 'next-i18next';
@@ -11,7 +11,11 @@ import getServerSideTranslations from 'shared/i18n/get-server-side-translations'
 
 const NoOrganisation: NextPage = () => {
   const { t } = useTranslation();
-  const login = useLogin();
+  const logout = useLogout();
+
+  const onLogout = (): void => {
+    void logout();
+  };
 
   return (
     <Container>
@@ -40,8 +44,8 @@ const NoOrganisation: NextPage = () => {
           />
         </p>
       </$Notification>
-      <Button theme="coat" iconLeft={<IconSignin />} onClick={login}>
-        {t('common:noOrganisationPage.loginButton')}
+      <Button theme="coat" iconLeft={<IconSignout />} onClick={onLogout}>
+        {t('common:noOrganisationPage.logoutButton')}
       </Button>
     </Container>
   );

--- a/frontend/kesaseteli/employer/src/pages/no-organisation.tsx
+++ b/frontend/kesaseteli/employer/src/pages/no-organisation.tsx
@@ -1,0 +1,53 @@
+import { Button, IconSignin } from 'hds-react';
+import useLogin from 'kesaseteli/employer/hooks/backend/useLogin';
+import { GetStaticProps, NextPage } from 'next';
+import Head from 'next/head';
+import { Trans, useTranslation } from 'next-i18next';
+import React from 'react';
+import Container from 'shared/components/container/Container';
+import LinkText from 'shared/components/link-text/LinkText';
+import { $Notification } from 'shared/components/notification/Notification.sc';
+import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+
+const NoOrganisation: NextPage = () => {
+  const { t } = useTranslation();
+  const login = useLogin();
+
+  return (
+    <Container>
+      <Head>
+        <title>
+          {t('common:noOrganisationPage.title')} | {t('common:appName')}
+        </title>
+      </Head>
+      <$Notification
+        label={t('common:noOrganisationPage.header')}
+        type="error"
+        size="large"
+      >
+        <p>{t('common:noOrganisationPage.content')}</p>
+        <p>{t('common:noOrganisationPage.instructions')}</p>
+        <p>
+          <Trans
+            i18nKey="common:noOrganisationPage.linkText"
+            components={{
+              // href should get overridden (https://react.i18next.com/latest/trans-component#overriding-react-component-props-v11.5.0),
+              // but for some reason it does not. However, the setter works, when href is left as unset.
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore ts(2741) link href and text will be set / overridden with values from translation.
+              lnk: <LinkText />,
+            }}
+          />
+        </p>
+      </$Notification>
+      <Button theme="coat" iconLeft={<IconSignin />} onClick={login}>
+        {t('common:noOrganisationPage.loginButton')}
+      </Button>
+    </Container>
+  );
+};
+
+export const getStaticProps: GetStaticProps =
+  getServerSideTranslations('common');
+
+export default NoOrganisation;

--- a/frontend/kesaseteli/employer/src/pages/thankyou.tsx
+++ b/frontend/kesaseteli/employer/src/pages/thankyou.tsx
@@ -1,6 +1,7 @@
 import { Button, IconCheckCircleFill } from 'hds-react';
 import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
 import useCreateApplicationQuery from 'kesaseteli/employer/hooks/backend/useCreateApplicationQuery';
+import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
 import ApplicationPersistenceService from 'kesaseteli/employer/services/ApplicationPersistenceService';
 import { extractEmployerFields } from 'kesaseteli/employer/utils/application.utils';
 import { GetStaticProps, NextPage } from 'next';
@@ -9,7 +10,6 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 import { useQueryClient } from 'react-query';
 import Container from 'shared/components/container/Container';
-import withAuth from 'shared/components/hocs/withAuth';
 import { $Header, $Heading } from 'shared/components/layout/Layout.sc';
 import { $Notification } from 'shared/components/notification/Notification.sc';
 import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
@@ -97,7 +97,7 @@ const ThankYouPage: NextPage = () => {
           </title>
         </Head>
         <$Notification
-          label={t(`common:thankyouPage.thankyouMessageLabel`)}
+          label={t('common:thankyouPage.thankyouMessageLabel')}
           type="success"
           size="large"
         >
@@ -135,4 +135,4 @@ const ThankYouPage: NextPage = () => {
 export const getStaticProps: GetStaticProps =
   getServerSideTranslations('common');
 
-export default withAuth(ThankYouPage);
+export default withEmployerAuth(ThankYouPage);

--- a/frontend/kesaseteli/handler/public/locales/fi/common.json
+++ b/frontend/kesaseteli/handler/public/locales/fi/common.json
@@ -30,7 +30,7 @@
     "sessionExpiredLabel": "Käyttäjäsessio vanhentui. Kirjaudu uudelleen sisään",
     "infoLabel": "Palvelun käyttäminen edellyttää vahvaa tunnistautumista",
     "logoutInfoContent": "Sinut on kirjattu ulos. Jos haluat jatkaa asiointia palvelussa, kirjaudu uudelleen sisään klikkaamalla alla olevasta painikkeesta.",
-    "infoContent": "Jotta voit edetä palvelussa, sinun täytyy tunnistautua. Voit valita itse, mitä tunnistustapaa haluat käyttää. Tunnistustietosi kulkevat suojatussa yhteydessä. Klikkaa alla olevasta painikkeesta tunnistautuaksesi."
+    "infoContent": "Jotta voit edetä palvelussa, sinun täytyy tunnistautua. Tunnistustietosi kulkevat suojatussa yhteydessä. Klikkaa alla olevasta painikkeesta tunnistautuaksesi."
   },
   "403Page": {
     "forbiddenPageLabel": "Sinulla ei ole oikeuksia",


### PR DESCRIPTION
YJDH-840.

Add a new page to provide instructions what to do, when something went wrong on authorization to act behalf of an organisation.

Add a HOC to follow whether user has authenticated but does not represent any organisation. This means that user might not have been authorized to act behalf of an organisation or there has been some error in process.

Also, some updates to login translations.