### PR TITLE
YJDH-648 | Kesäseteli backend: Fix creating company with None address values

### DIFF
--- a/backend/kesaseteli/companies/services.py
+++ b/backend/kesaseteli/companies/services.py
@@ -34,7 +34,12 @@ def get_or_create_company_using_company_data(company_data: dict) -> Company:
     business_id = company_data.pop("business_id")
     ytj_data = company_data.pop("ytj_json", {})
 
-    defaults = COMPANY_SAFE_DEFAULTS | {"name": "", "ytj_json": ytj_data} | company_data
+    defaults = {"name": "", "ytj_json": ytj_data} | company_data
+
+    # Overwrite defaults only for missing or None values
+    for key, value in COMPANY_SAFE_DEFAULTS.items():
+        if defaults.get(key, None) is None:
+            defaults[key] = value
 
     company, created = Company.objects.get_or_create(
         business_id=business_id, defaults=defaults

--- a/backend/kesaseteli/companies/tests/test_company_services.py
+++ b/backend/kesaseteli/companies/tests/test_company_services.py
@@ -78,3 +78,36 @@ def test_get_or_create_company_via_ytj_data_uses_defaults():
     assert company.postcode == ""
     assert company.city == ""
     assert company.ytj_json == ytj_data
+
+
+@pytest.mark.django_db
+def test_get_or_create_company_using_company_data_with_none_address_fields():
+    """
+    Test that get_or_create_company_using_company_data handles cases where
+    YTJ data uses "addresses" / "freeAddressLine" field instead of separate fields
+    for postcode, street_address and city.
+
+    An example from open public endpoint data:
+    @see https://avoindata.prh.fi/opendata-ytj-api/v3/companies?businessId=3156602-3
+    """
+    company_data = {
+        "business_id": "3156602-3",
+        "city": None,
+        "company_form": "Osakeyhtiö",
+        "industry": "Muu erikoistumaton vähittäiskauppa",
+        "name": "Test Company Oy",
+        "postcode": None,
+        "street_address": None,
+    }
+
+    result = get_or_create_company_using_company_data(company_data)
+
+    assert isinstance(result, Company)
+    assert result.business_id == "3156602-3"
+    assert result.city == ""
+    assert result.company_form == "Osakeyhtiö"
+    assert result.industry == "Muu erikoistumaton vähittäiskauppa"
+    assert result.name == "Test Company Oy"
+    assert result.postcode == ""
+    assert result.street_address == ""
+    assert result.ytj_json == {}


### PR DESCRIPTION
## Description :sparkles:

### Kesäseteli backend: Fix creating company with None address values

Example from production use is business ID 3156602-3, which uses
freeAddressLine, not structured address fields.

The data can be seen from an open public endpoint:
https://avoindata.prh.fi/opendata-ytj-api/v3/companies?businessId=3156602-3

## Issues :bug:

[YJDH-648](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-648)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-648]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ