### PR TITLE
Refactor employer and employment data persisting

### DIFF
--- a/frontend/kesaseteli/employer/DESIGN.md
+++ b/frontend/kesaseteli/employer/DESIGN.md
@@ -1,0 +1,80 @@
+# Kesäseteli Employer UI Design
+
+This document outlines the architecture and user flow for the Kesäseteli Employer application, specifically focusing on the Application Wizard and the data persistence lifecycle.
+
+## 1. Authentication & Organisation Context
+
+### Suomi.fi Authorization
+Users must authorize via **Suomi.fi e-Authorizations** to act on behalf of a company.
+
+### Organization Roles & Business ID
+- When the user logs in, the application retrieves their **Organization Roles**.
+- The **Business ID** (identifier) is extracted from these roles.
+- On the backend, `get_or_create_company_using_organization_roles` uses this Business ID to:
+    1.  Check if the company already exists in the database.
+    2.  If not, fetch official data (name, address, industry) from the **YTJ API**.
+    3.  Create or update the local `Company` record.
+
+---
+
+## 2. Application Wizard Flow
+
+The wizard manages the lifecycle of a Summer Voucher application across three main steps.
+
+### Step 1: Application Data
+This is the primary data entry view, split into two sections:
+
+#### A. Employer Section
+- Displays company details (prefilled from the YTJ data linked during initialization).
+- Contains contact person details and invoicing information.
+
+#### B. Employment Section
+- **Fetch Logic**: The user provides the youth's **Name** and **Voucher Serial Number**.
+- **API Call**: `fetchEmployment` calls the backend, which matches the data against the **Youth Summer Voucher API**.
+- **Data Merging**: If matched, the form is partially prefilled (birthdate, school, etc.). Custom logic in `useApplicationApi` ensures manual user edits are preserved during this merge.
+- **Attachments**: Users upload required documents (contract, payslip). Each upload is linked to the specific `EmployerSummerVoucher`.
+- **Audit Logging**: Every request to fetch youth data is audit-logged on the backend. If a match is found, the log links to the youth's application; if not, an anonymous access attempt is recorded for security monitoring.
+
+### Step 2: Summary & Confirmation
+- A read-only preview of all data provided in Step 1.
+- Allows the user to verify everything before the final "Submit" action.
+
+### Step 3: Completion (Thank You)
+- Displays a success message.
+- Provides navigation to return to the **Dashboard** or start a **New Application**.
+
+---
+
+## 3. Lifecycle & Draft Persistence
+
+To prevent data loss, the application maintains a "Draft" status on the backend. All drafts are saved with `status: 'draft'`.
+
+### Draft Lifecycle Diagram
+
+```mermaid
+graph TD
+    Start[Start Wizard] -->|1. Create Draft| Init[POST /employerapplications/]
+    Init -->|2. Add Voucher| AddV[addEmployment]
+    AddV -->|3. Fetch Data| Fetch[fetchEmployment]
+    Fetch -->|4. Upload| Attach[useUploadAttachmentQuery]
+    Attach -->|5. Validation| Next[updateApplication]
+    Next -->|6. Review| Step2[Step 2: Summary]
+    Step2 -->|7. Submit| Final[sendApplication]
+```
+
+### Technical Draft Triggers
+Drafts are created or updated automatically at these points:
+
+1.  **Wizard Initiation**: Triggered by `useCreateApplicationQuery`. This is the first time the application receives a UUID from the server.
+2.  **Adding Employment**: Triggered by `addEmployment` in `useApplicationApi`.
+3.  **Fetching Youth Data**: Triggered immediately after a successful youth data fetch to persist the prefilled info.
+4.  **Attachment Upload**: Triggered by `useUploadAttachmentQuery` every time a file is linked to a voucher.
+5.  **Navigation (Next)**: Triggered when the user clicks "Next" in Step 1. The form must be valid for this save to occur.
+
+---
+
+## 4. Technical Stack Highlights
+- **Frontend**: React, React Hook Form, React Query.
+- **State Management**: Form state is managed locally via `useFormContext` and synced to the backend via `useApplicationApi`.
+- **API**: Django Rest Framework (DRF) with custom ViewSets (`EmployerApplicationViewSet`) and Serializers.
+- **Persistence**: `ApplicationPersistenceService` synchronizes Step 1 fields to `sessionStorage`. Data is obfuscated (Base64) before storage to prevent PII (like IBANs) from being visible to simple browser scanners.

--- a/frontend/kesaseteli/employer/browser-tests/actions/application.actions.ts
+++ b/frontend/kesaseteli/employer/browser-tests/actions/application.actions.ts
@@ -4,8 +4,8 @@ import isRealIntegrationsEnabled from '@frontend/shared/src/flags/is-real-integr
 import Application from '@frontend/shared/src/types/application';
 import Employment from '@frontend/shared/src/types/employment';
 import { convertToUIDateFormat } from '@frontend/shared/src/utils/date.utils';
-
 import TestController from 'testcafe';
+
 import { getStep1Components } from '../application-page/step1.components';
 import { getStep2Components } from '../application-page/step2.components';
 import { getWizardComponents } from '../application-page/wizard.components';
@@ -41,11 +41,12 @@ export const fillEmployerDetails = async (
 export const fillEmploymentDetails = async (
   t: TestController,
   application: Application,
-  _expectedPreFill?: Partial<Employment>
-  // eslint-disable-next-line sonarjs/cognitive-complexity
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  expectedPreFill?: Partial<Employment>
 ): Promise<void> => {
   const step1 = getStep1Components(t);
   const step1Form = await step1.form();
+
   const { summer_vouchers } = application;
 
   if (summer_vouchers.length > 0) {

--- a/frontend/kesaseteli/employer/browser-tests/application-page/application.mocks.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/application.mocks.ts
@@ -35,6 +35,7 @@ export const MOCKED_EMPLOYEE_DATA = {
 export const FULLY_MOCKED_FORM_DATA = {
   ...MOCKED_EMPLOYEE_DATA,
   employee_name: 'Iines Insinööri',
+  summer_voucher_serial_number: '123456',
   employment_postcode: '00100', // using string for postcode to preserve padding
   employment_start_date: '2026-06-01',
   employment_end_date: '2026-08-31',
@@ -138,9 +139,24 @@ const restoreVoucherData = (
     });
   }
 
+  const employeeFields = [
+    'employee_phone_number',
+    'employee_home_city',
+    'employee_postcode',
+    'employee_school',
+    'employee_birthdate',
+  ] as const;
+
+  const updatedFields: Pick<Employment, typeof employeeFields[number]> = {};
+
+  employeeFields.forEach((key) => {
+    updatedFields[key] =
+      v[key] || requestVoucher?.[key] || MOCKED_EMPLOYEE_DATA[key] || '';
+  });
+
   return {
     ...v,
-    ...MOCKED_EMPLOYEE_DATA,
+    ...updatedFields,
     summer_voucher_serial_number: restoredSerialNumber || '',
     employee_name: restoredEmployeeName,
   };

--- a/frontend/kesaseteli/employer/browser-tests/application-page/application.mocks.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/application.mocks.ts
@@ -17,6 +17,7 @@ import {
 // Locally: load the dev cert as a trusted CA.
 // In CI: the cert file doesn't exist, so we must skip verification for the test proxy.
 const certPath = path.resolve(
+  // eslint-disable-next-line unicorn/prefer-module
   __dirname,
   '../../../../../localdevelopment/employer/nginx/localhost.crt'
 );

--- a/frontend/kesaseteli/employer/browser-tests/application-page/application.testcafe.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/application.testcafe.ts
@@ -266,7 +266,7 @@ test.requestHooks(getFetchEmployeeDataMock(FULLY_MOCKED_FORM_DATA))(
           employee_phone_number: typedPhoneNumber,
         },
       ],
-    } as any);
+    } as any); // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }
 );
 
@@ -347,6 +347,6 @@ test.requestHooks(
           employee_phone_number: dirtyPhoneNumber,
         },
       ],
-    } as any);
+    } as any); // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }
 );

--- a/frontend/kesaseteli/employer/browser-tests/application-page/application.testcafe.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/application.testcafe.ts
@@ -110,9 +110,13 @@ test.requestHooks(getFetchEmployeeDataMock(FULLY_MOCKED_FORM_DATA))(
     const step1Form = await step1Components.form();
     await step1Form.expectations.isFulFilledWith(application);
 
-    // Verify employment details are EMPTY for the new application
+    // Verify employment details are EMPTY for the new application to ensure no data leakage
     await t.expect(step1Form.selectors.employeeNameInput().value).eql('');
     await t.expect(step1Form.selectors.serialNumberInput().value).eql('');
+    await t.expect(step1Form.selectors.phoneNumberInput().value).eql('');
+    await t.expect(step1Form.selectors.employmentPostcodeInput().value).eql('');
+    await t.expect(step1Form.selectors.startDateInput().value).eql('');
+    await t.expect(step1Form.selectors.endDateInput().value).eql('');
   }
 );
 
@@ -222,5 +226,127 @@ test.requestHooks(getFetchEmployeeDataMock(FULLY_MOCKED_FORM_DATA))(
     const dashboard = getDashboardComponents(t);
     await dashboard.expectations.isLoaded();
     await urlUtils.expectations.urlChangedToLandingPage();
+  }
+);
+
+test.requestHooks(getFetchEmployeeDataMock(FULLY_MOCKED_FORM_DATA))(
+  'fetches employment data and ensures API does not overwrite user input',
+  async (t: TestController) => {
+    // 1. Start application and fill it normally using standard actions
+    // This ensures all fields (including attachments) are correctly filled
+    const { company, ...application } = await loginAndfillApplication(
+      t,
+      1,
+      FULLY_MOCKED_FORM_DATA
+    );
+
+    const step1Form = await step1Components.form();
+    const wizard = await getWizardComponents(t);
+
+    // MOVE BACK TO STEP 1 to modify data
+    await wizard.actions.clickGoToPreviousStepButton();
+    await step1Form.expectations.isPresent();
+
+    // 2. Type "dirty" data into some fields
+    const typedPhoneNumber = '0501234567';
+    await step1Form.actions.fillPhoneNumber(typedPhoneNumber);
+
+    // 3. Save and continue to verify that modified data is preserved
+    await wizard.actions.clickSaveAndContinueButton();
+
+    // 4. Verify Submission Integrity on Step 2 (Summary)
+    const step2 = getStep2Components(t);
+    const summary = await step2.summaryComponent();
+
+    await summary.expectations.isFulFilledWith({
+      ...application,
+      summer_vouchers: [
+        {
+          ...application.summer_vouchers[0],
+          employee_phone_number: typedPhoneNumber,
+        },
+      ],
+    } as any);
+  }
+);
+
+test.requestHooks(
+  getFetchEmployeeDataMock(FULLY_MOCKED_FORM_DATA),
+  attachmentsMock
+)(
+  'verifies data integrity and fetch behavior across all form sections',
+  async (t: TestController) => {
+    // 1. Login and start new application using the helper
+    // setting toStep = 1 fills the form and moves to Step 2
+    const application = await loginAndfillApplication(
+      t,
+      1,
+      FULLY_MOCKED_FORM_DATA
+    );
+
+    const step1Form = await step1Components.form();
+    const wizard = await getWizardComponents(t);
+
+    // Navigate back to Step 1 to verify data and re-fetch
+    await wizard.actions.clickGoToPreviousStepButton();
+    await step1Form.expectations.isPresent();
+
+    // 2. Verify fields are ENABLED as they were already filled in loginAndfillApplication
+    await t
+      .expect(step1Form.selectors.phoneNumberInput().hasAttribute('disabled'))
+      .notOk(await getErrorMessage(t));
+
+    // 3. Fill employer data (Step 1 section 1)
+    const typedContactPersonName = 'Original Contact Name';
+    await step1Form.actions.fillContactPersonName(typedContactPersonName);
+
+    // 4. Fill name and serial to enable fetch
+    await step1Form.actions.fillEmployeeName(
+      FULLY_MOCKED_FORM_DATA.employee_name as string
+    );
+    await step1Form.actions.fillSerialNumber(
+      FULLY_MOCKED_FORM_DATA.summer_voucher_serial_number as string
+    );
+
+    // 5. Fetch data
+    await step1Form.actions.clickFetchEmployeeDataButton();
+
+    // 6. Verify fields are now ENABLED and POPULATED
+    await t
+      .expect(step1Form.selectors.phoneNumberInput().hasAttribute('disabled'))
+      .notOk(await getErrorMessage(t));
+    await t
+      .expect(step1Form.selectors.birthdateInput().value)
+      .eql(
+        convertToUIDateFormat(FULLY_MOCKED_FORM_DATA.employee_birthdate),
+        await getErrorMessage(t)
+      );
+
+    // 7. Verify employer data was NOT overwritten by fetch
+    await t
+      .expect(step1Form.selectors.contactPersonNameInput().value)
+      .eql(typedContactPersonName, await getErrorMessage(t));
+
+    // 8. Modify a fetched field (Dirty Data)
+    const dirtyPhoneNumber = '0509998877';
+    await step1Form.actions.fillPhoneNumber(dirtyPhoneNumber);
+
+    // 9. Save and continue
+    await wizard.actions.clickSaveAndContinueButton();
+
+    // 10. Verify on Summary page (Step 2)
+    const step2 = getStep2Components(t);
+    const summary = await step2.summaryComponent();
+    await summary.expectations.isFulFilledWith({
+      ...application,
+      contact_person_name: typedContactPersonName,
+      summer_vouchers: [
+        {
+          ...application.summer_vouchers[0],
+          employee_name: FULLY_MOCKED_FORM_DATA.employee_name,
+          employee_phone_number: dirtyPhoneNumber,
+        },
+      ],
+    } as any);
   }
 );

--- a/frontend/kesaseteli/employer/browser-tests/application-page/step1.components.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/step1.components.ts
@@ -6,10 +6,9 @@ import {
 } from '@frontend/shared/browser-tests/utils/testcafe.utils';
 import Company from '@frontend/shared/src/types/company';
 import ContactInfo from '@frontend/shared/src/types/contact-info';
+import { convertToUIDateFormat } from '@frontend/shared/src/utils/date.utils';
 import { friendlyFormatIBAN } from 'ibantools';
 import TestController, { Selector } from 'testcafe';
-
-import { convertToUIDateFormat } from '@frontend/shared/src/utils/date.utils';
 
 const formSelector = () => Selector('form#employer-application-form');
 

--- a/frontend/kesaseteli/employer/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/employer/src/__tests__/index.test.tsx
@@ -118,12 +118,12 @@ describe('frontend/kesaseteli/employer/src/pages/index.tsx', () => {
         ...fakeObjectFactory.fakeApplication(),
         status: 'draft',
         is_mine: true,
-      } as any;
+      } as any; // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const otherDraft = {
         ...fakeObjectFactory.fakeApplication(),
         status: 'draft',
         is_mine: false,
-      } as any;
+      } as any; // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const applications = [otherDraft, myDraft]; // otherDraft is first
 
       expectAuthorizedReply(myUser);
@@ -136,12 +136,12 @@ describe('frontend/kesaseteli/employer/src/pages/index.tsx', () => {
       // Wait for the dashboard to render
       await waitFor(() => {
         expect(
-          screen.getByRole('button', { name: /Tee uusi hakemus/i })
+          screen.getByRole('button', { name: /tee uusi hakemus/i })
         ).toBeInTheDocument();
       });
 
       // Click the button
-      const button = screen.getByRole('button', { name: /Tee uusi hakemus/i });
+      const button = screen.getByRole('button', { name: /tee uusi hakemus/i });
       button.click();
 
       // Verify it redirects to MY draft, not the first one (otherDraft)

--- a/frontend/kesaseteli/employer/src/__tests__/utils/components/get-application-page-api.ts
+++ b/frontend/kesaseteli/employer/src/__tests__/utils/components/get-application-page-api.ts
@@ -232,44 +232,31 @@ const getApplicationPageApi = (
           const query =
             /ulkomaista tilinumeroa|foreign iban|utländskt kontonummer/i;
           if (visible) {
-            await waitFor(
-              () => {
-                expect(screen.queryByText(query)).toBeInTheDocument();
-                const payslipLink = screen.queryByRole('link', {
-                  name: /palkkatodistus-kohdassa|pay statement section|lönespecifikationen/i,
-                });
-                expect(payslipLink).toBeInTheDocument();
-                expect(payslipLink).toHaveAttribute(
-                  'href',
-                  expect.stringMatching(/#summer_vouchers\.0\.payslip$/)
-                );
-
-                const templateLinks = screen.queryAllByRole('link', {
-                  name: /tästä|here|här/i,
-                });
-                expect(templateLinks[0]).toHaveAttribute('href');
-                expect(templateLinks[0].getAttribute('href')).not.toBe('');
-              },
-              { timeout: 2000 }
+            await screen.findByText(query, undefined, { timeout: 2000 });
+            const payslipLink = screen.getByRole('link', {
+              name: /palkkatodistus-kohdassa|pay statement section|lönespecifikationen/i,
+            });
+            expect(payslipLink).toHaveAttribute(
+              'href',
+              expect.stringMatching(/#summer_vouchers\.0\.payslip$/)
             );
+
+            const templateLinks = screen.getAllByRole('link', {
+              name: /tästä|here|här/i,
+            });
+            expect(templateLinks[0]).toHaveAttribute('href');
+            expect(templateLinks[0].getAttribute('href')).not.toBe('');
           } else {
             await waitFor(
-              () => {
-                expect(screen.queryByText(query)).not.toBeInTheDocument();
-              },
+              () => expect(screen.queryByText(query)).not.toBeInTheDocument(),
               { timeout: 2000 }
             );
           }
         },
         payslipCustomMessageIsVisible: async (): Promise<void> => {
-          await waitFor(
-            () => {
-              expect(
-                screen.getByText(
-                  /(rahansiirtotodistus on pakollinen)|(money transaction template is also mandatory)|(kvitto på penningöverföring)/i
-                )
-              ).toBeInTheDocument();
-            },
+          await screen.findByText(
+            /(rahansiirtotodistus on pakollinen)|(money transaction template is also mandatory)|(kvitto på penningöverföring)/i,
+            undefined,
             { timeout: 2000 }
           );
         },
@@ -352,7 +339,6 @@ const getApplicationPageApi = (
           return [put, get];
         },
         clickNextButtonAndExpectToSaveApplication: async (): Promise<void> => {
-          // This actually submits now
           await waitForLoadingCompleted();
           await waitFor(() => {
             expect(
@@ -365,10 +351,6 @@ const getApplicationPageApi = (
             ...application,
             status: 'submitted',
           });
-          // After submit, we normally expect invalidation or redirect, not necessarily a get
-          // But based on useApplicationApi logic, it invalidates queries.
-          // The current test logic expects [put, get].
-          // Let's assume we still want to match the previous pattern but with status: submitted.
           await userEvent.click(
             screen.getByRole('button', {
               name: /(lähetä hakemus)|(application.buttons.last)/i,
@@ -379,10 +361,11 @@ const getApplicationPageApi = (
           });
         },
         toggleTermsAndConditions: async (): Promise<void> => {
-          const checkbox = screen.getByRole('checkbox', {
-            name: /(käyttöehdot)|(application.form.inputs.termsandconditions)/i,
-          });
+          const checkbox = screen.getByLabelText(
+            /(käyttöehdot)|(application.form.inputs.termsandconditions)/i
+          );
           await userEvent.click(checkbox);
+          await waitFor(() => expect(checkbox).toBeChecked());
         },
       },
     },

--- a/frontend/kesaseteli/employer/src/components/application/form/AttachmentInput.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/AttachmentInput.tsx
@@ -27,7 +27,14 @@ const validate = (
   val: FieldPathValue<ApplicationFormData, ApplicationFieldPath>
 ): boolean => !isEmpty(val);
 
-const AttachmentInput: React.FC<Props> = ({ index, id, required, disabled, readOnly, message: customMessage }) => {
+const AttachmentInput: React.FC<Props> = ({
+  index,
+  id,
+  required,
+  disabled,
+  readOnly,
+  message: customMessage,
+}) => {
   const { t } = useTranslation();
 
   const {
@@ -143,12 +150,14 @@ const AttachmentInput: React.FC<Props> = ({ index, id, required, disabled, readO
     }
   }, [getError, hasError, setError, attachmentType]);
 
-  const message = customMessage || `${t(
-    `common:application.form.helpers.${attachmentType}`
-  )} ${t('common:application.form.helpers.attachments')}`;
+  const message =
+    customMessage ||
+    `${t(`common:application.form.helpers.${attachmentType}`)} ${t(
+      'common:application.form.helpers.attachments'
+    )}`;
 
   if (disabled || readOnly) {
-    return <div>{message}</div>
+    return <div>{message}</div>;
   }
   if (applicationQuery.isSuccess) {
     return (

--- a/frontend/kesaseteli/employer/src/components/application/form/IbanInput.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/IbanInput.tsx
@@ -46,7 +46,8 @@ const IbanInput: React.FC<IbanInputProps> = ({
     if (!valid) {
       setErrorText(
         t(
-          `common:application.form.errors.${ValidationErrorsIBAN[errorCodes[0]]
+          `common:application.form.errors.${
+            ValidationErrorsIBAN[errorCodes[0]]
           }`
         )
       );
@@ -63,7 +64,8 @@ const IbanInput: React.FC<IbanInputProps> = ({
       value={getValue()}
       beforeMaskedValueChange={(newState) => {
         // eslint-disable-next-line no-param-reassign
-        newState.value = friendlyFormatIBAN(newState.value ?? undefined)?.trim() ?? '';
+        newState.value =
+          friendlyFormatIBAN(newState.value ?? undefined)?.trim() ?? '';
         return newState;
       }}
       onBlur={onBlur}
@@ -72,7 +74,7 @@ const IbanInput: React.FC<IbanInputProps> = ({
         (() => (
           <TextInputBase<ApplicationFormData>
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore  
+            // @ts-ignore
             registerOptions={{
               required: true,
               maxLength: 34,

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/EmployerForm.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/EmployerForm.tsx
@@ -59,7 +59,9 @@ const EmployerForm: React.FC = () => {
                 i18nKey="common:application.step1.employment_section.foreign_iban_note"
                 components={{
                   anchor: (
-                    <LinkText href="#summer_vouchers.0.payslip">{null}</LinkText>
+                    <LinkText href="#summer_vouchers.0.payslip">
+                      {null}
+                    </LinkText>
                   ),
                   lnk: (
                     <a target="_blank" rel="noopener noreferrer">

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
@@ -45,8 +45,8 @@ const useFetchEmployeeDataButtonState = (
     const integerStringRegex = /^\s*\d+\s*$/; // Allow leading and trailing whitespace
     setIsFetchEmployeeDataEnabled(
       (formDataVoucher.employee_name?.length ?? 0) > 0 &&
-      typeof formDataVoucher.summer_voucher_serial_number === 'string' &&
-      integerStringRegex.test(formDataVoucher.summer_voucher_serial_number)
+        typeof formDataVoucher.summer_voucher_serial_number === 'string' &&
+        integerStringRegex.test(formDataVoucher.summer_voucher_serial_number)
     );
   }, [getValues, index]);
 
@@ -70,7 +70,7 @@ const useFetchEmployeeData = (
   isEmployeeDataFetched: boolean;
   handleGetEmployeeData: () => void;
 } => {
-  const { getValues, reset, control } = useFormContext<Application>();
+  const { getValues, setValue, control } = useFormContext<Application>();
   const { fetchEmployment, updateApplication } = useApplicationApi();
 
   // Use dedicated state instead of deriving from form values
@@ -78,38 +78,27 @@ const useFetchEmployeeData = (
   const [isEmployeeDataFetched, setIsEmployeeDataFetched] =
     useState<boolean>(false);
 
-  const [employeePhoneNumber, employmentPostcode, employeeBirthdate] = useWatch({
-    control,
-    name: [
-      `summer_vouchers.${index}.employee_phone_number`,
-      `summer_vouchers.${index}.employment_postcode`,
-      `summer_vouchers.${index}.employee_birthdate`,
-    ],
-  });
+  const [employeePhoneNumber, employmentPostcode, employeeBirthdate] = useWatch(
+    {
+      control,
+      name: [
+        `summer_vouchers.${index}.employee_phone_number`,
+        `summer_vouchers.${index}.employment_postcode`,
+        `summer_vouchers.${index}.employee_birthdate`,
+      ],
+    }
+  );
 
   // Set fetched state when phone number, postcode or birthdate is populated
   useEffect(() => {
-    if (
-      employeePhoneNumber ||
-      employmentPostcode ||
-      employeeBirthdate
-    ) {
+    if (employeePhoneNumber || employmentPostcode || employeeBirthdate) {
       setIsEmployeeDataFetched(true);
     }
-  }, [
-    employeePhoneNumber,
-    employmentPostcode,
-    employeeBirthdate,
-  ]);
+  }, [employeePhoneNumber, employmentPostcode, employeeBirthdate]);
 
   const handleGetEmployeeData = useCallback((): void => {
     const currentValues = getValues();
     const voucher = currentValues.summer_vouchers[index];
-
-    const handleReset = (app: Application): void => {
-      // Don't reset the fetched state during form reset
-      reset(getFormApplication(app), { keepDirty: true });
-    };
 
     const performFetch = (appData: DraftApplication | Application): void => {
       const currentValues = getValues();
@@ -120,7 +109,13 @@ const useFetchEmployeeData = (
       }
 
       void fetchEmployment(currentValues, index, (app) => {
-        handleReset(app);
+        const updatedVoucher = app.summer_vouchers[index];
+        if (updatedVoucher) {
+          setValue(`summer_vouchers.${index}`, updatedVoucher, {
+            shouldDirty: true,
+            shouldValidate: true,
+          });
+        }
         setIsEmployeeDataFetched(true);
       });
     };
@@ -130,7 +125,7 @@ const useFetchEmployeeData = (
     } else {
       updateApplication(currentValues, (app) => performFetch(app));
     }
-  }, [getValues, fetchEmployment, index, reset, updateApplication]);
+  }, [getValues, fetchEmployment, index, setValue, updateApplication]);
 
   return {
     isEmployeeDataFetched,

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
@@ -19,7 +19,6 @@ import { EMPLOYEE_HIRED_WITHOUT_VOUCHER_ASSESSMENT } from 'shared/constants/empl
 import Application from 'shared/types/application';
 import DraftApplication from 'shared/types/draft-application';
 import Employment from 'shared/types/employment';
-import { getFormApplication } from 'shared/utils/application.utils';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
 import { getDecimalNumberRegex } from 'shared/utils/regex.utils';
 

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
@@ -10,10 +10,10 @@ import { Trans, useTranslation } from 'next-i18next';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import FormSection from 'shared/components/forms/section/FormSection';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import FormSectionDivider from 'shared/components/forms/section/FormSectionDivider';
 import FormSectionHeading from 'shared/components/forms/section/FormSectionHeading';
 import LinkText from 'shared/components/link-text/LinkText';
-import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { POSTAL_CODE_REGEX } from 'shared/constants';
 import { EMPLOYEE_HIRED_WITHOUT_VOUCHER_ASSESSMENT } from 'shared/constants/employee-constants';
 import Application from 'shared/types/application';
@@ -100,14 +100,14 @@ const useFetchEmployeeData = (
     const voucher = currentValues.summer_vouchers[index];
 
     const performFetch = (appData: DraftApplication | Application): void => {
-      const currentValues = getValues();
+      const values = getValues();
       // Ensure the voucher we are processing has the ID from the server (if it was just created)
       const serverVoucherId = appData.summer_vouchers?.[index]?.id;
       if (serverVoucherId) {
-        currentValues.summer_vouchers[index].id = serverVoucherId;
+        values.summer_vouchers[index].id = serverVoucherId;
       }
 
-      void fetchEmployment(currentValues, index, (app) => {
+      void fetchEmployment(values, index, (app) => {
         const updatedVoucher = app.summer_vouchers[index];
         if (updatedVoucher) {
           setValue(`summer_vouchers.${index}`, updatedVoucher, {
@@ -200,7 +200,7 @@ const EmploymentForm: React.FC<Props> = ({ index }) => {
             value={convertToUIDateFormat(employeeBirthdate)}
             readOnly
             disabled={disableEmploymentFields}
-            onChange={() => undefined}
+            onChange={() => {}}
           />
         </$GridCell>
 

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/Step1EmployerAndEmployment.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/Step1EmployerAndEmployment.tsx
@@ -7,20 +7,20 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 
 const Step1EmployerAndEmployment: React.FC = () => {
-    const { t } = useTranslation();
-    const { applicationQuery } = useApplicationApi();
+  const { t } = useTranslation();
+  const { applicationQuery } = useApplicationApi();
 
-    // Validating structure
-    const vouchers = applicationQuery.data?.summer_vouchers || [];
-    const currentVoucherIndex = vouchers.length > 0 ? vouchers.length - 1 : 0;
+  // Validating structure
+  const vouchers = applicationQuery.data?.summer_vouchers || [];
+  const currentVoucherIndex = vouchers.length > 0 ? vouchers.length - 1 : 0;
 
-    return (
-        <ApplicationForm title={t('common:application.step1.header')} step={1}>
-            <EmployerForm />
-            <EmploymentForm index={currentVoucherIndex} />
-            <ActionButtons />
-        </ApplicationForm>
-    );
+  return (
+    <ApplicationForm title={t('common:application.step1.header')} step={1}>
+      <EmployerForm />
+      <EmploymentForm index={currentVoucherIndex} />
+      <ActionButtons />
+    </ApplicationForm>
+  );
 };
 
 export default Step1EmployerAndEmployment;

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/__tests__/EmploymentForm.test.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/__tests__/EmploymentForm.test.tsx
@@ -1,14 +1,17 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
+import { getBackendDomain } from 'kesaseteli-shared/backend-api/backend-api';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import EmploymentForm from '../EmploymentForm';
-import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { ThemeProvider } from 'styled-components';
-import theme from 'shared/styles/theme';
 import BackendAPIProvider from 'shared/backend-api/BackendAPIProvider';
-import { getBackendDomain } from 'kesaseteli-shared/backend-api/backend-api';
+import theme from 'shared/styles/theme';
+import Application from 'shared/types/application';
+import Employment from 'shared/types/employment';
+import { ThemeProvider } from 'styled-components';
+
+import EmploymentForm from '../EmploymentForm';
 
 jest.mock('next-i18next', () => ({
   useTranslation: () => ({
@@ -19,12 +22,15 @@ jest.mock('next-i18next', () => ({
 
 jest.mock('kesaseteli/employer/hooks/application/useApplicationApi');
 
-const renderWithProviders = (index: number, initialValues?: any) => {
+const renderWithProviders = (
+  index: number,
+  initialValues?: Partial<Employment>
+): ReturnType<typeof render> => {
   const queryClient = new QueryClient();
-  const Component = () => {
-    const methods = useForm({
+  const Component: React.FC = () => {
+    const methods = useForm<Application>({
       defaultValues: {
-        summer_vouchers: [initialValues],
+        summer_vouchers: [initialValues as Employment],
       },
       mode: 'onBlur',
     });
@@ -78,7 +84,7 @@ describe('EmploymentForm', () => {
       screen.getByLabelText(
         /common:application.form.inputs.employee_phone_number/i
       )
-    ).not.toBeDisabled();
+    ).toBeEnabled();
 
     const birthdateInput = screen.getByLabelText(
       /common:application.form.inputs.employee_birthdate/i
@@ -109,8 +115,10 @@ describe('EmploymentForm', () => {
           expect(
             screen.queryByText(/common:application.form.errors.pattern/i)
           ).not.toBeInTheDocument();
+        });
+        await waitFor(() => {
           expect(
-            screen.queryByText(/common:application.form.errors.maxLength/i)
+            screen.queryByText(/common:application.form.errors.maxlength/i)
           ).not.toBeInTheDocument();
         });
       }
@@ -132,7 +140,7 @@ describe('EmploymentForm', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(/common:application.form.errors.maxLength/i)
+          screen.getByText(/common:application.form.errors.maxlength/i)
         ).toBeInTheDocument();
       });
     });
@@ -148,12 +156,12 @@ describe('EmploymentForm', () => {
       screen.getByLabelText(
         /common:application.form.inputs.employee_phone_number/i
       )
-    ).not.toBeDisabled();
+    ).toBeEnabled();
     expect(
       screen.getByLabelText(
         /common:application.form.inputs.employment_postcode/i
       )
-    ).not.toBeDisabled();
+    ).toBeEnabled();
   });
 
   it('activates the second part of the form when employment_postcode is present', () => {
@@ -166,11 +174,11 @@ describe('EmploymentForm', () => {
       screen.getByLabelText(
         /common:application.form.inputs.employee_phone_number/i
       )
-    ).not.toBeDisabled();
+    ).toBeEnabled();
     expect(
       screen.getByLabelText(
         /common:application.form.inputs.employment_postcode/i
       )
-    ).not.toBeDisabled();
+    ).toBeEnabled();
   });
 });

--- a/frontend/kesaseteli/employer/src/components/application/summary/ApplicationSummary.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/summary/ApplicationSummary.tsx
@@ -18,7 +18,11 @@ type Props = {
   filterVoucherId?: string; // Optional: Show only voucher with this ID (useful for summary step)
 };
 
-const ApplicationSummary: React.FC<Props> = ({ header, tooltip, filterVoucherId }) => {
+const ApplicationSummary: React.FC<Props> = ({
+  header,
+  tooltip,
+  filterVoucherId,
+}) => {
   const { t } = useTranslation();
   const { applicationQuery } = useApplicationApi();
   if (applicationQuery.isSuccess) {
@@ -33,7 +37,7 @@ const ApplicationSummary: React.FC<Props> = ({ header, tooltip, filterVoucherId 
     } = applicationQuery.data;
 
     const visibleVouchers = filterVoucherId
-      ? summer_vouchers.filter(v => v.id === filterVoucherId)
+      ? summer_vouchers.filter((v) => v.id === filterVoucherId)
       : summer_vouchers;
 
     return (
@@ -100,10 +104,12 @@ const ApplicationSummary: React.FC<Props> = ({ header, tooltip, filterVoucherId 
           data-testid="employment-section"
         >
           {visibleVouchers.map((employment) => {
-            // Find original index for EmploymentSummary if needed? 
+            // Find original index for EmploymentSummary if needed?
             // EmploymentSummary takes `index` prop to access `summer_vouchers[index]`.
             // So we need to find the REAL index of this voucher in the original array.
-            const realIndex = summer_vouchers.findIndex(v => v.id === employment.id);
+            const realIndex = summer_vouchers.findIndex(
+              (v) => v.id === employment.id
+            );
             return (
               <React.Fragment key={employment.id}>
                 <EmploymentSummary index={realIndex} />
@@ -119,4 +125,3 @@ const ApplicationSummary: React.FC<Props> = ({ header, tooltip, filterVoucherId 
 };
 
 export default ApplicationSummary;
-

--- a/frontend/kesaseteli/employer/src/components/application/summary/EmploymentSummary.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/summary/EmploymentSummary.tsx
@@ -42,10 +42,8 @@ const EmploymentSummary: React.FC<Props> = ({ index }) => {
         />
 
         <EmploymentFieldSummary fieldName="employee_birthdate" index={index}>
-          {t(
-            'common:application.form.inputs.employee_birthdate'
-          )}
-          : {convertToUIDateFormat(employee_birthdate)}
+          {t('common:application.form.inputs.employee_birthdate')}:{' '}
+          {convertToUIDateFormat(employee_birthdate)}
         </EmploymentFieldSummary>
 
         <EmploymentFieldSummary
@@ -90,7 +88,8 @@ const EmploymentSummary: React.FC<Props> = ({ index }) => {
         >
           {getLabel(t, 'hired_without_voucher_assessment')}:{' '}
           {t(
-            `common:application.form.selectionGroups.hired_without_voucher_assessment.${hired_without_voucher_assessment ?? ''
+            `common:application.form.selectionGroups.hired_without_voucher_assessment.${
+              hired_without_voucher_assessment ?? ''
             }`
           )}
         </EmploymentFieldSummary>

--- a/frontend/kesaseteli/employer/src/components/footer/Footer.tsx
+++ b/frontend/kesaseteli/employer/src/components/footer/Footer.tsx
@@ -11,10 +11,7 @@ const FooterSection: React.FC = () => {
 
   return (
     <$FooterWrapper>
-      <Footer
-        title={t('common:appName')}
-        theme="dark"
-      >
+      <Footer title={t('common:appName')} theme="dark">
         <Footer.Base
           copyrightHolder={t('common:footer.copyrightText')}
           copyrightText={t('common:footer.allRightsReservedText')}

--- a/frontend/kesaseteli/employer/src/hocs/__tests__/withOrganisation.test.tsx
+++ b/frontend/kesaseteli/employer/src/hocs/__tests__/withOrganisation.test.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import useCompanyQuery from 'kesaseteli/employer/hooks/backend/useCompanyQuery';
 import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
-import withOrganisation from '../withOrganisation';
+import React from 'react';
 import useAuth from 'shared/hooks/useAuth';
 import useGoToPage from 'shared/hooks/useGoToPage';
-import useCompanyQuery from 'kesaseteli/employer/hooks/backend/useCompanyQuery';
+
+import withOrganisation from '../withOrganisation';
 
 jest.mock('shared/hooks/useAuth', () => jest.fn());
 jest.mock('shared/hooks/useGoToPage', () => jest.fn());
 jest.mock('kesaseteli/employer/hooks/backend/useCompanyQuery', () => jest.fn());
 
 describe('withOrganisation', () => {
-  const MockComponent = () => <div>Mock Component</div>;
+  const MockComponent = (): JSX.Element => <div>Mock Component</div>;
   const WrappedComponent = withOrganisation(MockComponent);
   const mockGoToPage = jest.fn();
 

--- a/frontend/kesaseteli/employer/src/hocs/withEmployerAuth.tsx
+++ b/frontend/kesaseteli/employer/src/hocs/withEmployerAuth.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
 import { useRouter } from 'next/router';
+import React from 'react';
 import withAuth from 'shared/components/hocs/withAuth';
+
 import withOrganisation from './withOrganisation';
 
 /**

--- a/frontend/kesaseteli/employer/src/hocs/withOrganisation.tsx
+++ b/frontend/kesaseteli/employer/src/hocs/withOrganisation.tsx
@@ -1,10 +1,18 @@
 import useCompanyQuery from 'kesaseteli/employer/hooks/backend/useCompanyQuery';
+import { useRouter } from 'next/router';
 import React from 'react';
 import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
-import { useRouter } from 'next/router';
 import useAuth from 'shared/hooks/useAuth';
 import useGoToPage from 'shared/hooks/useGoToPage';
 import { isError } from 'shared/utils/type-guards';
+
+const isForbidden = (err: unknown): boolean =>
+  isError(err) &&
+  (err.message.includes('403') || err.message.includes('Forbidden'));
+
+const isNotFound = (err: unknown): boolean =>
+  isError(err) &&
+  (err.message.includes('404') || err.message.includes('Not Found'));
 
 /**
  * HOC that ensures the user has organization authorization.
@@ -24,14 +32,6 @@ const withOrganisation = <P extends JSX.IntrinsicAttributes>(
       isSuccess: isCompanySuccess,
       error: companyError,
     } = useCompanyQuery();
-
-    const isForbidden = (err: unknown): boolean =>
-      isError(err) &&
-      (err.message.includes('403') || err.message.includes('Forbidden'));
-
-    const isNotFound = (err: unknown): boolean =>
-      isError(err) &&
-      (err.message.includes('404') || err.message.includes('Not Found'));
 
     const isNoOrganisation = isCompanySuccess && !company?.name;
     const isAuthError = isForbidden(companyError) || isNotFound(companyError);

--- a/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
@@ -126,7 +126,10 @@ const useApplicationApi = <T = Application>(
   ) => {
     const summer_vouchers = [...(draftApplication.summer_vouchers ?? [])];
     if (summer_vouchers.length > index) {
-      summer_vouchers[index] = { ...summer_vouchers[index], ...employment };
+      summer_vouchers[index] = {
+        ...summer_vouchers[index],
+        ...employment,
+      };
     }
 
     return updateApplicationQuery.mutate(

--- a/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
@@ -16,6 +16,7 @@ import useRouterQueryParam from 'shared/hooks/useRouterQueryParam';
 import Application from 'shared/types/application';
 import DraftApplication from 'shared/types/draft-application';
 import { EmploymentBase } from 'shared/types/employment';
+import { getFormApplication } from 'shared/utils/application.utils';
 
 export type ApplicationApi<T> = {
   applicationId?: string;
@@ -112,7 +113,7 @@ const useApplicationApi = <T = Application>(
         status: 'draft',
         summer_vouchers,
       });
-      onSuccess(result);
+      onSuccess(getFormApplication(result));
     } catch (error) {
       handleUpdateError(error);
     }
@@ -135,7 +136,7 @@ const useApplicationApi = <T = Application>(
     return updateApplicationQuery.mutate(
       { ...draftApplication, status: 'draft', summer_vouchers },
       {
-        onSuccess: (data) => onSuccess(data),
+        onSuccess: (data) => onSuccess(getFormApplication(data)),
         onError: handleUpdateError,
       }
     );
@@ -212,37 +213,52 @@ const useApplicationApi = <T = Application>(
     );
   };
 
-  const updateApplication: ApplicationApi<T>['updateApplication'] = (
+  const handleMutationSuccess =
+    (onSuccess: () => void | Promise<void>) => () => {
+      clearLocalStorage(`application-${applicationId}`);
+      ApplicationPersistenceService.clearAll();
+      void queryClient.invalidateQueries(BackendEndpoint.EMPLOYER_APPLICATIONS);
+      return onSuccess();
+    };
+
+  const mutateApplication = (
     draftApplication: DraftApplication,
-    onSuccess = noop
-  ) =>
-    updateApplicationQuery.mutate(
-      { ...draftApplication, status: 'draft' },
+    status: Application['status'],
+    onMutationSuccess: (data: Application) => void | Promise<void>
+  ): void => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { termsAndConditions, ...applicationData } =
+      draftApplication as DraftApplication & { termsAndConditions?: boolean };
+    return updateApplicationQuery.mutate(
       {
-        onSuccess: (updatedApplication) => {
-          void onSuccess(updatedApplication);
-        },
+        ...applicationQuery.data,
+        ...applicationData,
+        id: applicationId as string,
+        status,
+      },
+      {
+        onSuccess: onMutationSuccess,
         onError: handleUpdateError,
       }
     );
+  };
 
-  const sendApplication: ApplicationApi<T>['sendApplication'] = (
-    completeApplication: Application,
+  const updateApplication: ApplicationApi<T>['updateApplication'] = (
+    draftApplication,
     onSuccess = noop
   ) =>
-    updateApplicationQuery.mutate(
-      { ...completeApplication, status: 'submitted' },
-      {
-        onSuccess: () => {
-          clearLocalStorage(`application-${completeApplication.id}`);
-          ApplicationPersistenceService.clearAll();
-          void queryClient.invalidateQueries(
-            BackendEndpoint.EMPLOYER_APPLICATIONS
-          );
-          return onSuccess();
-        },
-        onError: handleUpdateError,
-      }
+    mutateApplication(draftApplication, 'draft', (updatedApplication) => {
+      void onSuccess(getFormApplication(updatedApplication));
+    });
+
+  const sendApplication: ApplicationApi<T>['sendApplication'] = (
+    completeApplication,
+    onSuccess = noop
+  ) =>
+    mutateApplication(
+      completeApplication,
+      'submitted',
+      handleMutationSuccess(onSuccess)
     );
 
   const deleteApplication: ApplicationApi<T>['deleteApplication'] = (
@@ -250,14 +266,7 @@ const useApplicationApi = <T = Application>(
   ) => {
     if (applicationId) {
       return deleteApplicationQuery.mutate(applicationId, {
-        onSuccess: () => {
-          clearLocalStorage(`application-${applicationId}`);
-          ApplicationPersistenceService.clearAll();
-          void queryClient.invalidateQueries(
-            BackendEndpoint.EMPLOYER_APPLICATIONS
-          );
-          return onSuccess();
-        },
+        onSuccess: handleMutationSuccess(onSuccess),
         onError,
       });
     }

--- a/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
@@ -217,22 +217,6 @@ const useApplicationApi = <T = Application>(
       { ...draftApplication, status: 'draft' },
       {
         onSuccess: (updatedApplication) => {
-          (updatedApplication.summer_vouchers ?? []).forEach(
-            (voucher, index) => {
-              const formVoucher = draftApplication.summer_vouchers?.[index];
-              if (voucher.id && formVoucher) {
-                ApplicationPersistenceService.storeVoucherSupplement(
-                  voucher.id,
-                  {
-                    employment_start_date: formVoucher.employment_start_date,
-                    employment_end_date: formVoucher.employment_end_date,
-                    hired_without_voucher_assessment:
-                      formVoucher.hired_without_voucher_assessment,
-                  }
-                );
-              }
-            }
-          );
           void onSuccess(updatedApplication);
         },
         onError: handleUpdateError,

--- a/frontend/kesaseteli/employer/src/hooks/application/useApplicationFormField.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useApplicationFormField.ts
@@ -73,7 +73,8 @@ const useApplicationFormField = <V extends Value>(
       }
       return value as V;
     },
-    setValue: (value: V) => setValue(id, value, { shouldDirty: true, shouldTouch: true }),
+    setValue: (value: V) =>
+      setValue(id, value, { shouldDirty: true, shouldTouch: true }),
     watch: () => watch(id) as V,
     getError,
     hasError: () => Boolean(getError()),
@@ -99,15 +100,16 @@ const useApplicationFormField = <V extends Value>(
       }
     },
     setError: (error: ErrorOption) => setErrorF(id, error),
-    clearValue: () => setValue(id, '', { shouldDirty: true, shouldTouch: true }),
+    clearValue: () =>
+      setValue(id, '', { shouldDirty: true, shouldTouch: true }),
     trigger: () => trigger(id, { shouldFocus: true }),
     clearErrors: () => clearErrors(id),
     setFocus: () => {
       try {
         setFocus(id);
-      } catch (e) {
+      } catch (error) {
         // eslint-disable-next-line no-console
-        console.warn(`Could not set focus to field "${id}".`, e);
+        console.warn(`Could not set focus to field "${id}".`, error);
       }
     },
   };

--- a/frontend/kesaseteli/employer/src/hooks/application/usePersistFormValuesEffect.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/usePersistFormValuesEffect.ts
@@ -18,25 +18,6 @@ const usePersistFormValuesEffect = ({
 
     // Persist Employer fields (Step 1)
     ApplicationPersistenceService.storeEmployerData(values);
-
-    // Persist Voucher fields (especially search fields and manual inputs)
-    // IMPORTANT: We sanitize the voucher to exclude derived fields (birthdate, SSN, etc.)
-    // to prevent "zombie" results from leaking across search attempts.
-    (values.summer_vouchers ?? []).forEach((voucher) => {
-      const {
-        employee_birthdate,
-        employee_ssn,
-        employee_school,
-        employee_home_city,
-        ...safeVoucher
-      } = voucher;
-
-      // Use serial number or ID as key to ensure we can retrieve it correctly
-      const key = safeVoucher.id || safeVoucher.summer_voucher_serial_number;
-      if (key) {
-        ApplicationPersistenceService.storeVoucherSupplement(key, safeVoucher);
-      }
-    });
   }, [values, isDirty]);
 };
 

--- a/frontend/kesaseteli/employer/src/hooks/application/useResetApplicationFormValuesEffect.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useResetApplicationFormValuesEffect.ts
@@ -24,15 +24,6 @@ const createEmptyVoucher = (): Employment => ({
 const ensureVoucherExists = (vouchers: Employment[]): Employment[] =>
   vouchers.length > 0 ? vouchers : [createEmptyVoucher()];
 
-const mergeVoucherSupplements = (vouchers: Employment[]): Employment[] =>
-  vouchers.map((voucher) => {
-    const supplement = ApplicationPersistenceService.getVoucherSupplement(
-      // For new vouchers (no ID), we use the serial number as the key if available
-      voucher.id || voucher.summer_voucher_serial_number
-    );
-    return supplement ? { ...voucher, ...supplement } : voucher;
-  });
-
 const mergeEmployerData = (application: Application): void => {
   const employerData = ApplicationPersistenceService.getEmployerData();
   if (!employerData) return;
@@ -91,7 +82,7 @@ const useResetApplicationFormValuesEffect = ({
     const currentValues = getValues();
     const application = getFormApplication(applicationQuery.data);
     const vouchers = ensureVoucherExists(application.summer_vouchers ?? []);
-    application.summer_vouchers = mergeVoucherSupplements(vouchers);
+    application.summer_vouchers = vouchers;
 
     // Clever Fix: Because search inputs and date fields are often NOT immediately
     // persisted to the backend (read-only or draft state), we manually preserve

--- a/frontend/kesaseteli/employer/src/hooks/application/useResetApplicationFormValuesEffect.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useResetApplicationFormValuesEffect.ts
@@ -2,7 +2,7 @@ import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicat
 import ApplicationPersistenceService from 'kesaseteli/employer/services/ApplicationPersistenceService';
 import React from 'react';
 import { UseFormReturn } from 'react-hook-form';
-import Application from 'shared/types/application';
+import Application from 'shared/types/application-form-data';
 import ContactInfo from 'shared/types/contact-info';
 import Employment from 'shared/types/employment';
 import { getFormApplication } from 'shared/utils/application.utils';
@@ -23,6 +23,32 @@ const createEmptyVoucher = (): Employment => ({
 
 const ensureVoucherExists = (vouchers: Employment[]): Employment[] =>
   vouchers.length > 0 ? vouchers : [createEmptyVoucher()];
+
+const CONTACT_INFO_KEYS: (keyof ContactInfo)[] = [
+  'contact_person_name',
+  'contact_person_email',
+  'contact_person_phone_number',
+  'street_address',
+  'bank_account_number',
+];
+
+const EMPLOYMENT_KEYS: (keyof Employment)[] = [
+  'employee_name',
+  'summer_voucher_serial_number',
+  'employee_phone_number',
+  'employment_postcode',
+  'employment_start_date',
+  'employment_end_date',
+  'employment_work_hours',
+  'employment_salary_paid',
+  'employment_description',
+  'hired_without_voucher_assessment',
+];
+
+const APPLICATION_KEYS: (keyof Application)[] = [
+  ...CONTACT_INFO_KEYS,
+  'termsAndConditions',
+];
 
 const mergeEmployerData = (application: Application): void => {
   const employerData = ApplicationPersistenceService.getEmployerData();
@@ -49,27 +75,6 @@ const mergeUserValues = <T>(
   });
 };
 
-const CONTACT_INFO_KEYS: (keyof ContactInfo)[] = [
-  'contact_person_name',
-  'contact_person_email',
-  'contact_person_phone_number',
-  'street_address',
-  'bank_account_number',
-];
-
-const EMPLOYMENT_KEYS: (keyof Employment)[] = [
-  'employee_name',
-  'summer_voucher_serial_number',
-  'employee_phone_number',
-  'employment_postcode',
-  'employment_start_date',
-  'employment_end_date',
-  'employment_work_hours',
-  'employment_salary_paid',
-  'employment_description',
-  'hired_without_voucher_assessment',
-];
-
 const useResetApplicationFormValuesEffect = ({
   reset,
   getValues,
@@ -80,31 +85,33 @@ const useResetApplicationFormValuesEffect = ({
     if (!applicationQuery.isSuccess || !applicationQuery.data) return;
 
     const currentValues = getValues();
-    const application = getFormApplication(applicationQuery.data);
+    const application = getFormApplication(
+      applicationQuery.data
+    ) as Application;
     const vouchers = ensureVoucherExists(application.summer_vouchers ?? []);
     application.summer_vouchers = vouchers;
 
-    // Clever Fix: Because search inputs and date fields are often NOT immediately
-    // persisted to the backend (read-only or draft state), we manually preserve
-    // the user's current typed/selected values for these fields.
-    //
     // Comparison Hierarchy:
     // 1. On Initial Load (isDirty === false): We trust (Server Data + SessionStorage Data).
     // 2. During Active Edit (isDirty === true): We trust (User Typed Value) over Server Data.
     if (currentValues && isDirty) {
-      mergeUserValues(application, currentValues, CONTACT_INFO_KEYS);
+      mergeUserValues(application, currentValues, APPLICATION_KEYS);
 
-      application.summer_vouchers = application.summer_vouchers.map((v, i) => {
-        const current = currentValues.summer_vouchers?.[i];
-        const updatedVoucher = { ...v };
-        mergeUserValues(updatedVoucher, current, EMPLOYMENT_KEYS);
-        return updatedVoucher;
-      });
+      application.summer_vouchers = (application.summer_vouchers ?? []).map(
+        (v, i) => {
+          const current = currentValues.summer_vouchers?.[i];
+          const updatedVoucher = { ...v };
+          mergeUserValues(updatedVoucher, current, EMPLOYMENT_KEYS);
+          return updatedVoucher;
+        }
+      );
     }
 
     mergeEmployerData(application);
 
     reset(application, { keepDirty: isDirty });
+    // isDirty should not be a dependency here, because it makes the UI and browser tests flaky.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reset, applicationQuery.isSuccess, applicationQuery.data, getValues]);
 };
 

--- a/frontend/kesaseteli/employer/src/hooks/backend/useUserQuery.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useUserQuery.ts
@@ -1,5 +1,5 @@
-import { useRouter } from 'next/router';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
+import { useRouter } from 'next/router';
 import {
   QueryKey,
   useQuery,

--- a/frontend/kesaseteli/employer/src/pages/application.tsx
+++ b/frontend/kesaseteli/employer/src/pages/application.tsx
@@ -1,8 +1,8 @@
 import Step1EmployerAndEmployment from 'kesaseteli/employer/components/application/steps/step1/Step1EmployerAndEmployment';
 import Step2Summary from 'kesaseteli/employer/components/application/steps/step2/Step2Summary';
+import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
 import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
 import useStepStorage from 'kesaseteli/employer/hooks/wizard/useStepStorage';
-import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
 import { GetStaticProps, NextPage } from 'next';
 import * as React from 'react';
 import ApplicationWizard from 'shared/components/application-wizard/ApplicationWizard';

--- a/frontend/kesaseteli/employer/src/pages/index.tsx
+++ b/frontend/kesaseteli/employer/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import Dashboard from 'kesaseteli/employer/components/dashboard/Dashboard';
+import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
 import useApplicationsQuery from 'kesaseteli/employer/hooks/backend/useApplicationsQuery';
 import useCompanyQuery from 'kesaseteli/employer/hooks/backend/useCompanyQuery';
-import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
 import { DashboardVoucher } from 'kesaseteli/employer/types/types';
 import { GetStaticProps, NextPage } from 'next';
 import React from 'react';

--- a/frontend/kesaseteli/employer/src/pages/thankyou.tsx
+++ b/frontend/kesaseteli/employer/src/pages/thankyou.tsx
@@ -1,7 +1,7 @@
 import { Button, IconCheckCircleFill } from 'hds-react';
+import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
 import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
 import useCreateApplicationQuery from 'kesaseteli/employer/hooks/backend/useCreateApplicationQuery';
-import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
 import ApplicationPersistenceService from 'kesaseteli/employer/services/ApplicationPersistenceService';
 import { extractEmployerFields } from 'kesaseteli/employer/utils/application.utils';
 import { GetStaticProps, NextPage } from 'next';

--- a/frontend/kesaseteli/employer/src/services/ApplicationPersistenceService.ts
+++ b/frontend/kesaseteli/employer/src/services/ApplicationPersistenceService.ts
@@ -2,10 +2,8 @@
 
 import { extractEmployerFields } from 'kesaseteli/employer/utils/application.utils';
 import Application from 'shared/types/application';
-import Employment from 'shared/types/employment';
 
 const EMPLOYER_DATA_KEY = 'kesaseteli_employer_data';
-const SUPPLEMENT_PREFIX = 'kesaseteli_voucher_supplement_';
 
 /**
  * Service for managing application form data persistence in sessionStorage.
@@ -84,55 +82,12 @@ class ApplicationPersistenceService {
   }
 
   /**
-   * Stores supplemental data for a specific employment voucher in sessionStorage.
-   * Data is obfuscated before storage.
-   * @param voucherId The unique ID of the voucher (employment).
-   * @param data Partial employment data to persist.
-   */
-  public static storeVoucherSupplement(
-    voucherId: string,
-    data: Partial<Employment>
-  ): void {
-    if (typeof sessionStorage === 'undefined') return;
-    const encodedData = ApplicationPersistenceService.encode(
-      JSON.stringify(data)
-    );
-    sessionStorage.setItem(`${SUPPLEMENT_PREFIX}${voucherId}`, encodedData);
-  }
-
-  /**
-   * Retrieves supplemental data for a specific employment voucher from sessionStorage.
-   * Data is de-obfuscated after retrieval.
-   * @param voucherId The unique ID of the voucher (employment).
-   * @returns The stored partial employment data, or null if none exists.
-   */
-  public static getVoucherSupplement(
-    voucherId: string
-  ): Partial<Employment> | null {
-    if (typeof sessionStorage === 'undefined') return null;
-    const encodedData = sessionStorage.getItem(
-      `${SUPPLEMENT_PREFIX}${voucherId}`
-    );
-    if (!encodedData) return null;
-
-    try {
-      const decodedData = ApplicationPersistenceService.decode(encodedData);
-      return JSON.parse(decodedData) as Partial<Employment>;
-    } catch {
-      return null;
-    }
-  }
-
-  /**
    * Clears all persisted application data from sessionStorage.
    * Called on logout, successful submission, or when starting a fresh application.
    */
   public static clearAll(): void {
     if (typeof sessionStorage === 'undefined') return;
     sessionStorage.removeItem(EMPLOYER_DATA_KEY);
-    Object.keys(sessionStorage)
-      .filter((key) => key.startsWith(SUPPLEMENT_PREFIX))
-      .forEach((key) => sessionStorage.removeItem(key));
   }
 }
 

--- a/frontend/kesaseteli/employer/src/services/__tests__/ApplicationPersistenceService.test.ts
+++ b/frontend/kesaseteli/employer/src/services/__tests__/ApplicationPersistenceService.test.ts
@@ -1,11 +1,9 @@
 /* eslint-disable scanjs-rules/identifier_sessionStorage */
 import Application from 'shared/types/application';
-import Employment from 'shared/types/employment';
 
 import ApplicationPersistenceService from '../ApplicationPersistenceService';
 
 const EMPLOYER_DATA_KEY = 'kesaseteli_employer_data';
-const SUPPLEMENT_PREFIX = 'kesaseteli_voucher_supplement_';
 
 describe('ApplicationPersistenceService', () => {
   const mockEmployerData: Partial<Application> = {
@@ -14,10 +12,6 @@ describe('ApplicationPersistenceService', () => {
     contact_person_phone_number: '0401234567',
     street_address: 'Testikatu 1',
     bank_account_number: 'FI1234567890',
-  };
-
-  const mockVoucherSupplement: Partial<Employment> = {
-    employee_ssn: '010101-0101',
   };
 
   beforeEach(() => {
@@ -71,60 +65,13 @@ describe('ApplicationPersistenceService', () => {
     });
   });
 
-  describe('storeVoucherSupplement and getVoucherSupplement', () => {
-    it('should store and retrieve voucher supplement', () => {
-      const voucherId = 'test-voucher-id';
-      ApplicationPersistenceService.storeVoucherSupplement(
-        voucherId,
-        mockVoucherSupplement
-      );
-      const retrievedData =
-        ApplicationPersistenceService.getVoucherSupplement(voucherId);
-      expect(retrievedData).toEqual(mockVoucherSupplement);
-    });
-
-    it('should store supplement in obfuscated (Base64) format', () => {
-      const voucherId = 'test-voucher-id';
-      ApplicationPersistenceService.storeVoucherSupplement(
-        voucherId,
-        mockVoucherSupplement
-      );
-      const storedRaw = sessionStorage.getItem(
-        `${SUPPLEMENT_PREFIX}${voucherId}`
-      );
-
-      const decoded = atob(storedRaw || '');
-      expect(JSON.parse(decoded)).toEqual(mockVoucherSupplement);
-    });
-
-    it('should return null if no voucher supplement is stored', () => {
-      expect(
-        ApplicationPersistenceService.getVoucherSupplement('non-existent')
-      ).toBeNull();
-    });
-  });
-
   describe('clearAll', () => {
     it('should clear all persisted data', () => {
       ApplicationPersistenceService.storeEmployerData(mockEmployerData);
-      ApplicationPersistenceService.storeVoucherSupplement(
-        'v1',
-        mockVoucherSupplement
-      );
-      ApplicationPersistenceService.storeVoucherSupplement(
-        'v2',
-        mockVoucherSupplement
-      );
 
       ApplicationPersistenceService.clearAll();
 
       expect(ApplicationPersistenceService.getEmployerData()).toBeNull();
-      expect(
-        ApplicationPersistenceService.getVoucherSupplement('v1')
-      ).toBeNull();
-      expect(
-        ApplicationPersistenceService.getVoucherSupplement('v2')
-      ).toBeNull();
     });
 
     it('should only clear application-related data from sessionStorage', () => {


### PR DESCRIPTION
YJDH-852.

Instead of storing all fields that the API does not give in response to session storage, we should storage only the employer data, because the employment data is so sensitive. If user navigates away from the form or reloads the page, a dirty form should trigger unload event anyway, and ask for permission to navigate away with a prompt.


Refactor employer UI design and mocks to solidify the process:
- Added DESIGN.md to document the application wizard flow, draft persistence lifecycle, and security features (audit logging and sessionStorage obfuscation).
- Refined formatting and logic in application.mocks.ts to improve consistency and readability of the browser test infrastructure.
- Detailed the Suomi.fi 'Organisation Context' and backend YTJ linking to provide a clear architectural overview.
- Mapped the frontend draft triggers to specific API hooks for better maintenance.

The documentation now serves as a reliable source of truth for the multi-step wizard behavior and data persistence triggers.