### PR TITLE
YJDH-869 | Kesäseteli: Change "nuorten.helsinki" to "nuorten.hel.fi"

### DIFF
--- a/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
@@ -767,9 +767,9 @@ msgstr ""
 "employer pays normal employer’s contributions, holiday compensation and if "
 "needed evening etc supplements."
 
-msgid "https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/nuorelle/"
+msgid "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/nuorelle/"
 msgstr ""
-"https://nuorten.helsinki/en/studies-and-work/the-summer-job-voucher/for-"
+"https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/for-"
 "summer-job-seekers/"
 
 msgid "Lue lisää"
@@ -796,19 +796,19 @@ msgstr ""
 msgid "Muut käyttöehdot voit lukea täältä:"
 msgstr "Other terms of use can be read here:"
 
-msgid "https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/"
+msgid "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/"
 msgstr ""
-"https://nuorten.helsinki/en/studies-and-work/the-summer-job-voucher/for-"
+"https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/for-"
 "employers/"
 
 msgid "Helsinki"
 msgstr "Helsinki"
 
-msgid "https://nuorten.helsinki/kesaseteli/"
-msgstr "https://nuorten.helsinki/studies-and-work/the-summer-job-voucher/"
+msgid "https://nuorten.hel.fi/kesaseteli/"
+msgstr "https://nuorten.hel.fi/studies-and-work/the-summer-job-voucher/"
 
-msgid "nuorten.helsinki/kesaseteli/"
-msgstr "nuorten.helsinki/studies-and-work/the-summer-job-voucher/"
+msgid "nuorten.hel.fi/kesaseteli/"
+msgstr "nuorten.hel.fi/studies-and-work/the-summer-job-voucher/"
 
 msgid "Ei uusia käsittelemättömiä hakemuksia."
 msgstr ""

--- a/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
@@ -738,7 +738,7 @@ msgid ""
 "normaalit työnantajamaksut, lomakorvauksen ja mahdolliset lisät."
 msgstr ""
 
-msgid "https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/nuorelle/"
+msgid "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/nuorelle/"
 msgstr ""
 
 msgid "Lue lisää"
@@ -759,16 +759,16 @@ msgstr ""
 msgid "Muut käyttöehdot voit lukea täältä:"
 msgstr ""
 
-msgid "https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/"
+msgid "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/"
 msgstr ""
 
 msgid "Helsinki"
 msgstr ""
 
-msgid "https://nuorten.helsinki/kesaseteli/"
+msgid "https://nuorten.hel.fi/kesaseteli/"
 msgstr ""
 
-msgid "nuorten.helsinki/kesaseteli/"
+msgid "nuorten.hel.fi/kesaseteli/"
 msgstr ""
 
 msgid "Ei uusia käsittelemättömiä hakemuksia."

--- a/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
@@ -764,9 +764,9 @@ msgstr ""
 "förutsätter en högre lön. Dessutom betalar arbetsgivaren normala "
 "arbetsgivaravgifter, semesterersättning och möjliga andra tillägg."
 
-msgid "https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/nuorelle/"
+msgid "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/nuorelle/"
 msgstr ""
-"https://nuorten.helsinki/sv/studier-och-jobb/sommarsedeln/kesatyonhakijalle/"
+"https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/kesatyonhakijalle/"
 
 msgid "Lue lisää"
 msgstr "Läs mer"
@@ -792,18 +792,18 @@ msgstr ""
 msgid "Muut käyttöehdot voit lukea täältä:"
 msgstr "Anda användarvillkor kan läsas här:"
 
-msgid "https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/"
+msgid "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/"
 msgstr ""
-"https://nuorten.helsinki/sv/studier-och-jobb/sommarsedeln/at-arbetsgivaren/"
+"https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/at-arbetsgivaren/"
 
 msgid "Helsinki"
 msgstr "Helsingfors"
 
-msgid "https://nuorten.helsinki/kesaseteli/"
-msgstr "https://nuorten.helsinki/sommarsedeln/"
+msgid "https://nuorten.hel.fi/kesaseteli/"
+msgstr "https://nuorten.hel.fi/sommarsedeln/"
 
-msgid "nuorten.helsinki/kesaseteli/"
-msgstr "nuorten.helsinki/sommarsedeln/"
+msgid "nuorten.hel.fi/kesaseteli/"
+msgstr "nuorten.hel.fi/sommarsedeln/"
 
 msgid "Ei uusia käsittelemättömiä hakemuksia."
 msgstr ""

--- a/backend/kesaseteli/applications/templates/email/youth_summer_voucher_email_en.html
+++ b/backend/kesaseteli/applications/templates/email/youth_summer_voucher_email_en.html
@@ -59,27 +59,27 @@ Your {{ year }} Summer Job Voucher
                 <p>
                     <strong>Working days and pay:</strong>
                 <ul>
-                    <li>Minimum requirement is {{ min_work_hours }} hours for minimum of {{ min_work_compensation_with_euro_sign }} 
+                    <li>Minimum requirement is {{ min_work_hours }} hours for minimum of {{ min_work_compensation_with_euro_sign }}
                         (for {{ min_work_hours }} working hours) salary if not
                         the collective agreement state otherwise. On that the employer pays normal employer’s
                         contributions, holiday compensation and if needed evening etc supplements.</li>
                 </ul>
                 </p>
                 <p>
-                    <a href="https://nuorten.helsinki/en/studies-and-work/the-summer-job-voucher/for-summer-job-seekers/"
+                    <a href="https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/for-summer-job-seekers/"
                         style="color:#3675e5;text-decoration:underline">Read more</a>
                 </p>
                 <hr />
                 <h2>Instructions for employers</h2>
                 <p>
                     The City of Helsinki will provide a reimbursement of {{ voucher_value_with_euro_sign }} to each
-                    employer who employed a young person with the summer job voucher between {{ summer_job_period_localized_string }}. 
-                    The reimbursement has to be applied before {{ employer_summer_voucher_application_end_date_localized_string }} 
+                    employer who employed a young person with the summer job voucher between {{ summer_job_period_localized_string }}.
+                    The reimbursement has to be applied before {{ employer_summer_voucher_application_end_date_localized_string }}
                     from the link found at the Summer Job Voucher´s webpage.
                 </p>
                 <p>
                     Other terms of use can be read here:
-                    <a href="https://nuorten.helsinki/en/studies-and-work/the-summer-job-voucher/for-employers/"
+                    <a href="https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/for-employers/"
                         style="color:#3675e5;text-decoration:underline">Read more</a>
                 </p>
                 <hr />
@@ -91,8 +91,8 @@ Your {{ year }} Summer Job Voucher
                 <img alt="Helsinki" src="cid:helsinki_logo">
             </td>
             <td style="text-align:right;margin-left:0">
-                <a href="https://nuorten.helsinki/en/studies-and-work/the-summer-job-voucher/"
-                    style="color:#191919;text-decoration:underline">nuorten.helsinki/en/studies-and-work/the-summer-job-voucher/</a>
+                <a href="https://nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/"
+                    style="color:#191919;text-decoration:underline">nuorten.hel.fi/en/studies-and-work/the-summer-job-voucher/</a>
             </td>
         </tr>
     </table>

--- a/backend/kesaseteli/applications/templates/email/youth_summer_voucher_email_fi.html
+++ b/backend/kesaseteli/applications/templates/email/youth_summer_voucher_email_fi.html
@@ -56,7 +56,7 @@ Vuoden {{ year }} Kesäsetelisi
                         </ul>
                     </p>
                     <p>
-                        <a href="https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/nuorelle/" style="color:#3675e5;text-decoration:underline">Lue lisää</a>
+                        <a href="https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/nuorelle/" style="color:#3675e5;text-decoration:underline">Lue lisää</a>
                     </p>
                     <hr/>
                     <h2>Ohjeita työnantajalle</h2>
@@ -65,7 +65,7 @@ Vuoden {{ year }} Kesäsetelisi
                     </p>
                     <p>
                         Muut käyttöehdot voit lukea täältä:
-                        <a href="https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/" style="color:#3675e5;text-decoration:underline">Lue lisää</a>
+                        <a href="https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/tyonantajalle-2/" style="color:#3675e5;text-decoration:underline">Lue lisää</a>
                     </p>
                     <hr/>
                 </td>
@@ -76,7 +76,7 @@ Vuoden {{ year }} Kesäsetelisi
                     <img alt="Helsinki" src="cid:helsinki_logo">
                 </td>
                 <td style="text-align:right;margin-left:0">
-                    <a href="https://nuorten.helsinki/kesaseteli/" style="color:#191919;text-decoration:underline">nuorten.helsinki/kesaseteli/</a>
+                    <a href="https://nuorten.hel.fi/kesaseteli/" style="color:#191919;text-decoration:underline">nuorten.hel.fi/kesaseteli/</a>
                 </td>
             </tr>
         </table>

--- a/backend/kesaseteli/applications/templates/email/youth_summer_voucher_email_sv.html
+++ b/backend/kesaseteli/applications/templates/email/youth_summer_voucher_email_sv.html
@@ -66,7 +66,7 @@ Din Sommarsedel {{ year }}
                 </ul>
                 </p>
                 <p>
-                    <a href="https://nuorten.helsinki/sv/studier-och-jobb/sommarsedeln/kesatyonhakijalle/"
+                    <a href="https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/kesatyonhakijalle/"
                         style="color:#3675e5;text-decoration:underline">Läs mer</a>
                 </p>
                 <hr />
@@ -78,7 +78,7 @@ Din Sommarsedel {{ year }}
                 </p>
                 <p>
                     Anda användarvillkor kan läsas här:
-                    <a href="https://nuorten.helsinki/sv/studier-och-jobb/sommarsedeln/at-arbetsgivaren/"
+                    <a href="https://nuorten.hel.fi/sv/studier-och-jobb/sommarsedeln/at-arbetsgivaren/"
                         style="color:#3675e5;text-decoration:underline">Läs mer</a>
                 </p>
                 <hr />
@@ -90,8 +90,8 @@ Din Sommarsedel {{ year }}
                 <img alt="Helsingfors" src="cid:helsinki_logo">
             </td>
             <td style="text-align:right;margin-left:0">
-                <a href="https://nuorten.helsinki/sommarsedeln/"
-                    style="color:#191919;text-decoration:underline">nuorten.helsinki/sommarsedeln/</a>
+                <a href="https://nuorten.hel.fi/sommarsedeln/"
+                    style="color:#191919;text-decoration:underline">nuorten.hel.fi/sommarsedeln/</a>
             </td>
         </tr>
     </table>

--- a/backend/kesaseteli/docs/kesaseteli-endpoints.md
+++ b/backend/kesaseteli/docs/kesaseteli-endpoints.md
@@ -30,7 +30,6 @@ Youths use this UI to make a summer voucher application.
     * 🛜 DNS alias: https://nuortenkesaseteli.stage.hel.ninja/
 * **PROD:** https://kesaseteli-youth-ui-prod.apps.platta.hel.fi
     * 🛜 DNS alias: https://nuortenkesaseteli.hel.fi
-    * Redirect from: https://nuorten.helsinki/kesaseteli/kesasetelihakemus
 
 
 ### City employee frontend
@@ -77,9 +76,9 @@ Current redirect URI configuration for ADFS:
 - ✅ 🛜 https://kesaseteli.api.hel.fi/oauth2/callback
 - ✅ https://yjdh-kesaseteli-api-prod.apps.platta.hel.fi/oauth2/callback
 - ✅ https://yjdh-kesaseteli-api-test.agw.arodevtest.hel.fi/oauth2/callback
-- ✅ http://localhost:8000/oauth2/callback 
+- ✅ http://localhost:8000/oauth2/callback
     - **NOTE: There could be another port configured for local development too, e.g. 8080 or 8081.**
-- ⛔️ https://yjdh-kesaseteli-api-dev.agw.arodevtest.hel.fi/oauth2/callback 
+- ⛔️ https://yjdh-kesaseteli-api-dev.agw.arodevtest.hel.fi/oauth2/callback
     - **WARNING: No such domain.**
 
 What there should be in ADFS redirect URI configuration (status on 2026-01-26):
@@ -88,7 +87,7 @@ What there should be in ADFS redirect URI configuration (status on 2026-01-26):
 - ✅ 🛜 https://kesaseteli.api.hel.fi/oauth2/callback
 - ✅ https://yjdh-kesaseteli-api-prod.apps.platta.hel.fi/oauth2/callback
 - ✅ https://yjdh-kesaseteli-api-test.agw.arodevtest.hel.fi/oauth2/callback
-- ✅ http://localhost:8000/oauth2/callback 
+- ✅ http://localhost:8000/oauth2/callback
 - 🆕 http://localhost:8080/oauth2/callback
 - 🆕 http://localhost:8081/oauth2/callback
 - 🆕 https://yjdh-kesaseteli-api-dev.agw.arodevtest.hel.fi/oauth2/callback

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -601,7 +601,7 @@ SAML_CONFIG = {
                 ],
                 "information_url": [
                     {
-                        "text": "https://nuorten.helsinki/opiskelu-ja-tyo/kesaseteli/",
+                        "text": "https://nuorten.hel.fi/opiskelu-ja-tyo/kesaseteli/",
                         "lang": "fi",
                     },
                     {


### PR DESCRIPTION
## Description :sparkles:

### Kesäseteli: Change "nuorten.helsinki" to "nuorten.hel.fi"

Remove broken redirect mentioned in kesaseteli-endpoints.md:
https://nuorten.helsinki/kesaseteli/kesasetelihakemus does not redirect correctly anywhere.

The pre-commit hooks wanted to trim trailing whitespace etc,
so some of the changes are because of this.

## Related

- [YJDH-742](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-742) 433f064169250a15bae3ec9ffafe71d946dc0577 did similar
- [YJDH-869](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-869) Rest of the changes to nuorten.hel.fi

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-742]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[YJDH-869]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ