### PR TITLE
ci(ks): execute test workflows when PR to main is created

### DIFF
--- a/.github/workflows/ks-empl-frontend-tests.yml
+++ b/.github/workflows/ks-empl-frontend-tests.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     paths:
       - ".github/workflows/ks-empl-frontend-tests.yml"
+      - "frontend/kesaseteli/employer/**"
+      - "frontend/kesaseteli/shared/**"
+      - "frontend/shared/**"
+      - "frontend/jest.config.js"
+      - "frontend/tsconfig.json"
+      - "frontend/next.config.js"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ks-handler-frontend-tests.yml
+++ b/.github/workflows/ks-handler-frontend-tests.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     paths:
       - ".github/workflows/ks-handler-frontend-tests.yml"
+      - "frontend/kesaseteli/handler/**"
+      - "frontend/kesaseteli/shared/**"
+      - "frontend/shared/**"
+      - "frontend/jest.config.js"
+      - "frontend/tsconfig.json"
+      - "frontend/next.config.js"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ks-shared-frontend-tests.yml
+++ b/.github/workflows/ks-shared-frontend-tests.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - ".github/workflows/ks-shared-frontend-tests.yml"
+      - "frontend/kesaseteli/shared/**"
+      - "frontend/shared/**"
+      - "frontend/jest.config.js"
+      - "frontend/tsconfig.json"
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/ks-youth-frontend-tests.yml
+++ b/.github/workflows/ks-youth-frontend-tests.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     paths:
       - ".github/workflows/ks-youth-frontend-tests.yml"
+      - "frontend/kesaseteli/youth/**"
+      - "frontend/kesaseteli/shared/**"
+      - "frontend/shared/**"
+      - "frontend/jest.config.js"
+      - "frontend/tsconfig.json"
+      - "frontend/next.config.js"
   workflow_dispatch:
 
 jobs:

--- a/frontend/kesaseteli/employer/jest.config.js
+++ b/frontend/kesaseteli/employer/jest.config.js
@@ -6,9 +6,9 @@ module.exports = {
     [`^kesaseteli-shared\/(.*)$`]: '<rootDir>../shared/src/$1',
     [`^kesaseteli/employer\/(.*)$`]: '<rootDir>src/$1',
   },
+  testEnvironment: '<rootDir>/../../shared/jest-canvas-env.js',
   setupFilesAfterEnv: [
     '<rootDir>/../../shared/src/__tests__/utils/setupTests.ts',
-    '<rootDir>/../../shared/src/__tests__/utils/canvasMock.ts',
     '<rootDir>src/__tests__/utils/i18n/i18n-test.ts',
   ],
   coveragePathIgnorePatterns: ['<rootDir>/kesaseteli/employer/src/pages/'],

--- a/frontend/kesaseteli/employer/jest.config.js
+++ b/frontend/kesaseteli/employer/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   setupFilesAfterEnv: [
     '<rootDir>/../../shared/src/__tests__/utils/setupTests.ts',
+    '<rootDir>/../../shared/src/__tests__/utils/canvasMock.ts',
     '<rootDir>src/__tests__/utils/i18n/i18n-test.ts',
   ],
   coveragePathIgnorePatterns: ['<rootDir>/kesaseteli/employer/src/pages/'],

--- a/frontend/kesaseteli/handler/jest.config.js
+++ b/frontend/kesaseteli/handler/jest.config.js
@@ -11,9 +11,9 @@ module.exports = {
     [`^kesaseteli-shared\/(.*)$`]: '<rootDir>../shared/src/$1',
     [`^kesaseteli/handler\/(.*)$`]: '<rootDir>src/$1',
   },
+  testEnvironment: '<rootDir>/../../shared/jest-canvas-env.js',
   setupFilesAfterEnv: [
     '<rootDir>/../../shared/src/__tests__/utils/setupTests.ts',
-    '<rootDir>/../../shared/src/__tests__/utils/canvasMock.ts',
     '<rootDir>src/__tests__/utils/i18n/i18n-test.ts',
   ],
   coveragePathIgnorePatterns: ['<rootDir>/kesaseteli/handler/src/pages/'],

--- a/frontend/kesaseteli/handler/jest.config.js
+++ b/frontend/kesaseteli/handler/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   },
   setupFilesAfterEnv: [
     '<rootDir>/../../shared/src/__tests__/utils/setupTests.ts',
+    '<rootDir>/../../shared/src/__tests__/utils/canvasMock.ts',
     '<rootDir>src/__tests__/utils/i18n/i18n-test.ts',
   ],
   coveragePathIgnorePatterns: ['<rootDir>/kesaseteli/handler/src/pages/'],

--- a/frontend/kesaseteli/handler/src/components/form/ActionButtons.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/ActionButtons.tsx
@@ -1,7 +1,6 @@
 import { Button, IconCheck, IconCross } from 'hds-react';
 import useCompleteYouthApplicationQuery from 'kesaseteli/handler/hooks/backend/useCompleteYouthApplicationQuery';
 import CompleteOperation from 'kesaseteli/handler/types/complete-operation';
-import isVtjDisabled from 'kesaseteli-shared/flags/is-vtj-disabled';
 import ActivatedYouthApplication from 'kesaseteli-shared/types/activated-youth-application';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
@@ -27,14 +26,6 @@ const ActionButtons: React.FC<Props> = ({ application, ...gridCellprops }) => {
   } = application;
   const { confirm } = useConfirm();
   const { isLoading, mutate } = useCompleteYouthApplicationQuery(id);
-  const isVtjEnabled = !isVtjDisabled();
-  const vtjDataNotFound =
-    isVtjEnabled &&
-    (!encrypted_handler_vtj_json ||
-      !('Henkilo' in encrypted_handler_vtj_json) ||
-      encrypted_handler_vtj_json?.Henkilo?.Henkilotunnus?.[
-        '@voimassaolokoodi'
-      ] === '0');
   const icon = React.useMemo(
     () => ({
       accept: <IconCheck aria-hidden />,

--- a/frontend/kesaseteli/handler/src/components/form/HandlerForm.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/HandlerForm.tsx
@@ -8,6 +8,7 @@ import {
   YOUTH_APPLICATION_STATUS_WAITING_FOR_YOUTH_ACTION,
 } from 'kesaseteli-shared/constants/youth-application-status';
 import isVtjDisabled from 'kesaseteli-shared/flags/is-vtj-disabled';
+import useSummerVoucherConfigurationQuery from 'kesaseteli-shared/hooks/useSummerVoucherConfigurationQuery';
 import ActivatedYouthApplication from 'kesaseteli-shared/types/activated-youth-application';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
@@ -19,7 +20,6 @@ import {
   convertToUIDateFormat,
 } from 'shared/utils/date.utils';
 import { useTheme } from 'styled-components';
-import useSummerVoucherConfigurationQuery from 'kesaseteli-shared/hooks/useSummerVoucherConfigurationQuery';
 
 type Props = {
   application: ActivatedYouthApplication;

--- a/frontend/kesaseteli/handler/src/hooks/backend/useLogout.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/useLogout.ts
@@ -1,11 +1,11 @@
-import { useRouter } from 'next/router';
-import React from 'react';
 import {
   BackendEndpoint,
   getBackendUrl,
   getLogoutRedirectUrl,
   REDIRECT_FIELD_NAME,
 } from 'kesaseteli-shared/backend-api/backend-api';
+import { useRouter } from 'next/router';
+import React from 'react';
 
 const useLogout = (): (() => Promise<boolean>) => {
   const router = useRouter();

--- a/frontend/kesaseteli/handler/src/utils/map-vtj-data.ts
+++ b/frontend/kesaseteli/handler/src/utils/map-vtj-data.ts
@@ -27,6 +27,7 @@ const addressIsValid = (address?: VtjAddress | null): boolean =>
       })
     : false;
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export const mapVtjData = (application: ActivatedYouthApplication): VtjInfo => {
   const {
     encrypted_handler_vtj_json: vtjData,

--- a/frontend/kesaseteli/shared/jest.config.js
+++ b/frontend/kesaseteli/shared/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   setupFilesAfterEnv: [
     '<rootDir>/../../shared/src/__tests__/utils/setupTests.ts',
+    '<rootDir>/../../shared/src/__tests__/utils/canvasMock.ts',
   ],
   coveragePathIgnorePatterns: [],
 };

--- a/frontend/kesaseteli/shared/jest.config.js
+++ b/frontend/kesaseteli/shared/jest.config.js
@@ -6,9 +6,9 @@ module.exports = {
     ['^kesaseteli/shared/test/(.*)$']: '<rootDir>/test/$1',
     [`^kesaseteli/shared\/(.*)$`]: '<rootDir>src/$1',
   },
+  testEnvironment: '<rootDir>/../../shared/jest-canvas-env.js',
   setupFilesAfterEnv: [
     '<rootDir>/../../shared/src/__tests__/utils/setupTests.ts',
-    '<rootDir>/../../shared/src/__tests__/utils/canvasMock.ts',
   ],
   coveragePathIgnorePatterns: [],
 };

--- a/frontend/kesaseteli/youth/jest.config.js
+++ b/frontend/kesaseteli/youth/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   },
   setupFilesAfterEnv: [
     '<rootDir>/../../shared/src/__tests__/utils/setupTests.ts',
+    '<rootDir>/../../shared/src/__tests__/utils/canvasMock.ts',
     '<rootDir>src/__tests__/utils/i18n/i18n-test.ts',
   ],
   coveragePathIgnorePatterns: [

--- a/frontend/kesaseteli/youth/jest.config.js
+++ b/frontend/kesaseteli/youth/jest.config.js
@@ -11,9 +11,9 @@ module.exports = {
     [`^kesaseteli-shared\/(.*)$`]: '<rootDir>/../shared/src/$1',
     [`^kesaseteli/youth\/(.*)$`]: '<rootDir>src/$1',
   },
+  testEnvironment: '<rootDir>/../../shared/jest-canvas-env.js',
   setupFilesAfterEnv: [
     '<rootDir>/../../shared/src/__tests__/utils/setupTests.ts',
-    '<rootDir>/../../shared/src/__tests__/utils/canvasMock.ts',
     '<rootDir>src/__tests__/utils/i18n/i18n-test.ts',
   ],
   coveragePathIgnorePatterns: [

--- a/frontend/kesaseteli/youth/src/__tests__/additional_info.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/additional_info.test.tsx
@@ -42,7 +42,7 @@ describe('frontend/kesaseteli/youth/src/pages/additional_info.tsx', () => {
     });
     await waitFor(() =>
       expect(spyPush).toHaveBeenCalledWith(
-        `${DEFAULT_LANGUAGE}/500`,
+        `/${DEFAULT_LANGUAGE}/500`,
         undefined,
         { shallow: false }
       )

--- a/frontend/kesaseteli/youth/src/__tests__/email_in_use.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/email_in_use.test.tsx
@@ -23,7 +23,7 @@ describe('frontend/kesaseteli/youth/src/pages/email_in_use.tsx', () => {
     await emailInUseApi.expectations.pageIsLoaded();
     await emailInUseApi.actions.clickGoToFrontPageButton();
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`, undefined, {
+      expect(spyPush).toHaveBeenCalledWith(`/${DEFAULT_LANGUAGE}/`, undefined, {
         shallow: false,
       })
     );

--- a/frontend/kesaseteli/youth/src/__tests__/expired.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/expired.test.tsx
@@ -23,7 +23,7 @@ describe('frontend/kesaseteli/youth/src/pages/expired.tsx', () => {
     await expiredPageApi.expectations.pageIsLoaded();
     await expiredPageApi.actions.clickGoToFrontPageButton();
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`, undefined, {
+      expect(spyPush).toHaveBeenCalledWith(`/${DEFAULT_LANGUAGE}/`, undefined, {
         shallow: false,
       })
     );

--- a/frontend/kesaseteli/youth/src/__tests__/inadmissible_data.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/inadmissible_data.test.tsx
@@ -23,7 +23,7 @@ describe('frontend/kesaseteli/youth/src/pages/inadmissible_data.tsx', () => {
     await emailInUseApi.expectations.pageIsLoaded();
     await emailInUseApi.actions.clickGoToFrontPageButton();
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`, undefined, {
+      expect(spyPush).toHaveBeenCalledWith(`/${DEFAULT_LANGUAGE}/`, undefined, {
         shallow: false,
       })
     );

--- a/frontend/kesaseteli/youth/src/__tests__/index.recheck.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/index.recheck.test.tsx
@@ -76,7 +76,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
           });
           await waitFor(() =>
             expect(spyPush).toHaveBeenCalledWith(
-              `${language}/thankyou`,
+              `/${language}/thankyou`,
               undefined,
               { shallow: false }
             )
@@ -121,7 +121,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
           });
           await waitFor(() =>
             expect(spyPush).toHaveBeenCalledWith(
-              `${DEFAULT_LANGUAGE}/500`,
+              `/${DEFAULT_LANGUAGE}/500`,
               undefined,
               { shallow: false }
             )
@@ -149,7 +149,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
             });
             await waitFor(() =>
               expect(spyPush).toHaveBeenCalledWith(
-                `${DEFAULT_LANGUAGE}/${errorType}`
+                `/${DEFAULT_LANGUAGE}/${errorType}`
               )
             );
           });

--- a/frontend/kesaseteli/youth/src/__tests__/index.submission.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/index.submission.test.tsx
@@ -30,7 +30,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
         });
         await waitFor(() =>
           expect(spyPush).toHaveBeenCalledWith(
-            `${DEFAULT_LANGUAGE}/thankyou`,
+            `/${DEFAULT_LANGUAGE}/thankyou`,
             undefined,
             { shallow: false }
           )
@@ -48,7 +48,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
         });
         await waitFor(() =>
           expect(spyPush).toHaveBeenCalledWith(
-            `${DEFAULT_LANGUAGE}/thankyou`,
+            `/${DEFAULT_LANGUAGE}/thankyou`,
             undefined,
             { shallow: false }
           )
@@ -69,7 +69,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
         });
         await waitFor(() =>
           expect(spyPush).toHaveBeenCalledWith(
-            `${language}/thankyou`,
+            `/${language}/thankyou`,
             undefined,
             { shallow: false }
           )
@@ -102,7 +102,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
         });
         await waitFor(() =>
           expect(spyPush).toHaveBeenCalledWith(
-            `${DEFAULT_LANGUAGE}/500`,
+            `/${DEFAULT_LANGUAGE}/500`,
             undefined,
             { shallow: false }
           )
@@ -125,7 +125,7 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
           });
           await waitFor(() =>
             expect(spyPush).toHaveBeenCalledWith(
-              `${DEFAULT_LANGUAGE}/${errorType}`
+              `/${DEFAULT_LANGUAGE}/${errorType}`
             )
           );
         });

--- a/frontend/kesaseteli/youth/src/__tests__/thankyou.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/thankyou.test.tsx
@@ -25,7 +25,7 @@ describe('frontend/kesaseteli/youth/src/pages/thankyou.tsx', () => {
     await thankYouPageApi.expectations.pageIsLoaded();
     await thankYouPageApi.actions.clickGoToFrontPageButton();
     await waitFor(() =>
-      expect(spyPush).toHaveBeenCalledWith(`${DEFAULT_LANGUAGE}/`, undefined, {
+      expect(spyPush).toHaveBeenCalledWith(`/${DEFAULT_LANGUAGE}/`, undefined, {
         shallow: false,
       })
     );

--- a/frontend/kesaseteli/youth/src/__tests__/utils/components/get-index-page-api.ts
+++ b/frontend/kesaseteli/youth/src/__tests__/utils/components/get-index-page-api.ts
@@ -231,9 +231,13 @@ const getIndexPageApi = (lang?: Language) => {
         youthFormData[key] = Boolean(checkbox.getAttribute('value'));
       },
       async selectTargetGroup(label?: string | RegExp): Promise<void> {
-        const radioButton = label
-          ? await screen.findByRole('radio', { name: label })
-          : (await screen.findAllByRole('radio'))[0];
+        let radioButton: HTMLElement | undefined;
+        if (label) {
+          radioButton = await screen.findByRole('radio', { name: label });
+        } else {
+          const radioButtons = await screen.findAllByRole('radio');
+          [radioButton] = radioButtons;
+        }
 
         if (!radioButton) {
           throw new Error('No target groups found');

--- a/frontend/kesaseteli/youth/src/hooks/useHandleYouthApplicationSubmit.ts
+++ b/frontend/kesaseteli/youth/src/hooks/useHandleYouthApplicationSubmit.ts
@@ -80,7 +80,7 @@ const useHandleYouthApplicationSubmit = (): ReturnType => {
               `Application creation failed: ${error.response.data.code}`,
               gdprFormValues
             );
-            void router.push(`${locale}/${encodeURIComponent(errorCode)}`);
+            void router.push(`/${locale}/${encodeURIComponent(errorCode)}`);
             return;
 
           case 'please_recheck_data':

--- a/frontend/kesaseteli/youth/src/pages/index.tsx
+++ b/frontend/kesaseteli/youth/src/pages/index.tsx
@@ -1,7 +1,6 @@
-import useSummerVoucherConfigurationQuery from 'kesaseteli-shared/hooks/useSummerVoucherConfigurationQuery';
 import ApplicationNotOpen from 'kesaseteli/youth/components/ApplicationNotOpen';
 import YouthApplication from 'kesaseteli/youth/components/youth-form/YouthApplication';
-
+import useSummerVoucherConfigurationQuery from 'kesaseteli-shared/hooks/useSummerVoucherConfigurationQuery';
 import { GetStaticProps, NextPage } from 'next';
 import React from 'react';
 import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';

--- a/frontend/shared/jest-canvas-env.js
+++ b/frontend/shared/jest-canvas-env.js
@@ -1,0 +1,20 @@
+// jest-environment-jsdom bootstraps jsdom via native Node require() before
+// Jest's module sandbox (and thus moduleNameMapper) is active. jsdom tries to
+// require('canvas') and if the native binary is missing it throws. We
+// pre-populate Node's require cache with a stub here, at native-require time,
+// so jsdom receives an empty object instead of crashing.
+try {
+  const canvasPath = require.resolve('canvas');
+  if (!require.cache[canvasPath]) {
+    require.cache[canvasPath] = {
+      id: canvasPath,
+      filename: canvasPath,
+      loaded: true,
+      exports: {},
+    };
+  }
+} catch (_) {
+  // canvas is not resolvable at all, nothing to stub
+}
+
+module.exports = require('jest-environment-jsdom');

--- a/frontend/shared/src/__tests__/utils/canvasMock.ts
+++ b/frontend/shared/src/__tests__/utils/canvasMock.ts
@@ -1,0 +1,1 @@
+jest.mock('canvas', () => ({}), { virtual: true });

--- a/frontend/shared/src/__tests__/utils/canvasMock.ts
+++ b/frontend/shared/src/__tests__/utils/canvasMock.ts
@@ -1,1 +1,0 @@
-jest.mock('canvas', () => ({}), { virtual: true });


### PR DESCRIPTION
YJDH-877.

The unit tests, linters, code formatters, etc. that a global ci-node workflow job should run, were not executed in Kesäseteli frontend context when a PR was created, but only when a merge to main was done. That's too late, since we should get the feedback already before merging the PR.
