### PR TITLE
fix(ks): handle cancelled login and suomi-fi -logout next-path

### DIFF
--- a/backend/kesaseteli/kesaseteli/urls.py
+++ b/backend/kesaseteli/kesaseteli/urls.py
@@ -12,6 +12,7 @@ from applications.views import (
 from common.views import healthz, readiness
 from companies.api.v1.views import GetCompanyView
 from shared.suomi_fi.views import (
+    HelsinkiSaml2LogoutView,
     SuomiFiAssertionConsumerServiceView,
     SuomiFiMetadataView,
 )
@@ -63,14 +64,21 @@ if settings.NEXT_PUBLIC_ENABLE_SUOMIFI:
         path(
             "saml2/acs/",
             SuomiFiAssertionConsumerServiceView.as_view(),
-            name="suomifi_saml2_acs",
+            name="saml2_acs",
         )
     )
     urlpatterns.append(
         path(
             "saml2/metadata/",
             SuomiFiMetadataView.as_view(),
-            name="suomifi_saml2_metadata",
+            name="saml2_metadata",
+        )
+    )
+    urlpatterns.append(
+        path(
+            "saml2/logout/",
+            HelsinkiSaml2LogoutView.as_view(),
+            name="saml2_logout",
         )
     )
     urlpatterns.append(path("saml2/", include("djangosaml2.urls")))

--- a/backend/shared/shared/suomi_fi/tests/test_views.py
+++ b/backend/shared/shared/suomi_fi/tests/test_views.py
@@ -1,0 +1,92 @@
+from unittest import mock
+
+import pytest
+from django.http import HttpResponseRedirect
+from django.test import RequestFactory
+
+from shared.suomi_fi.views import (
+    RELAY_STATE_PARAM,
+    HelsinkiSaml2LogoutView,
+    SuomiFiAssertionConsumerServiceView,
+)
+
+
+@pytest.mark.django_db
+class TestSuomiFiViews:
+    def test_handle_acs_failure_with_relay_state(self):
+        factory = RequestFactory()
+        relay_state = "https://auth-started-here.hel.fi/fi/callback-here"
+        request = factory.post("/saml2/acs/", {RELAY_STATE_PARAM: relay_state})
+
+        view = SuomiFiAssertionConsumerServiceView()
+
+        with mock.patch(
+            "shared.suomi_fi.views.is_safe_redirect_url", return_value=True
+        ):
+            response = view.handle_acs_failure(request)
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == relay_state
+
+    def test_handle_acs_failure_without_relay_state(self):
+        factory = RequestFactory()
+        request = factory.post("/saml2/acs/")
+
+        view = SuomiFiAssertionConsumerServiceView()
+
+        # We need to mock the super().handle_acs_failure to avoid 403 error page rendering during test
+        with mock.patch(
+            "djangosaml2.views.AssertionConsumerServiceView.handle_acs_failure"
+        ) as mock_super:
+            view.handle_acs_failure(request)
+            mock_super.assert_called_once()
+
+    def test_helsinki_saml2_logout_view_captures_next(self):
+        factory = RequestFactory()
+        next_url = "/dashboard"
+        request = factory.get("/saml2/logout/", {"next": next_url})
+
+        view = HelsinkiSaml2LogoutView()
+
+        # Mock super().get to avoid full logout initiation
+        with mock.patch("djangosaml2.views.LogoutInitView.get", return_value=None):
+            view.get(request)
+
+        assert view.next_path == next_url
+
+    def test_handle_unsupported_slo_exception_redirects_to_next(self):
+        factory = RequestFactory()
+        next_url = "https://auth-started-here.hel.fi/fi/logout-callback"
+        request = factory.get("/saml2/logout/")
+
+        view = HelsinkiSaml2LogoutView()
+        view.next_path = next_url
+
+        with mock.patch(
+            "shared.suomi_fi.views.is_safe_redirect_url", return_value=True
+        ):
+            response = view.handle_unsupported_slo_exception(
+                request, Exception("SLO not supported")
+            )
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == next_url
+
+    def test_handle_unsupported_slo_exception_safe_check(self):
+        factory = RequestFactory()
+        next_url = "https://malicious.com"
+        request = factory.get("/saml2/logout/")
+
+        view = HelsinkiSaml2LogoutView()
+        view.next_path = next_url
+
+        with mock.patch(
+            "shared.suomi_fi.views.is_safe_redirect_url", return_value=False
+        ):
+            with mock.patch(
+                "djangosaml2.views.LogoutInitView.handle_unsupported_slo_exception"
+            ) as mock_super:
+                view.handle_unsupported_slo_exception(
+                    request, Exception("SLO not supported")
+                )
+                mock_super.assert_called_once()

--- a/backend/shared/shared/suomi_fi/views.py
+++ b/backend/shared/shared/suomi_fi/views.py
@@ -1,13 +1,22 @@
 from django.conf import settings
-from django.http import HttpRequest, HttpResponse
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
-from djangosaml2.views import AssertionConsumerServiceView, MetadataView
+from djangosaml2.views import (
+    AssertionConsumerServiceView,
+    LogoutInitView,
+    MetadataView,
+)
 from saml2.md import ServiceName
 from saml2.metadata import entity_descriptor
 
 from shared.common.utils import is_safe_redirect_url
+
+# "RelayState" is a standard SAML parameter name and no constant is exported
+# for it in djangosaml2 or pysaml2.
+RELAY_STATE_PARAM = "RelayState"
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -40,6 +49,49 @@ class SuomiFiAssertionConsumerServiceView(AssertionConsumerServiceView):
         if relay_state and is_safe_redirect_url(self.request, relay_state):
             self.request.session["eauth_next_url"] = relay_state
         return reverse("eauth_authentication_init")
+
+    def handle_acs_failure(self, request, exception=None, status=403, **kwargs):
+        """
+        Redirect back to the RelayState if it exists and is safe, instead of showing
+        the default error page. This handles cases like user cancelling the
+        authentication at Suomi.fi.
+
+        NOTE: "RelayState" is a standard SAML parameter name.
+        """
+        relay_state = request.POST.get(RELAY_STATE_PARAM) or request.GET.get(
+            RELAY_STATE_PARAM
+        )
+        if relay_state and is_safe_redirect_url(request, relay_state):
+            return HttpResponseRedirect(relay_state)
+
+        return super().handle_acs_failure(request, exception, status, **kwargs)
+
+
+class HelsinkiSaml2LogoutView(LogoutInitView):
+    """
+    SAML2 logout view that supports 'next' parameter.
+    """
+
+    def get(self, request, *args, **kwargs):
+        # Capture 'next' parameter so it can be used on failure.
+        # RELAY_STATE_PARAM is also checked as a fallback for standard SAML logout.
+        self.next_path = (
+            request.GET.get(REDIRECT_FIELD_NAME)
+            or request.GET.get(RELAY_STATE_PARAM)
+            or request.POST.get(RELAY_STATE_PARAM)
+        )
+        return super().get(request, *args, **kwargs)
+
+    def handle_unsupported_slo_exception(self, request, exception, *args, **kwargs):
+        if (
+            hasattr(self, "next_path")
+            and self.next_path
+            and is_safe_redirect_url(request, self.next_path)
+        ):
+            return HttpResponseRedirect(self.next_path)
+        return super().handle_unsupported_slo_exception(
+            request, exception, *args, **kwargs
+        )
 
 
 class SuomiFiMetadataView(MetadataView):

--- a/frontend/kesaseteli/employer/src/components/header/__tests__/Header.test.tsx
+++ b/frontend/kesaseteli/employer/src/components/header/__tests__/Header.test.tsx
@@ -41,7 +41,11 @@ describe('frontend/kesaseteli/employer/src/components/header/Header.tsx', () => 
     await headerApi.actions.clickLogoutButton(user);
     await waitFor(() =>
       expect(spyRouterPush).toHaveBeenCalledWith(
-        `${getBackendUrl('/oidc/logout/')}`
+        expect.stringMatching(
+          new RegExp(
+            `^${getBackendUrl('/oidc/logout/')}\\?next=https?%3A%2F%2F`
+          )
+        )
       )
     );
     await waitFor(() =>

--- a/frontend/kesaseteli/employer/src/hooks/backend/useLogout.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useLogout.ts
@@ -2,6 +2,7 @@ import ApplicationPersistenceService from 'kesaseteli/employer/services/Applicat
 import {
   BackendEndpoint,
   getBackendUrl,
+  getLogoutRedirectUrl,
   REDIRECT_FIELD_NAME,
 } from 'kesaseteli-shared/backend-api/backend-api';
 import { useRouter } from 'next/router';
@@ -13,14 +14,13 @@ const useLogout = (): ((logoutRedirectPath?: string) => Promise<boolean>) => {
     async (logoutRedirectPath?: string) => {
       ApplicationPersistenceService.clearAll();
       const logoutUrl = getBackendUrl(BackendEndpoint.LOGOUT);
-      if (logoutRedirectPath) {
-        return router.push(
-          `${logoutUrl}?${REDIRECT_FIELD_NAME}=${encodeURIComponent(
-            logoutRedirectPath
-          )}`
-        );
-      }
-      return router.push(logoutUrl);
+      const redirectPath =
+        logoutRedirectPath || getLogoutRedirectUrl(router.locale);
+      return router.push(
+        `${logoutUrl}?${REDIRECT_FIELD_NAME}=${encodeURIComponent(
+          redirectPath
+        )}`
+      );
     },
     [router]
   );

--- a/frontend/kesaseteli/handler/src/__tests__/index.test.tsx
+++ b/frontend/kesaseteli/handler/src/__tests__/index.test.tsx
@@ -55,7 +55,7 @@ describe('frontend/kesaseteli/handler/src/pages/index.tsx', () => {
     renderPage(HandlerIndex, { push: spyPush, query: { id: '123-abc' } });
     await waitFor(() =>
       expect(spyPush).toHaveBeenCalledWith(
-        `${DEFAULT_LANGUAGE}/500`,
+        `/${DEFAULT_LANGUAGE}/500`,
         undefined,
         { shallow: false }
       )
@@ -541,7 +541,7 @@ describe('frontend/kesaseteli/handler/src/pages/index.tsx', () => {
         await indexPageApi.actions.clickConfirmButton(operationType, 500);
         await waitFor(() =>
           expect(spyPush).toHaveBeenCalledWith(
-            `${DEFAULT_LANGUAGE}/500`,
+            `/${DEFAULT_LANGUAGE}/500`,
             undefined,
             { shallow: false }
           )

--- a/frontend/kesaseteli/handler/src/hooks/backend/useLogout.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/useLogout.ts
@@ -1,18 +1,20 @@
+import { useRouter } from 'next/router';
+import React from 'react';
 import {
   BackendEndpoint,
   getBackendUrl,
+  getLogoutRedirectUrl,
   REDIRECT_FIELD_NAME,
 } from 'kesaseteli-shared/backend-api/backend-api';
-import { useRouter } from 'next/router';
-import React from 'react';
 
 const useLogout = (): (() => Promise<boolean>) => {
   const router = useRouter();
   return React.useCallback(async () => {
-    const nextUrl = encodeURIComponent(window.location.origin);
     const logoutUrl = `${getBackendUrl(
       BackendEndpoint.ADFS_LOGOUT
-    )}?${REDIRECT_FIELD_NAME}=${nextUrl}`;
+    )}?${REDIRECT_FIELD_NAME}=${encodeURIComponent(
+      getLogoutRedirectUrl(router.locale)
+    )}`;
     return router.push(logoutUrl);
   }, [router]);
 };

--- a/frontend/kesaseteli/shared/src/backend-api/backend-api.ts
+++ b/frontend/kesaseteli/shared/src/backend-api/backend-api.ts
@@ -53,3 +53,6 @@ export const getYouthApplicationStatusQueryKey = (id: string): string =>
 
 export const getAdditionalInfoQueryKey = (id: string): string =>
   `${getYouthApplicationQueryKey(id)}additional_info/`;
+
+export const getLogoutRedirectUrl = (locale?: string): string =>
+  new URL(locale ?? '', window.location.origin).toString();


### PR DESCRIPTION
YJDH-614.

1. When a login process is cancelled, user was taken to authentication error / access denied page (API url: /saml2/acs).

2. When a logout from employer UI was called, user was taken to API root, when they should have been taken to employer UI login page.
