### PR TITLE
fix(ks,employer): prevent infinite loop on no-organisation page

### DIFF
--- a/frontend/kesaseteli/employer/src/hocs/__tests__/withOrganisation.test.tsx
+++ b/frontend/kesaseteli/employer/src/hocs/__tests__/withOrganisation.test.tsx
@@ -36,6 +36,19 @@ describe('withOrganisation', () => {
     expect(mockGoToPage).toHaveBeenCalledWith('/no-organisation');
   });
 
+  it('should redirect to /no-organisation when user gets 404 Not Found and is NOT on /no-organisation', () => {
+    const mockError = new Error('404 Not Found');
+    (useCompanyQuery as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isSuccess: false,
+      error: mockError,
+    });
+    renderComponent(<WrappedComponent />, { pathname: '/' });
+
+    expect(mockGoToPage).toHaveBeenCalledWith('/no-organisation');
+  });
+
   it('should NOT redirect to /no-organisation when user gets 403 Forbidden and is ALREADY on /no-organisation', () => {
     // This test reproduces the fix for the infinite loop issue.
     // Without the fix, the component would keep calling goToPage('/no-organisation')

--- a/frontend/kesaseteli/employer/src/hocs/withEmployerAuth.tsx
+++ b/frontend/kesaseteli/employer/src/hocs/withEmployerAuth.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import { useRouter } from 'next/router';
 import withAuth from 'shared/components/hocs/withAuth';
 import withOrganisation from './withOrganisation';
 
@@ -7,6 +9,15 @@ import withOrganisation from './withOrganisation';
  */
 const withEmployerAuth = <P extends JSX.IntrinsicAttributes>(
   WrappedComponent: React.FC<P>
-): React.FC<P> => withAuth(withOrganisation(WrappedComponent));
+): React.FC<P> => {
+  const AuthenticatedComponent = withAuth(withOrganisation(WrappedComponent));
+  return function Wrapped(props: P) {
+    const { pathname } = useRouter();
+    if (pathname === '/login' || pathname === '/no-organisation') {
+      return <WrappedComponent {...props} />;
+    }
+    return <AuthenticatedComponent {...props} />;
+  };
+};
 
 export default withEmployerAuth;

--- a/frontend/kesaseteli/employer/src/hocs/withOrganisation.tsx
+++ b/frontend/kesaseteli/employer/src/hocs/withOrganisation.tsx
@@ -29,8 +29,12 @@ const withOrganisation = <P extends JSX.IntrinsicAttributes>(
       isError(err) &&
       (err.message.includes('403') || err.message.includes('Forbidden'));
 
+    const isNotFound = (err: unknown): boolean =>
+      isError(err) &&
+      (err.message.includes('404') || err.message.includes('Not Found'));
+
     const isNoOrganisation = isCompanySuccess && !company?.name;
-    const isAuthError = isForbidden(companyError);
+    const isAuthError = isForbidden(companyError) || isNotFound(companyError);
 
     React.useEffect(() => {
       // Redirect to no-organisation only if authenticated but unauthorized for organizations

--- a/frontend/kesaseteli/employer/src/hooks/backend/useUserQuery.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useUserQuery.ts
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import {
   QueryKey,
@@ -17,14 +18,15 @@ const useUserQuery = <T = User>({
 }: UseQueryOptions<T> = {}): UseQueryResult<T> => {
   const isRouting = useIsRouting();
   const goToPage = useGoToPage();
+  const router = useRouter();
   return useQuery(BackendEndpoint.USER as QueryKey, {
     enabled: !!enabled && !isRouting,
     onError: useErrorHandler({
       onServerError: () => goToPage('/login?error=true'),
       onAuthError: () => {
         if (
-          !window.location.pathname.includes('/login') &&
-          !window.location.pathname.includes('/no-organisation')
+          router.pathname !== '/login' &&
+          router.pathname !== '/no-organisation'
         ) {
           goToPage('/login?sessionExpired=true');
         }


### PR DESCRIPTION
YJDH-840.

If I have logged in with ADFS, which means that I do not represent any company, I should be taken to no-organisation -page. However, an infinite loop takes in action instead and this commit tries to fix that.