### PR TITLE
fix(ks,employer): infinite loop when adfs used

### DIFF
--- a/frontend/kesaseteli/employer/src/__tests__/application.test.tsx
+++ b/frontend/kesaseteli/employer/src/__tests__/application.test.tsx
@@ -38,7 +38,7 @@ describe('frontend/kesaseteli/employer/src/pages/application.tsx', () => {
       renderPage(ApplicationPage, { push: spyPush });
       await waitFor(() =>
         expect(spyPush).toHaveBeenCalledWith(
-          `${DEFAULT_LANGUAGE}/login?sessionExpired=true`,
+          `/${DEFAULT_LANGUAGE}/login?sessionExpired=true`,
           undefined,
           { shallow: false }
         )
@@ -55,7 +55,7 @@ describe('frontend/kesaseteli/employer/src/pages/application.tsx', () => {
         });
         await waitFor(() =>
           expect(spyReplace).toHaveBeenCalledWith(
-            `${DEFAULT_LANGUAGE}/`,
+            `/${DEFAULT_LANGUAGE}/`,
             undefined,
             { shallow: false }
           )
@@ -72,7 +72,7 @@ describe('frontend/kesaseteli/employer/src/pages/application.tsx', () => {
           locale,
         });
         await waitFor(() =>
-          expect(spyReplace).toHaveBeenCalledWith(`${locale}/`, undefined, {
+          expect(spyReplace).toHaveBeenCalledWith(`/${locale}/`, undefined, {
             shallow: false,
           })
         );
@@ -86,7 +86,7 @@ describe('frontend/kesaseteli/employer/src/pages/application.tsx', () => {
           renderPage(ApplicationPage, { query: { id }, push: spyPush });
           await waitFor(() => {
             expect(spyPush).toHaveBeenCalledWith(
-              `${DEFAULT_LANGUAGE}/500`,
+              `/${DEFAULT_LANGUAGE}/500`,
               undefined,
               { shallow: false }
             );
@@ -209,32 +209,40 @@ describe('frontend/kesaseteli/employer/src/pages/application.tsx', () => {
           SLOW_JEST_TIMEOUT
         );
 
-        it('can traverse between wizard steps', async () => {
-          expectAuthorizedReply();
-          expectToGetApplicationFromBackend(application);
-          renderPage(ApplicationPage, { query: { id } });
-          const applicationPage = getApplicationPageApi(application);
-          await applicationPage.step1.expectations.stepIsLoaded();
-          await applicationPage.step1.actions.clickNextButton();
-          await applicationPage.step2.expectations.stepIsLoaded();
-          await applicationPage.step2.actions.clickPreviousButton();
-          await applicationPage.step1.expectations.stepIsLoaded();
-        }, SLOW_JEST_TIMEOUT);
+        it(
+          'can traverse between wizard steps',
+          async () => {
+            expectAuthorizedReply();
+            expectToGetApplicationFromBackend(application);
+            renderPage(ApplicationPage, { query: { id } });
+            const applicationPage = getApplicationPageApi(application);
+            await applicationPage.step1.expectations.stepIsLoaded();
+            await applicationPage.step1.actions.clickNextButton();
+            await applicationPage.step2.expectations.stepIsLoaded();
+            await applicationPage.step2.actions.clickPreviousButton();
+            await applicationPage.step1.expectations.stepIsLoaded();
+          },
+          SLOW_JEST_TIMEOUT
+        );
 
-        it('saves application when next button is clicked in step 2', async () => {
-          expectAuthorizedReply();
-          expectToGetApplicationFromBackend(application);
-          renderPage(ApplicationPage, { query: { id } });
-          const applicationPage = getApplicationPageApi(application);
-          await applicationPage.step1.expectations.stepIsLoaded();
-          await applicationPage.step1.actions.clickNextButton();
-          await applicationPage.step2.expectations.stepIsLoaded();
+        it(
+          'saves application when next button is clicked in step 2',
+          async () => {
+            expectAuthorizedReply();
+            expectToGetApplicationFromBackend(application);
+            renderPage(ApplicationPage, { query: { id } });
+            const applicationPage = getApplicationPageApi(application);
+            await applicationPage.step1.expectations.stepIsLoaded();
+            await applicationPage.step1.actions.clickNextButton();
+            await applicationPage.step2.expectations.stepIsLoaded();
 
-          await applicationPage.step2.actions.toggleTermsAndConditions();
-          applicationPage.step2.expectations.nextButtonIsEnabled();
+            await applicationPage.step2.actions.toggleTermsAndConditions();
+            applicationPage.step2.expectations.nextButtonIsEnabled();
 
-          await applicationPage.step2.actions.clickNextButtonAndExpectToSaveApplication();
-        }, SLOW_JEST_TIMEOUT);
+            await applicationPage.step2.actions.clickNextButtonAndExpectToSaveApplication();
+          },
+          SLOW_JEST_TIMEOUT
+        );
       });
     });
   });

--- a/frontend/kesaseteli/employer/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/employer/src/__tests__/index.test.tsx
@@ -32,7 +32,7 @@ describe('frontend/kesaseteli/employer/src/pages/index.tsx', () => {
     await waitFor(
       () =>
         expect(spyPush).toHaveBeenCalledWith(
-          `${DEFAULT_LANGUAGE}/login`,
+          `/${DEFAULT_LANGUAGE}/login`,
           undefined,
           {
             shallow: false,
@@ -52,7 +52,7 @@ describe('frontend/kesaseteli/employer/src/pages/index.tsx', () => {
       await waitFor(
         () =>
           expect(spyPush).toHaveBeenCalledWith(
-            `${DEFAULT_LANGUAGE}/500`,
+            `/${DEFAULT_LANGUAGE}/500`,
             undefined,
             { shallow: false }
           ),

--- a/frontend/kesaseteli/employer/src/hocs/__tests__/withOrganisation.test.tsx
+++ b/frontend/kesaseteli/employer/src/hocs/__tests__/withOrganisation.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
+import withOrganisation from '../withOrganisation';
+import useAuth from 'shared/hooks/useAuth';
+import useGoToPage from 'shared/hooks/useGoToPage';
+import useCompanyQuery from 'kesaseteli/employer/hooks/backend/useCompanyQuery';
+
+jest.mock('shared/hooks/useAuth', () => jest.fn());
+jest.mock('shared/hooks/useGoToPage', () => jest.fn());
+jest.mock('kesaseteli/employer/hooks/backend/useCompanyQuery', () => jest.fn());
+
+describe('withOrganisation', () => {
+  const MockComponent = () => <div>Mock Component</div>;
+  const WrappedComponent = withOrganisation(MockComponent);
+  const mockGoToPage = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useGoToPage as jest.Mock).mockReturnValue(mockGoToPage);
+    (useAuth as jest.Mock).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    });
+  });
+
+  it('should redirect to /no-organisation when user gets 403 Forbidden and is NOT on /no-organisation', () => {
+    const mockError = new Error('403 Forbidden');
+    (useCompanyQuery as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isSuccess: false,
+      error: mockError,
+    });
+    renderComponent(<WrappedComponent />, { pathname: '/' });
+
+    expect(mockGoToPage).toHaveBeenCalledWith('/no-organisation');
+  });
+
+  it('should NOT redirect to /no-organisation when user gets 403 Forbidden and is ALREADY on /no-organisation', () => {
+    // This test reproduces the fix for the infinite loop issue.
+    // Without the fix, the component would keep calling goToPage('/no-organisation')
+    // even when already on the /no-organisation page, causing an infinite loop.
+    const mockError = new Error('403 Forbidden');
+    (useCompanyQuery as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isSuccess: false,
+      error: mockError,
+    });
+    renderComponent(<WrappedComponent />, { pathname: '/no-organisation' });
+
+    expect(mockGoToPage).not.toHaveBeenCalled();
+  });
+
+  it('should redirect to /no-organisation when company has no name and is NOT on /no-organisation', () => {
+    (useCompanyQuery as jest.Mock).mockReturnValue({
+      data: { name: '' },
+      isLoading: false,
+      isSuccess: true,
+      error: null,
+    });
+    renderComponent(<WrappedComponent />, { pathname: '/' });
+
+    expect(mockGoToPage).toHaveBeenCalledWith('/no-organisation');
+  });
+
+  it('should render the component when company has a name', () => {
+    (useCompanyQuery as jest.Mock).mockReturnValue({
+      data: { name: 'Valid Company Oy' },
+      isLoading: false,
+      isSuccess: true,
+      error: null,
+    });
+    const {
+      renderResult: { getByText },
+    } = renderComponent(<WrappedComponent />, { pathname: '/' });
+
+    expect(getByText('Mock Component')).toBeInTheDocument();
+    expect(mockGoToPage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/kesaseteli/employer/src/hocs/withOrganisation.tsx
+++ b/frontend/kesaseteli/employer/src/hocs/withOrganisation.tsx
@@ -1,6 +1,7 @@
 import useCompanyQuery from 'kesaseteli/employer/hooks/backend/useCompanyQuery';
 import React from 'react';
 import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
+import { useRouter } from 'next/router';
 import useAuth from 'shared/hooks/useAuth';
 import useGoToPage from 'shared/hooks/useGoToPage';
 import { isError } from 'shared/utils/type-guards';
@@ -16,6 +17,7 @@ const withOrganisation = <P extends JSX.IntrinsicAttributes>(
     const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
     const goToPage = useGoToPage();
 
+    const router = useRouter();
     const {
       data: company,
       isLoading: isCompanyLoading,
@@ -35,7 +37,8 @@ const withOrganisation = <P extends JSX.IntrinsicAttributes>(
       if (
         isAuthenticated &&
         !isCompanyLoading &&
-        (isNoOrganisation || isAuthError)
+        (isNoOrganisation || isAuthError) &&
+        router.pathname !== '/no-organisation'
       ) {
         void goToPage('/no-organisation');
       }
@@ -45,6 +48,7 @@ const withOrganisation = <P extends JSX.IntrinsicAttributes>(
       isNoOrganisation,
       isAuthError,
       goToPage,
+      router.pathname,
     ]);
 
     // Show loading spinner while determining status

--- a/frontend/kesaseteli/employer/src/hooks/backend/useUserQuery.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useUserQuery.ts
@@ -21,6 +21,14 @@ const useUserQuery = <T = User>({
     enabled: !!enabled && !isRouting,
     onError: useErrorHandler({
       onServerError: () => goToPage('/login?error=true'),
+      onAuthError: () => {
+        if (
+          !window.location.pathname.includes('/login') &&
+          !window.location.pathname.includes('/no-organisation')
+        ) {
+          goToPage('/login?sessionExpired=true');
+        }
+      },
     }),
     select,
     refetchInterval,

--- a/frontend/shared/src/hooks/useGoToPage.ts
+++ b/frontend/shared/src/hooks/useGoToPage.ts
@@ -9,15 +9,23 @@ const useGoToPage = (): GoToPageFunction => {
   const locale = useLocale();
   const isAlreadyRouting = useIsRouting();
   return React.useCallback(
-    (pagePath, operation = 'push'): void => {
-      // if already routing, or we're trying to route to same path (including query params), do nothing
-      if (isAlreadyRouting || pagePath === router.asPath) {
-        return;
-      }
-      const path = `${locale}${pagePath || '/'}`;
-      // use shallow route when we are already on the same path (ignoring query params)
-      const shallow = pagePath === router.pathname;
-      void router[operation](path, undefined, { shallow });
+    (pagePath = '/', operation = 'push'): void => {
+      if (isAlreadyRouting) return;
+
+      // Ensure the path starts with a slash for consistent comparison and routing
+      const normalizedPath = pagePath.startsWith('/')
+        ? pagePath
+        : `/${pagePath}`;
+
+      // Guard: Don't route if we are already on the same path (including query params)
+      if (normalizedPath === router.asPath) return;
+
+      // Use shallow routing if only query parameters change (base path is the same)
+      const isSamePage = normalizedPath.split('?')[0] === router.pathname;
+
+      void router[operation](`/${locale}${normalizedPath}`, undefined, {
+        shallow: isSamePage,
+      });
     },
     [locale, router, isAlreadyRouting]
   );


### PR DESCRIPTION
YJDH-840.

In Employer UI the user should use SuomiFI auth, but if he is using SSO and ADFS instead, he might end up in infinite loop of error messages. This commit fixes the situation.
