### PR TITLE
YJDH-875 | Handle missing birthdates gracefully in youth applications' Excel export

### DIFF
--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -951,7 +951,7 @@ class YouthApplicationHandlingSerializer(serializers.ModelSerializer):
 class YouthApplicationExcelExportSerializer(serializers.ModelSerializer):
     application_year = serializers.SerializerMethodField()
     application_date = serializers.SerializerMethodField()
-    birth_year = serializers.IntegerField(source="birthdate.year")
+    birth_year = serializers.SerializerMethodField()
     birthdate = serializers.SerializerMethodField()
     confirmation_date = serializers.SerializerMethodField()
     handling_date = serializers.SerializerMethodField()
@@ -973,8 +973,17 @@ class YouthApplicationExcelExportSerializer(serializers.ModelSerializer):
             return None
         return obj.youth_summer_voucher.summer_voucher_serial_number
 
+    def get_birth_year(self, obj: YouthApplication) -> int:
+        try:
+            return obj.birthdate.year
+        except AttributeError:  # Handle invalid data gracefully
+            return -1  # Show a clearly invalid value
+
     def get_birthdate(self, obj: YouthApplication) -> str:
-        return obj.birthdate.isoformat()
+        try:
+            return obj.birthdate.isoformat()
+        except AttributeError:  # Handle invalid data gracefully
+            return "N/A"
 
     def get_application_year(self, obj: YouthApplication) -> int:
         return self.to_local_year(obj.created_at)

--- a/backend/kesaseteli/applications/tests/test_excel_export.py
+++ b/backend/kesaseteli/applications/tests/test_excel_export.py
@@ -607,3 +607,34 @@ def test_removable_reporting_field_titles():
 
 def test_removable_talpa_field_titles():
     check_removable_field_titles(REMOVABLE_TALPA_FIELD_TITLES)
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_youth_excel_download_with_missing_birthdate(staff_client):
+    """
+    Test that exporting youth applications' Excel uses fallback values for
+    birth_year and birthdate when birthdate is unavailable (This case should
+    not be creatable using end-user UIs, but was spotted e.g. in non-local
+    dev-environment and that crashed the youth application Excel export).
+    """
+    ActiveYouthApplicationFactory(social_security_number="", non_vtj_birthdate=None)
+
+    response = staff_client.get(youth_excel_download_url())
+
+    assert isinstance(response, StreamingHttpResponse)
+    assert response.status_code == 200
+
+    workbook = openpyxl.load_workbook(filename=BytesIO(response.getvalue()))
+    rows_generator = workbook.active.rows
+    _header_row = next(rows_generator)
+    data_row = next(rows_generator)  # exactly one application was created
+    with pytest.raises(StopIteration):
+        next(rows_generator)
+
+    source_fields = YouthApplicationExcelExportViewSet.source_fields()
+    row_by_field = dict(zip(source_fields, (cell.value for cell in data_row)))
+
+    # Test that birth_year and birthdate use their respective fallback values:
+    assert row_by_field["birth_year"] == -1
+    assert row_by_field["birthdate"] == "N/A"

--- a/backend/kesaseteli/applications/tests/test_youth_application_create_without_ssn.py
+++ b/backend/kesaseteli/applications/tests/test_youth_application_create_without_ssn.py
@@ -340,6 +340,40 @@ def test_post_with_required_field_empty_returns_bad_request(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        "test",
+        "today",
+        "2026-01-33",  # Invalid date, no 33 days in any month
+        "1.5.2020",  # Must be YYYY-MM-DD or YYYYMMDD
+        "2026-50",  # Must be YYYY-MM-DD or YYYYMMDD
+        "1st May 2020",  # Must be YYYY-MM-DD or YYYYMMDD
+        "05/01/2020",  # Must be YYYY-MM-DD or YYYYMMDD
+        ["2020-05-01"],  # No lists even with contents that'd be valid
+        123,
+        123.5,
+        {},
+        [],
+    ],
+)
+def test_post_with_invalid_non_vtj_birthdate_returns_bad_request(
+    staff_client, invalid_value
+):
+    data = VALID_TEST_DATA.copy()
+    data["non_vtj_birthdate"] = invalid_value
+
+    response = staff_client.post(
+        get_create_without_ssn_url(),
+        data=data,
+        content_type="application/json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert not YouthApplication.objects.exists()
+
+
+@pytest.mark.django_db
 def test_valid_post_as_anonymous_redirects_to_adfs_login(client):
     response = client.post(
         get_create_without_ssn_url(),


### PR DESCRIPTION
## Description :sparkles:

Handle missing birthdates gracefully in youth applications' Excel export.

## Issues :bug:

[YJDH-875](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-875)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-875]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ