### PR TITLE
YJDH-870 | Kesäseteli: Show "is up to date" info for email templates in Django admin

### DIFF
--- a/backend/kesaseteli/applications/admin.py
+++ b/backend/kesaseteli/applications/admin.py
@@ -192,17 +192,24 @@ class SchoolAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
 
 
 class EmailTemplateAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
-    list_display = ["type", "language", "subject", "modified_at"]
+    list_display = ["type", "language", "subject", "modified_at", "is_up_to_date"]
     list_filter = ["type", "language"]
     search_fields = ["subject", "html_body", "text_body"]
     readonly_fields = [
         "text_body",
         "created_at",
         "modified_at",
+        "is_up_to_date",
     ]
     actions = ["reinitialize_from_file", "send_to_me"]
     change_list_template = "admin/applications/emailtemplate/change_list.html"
     change_form_template = "admin/applications/emailtemplate/change_form.html"
+
+    def is_up_to_date(self, obj: EmailTemplate):
+        return EmailTemplateService.is_template_up_to_date(obj)
+
+    is_up_to_date.boolean = True  # i.e. True/False icon
+    is_up_to_date.short_description = _("Is up to date with source file?")
 
     def get_urls(self):
         urls = super().get_urls()

--- a/backend/kesaseteli/applications/services.py
+++ b/backend/kesaseteli/applications/services.py
@@ -29,7 +29,7 @@ from applications.tests.data.mock_vtj import (
     mock_vtj_person_id_query_not_found_content,
     mock_vtj_person_id_query_restricted_content,
 )
-from common.utils import are_same_texts, send_mail_with_error_logging
+from common.utils import are_same_texts, html_to_text, send_mail_with_error_logging
 from shared.vtj.vtj_client import VTJClient
 
 if TYPE_CHECKING:
@@ -76,10 +76,12 @@ class TargetGroupValidationService:
 
 class EmailTemplateService:
     @staticmethod
-    def reinitialize_from_file(template: EmailTemplate) -> bool:
+    def get_template_lines_from_file(template: EmailTemplate) -> list[str] | None:
         """
-        Reinitialize the EmailTemplate using Django's template loading system.
-        Avoids manual file IO by accessing the template source directly.
+        Get the lines of the template file corresponding to the given EmailTemplate.
+
+        :return List of lines of the template file corresponding to the given
+        EmailTemplate if the file is found and is valid, otherwise None.
         """
         template_path = f"email/{template.type}_email_{template.language}.html"
 
@@ -91,7 +93,7 @@ class EmailTemplateService:
             LOGGER.warning(
                 f"Template source not found or inaccessible: {template_path}"
             )
-            return False
+            return None
 
         lines = content.splitlines()
         if len(lines) < 3:
@@ -99,6 +101,42 @@ class EmailTemplateService:
                 f"Template file {template_path} is missing required lines "
                 "(Subject + Body)"
             )
+            return None
+
+        return lines
+
+    @staticmethod
+    def is_template_up_to_date(template: EmailTemplate) -> bool:
+        """
+        Check if the EmailTemplate content matches the corresponding template file.
+
+        :return: True if the content does match, False if it does not or the input file
+        is missing or invalid.
+        """
+        lines = EmailTemplateService.get_template_lines_from_file(template)
+        if lines is None:
+            return False
+
+        expected_subject = lines[0].strip()
+        expected_html_body_lines = lines[2:]
+        expected_text_body = html_to_text("\n".join(expected_html_body_lines))
+
+        return (
+            template.subject == expected_subject
+            and template.html_body.splitlines() == expected_html_body_lines
+            and template.text_body == expected_text_body
+        )
+
+    @staticmethod
+    def reinitialize_from_file(template: EmailTemplate) -> bool:
+        """
+        Reinitialize the EmailTemplate using Django's template loading system.
+        Avoids manual file IO by accessing the template source directly.
+
+        :return True if successful, False if input file is missing or invalid.
+        """
+        lines = EmailTemplateService.get_template_lines_from_file(template)
+        if lines is None:
             return False
 
         # Parse: Line 0 = Subject, Line 1 = Empty Separator, Line 2+ = Body

--- a/backend/kesaseteli/applications/tests/test_services.py
+++ b/backend/kesaseteli/applications/tests/test_services.py
@@ -82,3 +82,212 @@ def test_ensure_templates_exist(mock_reinitialize):
     assert count == expected_count
     assert EmailTemplate.objects.count() == expected_count
     assert mock_reinitialize.call_count == expected_count
+
+
+@mock.patch("applications.services.get_template")
+class TestGetTemplateLinesFromFile:
+    """
+    Tests for EmailTemplateService.get_template_lines_from_file.
+    """
+
+    def _mock_template(
+        self, template_type=EmailTemplateType.PROCESSING.value, language="fi"
+    ):
+        # Create a mock EmailTemplate object:
+        return mock.Mock(
+            spec=EmailTemplate,
+            type=template_type,
+            language=language,
+            subject="Old Subject",
+            html_body="Old HTML body",
+            text_body="Old text body",
+        )
+
+    def test_returns_none_when_file_not_found(self, mock_get_template):
+        mock_get_template.side_effect = TemplateDoesNotExist("not found")
+
+        assert (
+            EmailTemplateService.get_template_lines_from_file(self._mock_template())
+            is None
+        )
+
+    def test_returns_none_when_source_attribute_missing(self, mock_get_template):
+        mock_django_template = mock.Mock()
+        del mock_django_template.template.source  # Simulate missing source attribute
+        mock_get_template.return_value = mock_django_template
+
+        with pytest.raises(AttributeError):
+            _ = mock_django_template.template.source
+
+        assert (
+            EmailTemplateService.get_template_lines_from_file(self._mock_template())
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        "template_source", ["", "Subject", "Subject\n", "Subject\n\n"]
+    )
+    def test_returns_none_when_file_has_fewer_than_3_lines(
+        self, mock_get_template, template_source
+    ):
+        mock_django_template = mock.Mock()
+        mock_django_template.template.source = template_source
+        mock_get_template.return_value = mock_django_template
+
+        assert (
+            EmailTemplateService.get_template_lines_from_file(self._mock_template())
+            is None
+        )
+
+    def test_returns_all_lines_for_minimal_valid_file(self, mock_get_template):
+        # Exactly 3 lines: subject, separator, one body line
+        mock_django_template = mock.Mock()
+        mock_django_template.template.source = "Subject\n\n<p>Body</p>"
+        mock_get_template.return_value = mock_django_template
+
+        assert EmailTemplateService.get_template_lines_from_file(
+            self._mock_template()
+        ) == ["Subject", "", "<p>Body</p>"]
+
+    def test_returns_all_lines_for_multiline_body(self, mock_get_template):
+        mock_django_template = mock.Mock()
+        mock_django_template.template.source = (
+            "Subject\n\n<p>Line 1</p>\n<p>Line 2</p>\n<p>Line 3</p>"
+        )
+        mock_get_template.return_value = mock_django_template
+
+        assert EmailTemplateService.get_template_lines_from_file(
+            self._mock_template()
+        ) == [
+            "Subject",
+            "",
+            "<p>Line 1</p>",
+            "<p>Line 2</p>",
+            "<p>Line 3</p>",
+        ]
+
+    def test_uses_correct_path_from_type_and_language(self, mock_get_template):
+        mock_django_template = mock.Mock()
+        mock_django_template.template.source = "Subject\n\n<p>Body</p>"
+        mock_get_template.return_value = mock_django_template
+
+        EmailTemplateService.get_template_lines_from_file(
+            self._mock_template(
+                template_type=EmailTemplateType.ACTIVATION.value, language="sv"
+            )
+        )
+
+        mock_get_template.assert_called_once_with("email/activation_email_sv.html")
+
+
+@mock.patch("applications.services.EmailTemplateService.get_template_lines_from_file")
+class TestIsTemplateUpToDate:
+    """
+    Tests for EmailTemplateService.is_template_up_to_date.
+    """
+
+    def test_returns_false_when_lines_is_none(self, mock_get_template_lines_from_file):
+        """
+        Test that EmailTemplateService.is_template_up_to_date returns False when
+        EmailTemplateService.get_template_lines_from_file returns None.
+        """
+        mock_get_template_lines_from_file.return_value = None
+        assert (
+            EmailTemplateService.is_template_up_to_date(mock.Mock(spec=EmailTemplate))
+            is False
+        )
+
+    def test_returns_true_when_all_fields_match(
+        self, mock_get_template_lines_from_file
+    ):
+        mock_get_template_lines_from_file.return_value = [
+            "Subject",
+            "",
+            "<p>Hello world</p>",
+        ]
+
+        template = mock.Mock(spec=EmailTemplate)
+        template.subject = "Subject"
+        template.html_body = "<p>Hello world</p>"
+        template.text_body = "Hello world"
+
+        assert EmailTemplateService.is_template_up_to_date(template) is True
+
+    def test_returns_false_when_subject_differs(
+        self, mock_get_template_lines_from_file
+    ):
+        mock_get_template_lines_from_file.return_value = [
+            "Subject",
+            "",
+            "<p>Hello world</p>",
+        ]
+
+        template = mock.Mock(spec=EmailTemplate)
+        template.subject = "Different Subject"
+        template.html_body = "<p>Hello world</p>"
+        template.text_body = "Hello world"
+
+        assert EmailTemplateService.is_template_up_to_date(template) is False
+
+    def test_returns_false_when_only_html_body_differs(
+        self, mock_get_template_lines_from_file
+    ):
+        mock_get_template_lines_from_file.return_value = [
+            "Subject",
+            "",
+            "<p>Content from file</p>",
+        ]
+
+        template = mock.Mock(spec=EmailTemplate)
+        template.subject = "Subject"
+        template.html_body = "<p>Different content</p>"
+        template.text_body = "Content from file"
+
+        assert EmailTemplateService.is_template_up_to_date(template) is False
+
+    def test_returns_false_when_only_text_body_differs(
+        self, mock_get_template_lines_from_file
+    ):
+        mock_get_template_lines_from_file.return_value = [
+            "Subject",
+            "",
+            "<p>Hello world</p>",
+        ]
+
+        template = mock.Mock(spec=EmailTemplate)
+        template.subject = "Subject"
+        template.html_body = "<p>Hello world</p>"
+        template.text_body = "Different text body"
+
+        assert EmailTemplateService.is_template_up_to_date(template) is False
+
+    def test_strips_leading_trailing_whitespace_from_file_subject(
+        self, mock_get_template_lines_from_file
+    ):
+        mock_get_template_lines_from_file.return_value = [
+            "  Subject  ",
+            "",
+            "<p>Hello world</p>",
+        ]
+
+        template = mock.Mock(spec=EmailTemplate)
+        template.subject = "Subject"  # already stripped, should still match
+        template.html_body = "<p>Hello world</p>"
+        template.text_body = "Hello world"
+
+        assert EmailTemplateService.is_template_up_to_date(template) is True
+
+    def test_handles_multiline_html_body(self, mock_get_template_lines_from_file):
+        mock_get_template_lines_from_file.return_value = [
+            "Subject",
+            "",
+            "<p>First paragraph</p>",
+            "<p>Second paragraph</p>",
+        ]
+
+        template = mock.Mock(spec=EmailTemplate)
+        template.subject = "Subject"
+        template.html_body = "<p>First paragraph</p>\n<p>Second paragraph</p>"
+        template.text_body = "First paragraph\nSecond paragraph"
+
+        assert EmailTemplateService.is_template_up_to_date(template) is True


### PR DESCRIPTION
## Description :sparkles:

### Kesäseteli: Show "is up to date" info for email templates in Django admin

Shown in list and detail view for Django Admin's email templates.

## Related

[YJDH-870](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-870)

## Testing :alembic:

## Screenshots :camera_flash:

### Not all up to date (list view)

<img width="1899" height="961" alt="image" src="https://github.com/user-attachments/assets/136df467-9442-46f8-ae94-165cde92631b" />

### Not up to date (detail view)

<img width="1460" height="1215" alt="image" src="https://github.com/user-attachments/assets/10f23ee5-0d4f-4f29-b202-4b0c6b65826e" />

### All up to date (list view)

<img width="1898" height="1064" alt="image" src="https://github.com/user-attachments/assets/1d09fcd6-66ec-4b46-9e73-232124212650" />

### Up to date (detail view)

<img width="1472" height="1198" alt="image" src="https://github.com/user-attachments/assets/4d537374-a4ec-4cd5-bf38-61fb5ed929de" />

## Additional notes :spiral_notepad:


[YJDH-870]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ