### PR TITLE
YJDH-820 | Kesäseteli: Show more new auditlog fields in django admin

### DIFF
--- a/backend/kesaseteli/kesaseteli/admin.py
+++ b/backend/kesaseteli/kesaseteli/admin.py
@@ -1,3 +1,4 @@
+from auditlog.admin import LogEntry, LogEntryAdmin
 from auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
 from django.contrib import admin
 from django.contrib.auth import get_user_model
@@ -46,6 +47,21 @@ class KesaseteliGroupAdmin(AuditlogAdminViewAccessLogMixin, GroupAdmin):
     get_user_count.short_description = _("User count")
 
 
+class KesaseteliLogEntryAdmin(LogEntryAdmin):
+    _extra_detail_list_fields = ["additional_data", "content_type"]
+    _extra_detail_fields = _extra_detail_list_fields + [
+        "object_pk",
+        "remote_addr",
+        "actor_email",
+        "serialized_data",
+    ]
+    list_display = LogEntryAdmin.list_display + _extra_detail_list_fields
+    readonly_fields = LogEntryAdmin.readonly_fields + _extra_detail_fields
+    fieldsets = LogEntryAdmin.fieldsets + [
+        (_("Extra details"), {"fields": _extra_detail_fields})
+    ]
+
+
 if admin.site.is_registered(User):
     admin.site.unregister(User)
 admin.site.register(User, KesaseteliUserAdmin)
@@ -53,3 +69,7 @@ admin.site.register(User, KesaseteliUserAdmin)
 if admin.site.is_registered(Group):
     admin.site.unregister(Group)
 admin.site.register(Group, KesaseteliGroupAdmin)
+
+if admin.site.is_registered(LogEntry):
+    admin.site.unregister(LogEntry)
+admin.site.register(LogEntry, KesaseteliLogEntryAdmin)


### PR DESCRIPTION
## Description :sparkles:

### Kesäseteli: Show more new auditlog fields in django admin

Add more fields to be shown in Django admin for the new auditlogs to make viewing them through Django admin more useful.

## Related

[YJDH-820](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-820) (renewing auditlogging, took django-auditlog into use)

## Testing :alembic:

## Screenshots :camera_flash:

### List view after changes
<img width="2326" height="1271" alt="image" src="https://github.com/user-attachments/assets/eefd7b33-06ae-46ee-9627-83ca8dfee235" />

### Detail view after changes
<img width="1487" height="1317" alt="image" src="https://github.com/user-attachments/assets/16bd98b9-0c9e-4fb0-9102-3b864373f1c4" />

## Additional notes :spiral_notepad:


[YJDH-820]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ