### PR TITLE
YJDH-872 | Kesäseteli: Don't auditlog VTJ JSON fields

### DIFF
--- a/backend/kesaseteli/kesaseteli/auditlog_settings.py
+++ b/backend/kesaseteli/kesaseteli/auditlog_settings.py
@@ -41,7 +41,15 @@ AUDITLOG_INCLUDE_TRACKING_MODELS = (
     "applications.employersummervoucher",
     "applications.school",
     "applications.summervoucherconfiguration",
-    "applications.youthapplication",
+    {
+        "model": "applications.youthapplication",
+        "exclude_fields": [
+            # Remove VTJ JSON fields that don't bring much value to
+            # audit logging and contain a lot of personal data:
+            "encrypted_handler_vtj_json",
+            "encrypted_original_vtj_json",
+        ],
+    },
     "applications.youthsummervoucher",
     "auth.group",
     "auth.group_permissions",


### PR DESCRIPTION
## Description :sparkles:

Remove YouthApplication model's VTJ JSON fields from audit logging
as they don't bring much value to audit logging and they contain a lot
of personal data. The fields are:
 - `YouthApplication.encrypted_handler_vtj_json`
 - `YouthApplication.encrypted_original_vtj_json`

## Related

[YJDH-872](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-872)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-872]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ