### PR TITLE
feat(benefit): show applications with requested payslips and report salaries

### DIFF
--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -134,10 +134,19 @@ class BaseApplicationFilter(filters.FilterSet):
 
         query = Q(**query) | Q(status=ApplicationStatus.CANCELLED)
 
+        second_instalment_requested_query = Q(
+            calculation__instalments__instalment_number=2,
+            calculation__instalments__status=InstalmentStatus.REQUESTED,
+        )
+
         if value:
-            return queryset.filter(query)
+            return queryset.filter(query).filter(
+                ~second_instalment_requested_query
+            ).distinct()
         else:
-            return queryset.filter(~query)
+            return queryset.filter(
+                ~query | second_instalment_requested_query
+            ).distinct()
 
 
 class ApplicantApplicationFilter(BaseApplicationFilter):
@@ -376,7 +385,7 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
             qs = qs.filter(
                 calculation__instalments__instalment_number=2,
                 calculation__instalments__status=second_instalment_status,
-            )
+            ).distinct()
 
         ahjo_cases = request.query_params.get("ahjo_case") == "1"
         if ahjo_cases:

--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -790,6 +790,63 @@ class ApplicantApplicationViewSet(BaseApplicationViewSet):
             status=status.HTTP_201_CREATED,
         )
 
+    @action(methods=["GET"], detail=True, url_path="get_second_instalment_info")
+    @transaction.atomic
+    def get_second_instalment_info(self, request, pk) -> HttpResponse:
+        application = self.get_object()
+        if not application.calculation:
+            return Response(
+                {"detail": _("No calculation found")},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        second_instalment = application.calculation.instalments.filter(
+            instalment_number=2
+        ).first()
+        if not second_instalment:
+            return Response(
+                {"detail": _("No second instalment found")},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        instalment_start_date = application.calculation.start_date + relativedelta(
+            months=6
+        )
+        instalment_end_date = application.calculation.end_date
+        return Response(
+            {
+                "application_number": application.application_number,
+                "submitted_at": application.submitted_at,
+                "employee_first_name": application.employee.first_name,
+                "employee_last_name": application.employee.last_name,
+                "start_date": instalment_start_date,
+                "end_date": instalment_end_date,
+                "amount": second_instalment.amount,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    @action(methods=["POST"], detail=True, url_path="second_instalment_respond")
+    @transaction.atomic
+    def second_instalment_respond(self, request, pk) -> HttpResponse:
+        application = self.get_object()
+        if not application.calculation:
+            return Response(
+                {"detail": "Application calculation not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        second_instalment = application.calculation.instalments.filter(
+            instalment_number=2
+        ).first()
+        if not second_instalment:
+            return Response(
+                {"detail": "Second instalment not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        second_instalment.status = InstalmentStatus.RESPONDED
+        second_instalment.save()
+        return Response(
+            status=status.HTTP_200_OK,
+        )
+
 
 @extend_schema(
     description=(

--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -134,25 +134,24 @@ class BaseApplicationFilter(filters.FilterSet):
 
         query = Q(**query) | Q(status=ApplicationStatus.CANCELLED)
 
-        second_instalment_requested_query = Q(
-            calculation__instalments__instalment_number=2,
-            calculation__instalments__status=InstalmentStatus.REQUESTED,
-        )
-        not_cancelled_query = ~Q(status=ApplicationStatus.CANCELLED)
-
-        active_second_instalment_requested_query = (
-            second_instalment_requested_query & not_cancelled_query
+        active_second_instalment_requested_application_pks = (
+            Application.objects.filter(
+                calculation__instalments__instalment_number=2,
+                calculation__instalments__status=InstalmentStatus.REQUESTED,
+            )
+            .exclude(status=ApplicationStatus.CANCELLED)
+            .values("pk")
         )
 
         if value:
             return (
                 queryset.filter(query)
-                .filter(~active_second_instalment_requested_query)
+                .exclude(pk__in=active_second_instalment_requested_application_pks)
                 .distinct()
             )
         else:
             return queryset.filter(
-                ~query | active_second_instalment_requested_query
+                ~query | Q(pk__in=active_second_instalment_requested_application_pks)
             ).distinct()
 
 
@@ -304,17 +303,22 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
     def post_attachment(self, request, *args, **kwargs):
         """
         Upload a single file as attachment.
-        Validate that adding attachments is allowed in this application status
+        Validate that adding attachments is allowed in this application status.
+        Only PAYSLIPs and OTHER_ATTACHMENTs can be added in the
+        current application state.
         """
         obj = self.get_object()
 
         attachment_type = request.data.get("attachment_type")
-        if attachment_type != AttachmentType.PAYSLIP:
-            if not ApplicationStatus.is_editable_status(self.request.user, obj.status):
-                return Response(
-                    {"detail": _("Operation not allowed for this application status.")},
-                    status=status.HTTP_403_FORBIDDEN,
-                )
+        if not (
+            attachment_type == AttachmentType.PAYSLIP
+            or attachment_type == AttachmentType.OTHER_ATTACHMENT
+            or ApplicationStatus.is_editable_status(self.request.user, obj.status)
+        ):
+            return Response(
+                {"detail": _("Operation not allowed for this application status.")},
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         # Validate request data
         serializer = AttachmentSerializer(
@@ -428,21 +432,15 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
         if not attachment:
             return self._attachment_not_found()
 
-        if (
+        if not (
             attachment.attachment_type == AttachmentType.PAYSLIP
-            and not request.user.is_handler()
+            or attachment.attachment_type == AttachmentType.OTHER_ATTACHMENT
+            or ApplicationStatus.is_editable_status(self.request.user, obj.status)
         ):
             return Response(
                 {"detail": _("Operation not allowed for this application status.")},
                 status=status.HTTP_403_FORBIDDEN,
             )
-
-        if attachment.attachment_type != AttachmentType.PAYSLIP:
-            if not ApplicationStatus.is_editable_status(self.request.user, obj.status):
-                return Response(
-                    {"detail": _("Operation not allowed for this application status.")},
-                    status=status.HTTP_403_FORBIDDEN,
-                )
         if instance := attachment:
             audit_logging.log(
                 request.user,
@@ -807,6 +805,16 @@ class ApplicantApplicationViewSet(BaseApplicationViewSet):
                 {"detail": _("No second instalment found")},
                 status=status.HTTP_404_NOT_FOUND,
             )
+
+        if (
+            not application.calculation.start_date
+            or not application.calculation.end_date
+        ):
+            return Response(
+                {"detail": _("Calculation start or end date is missing")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         instalment_start_date = application.calculation.start_date + relativedelta(
             months=6
         )
@@ -840,6 +848,11 @@ class ApplicantApplicationViewSet(BaseApplicationViewSet):
             return Response(
                 {"detail": "Second instalment not found"},
                 status=status.HTTP_404_NOT_FOUND,
+            )
+        if not second_instalment.status == InstalmentStatus.REQUESTED:
+            return Response(
+                {"detail": "Second instalment status is not REQUESTED"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
         second_instalment.status = InstalmentStatus.RESPONDED
         second_instalment.save()

--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -847,6 +847,21 @@ class ApplicantApplicationViewSet(BaseApplicationViewSet):
             status=status.HTTP_200_OK,
         )
 
+    @action(methods=["PATCH"], detail=True, url_path="change_employer_assurance")
+    @transaction.atomic
+    def change_employer_assurance(self, request, pk) -> HttpResponse:
+        try:
+            employer_assurance = request.data["employerAssurance"]
+        except KeyError:
+            return Response(
+                {"detail": "employerAssurance is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        application = self.get_object()
+        application.employer_assurance = employer_assurance
+        application.save()
+        return Response(status=status.HTTP_200_OK)
+
 
 @extend_schema(
     description=(

--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -140,7 +140,7 @@ class BaseApplicationFilter(filters.FilterSet):
                 calculation__instalments__status=InstalmentStatus.REQUESTED,
             )
             .exclude(status=ApplicationStatus.CANCELLED)
-            .values("pk")
+            .values_list("pk", flat=True)
         )
 
         if value:
@@ -363,7 +363,7 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
                 instalment_number=2,
             )
             .order_by("created_at", "pk")
-            .values("due_date")[:1]
+            .values_list("due_date", flat=True)[:1]
         )
 
         qs = qs.annotate(
@@ -849,7 +849,7 @@ class ApplicantApplicationViewSet(BaseApplicationViewSet):
                 {"detail": "Second instalment not found"},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        if not second_instalment.status == InstalmentStatus.REQUESTED:
+        if second_instalment.status != InstalmentStatus.REQUESTED:
             return Response(
                 {"detail": "Second instalment status is not REQUESTED"},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.core import exceptions
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.db import transaction
-from django.db.models import Prefetch, Q, QuerySet
+from django.db.models import Prefetch, Q, QuerySet, OuterRef, Subquery
 from django.http import FileResponse, HttpResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -74,6 +74,7 @@ from applications.services.generate_application_summary import (
     get_context_for_summary_context,
 )
 from calculator.enums import InstalmentStatus
+from calculator.models import Instalment
 from common.permissions import BFIsApplicant, BFIsHandler, TermsOfServiceAccepted
 from messages.automatic_messages import send_application_reopened_message
 from messages.models import MessageType
@@ -336,6 +337,15 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
             exclude_fields | (extra_exclude_fields - fields)
         )
 
+        second_instalment_due_date = Instalment.objects.filter(
+            calculation=OuterRef("calculation"),
+            instalment_number=2,
+        ).values("due_date")[:1]
+
+        qs = qs.annotate(
+            second_instalment_due_date=Subquery(second_instalment_due_date)
+        )
+
         order_by = request.query_params.get("order_by")
         if (
             order_by
@@ -360,6 +370,13 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
                     Q(archived=should_filter_archived)
                     | Q(pk__in=self._get_application_pks_with_instalments())
                 )
+
+        second_instalment_status = request.query_params.get("second_instalment_status")
+        if second_instalment_status:
+            qs = qs.filter(
+                calculation__instalments__instalment_number=2,
+                calculation__instalments__status=second_instalment_status,
+            )
 
         ahjo_cases = request.query_params.get("ahjo_case") == "1"
         if ahjo_cases:

--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.core import exceptions
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.db import transaction
-from django.db.models import Prefetch, Q, QuerySet, OuterRef, Subquery
+from django.db.models import OuterRef, Prefetch, Q, QuerySet, Subquery
 from django.http import FileResponse, HttpResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -46,6 +46,7 @@ from applications.enums import (
     ApplicationBatchStatus,
     ApplicationOrigin,
     ApplicationStatus,
+    AttachmentType,
 )
 from applications.models import (
     AhjoSetting,
@@ -83,7 +84,6 @@ from shared.audit_log.enums import Operation
 from shared.audit_log.viewsets import AuditLoggingModelViewSet
 from users.models import User
 from users.utils import get_company_from_request
-from applications.enums import AttachmentType
 
 log = logging.getLogger(__name__)
 
@@ -138,14 +138,21 @@ class BaseApplicationFilter(filters.FilterSet):
             calculation__instalments__instalment_number=2,
             calculation__instalments__status=InstalmentStatus.REQUESTED,
         )
+        not_cancelled_query = ~Q(status=ApplicationStatus.CANCELLED)
+
+        active_second_instalment_requested_query = (
+            second_instalment_requested_query & not_cancelled_query
+        )
 
         if value:
-            return queryset.filter(query).filter(
-                ~second_instalment_requested_query
-            ).distinct()
+            return (
+                queryset.filter(query)
+                .filter(~active_second_instalment_requested_query)
+                .distinct()
+            )
         else:
             return queryset.filter(
-                ~query | second_instalment_requested_query
+                ~query | active_second_instalment_requested_query
             ).distinct()
 
 
@@ -346,10 +353,14 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
             exclude_fields | (extra_exclude_fields - fields)
         )
 
-        second_instalment_due_date = Instalment.objects.filter(
-            calculation=OuterRef("calculation"),
-            instalment_number=2,
-        ).values("due_date")[:1]
+        second_instalment_due_date = (
+            Instalment.objects.filter(
+                calculation=OuterRef("calculation"),
+                instalment_number=2,
+            )
+            .order_by("created_at", "pk")
+            .values("due_date")[:1]
+        )
 
         qs = qs.annotate(
             second_instalment_due_date=Subquery(second_instalment_due_date)
@@ -417,7 +428,10 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
         if not attachment:
             return self._attachment_not_found()
 
-        if attachment.attachment_type == AttachmentType.PAYSLIP and not request.user.is_handler():
+        if (
+            attachment.attachment_type == AttachmentType.PAYSLIP
+            and not request.user.is_handler()
+        ):
             return Response(
                 {"detail": _("Operation not allowed for this application status.")},
                 status=status.HTTP_403_FORBIDDEN,
@@ -934,7 +948,6 @@ class HandlerApplicationViewSet(BaseApplicationViewSet):
             status=status.HTTP_201_CREATED,
         )
 
-
     @action(methods=["PATCH"], detail=True, url_path="change_employer_assurance")
     @transaction.atomic
     def change_employer_assurance(self, request, pk) -> HttpResponse:
@@ -949,7 +962,6 @@ class HandlerApplicationViewSet(BaseApplicationViewSet):
         application.employer_assurance = employer_assurance
         application.save()
         return Response(status=status.HTTP_200_OK)
-
 
     @action(methods=["PATCH"], detail=True, url_path="require_additional_information")
     @transaction.atomic

--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -165,7 +165,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
             "Total amount must be less than MAX_AID_AMOUNT"
         ),
     )
-
+    second_instalment_due_date = serializers.DateField(read_only=True, required=False)
     class Meta:
         model = Application
         fields = [
@@ -216,6 +216,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
             "employer_assurance",
             "de_minimis_aid",
             "de_minimis_aid_set",
+            "second_instalment_due_date",
             "modified_at",
             "created_at",
             "additional_information_needed_by",

--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1,5 +1,4 @@
 import logging
-
 from datetime import date, timedelta
 from typing import Dict, List, Union
 
@@ -166,6 +165,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
         ),
     )
     second_instalment_due_date = serializers.DateField(read_only=True, required=False)
+
     class Meta:
         model = Application
         fields = [
@@ -1427,9 +1427,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
         data from the service bus and update the company's industry and industry_code.
         """
         try:
-            refreshed = get_or_create_organisation_with_business_id(
-                company.business_id
-            )
+            refreshed = get_or_create_organisation_with_business_id(company.business_id)
             company.industry_code = refreshed.industry_code
             company.industry = refreshed.industry
             company.save(update_fields=["industry_code", "industry"])

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -251,6 +251,91 @@ def test_no_applications_with_requested_instalments(api_client, application):
     assert response.status_code == 200
 
 
+@pytest.mark.django_db
+def test_mark_application_as_responded(api_client, application):
+    application.calculation = Calculation(
+        application=application,
+        monthly_pay=1234,
+        vacation_money=123,
+        other_expenses=321,
+        start_date=date.today() - relativedelta(days=30),
+        end_date=date.today() + relativedelta(months=9),
+        state_aid_max_percentage=0,
+        calculated_benefit_amount=12000,
+    )
+    application.calculation.save()
+    Instalment.objects.create(
+        calculation=application.calculation,
+        amount=9000,
+        instalment_number=1,
+        status=InstalmentStatus.PAID,
+        due_date=date.today() - relativedelta(months=1),
+    )
+    instalment_2 = Instalment.objects.create(
+        calculation=application.calculation,
+        amount=9000,
+        instalment_number=2,
+        status=InstalmentStatus.REQUESTED,
+        due_date=date.today() + relativedelta(months=6),
+    )
+    response = api_client.post(
+        reverse(
+            "v1:applicant-application-second-instalment-respond", args=[application.id]
+        )
+    )
+    assert response.status_code == 200
+    instalment_2.refresh_from_db()
+    assert instalment_2.status == InstalmentStatus.RESPONDED
+
+
+@pytest.mark.django_db
+def test_get_second_instalment_info(api_client, application):
+    application.calculation = Calculation(
+        application=application,
+        monthly_pay=1234,
+        vacation_money=123,
+        other_expenses=321,
+        start_date=date.today() - relativedelta(months=1),
+        end_date=date.today() + relativedelta(months=9),
+        state_aid_max_percentage=0,
+        calculated_benefit_amount=12000,
+    )
+    application.calculation.save()
+    Instalment.objects.create(
+        calculation=application.calculation,
+        amount=9000,
+        instalment_number=1,
+        status=InstalmentStatus.PAID,
+        due_date=date.today() - relativedelta(months=1),
+    )
+    instalment_2 = Instalment.objects.create(
+        calculation=application.calculation,
+        amount=9000,
+        instalment_number=2,
+        status=InstalmentStatus.REQUESTED,
+        due_date=application.calculation.start_date + relativedelta(months=6),
+    )
+    response = api_client.get(
+        reverse(
+            "v1:applicant-application-get-second-instalment-info", args=[application.id]
+        )
+    )
+    assert response.status_code == 200
+    assert len(response.data) == 7
+    assert response.data[
+        "start_date"
+    ] == application.calculation.start_date + relativedelta(months=6)
+    assert response.data["end_date"] == application.calculation.end_date
+    assert response.data["amount"] == instalment_2.amount
+    assert response.data["employee_first_name"] == application.employee.first_name
+    assert response.data["employee_last_name"] == application.employee.last_name
+    assert response.data["application_number"] == application.application_number
+
+    # submitted_at is an annotation to the application object
+    application_1 = Application.objects.filter(id=application.id).first()
+    assert response.data["submitted_at"] == application_1.submitted_at
+
+
 @pytest.mark.parametrize(
     "view_name",
     [

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -185,9 +185,11 @@ def test_fetch_only_instalment_requested(api_client, application):
         status=InstalmentStatus.REQUESTED,
         due_date=date.today() + relativedelta(months=5),
     )
-    application_2 = ApplicationFactory(status=ApplicationStatus.ACCEPTED)
+    application_2 = ApplicationFactory(
+        company=application.company, status=ApplicationStatus.ACCEPTED
+    )
     application_2.calculation = Calculation(
-        application=application,
+        application=application_2,
         monthly_pay=1234,
         vacation_money=123,
         other_expenses=321,

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -288,6 +288,31 @@ def test_mark_application_as_responded(api_client, application):
     assert instalment_2.status == InstalmentStatus.RESPONDED
 
 
+@pytest.mark.parametrize(
+    "employer_assurance,sent_employer_assurance",
+    [
+        (None, False),
+        (None, True),
+        (False, True),
+        (True, False),
+    ],
+)
+@pytest.mark.django_db
+def test_applicant_change_employer_assurance(
+    api_client, application, employer_assurance, sent_employer_assurance
+):
+    application.employer_assurance = employer_assurance
+    response = api_client.patch(
+        reverse(
+            "v1:applicant-application-change-employer-assurance", args=[application.id]
+        ),
+        {"employerAssurance": str(sent_employer_assurance)},
+    )
+    application.refresh_from_db()
+    assert response.status_code == 200
+    assert application.employer_assurance == sent_employer_assurance
+
+
 @pytest.mark.django_db
 def test_get_second_instalment_info(api_client, application):
     application.calculation = Calculation(

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -112,6 +112,143 @@ def test_applications_second_instalment_fetched(handler_api_client, application)
     assert response.status_code == 200
 
 
+@pytest.mark.django_db
+def test_fetch_applications_with_requested_2nd_instalment(api_client, application):
+    """
+    Test that application with 2nd instalment in REQUESTED status is fetched.
+    """
+    application.calculation = Calculation(
+        application=application,
+        monthly_pay=1234,
+        vacation_money=123,
+        other_expenses=321,
+        start_date=date.today() - relativedelta(days=30),
+        end_date=date.today() + relativedelta(months=9),
+        state_aid_max_percentage=0,
+        calculated_benefit_amount=12000,
+    )
+    application.calculation.save()
+    Instalment.objects.create(
+        calculation=application.calculation,
+        amount=9000,
+        instalment_number=1,
+        status=InstalmentStatus.PAID,
+        due_date=date.today() - relativedelta(months=1),
+    )
+    Instalment.objects.create(
+        calculation=application.calculation,
+        amount=9000,
+        instalment_number=2,
+        status=InstalmentStatus.REQUESTED,
+        due_date=date.today() + relativedelta(months=5),
+    )
+    response = api_client.get(
+        reverse("v1:applicant-application-simplified-application-list")
+        + "?second_instalment_status=requested"
+    )
+    assert len(response.data) == 1
+    assert response.status_code == 200
+    assert response.data[0]["id"] == str(application.id)
+    assert response.data[0]["second_instalment_due_date"] == str(
+        date.today() + relativedelta(months=5)
+    )
+
+
+@pytest.mark.django_db
+def test_fetch_only_instalment_requested(api_client, application):
+    """
+    Test that only the application with 2nd instalment in REQUESTED
+    status is fetched.
+    """
+    application.calculation = Calculation(
+        application=application,
+        monthly_pay=1234,
+        vacation_money=123,
+        other_expenses=321,
+        start_date=date.today() - relativedelta(days=30),
+        end_date=date.today() + relativedelta(months=9),
+        state_aid_max_percentage=0,
+        calculated_benefit_amount=12000,
+    )
+    application.calculation.save()
+    Instalment.objects.create(
+        calculation=application.calculation,
+        amount=9000,
+        instalment_number=1,
+        status=InstalmentStatus.PAID,
+        due_date=date.today() - relativedelta(months=1),
+    )
+    Instalment.objects.create(
+        calculation=application.calculation,
+        amount=9000,
+        instalment_number=2,
+        status=InstalmentStatus.REQUESTED,
+        due_date=date.today() + relativedelta(months=5),
+    )
+    application_2 = ApplicationFactory(status=ApplicationStatus.ACCEPTED)
+    application_2.calculation = Calculation(
+        application=application,
+        monthly_pay=1234,
+        vacation_money=123,
+        other_expenses=321,
+        start_date=date.today() - relativedelta(days=30),
+        end_date=date.today() + relativedelta(months=9),
+        state_aid_max_percentage=0,
+        calculated_benefit_amount=12000,
+    )
+    application_2.calculation.save()
+
+    response = api_client.get(
+        reverse("v1:applicant-application-simplified-application-list")
+        + "?second_instalment_status=requested"
+    )
+    assert len(response.data) == 1
+    assert response.status_code == 200
+    assert response.data[0]["id"] == str(application.id)
+    assert response.data[0]["second_instalment_due_date"] == str(
+        date.today() + relativedelta(months=5)
+    )
+
+
+@pytest.mark.django_db
+def test_no_applications_with_requested_instalments(api_client, application):
+    """
+    Test that no applications with other than REQUESTED 2nd instalment
+    status are fetched.
+    """
+    application.calculation = Calculation(
+        application=application,
+        monthly_pay=1234,
+        vacation_money=123,
+        other_expenses=321,
+        start_date=date.today() - relativedelta(days=30),
+        end_date=date.today() + relativedelta(months=9),
+        state_aid_max_percentage=0,
+        calculated_benefit_amount=12000,
+    )
+    application.calculation.save()
+    Instalment.objects.create(
+        calculation=application.calculation,
+        amount=9000,
+        instalment_number=1,
+        status=InstalmentStatus.PAID,
+        due_date=date.today() - relativedelta(months=1),
+    )
+    Instalment.objects.create(
+        calculation=application.calculation,
+        amount=9000,
+        instalment_number=2,
+        status=InstalmentStatus.RESPONDED,
+        due_date=date.today() + relativedelta(months=5),
+    )
+    response = api_client.get(
+        reverse("v1:applicant-application-simplified-application-list")
+        + "?second_instalment_status=requested"
+    )
+    assert len(response.data) == 0
+    assert response.status_code == 200
+
+
 @pytest.mark.parametrize(
     "view_name",
     [
@@ -2664,6 +2801,7 @@ def test_notify_applications_one_application(mock_send_notification_mail):
     assert count == 1
     assert apps[0] == app.application_number
 
+
 @pytest.mark.django_db
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 @mock.patch(
@@ -2701,6 +2839,7 @@ def test_notify_applications_no_applications(mock_send_notification_mail):
     # notify_applications must return the sum of _send_notification_mail return values
     assert count == 0
     assert apps == []
+
 
 @pytest.mark.django_db
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
@@ -2756,6 +2895,7 @@ def test_notify_applications_matching_unmatching(mock_send_notification_mail):
     assert mock_send_notification_mail.call_count == 5
     for app in apps:
         assert app.application_number in notified_applications
+
 
 @pytest.mark.django_db
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
@@ -3020,10 +3160,10 @@ def test_change_employer_assurance_wrong_key(handler_api_client):
             "v1:handler-application-change-employer-assurance",
             kwargs={"pk": application.id},
         ),
-        {"illegal_key": 'true'},
+        {"illegal_key": "true"},
     )
     assert response.status_code == 400
-    assert application.employer_assurance == False
+    assert not application.employer_assurance
 
 
 @pytest.mark.django_db

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -27,8 +27,8 @@
         "contract": "Show less"
       },
       "secondInstalments": {
-        "heading": "Payment information for receiving 2nd instalment",
-        "prompt1": "Deliver information by",
+        "heading": "Salary information to receive the second payment.",
+        "prompt1": "Submit information by",
         "prompt2": "",
         "button": "Respond"
       },

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -406,6 +406,14 @@
           "helsinkiBenefitVoucher": {
             "title": "The Helsinki benefit card",
             "message": "Add Helsinki benefit card if one has been issued"
+          },
+          "payslip": {
+            "title": "Palkkakuitti",
+            "message": ""
+          },
+          "otherAttachment": {
+            "title": "Muu liite",
+            "message": "Tarvittaessa voit lisätä tähän toisen liitteen"
           }
         },
         "add": "Attach the file",
@@ -566,6 +574,26 @@
         },
         "details": "Changes in employment",
         "billing": "Invoicing details"
+      }
+    },
+    "secondInstalmentUpload": {
+      "heading": "Ilmoita palkan maksusta",
+      "applicationNumber": "Hakemusnumero",
+      "submittedAt": "Lähetetty",
+      "condition": "Saadaksesi toisen maksuerän sinun tulee toimittaa tosite tähän saakka maksetuista palkoista.",
+      "conditionSpecial": "(palkkakuitti tai pankin tosite maksetusta palkasta)",
+      "missingApplicationId": "Hakemuksen tunnistetta ei löytynyt.",
+      "secondInstalmentInfoError": "Toisen maksuerän tietoja ei voitu hakea.",
+      "successTitle": "Palkkatietoilmoitus lähetetty",
+      "successMessage1": "Hakemuksen",
+      "successMessage2": "palkkatiedot toimitettu.",
+      "errorTitle": "Virhe palkkatietojen lähetyksessä",
+      "errorMessage": "Palkkatietoilmoituksen lähetys epäonnistui.",
+      "missingPayslipTitle": "Palkkakuitti puuttuu",
+      "missingPayslipMessage": "Lisää vähintään yksi palkkakuitti ennen lähettämistä.",
+      "buttons": {
+        "submit": "Lähetä",
+        "back": "Peruuta"
       }
     }
   },

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -26,6 +26,12 @@
         "expand": "Show more",
         "contract": "Show less"
       },
+      "secondInstalments": {
+        "heading": "Payment information for receiving 2nd instalment",
+        "prompt1": "Deliver information by",
+        "prompt2": "",
+        "button": "Respond"
+      },
       "noApplications": "No submitted Helsinki benefit applications",
       "navigateToDecisions": "See all applications with decisions",
       "alterationReminder": {

--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -408,12 +408,12 @@
             "message": "Add Helsinki benefit card if one has been issued"
           },
           "payslip": {
-            "title": "Palkkakuitti",
+            "title": "Salary slip or bank receipt for the salary paid",
             "message": ""
           },
           "otherAttachment": {
-            "title": "Muu liite",
-            "message": "Tarvittaessa voit lisätä tähän toisen liitteen"
+            "title": "Other attachment",
+            "message": "If necessary, you can submit additional attachments here."
           }
         },
         "add": "Attach the file",
@@ -577,23 +577,26 @@
       }
     },
     "secondInstalmentUpload": {
-      "heading": "Ilmoita palkan maksusta",
-      "applicationNumber": "Hakemusnumero",
-      "submittedAt": "Lähetetty",
-      "condition": "Saadaksesi toisen maksuerän sinun tulee toimittaa tosite tähän saakka maksetuista palkoista.",
-      "conditionSpecial": "(palkkakuitti tai pankin tosite maksetusta palkasta)",
-      "missingApplicationId": "Hakemuksen tunnistetta ei löytynyt.",
-      "secondInstalmentInfoError": "Toisen maksuerän tietoja ei voitu hakea.",
-      "successTitle": "Palkkatietoilmoitus lähetetty",
-      "successMessage1": "Hakemuksen",
-      "successMessage2": "palkkatiedot toimitettu.",
-      "errorTitle": "Virhe palkkatietojen lähetyksessä",
-      "errorMessage": "Palkkatietoilmoituksen lähetys epäonnistui.",
-      "missingPayslipTitle": "Palkkakuitti puuttuu",
-      "missingPayslipMessage": "Lisää vähintään yksi palkkakuitti ennen lähettämistä.",
+      "heading": "Report paid salary",
+      "applicationNumber": "Application number",
+      "submittedAt": "Submitted",
+      "instalmentInfo1": "The second payment installment of the subsidy is",
+      "instalmentInfo2": "euros for the period",
+      "condition": "To receive the second payment installment, you must submit information regarding the salary paid so far",
+      "conditionSpecial": "(salary slips or bank receipts for the salaries paid)",
+      "employerAssurance": "I certify that the employment relationship has been carried out as planned and the employee has been paid the stated salary.",
+      "missingApplicationId": "The application identifier was not found.",
+      "secondInstalmentInfoError": "The information of the second installment could not be retrieved.",
+      "successTitle": "Salary information submitted",
+      "successMessage1": "Application",
+      "successMessage2": "salary information submitted.",
+      "errorTitle": "Error in sending salary information",
+      "errorMessage": "Sending the salary information notification failed.",
+      "missingPayslipTitle": "Salary receipt or bank slip missing",
+      "missingPayslipMessage": "Add at least one pay slip or bank statement before sending.",
       "buttons": {
-        "submit": "Lähetä",
-        "back": "Peruuta"
+        "submit": "Send",
+        "back": "Cancel"
       }
     }
   },

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -26,6 +26,12 @@
         "expand": "Näytä lisää",
         "contract": "Näytä vähemmän"
       },
+      "secondInstalments": {
+        "heading": "Palkkatiedot 2. maksuerän saamiseksi",
+        "prompt1": "Toimita tiedot",
+        "prompt2": "mennessä",
+        "button": "Vastaa"
+      },
       "noApplications": "Ei avoimia Helsinki-lisä -hakemuksia",
       "navigateToDecisions": "Katso kaikki päätökset",
       "alterationReminder": {

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -406,6 +406,14 @@
           "helsinkiBenefitVoucher": {
             "title": "Helsinki-lisä -kortti",
             "message": "Lisää Helsinki-lisä -kortti, jos sellainen on myönnetty"
+          },
+          "payslip": {
+            "title": "Palkkakuitti",
+            "message": ""
+          },
+          "otherAttachment": {
+            "title": "Muu liite",
+            "message": "Tarvittaessa voit lisätä tähän toisen liitteen"
           }
         },
         "add": "Liitä tiedosto",
@@ -566,6 +574,26 @@
         },
         "details": "Muutokset työsuhteessa",
         "billing": "Laskutustiedot"
+      }
+    },
+    "secondInstalmentUpload": {
+      "heading": "Ilmoita palkan maksusta",
+      "applicationNumber": "Hakemusnumero",
+      "submittedAt": "Lähetetty",
+      "condition": "Saadaksesi toisen maksuerän sinun tulee toimittaa tosite tähän saakka maksetuista palkoista.",
+      "conditionSpecial": "(palkkakuitti tai pankin tosite maksetusta palkasta)",
+      "missingApplicationId": "Hakemuksen tunnistetta ei löytynyt.",
+      "secondInstalmentInfoError": "Toisen maksuerän tietoja ei voitu hakea.",
+      "successTitle": "Palkkatietoilmoitus lähetetty",
+      "successMessage1": "Hakemuksen",
+      "successMessage2": "palkkatiedot toimitettu.",
+      "errorTitle": "Virhe palkkatietojen lähetyksessä",
+      "errorMessage": "Palkkatietoilmoituksen lähetys epäonnistui.",
+      "missingPayslipTitle": "Palkkakuitti puuttuu",
+      "missingPayslipMessage": "Lisää vähintään yksi palkkakuitti ennen lähettämistä.",
+      "buttons": {
+        "submit": "Lähetä",
+        "back": "Peruuta"
       }
     }
   },

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -408,12 +408,12 @@
             "message": "Lisää Helsinki-lisä -kortti, jos sellainen on myönnetty"
           },
           "payslip": {
-            "title": "Palkkakuitti",
+            "title": "Palkkakuitti tai pankin tosite maksetuista palkoista",
             "message": ""
           },
           "otherAttachment": {
-            "title": "Muu liite",
-            "message": "Tarvittaessa voit lisätä tähän toisen liitteen"
+            "title": "Lisää liite",
+            "message": "Tarvittaessa voit lisätä tähän toisen liitteen."
           }
         },
         "add": "Liitä tiedosto",
@@ -577,20 +577,23 @@
       }
     },
     "secondInstalmentUpload": {
-      "heading": "Ilmoita palkan maksusta",
+      "heading": "Ilmoita maksetusta palkasta",
       "applicationNumber": "Hakemusnumero",
       "submittedAt": "Lähetetty",
-      "condition": "Saadaksesi toisen maksuerän sinun tulee toimittaa tosite tähän saakka maksetuista palkoista.",
-      "conditionSpecial": "(palkkakuitti tai pankin tosite maksetusta palkasta)",
+      "instalmentInfo1": "Tuen toinen maksuerä on",
+      "instalmentInfo2": "euroa ajalle",
+      "condition": "Saadaksesi toisen maksuerän sinun tulee toimittaa tiedot tähän saakka maksetuista palkoista´",
+      "conditionSpecial": "(palkkakuitit tai pankin tositteet maksetuista palkoista)",
+      "employerAssurance": "Vakuutan työsuhteen toteutuneen suunnitellusti ja työntekijälle on maksettu hakemuksen mukaista palkkaa.",
       "missingApplicationId": "Hakemuksen tunnistetta ei löytynyt.",
       "secondInstalmentInfoError": "Toisen maksuerän tietoja ei voitu hakea.",
       "successTitle": "Palkkatietoilmoitus lähetetty",
-      "successMessage1": "Hakemuksen",
-      "successMessage2": "palkkatiedot toimitettu.",
+      "successMessage1": "Hakemus",
+      "successMessage2": "palkkatiedot lähetetty.",
       "errorTitle": "Virhe palkkatietojen lähetyksessä",
       "errorMessage": "Palkkatietoilmoituksen lähetys epäonnistui.",
-      "missingPayslipTitle": "Palkkakuitti puuttuu",
-      "missingPayslipMessage": "Lisää vähintään yksi palkkakuitti ennen lähettämistä.",
+      "missingPayslipTitle": "Palkkakuitti tai pankkitosite puuttuvat",
+      "missingPayslipMessage": "Lisää vähintään yksi palkkakuitti tai pankintosite ennen lähettämistä.",
       "buttons": {
         "submit": "Lähetä",
         "back": "Peruuta"

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -582,7 +582,7 @@
       "submittedAt": "Lähetetty",
       "instalmentInfo1": "Tuen toinen maksuerä on",
       "instalmentInfo2": "euroa ajalle",
-      "condition": "Saadaksesi toisen maksuerän sinun tulee toimittaa tiedot tähän saakka maksetuista palkoista´",
+      "condition": "Saadaksesi toisen maksuerän sinun tulee toimittaa tiedot tähän saakka maksetuista palkoista",
       "conditionSpecial": "(palkkakuitit tai pankin tositteet maksetuista palkoista)",
       "employerAssurance": "Vakuutan työsuhteen toteutuneen suunnitellusti ja työntekijälle on maksettu hakemuksen mukaista palkkaa.",
       "missingApplicationId": "Hakemuksen tunnistetta ei löytynyt.",

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -26,6 +26,12 @@
         "expand": "Visa fler",
         "contract": "Visa mindre"
       },
+      "secondInstalments": {
+        "heading": "Palkkatiedot 2. maksuerän saamiseksi",
+        "prompt1": "Toimita tiedot",
+        "prompt2": "mennessä",
+        "button": "Svara"
+      },
       "noApplications": "Inga öppna ansökningar om Helsingforstillägget",
       "navigateToDecisions": "Se alla ansökningar med beslut",
       "alterationReminder": {

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -27,9 +27,9 @@
         "contract": "Visa mindre"
       },
       "secondInstalments": {
-        "heading": "Palkkatiedot 2. maksuerän saamiseksi",
-        "prompt1": "Toimita tiedot",
-        "prompt2": "mennessä",
+        "heading": "Löneinformation för att få den andra utbetalningen.",
+        "prompt1": "Skicka in informationen senast",
+        "prompt2": "",
         "button": "Svara"
       },
       "noApplications": "Inga öppna ansökningar om Helsingforstillägget",

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -408,12 +408,12 @@
             "message": "Lägg till Helsingforstilläggskortet om en har utfärdats"
           },
           "payslip": {
-            "title": "Palkkakuitti",
+            "title": "Lönespecifikation eller bankkvitto för utbetald lön",
             "message": ""
           },
           "otherAttachment": {
-            "title": "Muu liite",
-            "message": "Tarvittaessa voit lisätä tähän toisen liitteen"
+            "title": "Bifoga en bilaga",
+            "message": "Vid behov kan du lägga till ytterligare bilagor här."
           }
         },
         "add": "Bifoga fil",
@@ -577,23 +577,26 @@
       }
     },
     "secondInstalmentUpload": {
-      "heading": "Ilmoita palkan maksusta",
-      "applicationNumber": "Hakemusnumero",
-      "submittedAt": "Lähetetty",
-      "condition": "Saadaksesi toisen maksuerän sinun tulee toimittaa tosite tähän saakka maksetuista palkoista.",
-      "conditionSpecial": "(palkkakuitti tai pankin tosite maksetusta palkasta)",
-      "missingApplicationId": "Hakemuksen tunnistetta ei löytynyt.",
-      "secondInstalmentInfoError": "Toisen maksuerän tietoja ei voitu hakea.",
-      "successTitle": "Palkkatietoilmoitus lähetetty",
-      "successMessage1": "Hakemuksen",
-      "successMessage2": "palkkatiedot toimitettu.",
-      "errorTitle": "Virhe palkkatietojen lähetyksessä",
-      "errorMessage": "Palkkatietoilmoituksen lähetys epäonnistui.",
-      "missingPayslipTitle": "Palkkakuitti puuttuu",
-      "missingPayslipMessage": "Lisää vähintään yksi palkkakuitti ennen lähettämistä.",
+      "heading": "Anmäla utbetald lön",
+      "applicationNumber": "Ansökningsnummer",
+      "submittedAt": "Skickad",
+      "instalmentInfo1": "Den andra utbetalningen av stödet är",
+      "instalmentInfo2": "euro för perioden",
+      "condition": "För att få den andra utbetalningen måste du skicka in uppgifter om den lön som hittills utbetalats",
+      "conditionSpecial": "(lönespecifikationer eller bankkvitton för utbetalda löner)",
+      "employerAssurance": "Jag intygar att anställningsförhållandet har genomförts enligt plan och att den anställde har fått utbetald lön.",
+      "missingApplicationId": "Applikationens identifierare hittades inte.",
+      "secondInstalmentInfoError": "Informationen om den andra delen kunde inte hämtas.",
+      "successTitle": "Löneuppgifter skickade",
+      "successMessage1": "Ansökan",
+      "successMessage2": "löneuppgifter skickade.",
+      "errorTitle": "Fel vid sändning av löneinformation",
+      "errorMessage": "Det gick inte att skicka meddelandet om löneinformation.",
+      "missingPayslipTitle": "Lönekvitto eller banksedel saknas",
+      "missingPayslipMessage": "Lägg till minst ett lönebesked eller kontoutdrag innan du skickar.",
       "buttons": {
-        "submit": "Lähetä",
-        "back": "Peruuta"
+        "submit": "Skicka",
+        "back": "Avbryt"
       }
     }
   },

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -406,6 +406,14 @@
           "helsinkiBenefitVoucher": {
             "title": "Helsingforstilläggskortet",
             "message": "Lägg till Helsingforstilläggskortet om en har utfärdats"
+          },
+          "payslip": {
+            "title": "Palkkakuitti",
+            "message": ""
+          },
+          "otherAttachment": {
+            "title": "Muu liite",
+            "message": "Tarvittaessa voit lisätä tähän toisen liitteen"
           }
         },
         "add": "Bifoga fil",
@@ -566,6 +574,26 @@
         },
         "details": "Ändringar i anställningen",
         "billing": "Faktureringsuppgifter"
+      }
+    },
+    "secondInstalmentUpload": {
+      "heading": "Ilmoita palkan maksusta",
+      "applicationNumber": "Hakemusnumero",
+      "submittedAt": "Lähetetty",
+      "condition": "Saadaksesi toisen maksuerän sinun tulee toimittaa tosite tähän saakka maksetuista palkoista.",
+      "conditionSpecial": "(palkkakuitti tai pankin tosite maksetusta palkasta)",
+      "missingApplicationId": "Hakemuksen tunnistetta ei löytynyt.",
+      "secondInstalmentInfoError": "Toisen maksuerän tietoja ei voitu hakea.",
+      "successTitle": "Palkkatietoilmoitus lähetetty",
+      "successMessage1": "Hakemuksen",
+      "successMessage2": "palkkatiedot toimitettu.",
+      "errorTitle": "Virhe palkkatietojen lähetyksessä",
+      "errorMessage": "Palkkatietoilmoituksen lähetys epäonnistui.",
+      "missingPayslipTitle": "Palkkakuitti puuttuu",
+      "missingPayslipMessage": "Lisää vähintään yksi palkkakuitti ennen lähettämistä.",
+      "buttons": {
+        "submit": "Lähetä",
+        "back": "Peruuta"
       }
     }
   },

--- a/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/ApplicationList.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { OptionType } from 'shared/types/common';
 
 import ListItem from './listItem/ListItem';
+import SecondInstalmentListItem from './listItem/SecondInstalmentListItem';
 import useApplicationList from './useApplicationList';
 
 export interface ApplicationListProps {
@@ -14,18 +15,20 @@ export interface ApplicationListProps {
   onListLengthChanged?: (isLoading: boolean, length: number) => void;
   beforeList?: React.ReactNode;
   afterList?: React.ReactNode;
+  secondInstalmentStatus?: string;
 }
 
 const ApplicationList: React.FC<ApplicationListProps> = ({
-  heading,
-  status,
-  isArchived,
-  orderByOptions,
-  noItemsText,
-  onListLengthChanged,
-  beforeList,
-  afterList,
-}) => {
+                                                           heading,
+                                                           status,
+                                                           isArchived,
+                                                           orderByOptions,
+                                                           noItemsText,
+                                                           onListLengthChanged,
+                                                           beforeList,
+                                                           afterList,
+                                                           secondInstalmentStatus,
+                                                         }) => {
   const {
     list,
     shouldShowSkeleton,
@@ -38,10 +41,17 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
     status,
     isArchived,
     orderByOptions,
+    secondInstalmentStatus,
   });
 
   const items =
-    list?.map((props) => <ListItem key={props.id} {...props} />) || [];
+    list?.map((props) =>
+      secondInstalmentStatus ? (
+        <SecondInstalmentListItem key={props.id} {...props} />
+      ) : (
+        <ListItem key={props.id} {...props} />
+      )
+    ) || [];
 
   return (
     <ListContents

--- a/frontend/benefit/applicant/src/components/applications/applicationList/__tests__/useApplicationList.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/__tests__/useApplicationList.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook } from '@testing-library/react-hooks';
+import FrontPageContext from 'benefit/applicant/context/FrontPageContext';
+import useApplicationsQuery from 'benefit/applicant/hooks/useApplicationsQuery';
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
+import { ApplicationData } from 'benefit-shared/types/application';
+import React from 'react';
+
+import useApplicationList from '../useApplicationList';
+
+jest.mock('benefit/applicant/hooks/useApplicationsQuery');
+jest.mock('benefit/applicant/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+jest.mock('shared/hooks/useLocale', () => jest.fn(() => 'fi'));
+jest.mock('shared/server/is-server-side', () => jest.fn(() => false));
+
+const mockedUseApplicationsQuery = useApplicationsQuery as jest.MockedFunction<
+  typeof useApplicationsQuery
+>;
+
+const getApplicationData = (
+  overrides: Partial<ApplicationData> = {}
+): ApplicationData =>
+  ({
+    id: 'application-id',
+    status: APPLICATION_STATUSES.ACCEPTED,
+    employee: {
+      first_name: 'Test',
+      last_name: 'Employee',
+    },
+    submitted_at: '2026-03-01',
+    application_number: 123_456,
+    unread_messages_count: 0,
+    company_contact_person_first_name: 'Test',
+    company_contact_person_last_name: 'Contact',
+    second_instalment_due_date: '2026-04-18',
+    ...overrides,
+  } as ApplicationData);
+
+describe('useApplicationList', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
+    <FrontPageContext.Provider value={{ errors: [], setError: jest.fn() }}>
+      {children}
+    </FrontPageContext.Provider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('subtracts 15 days from second_instalment_due_date and formats it for UI', () => {
+    mockedUseApplicationsQuery.mockReturnValue({
+      data: [getApplicationData()],
+      error: null,
+      isLoading: false,
+    } as ReturnType<typeof useApplicationsQuery>);
+
+    const { result } = renderHook(
+      () =>
+        useApplicationList({
+          status: [APPLICATION_STATUSES.ACCEPTED],
+          secondInstalmentStatus: 'requested',
+        }),
+      { wrapper }
+    );
+
+    expect(result.current.list[0].secondInstalmentDueDate).toBe('3.4.2026');
+  });
+
+  it('sets secondInstalmentDueDate to dash when backend due date is missing', () => {
+    mockedUseApplicationsQuery.mockReturnValue({
+      data: [
+        getApplicationData({
+          second_instalment_due_date: undefined,
+        }),
+      ],
+      error: null,
+      isLoading: false,
+    } as ReturnType<typeof useApplicationsQuery>);
+
+    const { result } = renderHook(
+      () =>
+        useApplicationList({
+          status: [APPLICATION_STATUSES.ACCEPTED],
+          secondInstalmentStatus: 'requested',
+        }),
+      { wrapper }
+    );
+
+    expect(result.current.list[0].secondInstalmentDueDate).toBe('-');
+  });
+});

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
@@ -1,0 +1,89 @@
+import { useTranslation } from 'benefit/applicant/i18n';
+import { ApplicationListItemData } from 'benefit-shared/types/application';
+import { Button, IconAlertCircleFill, IconPen } from 'hds-react';
+import React from 'react';
+import styled, { DefaultTheme } from 'styled-components';
+
+import {
+  $Avatar,
+  $DataColumn,
+  $DataHeader,
+  $DataValue,
+  $ItemContent,
+  $ListItem,
+  $ListItemWrapper,
+  $StatusDataColumn,
+  $StatusDataValue,
+} from './ListItem.sc';
+
+export type SecondInstalmentListItemProps = ApplicationListItemData;
+
+const $StatusText = styled.span`
+  color: ${(props: { theme: DefaultTheme }) => props.theme.colors.summerDark};
+  display: inline-flex;
+  align-items: center;
+  gap: ${(props: { theme: DefaultTheme }) => props.theme.spacing.xs3};
+  padding: ${(props: { theme: DefaultTheme }) => props.theme.spacing.xs3}
+  ${(props: { theme: DefaultTheme }) => props.theme.spacing.xs2};
+`;
+
+const SecondInstalmentListItem: React.FC<SecondInstalmentListItemProps> = ({
+                                                                             avatar,
+                                                                             contactPersonName,
+                                                                             name,
+                                                                             submittedAt,
+                                                                             applicationNum,
+                                                                             secondInstalmentDueDate,
+                                                                           }) => {
+  const { t } = useTranslation();
+  const translationBase = 'common:applications.list';
+
+  return (
+    <$ListItemWrapper>
+      <$ListItem>
+        <$ItemContent>
+          <$Avatar $backgroundColor="summerDark" title={contactPersonName}>
+            {avatar?.initials}
+          </$Avatar>
+
+          <$DataColumn>
+            <$DataHeader>{t(`${translationBase}.common.employee`)}</$DataHeader>
+            <$DataValue>{name}</$DataValue>
+          </$DataColumn>
+
+          <$DataColumn>
+            <$DataHeader>{t(`${translationBase}.common.sent`)}</$DataHeader>
+            <$DataValue>{submittedAt}</$DataValue>
+          </$DataColumn>
+
+          <$DataColumn>
+            <$DataHeader>
+              {t(`${translationBase}.common.applicationNumber`)}
+            </$DataHeader>
+            <$DataValue>{applicationNum}</$DataValue>
+          </$DataColumn>
+
+          <$StatusDataColumn>
+            <$DataHeader>{t(`${translationBase}.common.status`)}</$DataHeader>
+            <$StatusDataValue>
+              <$StatusText>
+                <IconAlertCircleFill aria-hidden="true" />
+                <span>{t(`${translationBase}.secondInstalments.prompt1`)}&nbsp;{secondInstalmentDueDate}&nbsp;
+                  {t(`${translationBase}.secondInstalments.prompt2`)}</span>
+              </$StatusText>
+            </$StatusDataValue>
+          </$StatusDataColumn>
+
+          <$DataColumn>
+            <Button iconLeft={<IconPen />} variant="primary" theme="coat">
+              {t(`${translationBase}.secondInstalments.button`)}
+            </Button>
+          </$DataColumn>
+
+        </$ItemContent>
+      </$ListItem>
+    </$ListItemWrapper>
+  );
+};
+
+export default SecondInstalmentListItem;

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
@@ -73,8 +73,8 @@ const SecondInstalmentListItem: React.FC<SecondInstalmentListItemProps> = ({
               <$StatusText>
                 <IconAlertCircleFill aria-hidden="true" />
                 <span>
-                  {t(`${translationBase}.secondInstalments.prompt1`)}&nbsp;
-                  {secondInstalmentDueDate}&nbsp;
+                  {t(`${translationBase}.secondInstalments.prompt1`)}{' '}
+                  {secondInstalmentDueDate}{' '}
                   {t(`${translationBase}.secondInstalments.prompt2`)}
                 </span>
               </$StatusText>

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
@@ -34,6 +34,7 @@ const SecondInstalmentListItem: React.FC<SecondInstalmentListItemProps> = ({
                                                                              submittedAt,
                                                                              applicationNum,
                                                                              secondInstalmentDueDate,
+                                                                             allowedAction,
                                                                            }) => {
   const { t } = useTranslation();
   const translationBase = 'common:applications.list';
@@ -75,7 +76,12 @@ const SecondInstalmentListItem: React.FC<SecondInstalmentListItemProps> = ({
           </$StatusDataColumn>
 
           <$DataColumn>
-            <Button iconLeft={<IconPen />} variant="primary" theme="coat">
+            <Button
+              iconLeft={<IconPen />}
+              variant="primary"
+              theme="coat"
+              onClick={() => allowedAction?.handleAction(false)}
+            >
               {t(`${translationBase}.secondInstalments.button`)}
             </Button>
           </$DataColumn>

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
@@ -1,6 +1,8 @@
+import { ROUTES } from 'benefit/applicant/constants';
 import { useTranslation } from 'benefit/applicant/i18n';
 import { ApplicationListItemData } from 'benefit-shared/types/application';
 import { Button, IconAlertCircleFill, IconPen } from 'hds-react';
+import { useRouter } from 'next/router';
 import React from 'react';
 import styled, { DefaultTheme } from 'styled-components';
 
@@ -28,15 +30,16 @@ const $StatusText = styled.span`
 `;
 
 const SecondInstalmentListItem: React.FC<SecondInstalmentListItemProps> = ({
-                                                                             avatar,
-                                                                             contactPersonName,
-                                                                             name,
-                                                                             submittedAt,
-                                                                             applicationNum,
-                                                                             secondInstalmentDueDate,
-                                                                             allowedAction,
-                                                                           }) => {
+  avatar,
+  contactPersonName,
+  name,
+  submittedAt,
+  applicationNum,
+  secondInstalmentDueDate,
+  id,
+}) => {
   const { t } = useTranslation();
+  const router = useRouter();
   const translationBase = 'common:applications.list';
 
   return (
@@ -69,8 +72,11 @@ const SecondInstalmentListItem: React.FC<SecondInstalmentListItemProps> = ({
             <$StatusDataValue>
               <$StatusText>
                 <IconAlertCircleFill aria-hidden="true" />
-                <span>{t(`${translationBase}.secondInstalments.prompt1`)}&nbsp;{secondInstalmentDueDate}&nbsp;
-                  {t(`${translationBase}.secondInstalments.prompt2`)}</span>
+                <span>
+                  {t(`${translationBase}.secondInstalments.prompt1`)}&nbsp;
+                  {secondInstalmentDueDate}&nbsp;
+                  {t(`${translationBase}.secondInstalments.prompt2`)}
+                </span>
               </$StatusText>
             </$StatusDataValue>
           </$StatusDataColumn>
@@ -80,12 +86,13 @@ const SecondInstalmentListItem: React.FC<SecondInstalmentListItemProps> = ({
               iconLeft={<IconPen />}
               variant="primary"
               theme="coat"
-              onClick={() => allowedAction?.handleAction(false)}
+              onClick={() =>
+                router.push(`${ROUTES.APPLICATION_ALTERATION}?id=${id ?? ''}`)
+              }
             >
               {t(`${translationBase}.secondInstalments.button`)}
             </Button>
           </$DataColumn>
-
         </$ItemContent>
       </$ListItem>
     </$ListItemWrapper>

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
@@ -87,7 +87,7 @@ const SecondInstalmentListItem: React.FC<SecondInstalmentListItemProps> = ({
               variant="primary"
               theme="coat"
               onClick={() =>
-                router.push(`${ROUTES.APPLICATION_ALTERATION}?id=${id ?? ''}`)
+                router.push(`${ROUTES.SECOND_INSTALMENT_UPLOAD}?id=${id ?? ''}`)
               }
             >
               {t(`${translationBase}.secondInstalments.button`)}

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/__tests__/SecondInstalmentListItem.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/__tests__/SecondInstalmentListItem.test.tsx
@@ -1,9 +1,12 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import renderComponent from 'benefit/applicant/__tests__/utils/render-component';
+import { ROUTES } from 'benefit/applicant/constants';
 import { ApplicationListItemData } from 'benefit-shared/types/application';
 import React from 'react';
 
 import SecondInstalmentListItem from '../SecondInstalmentListItem';
+
+const pushMock = jest.fn();
 
 jest.mock('benefit/applicant/i18n', () => ({
   useTranslation: () => ({
@@ -11,15 +14,23 @@ jest.mock('benefit/applicant/i18n', () => ({
   }),
 }));
 
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
 jest.mock('hds-react', () => ({
   Button: ({
-             children,
-             iconLeft,
-           }: {
+    children,
+    iconLeft,
+    onClick,
+  }: {
     children: React.ReactNode;
     iconLeft?: React.ReactNode;
+    onClick?: () => void;
   }) => (
-    <button type="button">
+    <button type="button" onClick={onClick}>
       {iconLeft}
       {children}
     </button>
@@ -116,5 +127,19 @@ describe('SecondInstalmentListItem', () => {
 
     expect(screen.getByTestId('pen-icon')).toBeInTheDocument();
     expect(screen.getByTestId('warning-icon')).toBeInTheDocument();
+  });
+
+  it('navigates to application alteration when answer button is clicked', () => {
+    getComponent();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /common:applications\.list\.secondinstalments\.button/i,
+      })
+    );
+
+    expect(pushMock).toHaveBeenCalledWith(
+      `${ROUTES.APPLICATION_ALTERATION}?id=application-id`
+    );
   });
 });

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/__tests__/SecondInstalmentListItem.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/__tests__/SecondInstalmentListItem.test.tsx
@@ -129,7 +129,7 @@ describe('SecondInstalmentListItem', () => {
     expect(screen.getByTestId('warning-icon')).toBeInTheDocument();
   });
 
-  it('navigates to application alteration when answer button is clicked', () => {
+  it('navigates to second instalment payslip upload page when answer button is clicked', () => {
     getComponent();
 
     fireEvent.click(
@@ -139,7 +139,8 @@ describe('SecondInstalmentListItem', () => {
     );
 
     expect(pushMock).toHaveBeenCalledWith(
-      `${ROUTES.APPLICATION_ALTERATION}?id=application-id`
+      `${ROUTES.SECOND_INSTALMENT_UPLOAD}?id=application-id`
     );
   });
+
 });

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/__tests__/SecondInstalmentListItem.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/__tests__/SecondInstalmentListItem.test.tsx
@@ -1,0 +1,120 @@
+import { screen } from '@testing-library/react';
+import renderComponent from 'benefit/applicant/__tests__/utils/render-component';
+import { ApplicationListItemData } from 'benefit-shared/types/application';
+import React from 'react';
+
+import SecondInstalmentListItem from '../SecondInstalmentListItem';
+
+jest.mock('benefit/applicant/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('hds-react', () => ({
+  Button: ({
+             children,
+             iconLeft,
+           }: {
+    children: React.ReactNode;
+    iconLeft?: React.ReactNode;
+  }) => (
+    <button type="button">
+      {iconLeft}
+      {children}
+    </button>
+  ),
+  IconAlertCircleFill: () => <svg data-testid="warning-icon" />,
+  IconPen: () => <svg data-testid="pen-icon" />,
+}));
+
+describe('SecondInstalmentListItem', () => {
+  const defaultProps: ApplicationListItemData = {
+    id: 'application-id',
+    name: 'Test Employee',
+    avatar: {
+      initials: 'TE',
+      color: 'summerDark',
+    },
+    contactPersonName: 'Test Contact',
+    submittedAt: '1.4.2026',
+    applicationNum: 123_456,
+    secondInstalmentDueDate: '4.4.2026',
+  };
+
+  const getComponent = (
+    props: Partial<ApplicationListItemData> = {}
+  ): ReturnType<typeof renderComponent> =>
+    renderComponent(<SecondInstalmentListItem {...defaultProps} {...props} />);
+
+  it('renders employee column heading and employee name', () => {
+    getComponent();
+
+    expect(
+      screen.getByText('common:applications.list.common.employee')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Test Employee')).toBeInTheDocument();
+  });
+
+  it('renders application date column heading and submitted date', () => {
+    getComponent();
+
+    expect(
+      screen.getByText('common:applications.list.common.sent')
+    ).toBeInTheDocument();
+    expect(screen.getByText('1.4.2026')).toBeInTheDocument();
+  });
+
+  it('renders application number column heading and application number', () => {
+    getComponent();
+
+    expect(
+      screen.getByText('common:applications.list.common.applicationNumber')
+    ).toBeInTheDocument();
+    expect(screen.getByText('123456')).toBeInTheDocument();
+  });
+
+  it('renders status column heading', () => {
+    getComponent();
+
+    expect(
+      screen.getByText('common:applications.list.common.status')
+    ).toBeInTheDocument();
+  });
+
+  it('renders status text with the second instalment due date', () => {
+    getComponent();
+
+    expect(
+      screen.getByText((content) =>
+        content.includes(
+          'common:applications.list.secondInstalments.prompt1'
+        ) &&
+        content.includes('4.4.2026') &&
+        content.includes('common:applications.list.secondInstalments.prompt2')
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders avatar initials with contact person as title', () => {
+    getComponent();
+
+    const avatar = screen.getByTitle('Test Contact');
+
+    expect(avatar).toBeInTheDocument();
+    expect(avatar).toHaveTextContent('TE');
+  });
+
+  it('renders answer button with pen icon and warning icon in status column', () => {
+    getComponent();
+
+    expect(
+      screen.getByRole('button', {
+        name: /common:applications\.list\.secondinstalments\.button/i,
+      })
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('pen-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('warning-icon')).toBeInTheDocument();
+  });
+});

--- a/frontend/benefit/applicant/src/components/applications/applicationList/useApplicationList.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/useApplicationList.ts
@@ -7,6 +7,7 @@ import {
   ApplicationAllowedAction,
   ApplicationListItemData,
 } from 'benefit-shared/types/application';
+import subDays from 'date-fns/subDays';
 import { IconPen } from 'hds-react';
 import camelCase from 'lodash/camelCase';
 import { useRouter } from 'next/router';
@@ -19,6 +20,7 @@ import { OptionType } from 'shared/types/common';
 import {
   convertToUIDateAndTimeFormat,
   convertToUIDateFormat,
+  parseDate,
 } from 'shared/utils/date.utils';
 import { getInitials } from 'shared/utils/string.utils';
 import { DefaultTheme } from 'styled-components';
@@ -73,10 +75,10 @@ const getEmployeeFullName = (firstName: string, lastName: string): string => {
   return name === ' ' ? '-' : name;
 };
 
-const getDateDaysBefore = (date: string, daysBefore: number): Date => {
-  const parsedDate = new Date(`${date}T00:00:00`);
-  parsedDate.setDate(parsedDate.getDate() - daysBefore);
-  return parsedDate;
+const getDateDaysBefore = (date: string, daysBefore: number): Date | undefined => {
+  const parsedDate = parseDate(date);
+
+  return parsedDate ? subDays(parsedDate, daysBefore) : undefined;
 };
 
 const useApplicationList = ({
@@ -179,8 +181,11 @@ const useApplicationList = ({
     const submittedAt = submitted_at
       ? convertToUIDateFormat(submitted_at)
       : '-';
+
+    // Calculate second instalment due date to allow for 14 days delivery
+    // i.e., 15 days before the second instalment due date.
     const secondInstalmentDueDate = second_instalment_due_date
-      ? convertToUIDateFormat(getDateDaysBefore(second_instalment_due_date, 14))
+      ? convertToUIDateFormat(getDateDaysBefore(second_instalment_due_date, 15))
       : '-';
     const modifiedAtWithTime =
       modified_at && convertToUIDateAndTimeFormat(modified_at);

--- a/frontend/benefit/applicant/src/components/applications/applicationList/useApplicationList.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/useApplicationList.ts
@@ -30,6 +30,7 @@ interface Props {
   status: string[];
   isArchived?: boolean;
   orderByOptions?: OptionType[];
+  secondInstalmentStatus?: string;
 }
 
 export interface ApplicationListProps {
@@ -72,11 +73,18 @@ const getEmployeeFullName = (firstName: string, lastName: string): string => {
   return name === ' ' ? '-' : name;
 };
 
+const getDateDaysBefore = (date: string, daysBefore: number): Date => {
+  const parsedDate = new Date(`${date}T00:00:00`);
+  parsedDate.setDate(parsedDate.getDate() - daysBefore);
+  return parsedDate;
+};
+
 const useApplicationList = ({
-  status,
-  isArchived,
-  orderByOptions,
-}: Props): ApplicationListProps => {
+                              status,
+                              isArchived,
+                              orderByOptions,
+                              secondInstalmentStatus,
+                            }: Props): ApplicationListProps => {
   const { t } = useTranslation();
   const router = useRouter();
   const [orderBy, setOrderBy] = useState<OptionType>(
@@ -91,6 +99,7 @@ const useApplicationList = ({
     status,
     isArchived,
     orderBy: orderBy.value.toString(),
+    secondInstalmentStatus,
   });
 
   const { errors, setError } = React.useContext(FrontPageContext);
@@ -150,6 +159,7 @@ const useApplicationList = ({
       end_date,
       company_contact_person_first_name,
       company_contact_person_last_name,
+      second_instalment_due_date,
     } = application;
 
     const employeeName = getEmployeeFullName(
@@ -168,6 +178,9 @@ const useApplicationList = ({
     const allowedAction = appStatus && getAllowedActions(id, appStatus);
     const submittedAt = submitted_at
       ? convertToUIDateFormat(submitted_at)
+      : '-';
+    const secondInstalmentDueDate = second_instalment_due_date
+      ? convertToUIDateFormat(getDateDaysBefore(second_instalment_due_date, 14))
       : '-';
     const modifiedAtWithTime =
       modified_at && convertToUIDateAndTimeFormat(modified_at);
@@ -194,6 +207,7 @@ const useApplicationList = ({
       unreadMessagesCount: unread_messages_count ?? 0,
       batch,
       contactPersonName,
+      secondInstalmentDueDate,
     };
     const draftProps = { modifiedAt: modifiedAtWithTime };
     const submittedProps = {

--- a/frontend/benefit/applicant/src/components/applications/applicationList/useApplicationList.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/useApplicationList.ts
@@ -182,7 +182,7 @@ const useApplicationList = ({
       ? convertToUIDateFormat(submitted_at)
       : '-';
 
-    // Calculate second instalment due date to allow for 14 days delivery
+    // Calculate second instalment due date to allow for 15 days delivery
     // i.e., 15 days before the second instalment due date.
     const secondInstalmentDueDate = second_instalment_due_date
       ? convertToUIDateFormat(getDateDaysBefore(second_instalment_due_date, 15))

--- a/frontend/benefit/applicant/src/components/applications/secondInstalmentUpload/SecondInstalmentUploadPage.tsx
+++ b/frontend/benefit/applicant/src/components/applications/secondInstalmentUpload/SecondInstalmentUploadPage.tsx
@@ -1,0 +1,263 @@
+import AttachmentsList from 'benefit/applicant/components/applications/forms/application/step3/attachmentsList/AttachmentsList';
+import { ROUTES } from 'benefit/applicant/constants';
+import useApplicationQuery from 'benefit/applicant/hooks/useApplicationQuery';
+import useSecondInstalmentInfoQuery from 'benefit/applicant/hooks/useSecondInstalmentInfoQuery';
+import useSecondInstalmentRespondMutation from 'benefit/applicant/hooks/useSecondInstalmentRespondMutation';
+import { useTranslation } from 'benefit/applicant/i18n';
+import { ATTACHMENT_TYPES } from 'benefit-shared/constants';
+import { Button, IconArrowRight, LoadingSpinner } from 'hds-react';
+import { useRouter } from 'next/router';
+import React from 'react';
+import Container from 'shared/components/container/Container';
+import {
+  $Grid,
+  $GridCell,
+} from 'shared/components/forms/section/FormSection.sc';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import showSuccessToast from 'shared/components/toast/show-success-toast';
+import { BenefitAttachment } from 'shared/types/attachment';
+import {
+  convertToUIDateAndTimeFormat,
+  convertToUIDateFormat,
+} from 'shared/utils/date.utils';
+
+const FOG_COLOR = 'var(--color-fog)';
+
+const formatEuroAmount = (amount: number | string): string =>
+  new Intl.NumberFormat('fi-FI', {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 0,
+  }).format(Number(amount));
+
+const getFileNameFromPath = (path?: string): string =>
+  path?.split('/').filter(Boolean).at(-1) ?? '';
+
+const normalizeAttachmentFileNames = (
+  attachments: BenefitAttachment[] = []
+): BenefitAttachment[] =>
+  attachments.map((attachment) => {
+    const snakeCaseAttachment = attachment as BenefitAttachment & {
+      attachment_type?: string;
+      attachment_file?: string;
+      attachment_file_name?: string;
+      created_at?: string;
+    };
+
+    const attachmentFile =
+      attachment.attachmentFile || snakeCaseAttachment.attachment_file || '';
+
+    return {
+      ...attachment,
+      attachmentType:
+        attachment.attachmentType || snakeCaseAttachment.attachment_type || '',
+      attachmentFile,
+      attachmentFileName:
+        attachment.attachmentFileName ||
+        snakeCaseAttachment.attachment_file_name ||
+        getFileNameFromPath(attachmentFile),
+      createdAt: attachment.createdAt || snakeCaseAttachment.created_at,
+    };
+  });
+
+const SecondInstalmentUploadPage: React.FC = () => {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const [isNavigatingBack, setIsNavigatingBack] = React.useState(false);
+
+  const applicationId =
+    typeof router.query.id === 'string' ? router.query.id : undefined;
+
+  const { data: application } = useApplicationQuery(applicationId ?? '');
+  const attachments = React.useMemo(
+    () => normalizeAttachmentFileNames(application?.attachments),
+    [application?.attachments]
+  );
+  const hasPayslipAttachment = React.useMemo(
+    () =>
+      attachments.some(
+        (attachment) => attachment.attachmentType === ATTACHMENT_TYPES.PAYSLIP
+      ),
+    [attachments]
+  );
+
+  const {
+    data: secondInstalmentInfo,
+    isLoading: isSecondInstalmentInfoLoading,
+    isError: isSecondInstalmentInfoError,
+  } = useSecondInstalmentInfoQuery(applicationId);
+
+  const {
+    mutate: secondInstalmentRespond,
+    isLoading: isSubmittingSecondInstalmentResponse,
+  } = useSecondInstalmentRespondMutation();
+
+  const handleSubmit = React.useCallback((): void => {
+    if (isNavigatingBack || !applicationId) {
+      return;
+    }
+
+    if (!hasPayslipAttachment) {
+      showErrorToast(
+        t('common:applications.secondInstalmentUpload.missingPayslipTitle'),
+        t('common:applications.secondInstalmentUpload.missingPayslipMessage')
+      );
+      return;
+    }
+
+    setIsNavigatingBack(true);
+
+    secondInstalmentRespond(
+      { applicationId },
+      {
+        onSuccess: () => {
+          showSuccessToast(
+            t('common:applications.secondInstalmentUpload.successTitle'),
+            [
+              t('common:applications.secondInstalmentUpload.successMessage1'),
+              (secondInstalmentInfo?.application_number ?? '').toString(),
+              t('common:applications.secondInstalmentUpload.successMessage2'),
+            ].join(' ')
+          );
+          void router.replace(`${ROUTES.APPLICATION_FORM}?id=${applicationId}`);
+        },
+        onError: () => {
+          showErrorToast(
+            t('common:applications.secondInstalmentUpload.errorTitle'),
+            t('common:applications.secondInstalmentUpload.errorMessage')
+          );
+          setIsNavigatingBack(false);
+        },
+      }
+    );
+  }, [
+    applicationId,
+    hasPayslipAttachment,
+    isNavigatingBack,
+    router,
+    secondInstalmentInfo?.application_number,
+    secondInstalmentRespond,
+    t,
+  ]);
+
+  const handleBack = React.useCallback((): void => {
+    if (isNavigatingBack) {
+      return;
+    }
+
+    setIsNavigatingBack(true);
+    void router.replace(ROUTES.HOME);
+  }, [isNavigatingBack, router]);
+
+  return (
+    <Container>
+      <h1>{t('common:applications.secondInstalmentUpload.heading')}</h1>
+
+      {isSecondInstalmentInfoLoading && <LoadingSpinner />}
+
+      {isSecondInstalmentInfoError && (
+        <p>
+          {t(
+            'common:applications.secondInstalmentUpload.secondInstalmentInfoError'
+          )}
+        </p>
+      )}
+
+      {secondInstalmentInfo && (
+        <>
+          <$Grid columns={12} css={{ marginBottom: '24px' }}>
+            <$GridCell $colSpan={6}>
+              <span css={{ color: FOG_COLOR }}>
+                {secondInstalmentInfo.employee_first_name}&nbsp;
+                {secondInstalmentInfo.employee_last_name}
+              </span>
+            </$GridCell>
+            <$GridCell $colSpan={6} justifySelf="end">
+              <span css={{ color: FOG_COLOR }}>
+                {t(
+                  'common:applications.secondInstalmentUpload.applicationNumber'
+                )}
+                : {secondInstalmentInfo.application_number}
+                {' | '}
+                {t(
+                  'common:applications.secondInstalmentUpload.submittedAt'
+                )}{' '}
+                {convertToUIDateAndTimeFormat(
+                  secondInstalmentInfo.submitted_at
+                )}
+              </span>
+            </$GridCell>
+          </$Grid>
+          <hr css={{ color: FOG_COLOR }} />
+        </>
+      )}
+
+      {secondInstalmentInfo && (
+        <p>
+          Tuen toinen maksuerä on{' '}
+          {formatEuroAmount(secondInstalmentInfo.amount)} euroa ajalle{' '}
+          {convertToUIDateFormat(secondInstalmentInfo.start_date)} -{' '}
+          {convertToUIDateFormat(secondInstalmentInfo.end_date)}
+        </p>
+      )}
+
+      <p>{t('common:applications.secondInstalmentUpload.condition')}</p>
+
+      {!applicationId && (
+        <p>
+          {t('common:applications.secondInstalmentUpload.missingApplicationId')}
+        </p>
+      )}
+
+      <ul>
+        <AttachmentsList
+          as="li"
+          attachments={attachments}
+          attachmentType={ATTACHMENT_TYPES.PAYSLIP}
+          attachmentTypeTranslationKey="payslip"
+          required
+        />
+        <AttachmentsList
+          as="li"
+          attachments={attachments}
+          attachmentType={ATTACHMENT_TYPES.OTHER_ATTACHMENT}
+          attachmentTypeTranslationKey="otherAttachment"
+        />
+      </ul>
+      <$Grid columns={2} css={{ marginTop: '24px' }}>
+        <$GridCell>
+          <Button
+            css={{ marginLeft: '16px' }}
+            theme="black"
+            variant="secondary"
+            disabled={isNavigatingBack}
+            onClick={handleBack}
+          >
+            {t('common:applications.secondInstalmentUpload.buttons.back')}
+          </Button>
+        </$GridCell>
+        <$GridCell justifySelf="end">
+          <Button
+            css={{ marginLeft: '16px' }}
+            theme="coat"
+            variant="primary"
+            disabled={
+              isNavigatingBack ||
+              isSubmittingSecondInstalmentResponse ||
+              !applicationId
+            }
+            iconRight={<IconArrowRight />}
+            onClick={handleSubmit}
+          >
+            {isSubmittingSecondInstalmentResponse ? (
+              <LoadingSpinner small />
+            ) : (
+              t('common:applications.secondInstalmentUpload.buttons.submit')
+            )}
+          </Button>
+        </$GridCell>
+      </$Grid>
+    </Container>
+  );
+};
+
+export default SecondInstalmentUploadPage;

--- a/frontend/benefit/applicant/src/components/applications/secondInstalmentUpload/SecondInstalmentUploadPage.tsx
+++ b/frontend/benefit/applicant/src/components/applications/secondInstalmentUpload/SecondInstalmentUploadPage.tsx
@@ -1,6 +1,7 @@
 import AttachmentsList from 'benefit/applicant/components/applications/forms/application/step3/attachmentsList/AttachmentsList';
 import { ROUTES } from 'benefit/applicant/constants';
 import useApplicationQuery from 'benefit/applicant/hooks/useApplicationQuery';
+import useChangeEmployerAssuranceMutation from 'benefit/applicant/hooks/useChangeEmployerAssuranceMutation';
 import useSecondInstalmentInfoQuery from 'benefit/applicant/hooks/useSecondInstalmentInfoQuery';
 import useSecondInstalmentRespondMutation from 'benefit/applicant/hooks/useSecondInstalmentRespondMutation';
 import { useTranslation } from 'benefit/applicant/i18n';
@@ -9,25 +10,19 @@ import { Button, IconArrowRight, LoadingSpinner } from 'hds-react';
 import { useRouter } from 'next/router';
 import React from 'react';
 import Container from 'shared/components/container/Container';
+import { $Checkbox } from 'shared/components/forms/fields/Fields.sc';
 import {
   $Grid,
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
 import showErrorToast from 'shared/components/toast/show-error-toast';
 import showSuccessToast from 'shared/components/toast/show-success-toast';
+import useLocale from 'shared/hooks/useLocale';
 import { BenefitAttachment } from 'shared/types/attachment';
 import {
   convertToUIDateAndTimeFormat,
   convertToUIDateFormat,
 } from 'shared/utils/date.utils';
-
-const FOG_COLOR = 'var(--color-fog)';
-
-const formatEuroAmount = (amount: number | string): string =>
-  new Intl.NumberFormat('fi-FI', {
-    maximumFractionDigits: 2,
-    minimumFractionDigits: 0,
-  }).format(Number(amount));
 
 const getFileNameFromPath = (path?: string): string =>
   path?.split('/').filter(Boolean).at(-1) ?? '';
@@ -60,14 +55,39 @@ const normalizeAttachmentFileNames = (
   });
 
 const SecondInstalmentUploadPage: React.FC = () => {
+  const locale = useLocale();
   const { t } = useTranslation();
   const router = useRouter();
   const [isNavigatingBack, setIsNavigatingBack] = React.useState(false);
+  const [assuranceChecked, setAssuranceChecked] = React.useState(false);
 
   const applicationId =
     typeof router.query.id === 'string' ? router.query.id : undefined;
 
   const { data: application } = useApplicationQuery(applicationId ?? '');
+
+  React.useEffect(() => {
+    const applicationWithSnakeCaseFields = application as
+      | { employer_assurance?: boolean | null }
+      | undefined;
+
+    setAssuranceChecked(
+      Boolean(
+        application?.employer_assurance ??
+        applicationWithSnakeCaseFields?.employer_assurance
+      )
+    );
+  }, [application]);
+
+  const formatEuroAmount = React.useCallback(
+    (amount: number | string): string =>
+      new Intl.NumberFormat(`${locale}-FI`, {
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 0,
+      }).format(Number(amount)),
+    [locale]
+  );
+
   const attachments = React.useMemo(
     () => normalizeAttachmentFileNames(application?.attachments),
     [application?.attachments]
@@ -90,6 +110,29 @@ const SecondInstalmentUploadPage: React.FC = () => {
     mutate: secondInstalmentRespond,
     isLoading: isSubmittingSecondInstalmentResponse,
   } = useSecondInstalmentRespondMutation();
+
+  const {
+    mutate: changeEmployerAssurance,
+    isLoading: isChangingEmployerAssurance,
+  } = useChangeEmployerAssuranceMutation();
+
+  const handleEmployerAssuranceChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>): void => {
+      const { checked } = event.target;
+
+      setAssuranceChecked(checked);
+
+      if (!applicationId) {
+        return;
+      }
+
+      changeEmployerAssurance({
+        applicationId,
+        employerAssurance: checked,
+      });
+    },
+    [applicationId, changeEmployerAssurance]
+  );
 
   const handleSubmit = React.useCallback((): void => {
     if (isNavigatingBack || !applicationId) {
@@ -118,7 +161,7 @@ const SecondInstalmentUploadPage: React.FC = () => {
               t('common:applications.secondInstalmentUpload.successMessage2'),
             ].join(' ')
           );
-          void router.replace(`${ROUTES.APPLICATION_FORM}?id=${applicationId}`);
+          void router.replace(ROUTES.HOME);
         },
         onError: () => {
           showErrorToast(
@@ -164,15 +207,15 @@ const SecondInstalmentUploadPage: React.FC = () => {
 
       {secondInstalmentInfo && (
         <>
-          <$Grid columns={12} css={{ marginBottom: '24px' }}>
+          <$Grid columns={12} css={{ marginBottom: '6px' }}>
             <$GridCell $colSpan={6}>
-              <span css={{ color: FOG_COLOR }}>
-                {secondInstalmentInfo.employee_first_name}&nbsp;
+              <span>
+                {secondInstalmentInfo.employee_first_name}{' '}
                 {secondInstalmentInfo.employee_last_name}
               </span>
             </$GridCell>
             <$GridCell $colSpan={6} justifySelf="end">
-              <span css={{ color: FOG_COLOR }}>
+              <span css={{ color: 'var(--color-fog)' }}>
                 {t(
                   'common:applications.secondInstalmentUpload.applicationNumber'
                 )}
@@ -187,42 +230,63 @@ const SecondInstalmentUploadPage: React.FC = () => {
               </span>
             </$GridCell>
           </$Grid>
-          <hr css={{ color: FOG_COLOR }} />
+          <hr css={{ marginTop: '6px', marginBottom: '6px' }} />
         </>
       )}
 
       {secondInstalmentInfo && (
         <p>
-          Tuen toinen maksuerä on{' '}
-          {formatEuroAmount(secondInstalmentInfo.amount)} euroa ajalle{' '}
+          {t('common:applications.secondInstalmentUpload.instalmentInfo1')}{' '}
+          {formatEuroAmount(secondInstalmentInfo.amount)}{' '}
+          {t('common:applications.secondInstalmentUpload.instalmentInfo2')}{' '}
           {convertToUIDateFormat(secondInstalmentInfo.start_date)} -{' '}
-          {convertToUIDateFormat(secondInstalmentInfo.end_date)}
+          {convertToUIDateFormat(secondInstalmentInfo.end_date)}.
         </p>
       )}
 
-      <p>{t('common:applications.secondInstalmentUpload.condition')}</p>
+      <p>
+        {t('common:applications.secondInstalmentUpload.condition')}
+        <br />
+        {t('common:applications.secondInstalmentUpload.conditionSpecial')}
+      </p>
 
       {!applicationId && (
         <p>
           {t('common:applications.secondInstalmentUpload.missingApplicationId')}
         </p>
       )}
-
-      <ul>
-        <AttachmentsList
-          as="li"
-          attachments={attachments}
-          attachmentType={ATTACHMENT_TYPES.PAYSLIP}
-          attachmentTypeTranslationKey="payslip"
-          required
-        />
-        <AttachmentsList
-          as="li"
-          attachments={attachments}
-          attachmentType={ATTACHMENT_TYPES.OTHER_ATTACHMENT}
-          attachmentTypeTranslationKey="otherAttachment"
-        />
-      </ul>
+      <$Grid columns={1}>
+        <$GridCell colSpan={1}>
+          <$Checkbox
+            id="employer-assurance"
+            name="employer-assurance"
+            label={`${t(
+              'common:applications.secondInstalmentUpload.employerAssurance'
+            )} *`}
+            checked={assuranceChecked}
+            disabled={isChangingEmployerAssurance}
+            onChange={handleEmployerAssuranceChange}
+            required
+          />
+        </$GridCell>
+        <$GridCell colSpan={1}>
+          <ul>
+            <AttachmentsList
+              as="li"
+              attachments={attachments}
+              attachmentType={ATTACHMENT_TYPES.PAYSLIP}
+              attachmentTypeTranslationKey="payslip"
+              required
+            />
+            <AttachmentsList
+              as="li"
+              attachments={attachments}
+              attachmentType={ATTACHMENT_TYPES.OTHER_ATTACHMENT}
+              attachmentTypeTranslationKey="otherAttachment"
+            />
+          </ul>
+        </$GridCell>
+      </$Grid>
       <$Grid columns={2} css={{ marginTop: '24px' }}>
         <$GridCell>
           <Button
@@ -243,6 +307,8 @@ const SecondInstalmentUploadPage: React.FC = () => {
             disabled={
               isNavigatingBack ||
               isSubmittingSecondInstalmentResponse ||
+              !hasPayslipAttachment ||
+              !assuranceChecked ||
               !applicationId
             }
             iconRight={<IconArrowRight />}

--- a/frontend/benefit/applicant/src/components/applications/secondInstalmentUpload/__tests__/SecondInstalmentUploadPage.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/secondInstalmentUpload/__tests__/SecondInstalmentUploadPage.test.tsx
@@ -1,0 +1,390 @@
+import { fireEvent, screen } from '@testing-library/react';
+import renderComponent from 'benefit/applicant/__tests__/utils/render-component';
+import { ROUTES } from 'benefit/applicant/constants';
+import useApplicationQuery from 'benefit/applicant/hooks/useApplicationQuery';
+import useChangeEmployerAssuranceMutation from 'benefit/applicant/hooks/useChangeEmployerAssuranceMutation';
+import useSecondInstalmentInfoQuery from 'benefit/applicant/hooks/useSecondInstalmentInfoQuery';
+import useSecondInstalmentRespondMutation from 'benefit/applicant/hooks/useSecondInstalmentRespondMutation';
+import { ATTACHMENT_TYPES } from 'benefit-shared/constants';
+import React from 'react';
+import showSuccessToast from 'shared/components/toast/show-success-toast';
+
+import SecondInstalmentUploadPage from '../SecondInstalmentUploadPage';
+
+const replaceMock = jest.fn();
+const secondInstalmentRespondMock = jest.fn();
+const changeEmployerAssuranceMock = jest.fn();
+
+jest.mock('shared/components/forms/fields/Fields.sc', () => ({
+  $Checkbox: ({
+    checked,
+    disabled,
+    id,
+    label,
+    name,
+    onChange,
+    required,
+  }: {
+    checked?: boolean;
+    disabled?: boolean;
+    id?: string;
+    label: string;
+    name?: string;
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
+    required?: boolean;
+  }) => (
+    <label htmlFor={id}>
+      {label}
+      <input
+        id={id}
+        name={name}
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        required={required}
+        onChange={onChange}
+      />
+    </label>
+  ),
+}));
+jest.mock('benefit/applicant/hooks/useApplicationQuery');
+jest.mock('benefit/applicant/hooks/useChangeEmployerAssuranceMutation');
+jest.mock('benefit/applicant/hooks/useSecondInstalmentInfoQuery');
+jest.mock('benefit/applicant/hooks/useSecondInstalmentRespondMutation');
+jest.mock('shared/components/toast/show-error-toast', () => jest.fn());
+jest.mock('shared/components/toast/show-success-toast', () => jest.fn());
+
+jest.mock('benefit/applicant/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {
+      id: 'application-id',
+    },
+    replace: replaceMock,
+  }),
+}));
+
+jest.mock(
+  'benefit/applicant/components/applications/forms/application/step3/attachmentsList/AttachmentsList',
+  () =>
+    ({
+      attachmentType,
+      attachments,
+      required,
+    }: {
+      attachmentType: string;
+      attachments?: Array<{
+        attachmentType: string;
+        attachmentFileName?: string;
+      }>;
+      required?: boolean;
+    }) => {
+      const files =
+        attachments?.filter(
+          (attachment) => attachment.attachmentType === attachmentType
+        ) ?? [];
+
+      return (
+        <li data-testid={`attachment-list-${attachmentType}`}>
+          <h2>
+            {attachmentType}
+            {required ? ' *' : ''}
+          </h2>
+          {files.map((file) => (
+            <span key={file.attachmentFileName}>{file.attachmentFileName}</span>
+          ))}
+        </li>
+      );
+    }
+);
+
+jest.mock('hds-react', () => ({
+  Button: ({
+    children,
+    disabled,
+    iconRight,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+    iconRight?: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" disabled={disabled} onClick={onClick}>
+      {children}
+      {iconRight}
+    </button>
+  ),
+  IconArrowRight: () => <svg data-testid="arrow-right-icon" />,
+  LoadingSpinner: ({ small }: { small?: boolean }) => (
+    <span data-testid={small ? 'small-loading-spinner' : 'loading-spinner'} />
+  ),
+}));
+
+const mockedUseApplicationQuery = useApplicationQuery as jest.MockedFunction<
+  typeof useApplicationQuery
+>;
+
+const mockedUseChangeEmployerAssuranceMutation =
+  useChangeEmployerAssuranceMutation as jest.MockedFunction<
+    typeof useChangeEmployerAssuranceMutation
+  >;
+
+const mockedUseSecondInstalmentInfoQuery =
+  useSecondInstalmentInfoQuery as jest.MockedFunction<
+    typeof useSecondInstalmentInfoQuery
+  >;
+
+const mockedUseSecondInstalmentRespondMutation =
+  useSecondInstalmentRespondMutation as jest.MockedFunction<
+    typeof useSecondInstalmentRespondMutation
+  >;
+
+const mockedShowSuccessToast = showSuccessToast as jest.MockedFunction<
+  typeof showSuccessToast
+>;
+
+const payslipAttachment = {
+  id: 'payslip-id',
+  application: 'application-id',
+  attachmentType: ATTACHMENT_TYPES.PAYSLIP,
+  attachmentFile: '/media/payslip.pdf',
+  attachmentFileName: 'payslip.pdf',
+  contentType: 'application/pdf',
+};
+
+const otherAttachment = {
+  id: 'other-id',
+  application: 'application-id',
+  attachmentType: ATTACHMENT_TYPES.OTHER_ATTACHMENT,
+  attachmentFile: '/media/other.pdf',
+  attachmentFileName: 'other.pdf',
+  contentType: 'application/pdf',
+};
+
+const secondInstalmentInfo = {
+  amount: 1234,
+  start_date: '2026-01-01',
+  end_date: '2026-06-30',
+  employee_first_name: 'Test',
+  employee_last_name: 'Employee',
+  submitted_at: '2026-01-02T10:15:00Z',
+  application_number: '123456',
+};
+
+const setupMocks = ({
+  attachments = [payslipAttachment],
+  employerAssurance = true,
+  info = secondInstalmentInfo,
+  infoIsError = false,
+  infoIsLoading = false,
+  respondIsLoading = false,
+  changeEmployerAssuranceIsLoading = false,
+}: {
+  attachments?: typeof payslipAttachment[];
+  employerAssurance?: boolean;
+  info?: typeof secondInstalmentInfo;
+  infoIsError?: boolean;
+  infoIsLoading?: boolean;
+  respondIsLoading?: boolean;
+  changeEmployerAssuranceIsLoading?: boolean;
+} = {}): void => {
+  mockedUseApplicationQuery.mockReturnValue({
+    data: {
+      attachments,
+      employer_assurance: employerAssurance,
+    },
+  } as ReturnType<typeof useApplicationQuery>);
+
+  mockedUseSecondInstalmentInfoQuery.mockReturnValue({
+    data: info,
+    isError: infoIsError,
+    isLoading: infoIsLoading,
+  } as ReturnType<typeof useSecondInstalmentInfoQuery>);
+
+  mockedUseSecondInstalmentRespondMutation.mockReturnValue({
+    mutate: secondInstalmentRespondMock,
+    isLoading: respondIsLoading,
+  } as unknown as ReturnType<typeof useSecondInstalmentRespondMutation>);
+
+  mockedUseChangeEmployerAssuranceMutation.mockReturnValue({
+    mutate: changeEmployerAssuranceMock,
+    isLoading: changeEmployerAssuranceIsLoading,
+  } as unknown as ReturnType<typeof useChangeEmployerAssuranceMutation>);
+};
+
+const renderPage = (): ReturnType<typeof renderComponent> =>
+  renderComponent(<SecondInstalmentUploadPage />);
+
+describe('SecondInstalmentUploadPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks();
+  });
+
+  it('renders page heading', () => {
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'common:applications.secondInstalmentUpload.heading',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('renders employee name and application number', () => {
+    renderPage();
+
+    expect(screen.getByText(/Test\s+Employee/)).toBeInTheDocument();
+    expect(screen.getByText(/123456/)).toBeInTheDocument();
+  });
+
+  it('renders second instalment amount and date range', () => {
+    renderPage();
+
+    expect(
+      screen.getByText((_content, element) => {
+        if (element?.tagName.toLowerCase() !== 'p') {
+          return false;
+        }
+
+        const text = element.textContent?.replace(/\u00A0/g, ' ') ?? '';
+
+        return (
+          text.includes(
+            'common:applications.secondInstalmentUpload.instalmentInfo1'
+          ) &&
+          text.includes('1 234') &&
+          text.includes(
+            'common:applications.secondInstalmentUpload.instalmentInfo2'
+          ) &&
+          text.includes('1.1.2026') &&
+          text.includes('30.6.2026')
+        );
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('renders loading spinner when second instalment info is loading', () => {
+    setupMocks({
+      infoIsLoading: true,
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+  });
+
+  it('renders error message when second instalment info query fails', () => {
+    setupMocks({
+      infoIsError: true,
+    });
+
+    renderPage();
+
+    expect(
+      screen.getByText(
+        'common:applications.secondInstalmentUpload.secondInstalmentInfoError'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders attachment file names in correct attachment areas', () => {
+    setupMocks({
+      attachments: [payslipAttachment, otherAttachment],
+    });
+
+    renderPage();
+
+    expect(screen.getByText('payslip.pdf')).toBeInTheDocument();
+    expect(screen.getByText('other.pdf')).toBeInTheDocument();
+  });
+
+  it('disables Lähetä button if there are no files in the Palkkakuitti attachment component', () => {
+    setupMocks({
+      attachments: [otherAttachment],
+    });
+
+    renderPage();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'common:applications.secondInstalmentUpload.buttons.submit',
+      })
+    ).toBeDisabled();
+
+    expect(secondInstalmentRespondMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('submits second instalment response and navigates to application view when payslip exists', () => {
+    secondInstalmentRespondMock.mockImplementation((_payload, options) => {
+      options?.onSuccess?.();
+    });
+
+    renderPage();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'common:applications.secondInstalmentUpload.buttons.submit',
+      })
+    );
+
+    expect(secondInstalmentRespondMock).toHaveBeenCalledWith(
+      { applicationId: 'application-id' },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      })
+    );
+    expect(mockedShowSuccessToast).toHaveBeenCalledWith(
+      'common:applications.secondInstalmentUpload.successTitle',
+      [
+        'common:applications.secondInstalmentUpload.successMessage1',
+        '123456',
+        'common:applications.secondInstalmentUpload.successMessage2',
+      ].join(' ')
+    );
+    expect(replaceMock).toHaveBeenCalledWith(
+      `${ROUTES.HOME}`
+    );
+  });
+
+  it('renders employer assurance checkbox checked when employer assurance exists on application', () => {
+    setupMocks({
+      employerAssurance: true,
+    });
+
+    renderPage();
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'common:applications.secondInstalmentUpload.employerAssurance *',
+      })
+    ).toBeChecked();
+  });
+
+  it('calls backend when employer assurance checkbox value is changed', () => {
+    setupMocks({
+      employerAssurance: false,
+    });
+
+    renderPage();
+
+    fireEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'common:applications.secondInstalmentUpload.employerAssurance *',
+      })
+    );
+
+    expect(changeEmployerAssuranceMock).toHaveBeenCalledWith({
+      applicationId: 'application-id',
+      employerAssurance: true,
+    });
+  });
+});

--- a/frontend/benefit/applicant/src/constants.ts
+++ b/frontend/benefit/applicant/src/constants.ts
@@ -12,6 +12,7 @@ export enum ROUTES {
   HOME = '/',
   APPLICATION_FORM = '/application',
   APPLICATION_ALTERATION = '/application/alteration',
+  SECOND_INSTALMENT_UPLOAD = '/application/second-instalment-upload',
   LOGIN = '/login',
   TERMS_OF_SERVICE = '/terms-of-service',
   ACCESSIBILITY_STATEMENT = '/accessibility-statement',

--- a/frontend/benefit/applicant/src/hooks/useApplicationsQuery.ts
+++ b/frontend/benefit/applicant/src/hooks/useApplicationsQuery.ts
@@ -4,18 +4,26 @@ import { useQuery, UseQueryResult } from 'react-query';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 
 const useApplicationsQuery = ({
-  status,
-  isArchived,
-  orderBy = 'id',
-}: {
+                                status,
+                                isArchived,
+                                orderBy = 'id',
+                                secondInstalmentStatus,
+                              }: {
   status: string[];
   isArchived?: boolean;
   orderBy?: string;
+  secondInstalmentStatus?: string;
 }): UseQueryResult<ApplicationData[], Error> => {
   const { axios, handleResponse } = useBackendAPI();
 
   return useQuery<ApplicationData[], Error>(
-    ['applicationsList', ...status, orderBy, isArchived ? '1' : '0'],
+    [
+      'applicationsList',
+      ...status,
+      orderBy,
+      isArchived ? '1' : '0',
+      secondInstalmentStatus ?? '',
+    ],
     async () => {
       const res = axios.get<ApplicationData[]>(
         `${BackendEndpoint.APPLICATIONS_SIMPLIFIED}`,
@@ -24,6 +32,7 @@ const useApplicationsQuery = ({
             status: status.join(','),
             archived_for_applicant: isArchived ?? undefined,
             order_by: orderBy,
+            second_instalment_status: secondInstalmentStatus,
           },
         }
       );

--- a/frontend/benefit/applicant/src/hooks/useChangeEmployerAssuranceMutation.ts
+++ b/frontend/benefit/applicant/src/hooks/useChangeEmployerAssuranceMutation.ts
@@ -1,0 +1,39 @@
+import { ErrorResponse } from 'benefit/applicant/types/common';
+import { ApplicantEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+type ChangeEmployerAssuranceParams = {
+  applicationId: string;
+  employerAssurance: boolean;
+};
+
+const useChangeEmployerAssuranceMutation = (): UseMutationResult<
+  void,
+  ErrorResponse,
+  ChangeEmployerAssuranceParams
+> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const queryClient = useQueryClient();
+
+  return useMutation<void, ErrorResponse, ChangeEmployerAssuranceParams>(
+    ({ applicationId, employerAssurance }) =>
+      handleResponse<void>(
+        axios.patch(
+          ApplicantEndpoint.CHANGE_EMPLOYER_ASSURANCE(applicationId),
+          {
+            employerAssurance,
+          }
+        )
+      ),
+    {
+      onSuccess: (_data, { applicationId }) => {
+        void queryClient.invalidateQueries('applications');
+        void queryClient.invalidateQueries(['applications', applicationId]);
+        void queryClient.invalidateQueries('application');
+      },
+    }
+  );
+};
+
+export default useChangeEmployerAssuranceMutation;

--- a/frontend/benefit/applicant/src/hooks/useSecondInstalmentInfoQuery.ts
+++ b/frontend/benefit/applicant/src/hooks/useSecondInstalmentInfoQuery.ts
@@ -1,0 +1,33 @@
+import { ErrorResponse } from 'benefit/applicant/types/common';
+import { ApplicantEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { useQuery, UseQueryResult } from 'react-query';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+export type SecondInstalmentInfoData = {
+  amount: number | string;
+  start_date: string;
+  end_date: string;
+  employee_first_name: string;
+  employee_last_name: string;
+  submitted_at: string;
+  application_number: string;
+};
+
+const useSecondInstalmentInfoQuery = (
+  applicationId?: string
+): UseQueryResult<SecondInstalmentInfoData, ErrorResponse> => {
+  const { axios, handleResponse } = useBackendAPI();
+
+  return useQuery<SecondInstalmentInfoData, ErrorResponse>(
+    ['secondInstalmentInfo', applicationId],
+    () =>
+      handleResponse<SecondInstalmentInfoData>(
+        axios.get(ApplicantEndpoint.SECOND_INSTALMENT_INFO(applicationId ?? ''))
+      ),
+    {
+      enabled: Boolean(applicationId),
+    }
+  );
+};
+
+export default useSecondInstalmentInfoQuery;

--- a/frontend/benefit/applicant/src/hooks/useSecondInstalmentRespondMutation.ts
+++ b/frontend/benefit/applicant/src/hooks/useSecondInstalmentRespondMutation.ts
@@ -1,0 +1,32 @@
+import { ErrorResponse } from 'benefit/applicant/types/common';
+import { ApplicantEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+type SecondInstalmentRespondParams = {
+  applicationId: string;
+};
+
+const useSecondInstalmentRespondMutation = (): UseMutationResult<
+  void,
+  ErrorResponse,
+  SecondInstalmentRespondParams
+> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const queryClient = useQueryClient();
+
+  return useMutation<void, ErrorResponse, SecondInstalmentRespondParams>(
+    ({ applicationId }) =>
+      handleResponse<void>(
+        axios.post(ApplicantEndpoint.SECOND_INSTALMENT_RESPOND(applicationId))
+      ),
+    {
+      onSuccess: () => {
+        void queryClient.invalidateQueries('applications');
+        void queryClient.invalidateQueries('application');
+      },
+    }
+  );
+};
+
+export default useSecondInstalmentRespondMutation;

--- a/frontend/benefit/applicant/src/pages/application/second-instalment-upload.tsx
+++ b/frontend/benefit/applicant/src/pages/application/second-instalment-upload.tsx
@@ -1,0 +1,12 @@
+import SecondInstalmentUploadPage from 'benefit/applicant/components/applications/secondInstalmentUpload/SecondInstalmentUploadPage';
+import { GetStaticProps, NextPage } from 'next';
+import React from 'react';
+import withAuth from 'shared/components/hocs/withAuth';
+import getServerSideTranslations from 'shared/i18n/get-server-side-translations';
+
+const SecondInstalmentUpload: NextPage = () => <SecondInstalmentUploadPage />;
+
+export const getStaticProps: GetStaticProps =
+  getServerSideTranslations('common');
+
+export default withAuth(SecondInstalmentUpload);

--- a/frontend/benefit/applicant/src/pages/index.tsx
+++ b/frontend/benefit/applicant/src/pages/index.tsx
@@ -6,6 +6,7 @@ import FrontPageMainIngress from 'benefit/applicant/components/mainIngress/front
 import PrerequisiteReminder from 'benefit/applicant/components/prerequisiteReminder/PrerequisiteReminder';
 import AppContext from 'benefit/applicant/context/AppContext';
 import { useTranslation } from 'benefit/applicant/i18n';
+import { INSTALMENT_STATUSES } from 'benefit-shared/constants';
 import { Button, IconArrowRight } from 'hds-react';
 import { GetStaticProps, NextPage } from 'next';
 import Head from 'next/head';
@@ -94,6 +95,12 @@ const ApplicantIndex: NextPage = () => {
               ]}
               initialItems={4}
               onListLengthChanged={onDraftChange}
+            />
+            <ApplicationList
+              heading={t('common:applications.list.secondInstalments.heading')}
+              status={SUBMITTED_STATUSES}
+              isArchived={false}
+              secondInstalmentStatus={INSTALMENT_STATUSES.REQUESTED}
             />
             <ApplicationList
               heading={t('common:applications.list.submitted.heading')}

--- a/frontend/benefit/applicant/src/pages/index.tsx
+++ b/frontend/benefit/applicant/src/pages/index.tsx
@@ -89,6 +89,13 @@ const ApplicantIndex: NextPage = () => {
           <NoApplications />
         ) : (
           <>
+            <ApplicationList
+              heading={t('common:applications.list.secondInstalments.heading')}
+              status={SUBMITTED_STATUSES}
+              isArchived={false}
+              secondInstalmentStatus={INSTALMENT_STATUSES.REQUESTED}
+              onListLengthChanged={onSecondInstalmentChange}
+            />
             <ExpandableApplicationList
               heading={t('common:applications.list.moreInfo.heading')}
               status={['additional_information_needed']}
@@ -106,13 +113,6 @@ const ApplicantIndex: NextPage = () => {
               ]}
               initialItems={4}
               onListLengthChanged={onDraftChange}
-            />
-            <ApplicationList
-              heading={t('common:applications.list.secondInstalments.heading')}
-              status={SUBMITTED_STATUSES}
-              isArchived={false}
-              secondInstalmentStatus={INSTALMENT_STATUSES.REQUESTED}
-              onListLengthChanged={onSecondInstalmentChange}
             />
             <ApplicationList
               heading={t('common:applications.list.submitted.heading')}

--- a/frontend/benefit/applicant/src/pages/index.tsx
+++ b/frontend/benefit/applicant/src/pages/index.tsx
@@ -45,6 +45,9 @@ const ApplicantIndex: NextPage = () => {
 
   const [infoNeededCount, setInfoNeededCount] = useState<number | null>(null);
   const [draftCount, setDraftCount] = useState<number | null>(null);
+  const [secondInstalmentCount, setSecondInstalmentCount] = useState<
+    number | null
+  >(null);
   const [submittedCount, setSubmittedCount] = useState<number | null>(null);
 
   const onInfoNeededChange = useCallback(
@@ -57,15 +60,23 @@ const ApplicantIndex: NextPage = () => {
       setDraftCount(isLoading ? null : count),
     []
   );
+  const onSecondInstalmentChange = useCallback(
+    (isLoading: boolean, count: number) =>
+      setSecondInstalmentCount(isLoading ? null : count),
+    []
+  );
   const onSubmittedChange = useCallback(
     (isLoading: boolean, count: number) =>
       setSubmittedCount(isLoading ? null : count),
     []
   );
 
-  const noApplications = [infoNeededCount, draftCount, submittedCount].every(
-    (item) => item === 0
-  );
+  const noApplications = [
+    infoNeededCount,
+    draftCount,
+    secondInstalmentCount,
+    submittedCount,
+  ].every((item) => item === 0);
 
   return (
     <>
@@ -101,6 +112,7 @@ const ApplicantIndex: NextPage = () => {
               status={SUBMITTED_STATUSES}
               isArchived={false}
               secondInstalmentStatus={INSTALMENT_STATUSES.REQUESTED}
+              onListLengthChanged={onSecondInstalmentChange}
             />
             <ApplicationList
               heading={t('common:applications.list.submitted.heading')}

--- a/frontend/benefit/handler/src/hooks/applicationHandling/useRouterNavigation.ts
+++ b/frontend/benefit/handler/src/hooks/applicationHandling/useRouterNavigation.ts
@@ -88,6 +88,14 @@ export const useRouterNavigation = (
 
     const previousLocation = getPreviousLocationData().pathname;
 
+    // If a returnTab is explicitly set in the URL, always honour it (e.g. tab=6 for Maksuerät)
+    const returnTabRaw = router.query?.returnTab;
+    const returnTab =
+      typeof returnTabRaw === 'string' ? parseInt(returnTabRaw, 10) : NaN;
+    if (!Number.isNaN(returnTab)) {
+      return router.push(`/?tab=${returnTab}`);
+    }
+
     // When coming from the alteration page (open application in new window), return to the alteration page
     if (
       getPreviousLocationData().length === 1 &&

--- a/frontend/benefit/handler/src/hooks/applicationHandling/useRouterNavigation.ts
+++ b/frontend/benefit/handler/src/hooks/applicationHandling/useRouterNavigation.ts
@@ -88,7 +88,7 @@ export const useRouterNavigation = (
 
     const previousLocation = getPreviousLocationData().pathname;
 
-    // If a returnTab is explicitly set in the URL, always honour it (e.g. tab=6 for Maksuerät)
+    // If a returnTab is explicitly set in the URL, always honour it (e.g. returnTab=6 for Maksuerät)
     const returnTabRaw = router.query?.returnTab;
     const returnTab =
       typeof returnTabRaw === 'string' ? parseInt(returnTabRaw, 10) : NaN;

--- a/frontend/benefit/shared/src/backend-api/backend-api.ts
+++ b/frontend/benefit/shared/src/backend-api/backend-api.ts
@@ -74,6 +74,8 @@ export const ApplicantEndpoint = {
     `${applicationsBase(id)}get_second_instalment_info/`,
   SECOND_INSTALMENT_RESPOND: (id: string) =>
     `${applicationsBase(id)}second_instalment_respond/`,
+  CHANGE_EMPLOYER_ASSURANCE: (id: string) =>
+    `${applicationsBase(id)}change_employer_assurance/`,
 } as const;
 
 export const BackendEndPoints = Object.values(BackendEndpoint);

--- a/frontend/benefit/shared/src/backend-api/backend-api.ts
+++ b/frontend/benefit/shared/src/backend-api/backend-api.ts
@@ -70,6 +70,10 @@ const applicationsBase = (id: string): string =>
 export const ApplicantEndpoint = {
   APPLICATIONS_CLONE_AS_DRAFT: (id: string) =>
     `${applicationsBase(id)}clone_as_draft/`,
+  SECOND_INSTALMENT_INFO: (id: string) =>
+    `${applicationsBase(id)}get_second_instalment_info/`,
+  SECOND_INSTALMENT_RESPOND: (id: string) =>
+    `${applicationsBase(id)}second_instalment_respond/`,
 } as const;
 
 export const BackendEndPoints = Object.values(BackendEndpoint);

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -523,6 +523,7 @@ export type ApplicationData = {
   ahjo_error?: AhjoErrorData;
   first_instalment?: InstalmentData;
   second_instalment?: InstalmentData;
+  second_instalment_due_date?: string;
   employer_assurance?: boolean | null;
 };
 
@@ -626,6 +627,7 @@ export type ApplicationListItemData = {
   calculatedBenefitAmount?: string;
   firstInstalment?: Instalment;
   secondInstalment?: Instalment;
+  secondInstalmentDueDate?: string;
 };
 
 export type TextProp = 'textFi' | 'textEn' | 'textSv';


### PR DESCRIPTION
## Description

Add applications with 2nd installment status REQUESTED to the front page.
Allow for sending payslips to the applications with REQUESTED status
on the second instalment.

### Business logic

1. Applicant gets email request for payslips to allow for paying 2nd instalment (__implemented earlier__)
2. Applicant gets a list of the applications requiring PAYSLIPs on the index page (applications with 2nd instalment in REQUESTED state)
3. Applicant uses the new UI (```SecondInstalmentUpload.tsx```) to send payslips and other attachments
4. 2nd instalment is set to RESPONDED state

## Motivation and context

[HL-1745](https://helsinkisolutionoffice.atlassian.net/browse/HL-1745)
[HL-1753](https://helsinkisolutionoffice.atlassian.net/browse/HL-1753)

## Testing

Jest tests for frontend.

Backend tests:
- fetching an application with 2nd instalment in status REQUESTED
- fetching only an application with 2nd instalment status REQUESTED and not an application without instalments.
- fetching no applications when 2nd instalment status is RESPONDED.
- getting second instalment info
- marking second instalment status as RESPONDED
- changing applicant side employer assurance

[HL-1745]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HL-1753]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ