### PR TITLE
YJDH-868 | Kesäseteli: Remove employee_ssn from fetch_employee_data & some others

### DIFF
--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -248,7 +248,6 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
             "summer_voucher_serial_number",
             "employee_name",
             "employee_school",
-            "employee_ssn",
             "employee_birthdate",
             "employee_phone_number",
             "employee_home_city",
@@ -266,7 +265,6 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
         read_only_fields = [
             "ordering",
             "employee_school",
-            "employee_ssn",
             "employee_birthdate",
             "employee_home_city",
             "employee_postcode",

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -326,7 +326,6 @@ class YouthApplicationViewSet(ModelViewSet):
             data={
                 "employer_summer_voucher_id": str(employer_summer_voucher_id),
                 "employee_name": youth_application.name,
-                "employee_ssn": youth_application.social_security_number,
                 "employee_birthdate": youth_application.birthdate,
                 "employee_phone_number": youth_application.phone_number,
                 "employee_home_city": youth_application.home_municipality,

--- a/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
+++ b/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
@@ -1305,7 +1305,6 @@ def test_youth_application_fetch_employee_data(user_client):
         assert response.data == {
             "employer_summer_voucher_id": str(employer_summer_voucher.id),
             "employee_name": "John Doe",
-            "employee_ssn": "111111-111C",
             "employee_birthdate": date(1911, 11, 11),
             "employee_phone_number": "123456789",
             "employee_home_city": "Helsinki",

--- a/frontend/kesaseteli/employer/browser-tests/types.ts
+++ b/frontend/kesaseteli/employer/browser-tests/types.ts
@@ -33,7 +33,6 @@ export type VoucherData = {
   id: string;
   summer_voucher_serial_number?: string;
   employee_name?: string;
-  employee_ssn: string;
   employee_birthdate?: string;
   employee_phone_number: string;
   employee_home_city: string;

--- a/frontend/shared/src/__tests__/utils/FakeObjectFactory.ts
+++ b/frontend/shared/src/__tests__/utils/FakeObjectFactory.ts
@@ -111,7 +111,6 @@ class FakeObjectFactory {
       id: this.generateId(),
       employee_name: faker.name.findName(),
       employee_school: faker.commerce.department(),
-      employee_ssn: '111111-111C',
       employee_birthdate: '2000-01-01',
       employee_phone_number: faker.phone.phoneNumber(),
       // for example dots are not allowed in city name, so let's remove them (St. Louis -> St Louis)

--- a/frontend/shared/src/types/employment.d.ts
+++ b/frontend/shared/src/types/employment.d.ts
@@ -12,7 +12,6 @@ export type EmployeeHiredWithoutVoucherAssessment =
 
 export type EmploymentBase = {
   employee_name?: string;
-  employee_ssn?: string;
   employee_birthdate?: string;
   employee_phone_number?: string;
   employee_home_city?: string;

--- a/frontend/shared/src/utils/__tests__/mask-gdpr-data.test.ts
+++ b/frontend/shared/src/utils/__tests__/mask-gdpr-data.test.ts
@@ -55,7 +55,6 @@ describe('frontend/shared/src/utils/masked-gdpr-data.ts', () => {
       summer_vouchers: application.summer_vouchers.map((voucher) => ({
         ...voucher,
         employee_name: masked(voucher.employee_name),
-        employee_ssn: masked(voucher.employee_ssn),
         employee_phone_number: masked(voucher.employee_phone_number),
       })),
     });


### PR DESCRIPTION
## Description :sparkles:

**NOTE**:
- In handlers' UI access to youth's social security number may be warranted for checking their identity, but IMHO the way how they access it, if needed, can be thought of when implementing that functionality.

### Kesäseteli: Remove employee_ssn from fetch_employee_data & some others

The employee_ssn is unused and unnecessary in fetch_employee_data, and should be removed to remove unnecessary spreading of sensitive data.

## Related

[YJDH-868](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-868)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-868]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ