### PR TITLE
fix(ks,shared): suomi-fi logout relay state handling for next-url

### DIFF
--- a/backend/kesaseteli/kesaseteli/urls.py
+++ b/backend/kesaseteli/kesaseteli/urls.py
@@ -12,6 +12,7 @@ from applications.views import (
 from common.views import healthz, readiness
 from companies.api.v1.views import GetCompanyView
 from shared.suomi_fi.views import (
+    HelsinkiSaml2LogoutServiceView,
     HelsinkiSaml2LogoutView,
     SuomiFiAssertionConsumerServiceView,
     SuomiFiMetadataView,
@@ -79,6 +80,21 @@ if settings.NEXT_PUBLIC_ENABLE_SUOMIFI:
             "saml2/logout/",
             HelsinkiSaml2LogoutView.as_view(),
             name="saml2_logout",
+        )
+    )
+
+    urlpatterns.append(
+        path(
+            "saml2/ls/",
+            HelsinkiSaml2LogoutServiceView.as_view(),
+            name="saml2_ls",
+        )
+    )
+    urlpatterns.append(
+        path(
+            "saml2/ls/post/",
+            HelsinkiSaml2LogoutServiceView.as_view(),
+            name="saml2_ls_post",
         )
     )
     urlpatterns.append(path("saml2/", include("djangosaml2.urls")))

--- a/backend/shared/shared/suomi_fi/tests/test_views.py
+++ b/backend/shared/shared/suomi_fi/tests/test_views.py
@@ -2,10 +2,11 @@ from unittest import mock
 
 import pytest
 from django.http import HttpResponseRedirect
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 
 from shared.suomi_fi.views import (
     RELAY_STATE_PARAM,
+    HelsinkiSaml2LogoutServiceView,
     HelsinkiSaml2LogoutView,
     SuomiFiAssertionConsumerServiceView,
 )
@@ -45,6 +46,7 @@ class TestSuomiFiViews:
         factory = RequestFactory()
         next_url = "/dashboard"
         request = factory.get("/saml2/logout/", {"next": next_url})
+        request.session = {}
 
         view = HelsinkiSaml2LogoutView()
 
@@ -90,3 +92,110 @@ class TestSuomiFiViews:
                     request, Exception("SLO not supported")
                 )
                 mock_super.assert_called_once()
+
+    def test_helsinki_saml2_logout_view_sets_next_path_to_session(self):
+        factory = RequestFactory()
+        next_url = "https://kesaseteli.dev.hel.ninja/fi"
+        request = factory.get("/saml2/logout/", {"next": next_url})
+        request.session = {}
+
+        view = HelsinkiSaml2LogoutView()
+
+        with mock.patch("djangosaml2.views.LogoutInitView.get", return_value=None):
+            with mock.patch(
+                "shared.suomi_fi.views.is_safe_redirect_url", return_value=True
+            ):
+                view.get(request)
+
+        assert request.session.get("saml2_logout_next_path") == next_url
+
+    @override_settings(LOGOUT_REDIRECT_URL="/")
+    def test_helsinki_saml2_logout_service_view_restores_next_path(self):
+        factory = RequestFactory()
+        next_url = "https://kesaseteli.dev.hel.ninja/fi"
+
+        request = factory.get("/saml2/ls/?SAMLResponse=foo&RelayState=bar")
+        request.session = {"saml2_logout_next_path": next_url}
+
+        view = HelsinkiSaml2LogoutServiceView()
+
+        fallback_response = HttpResponseRedirect("/")
+        with mock.patch(
+            "djangosaml2.views.LogoutView.get", return_value=fallback_response
+        ):
+            with mock.patch(
+                "shared.suomi_fi.views.is_safe_redirect_url", return_value=True
+            ):
+                response = view.get(request)
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == next_url
+        assert "saml2_logout_next_path" not in request.session
+
+    @override_settings(LOGOUT_REDIRECT_URL="/")
+    def test_helsinki_saml2_logout_service_view_ignores_unsafe_next_path(self):
+        factory = RequestFactory()
+        next_url = "https://malicious.com"
+
+        request = factory.get("/saml2/ls/?SAMLResponse=foo&RelayState=bar")
+        request.session = {"saml2_logout_next_path": next_url}
+
+        view = HelsinkiSaml2LogoutServiceView()
+
+        fallback_response = HttpResponseRedirect("/")
+        with mock.patch(
+            "djangosaml2.views.LogoutView.get", return_value=fallback_response
+        ):
+            with mock.patch(
+                "shared.suomi_fi.views.is_safe_redirect_url", return_value=False
+            ):
+                response = view.get(request)
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == "/"
+
+    @override_settings(LOGOUT_REDIRECT_URL="/")
+    def test_logout_redirection_flow_integration(self):
+        """
+        Integration test replicating the HAR flow:
+        1. Initiation with 'next' parameter sets the session.
+        2. Callback from IdP retrieves that same session.
+        3. Final redirect to the original 'next' URL.
+        """
+        factory = RequestFactory()
+        next_url = "https://kesaseteli.dev.hel.ninja/fi"
+
+        # Step 1: Start logout (Initiator)
+        request_init = factory.get("/saml2/logout/", {"next": next_url})
+        request_init.session = {}  # Manually attach session
+
+        view_init = HelsinkiSaml2LogoutView()
+        with mock.patch("djangosaml2.views.LogoutInitView.get", return_value=None):
+            with mock.patch(
+                "shared.suomi_fi.views.is_safe_redirect_url", return_value=True
+            ):
+                view_init.get(request_init)
+
+        # Verify session was set
+        assert request_init.session.get("saml2_logout_next_path") == next_url
+
+        # Step 2: Return from IdP (Service)
+        request_ls = factory.get(
+            "/saml2/ls/", {"SAMLResponse": "foo", "RelayState": "bar"}
+        )
+        # We simulate the handoff by passing the session object from step 1
+        request_ls.session = request_init.session
+
+        view_ls = HelsinkiSaml2LogoutServiceView()
+        fallback_response = HttpResponseRedirect("/")
+        with mock.patch(
+            "djangosaml2.views.LogoutView.get", return_value=fallback_response
+        ):
+            with mock.patch(
+                "shared.suomi_fi.views.is_safe_redirect_url", return_value=True
+            ):
+                response = view_ls.get(request_ls)
+
+        # Step 3: Final Result
+        assert response.status_code == 302
+        assert response.url == next_url

--- a/backend/shared/shared/suomi_fi/views.py
+++ b/backend/shared/shared/suomi_fi/views.py
@@ -1,12 +1,14 @@
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.shortcuts import resolve_url
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from djangosaml2.views import (
     AssertionConsumerServiceView,
     LogoutInitView,
+    LogoutView,
     MetadataView,
 )
 from saml2.md import ServiceName
@@ -69,7 +71,11 @@ class SuomiFiAssertionConsumerServiceView(AssertionConsumerServiceView):
 
 class HelsinkiSaml2LogoutView(LogoutInitView):
     """
-    SAML2 logout view that supports 'next' parameter.
+    SAML2 Logout INITIATOR view.
+
+    This is the "Entry Door": it is called by the frontend to start the logout.
+    It captures the 'next' redirect URL and stashes it in the session before
+    redirecting the user to the IdP (Suomi.fi).
     """
 
     def get(self, request, *args, **kwargs):
@@ -80,9 +86,17 @@ class HelsinkiSaml2LogoutView(LogoutInitView):
             or request.GET.get(RELAY_STATE_PARAM)
             or request.POST.get(RELAY_STATE_PARAM)
         )
+        if self.next_path and is_safe_redirect_url(request, self.next_path):
+            request.session["saml2_logout_next_path"] = self.next_path
+
         return super().get(request, *args, **kwargs)
 
     def handle_unsupported_slo_exception(self, request, exception, *args, **kwargs):
+        """
+        Handle cases where the SAML logout fails to initiate (e.g., IdP doesn't
+        support SLO or is unavailable). This ensures the user is still redirected
+        to the 'next' URL instead of being dumped at the API root.
+        """
         if (
             hasattr(self, "next_path")
             and self.next_path
@@ -92,6 +106,51 @@ class HelsinkiSaml2LogoutView(LogoutInitView):
         return super().handle_unsupported_slo_exception(
             request, exception, *args, **kwargs
         )
+
+
+class HelsinkiSaml2LogoutServiceView(LogoutView):
+    """
+    SAML2 Logout CALLBACK view (Single Logout Service / SLS).
+
+    This is the "Return Door": it is called by the IdP (Suomi.fi) after the
+    logout is finished on their end. It recovers the 'next' URL from the
+    session to ensure the user is returned to the correct frontend page.
+    """
+
+    def _handle_response(self, request, response):
+        """
+        Intercept the final response from djangosaml2's LogoutView to fix a known
+        routing issue during the SAML Single Logout (SLO) flow.
+
+        Why this is needed:
+        1. When initiating the logout, pysaml2 internally populates the SAML
+           `RelayState` parameter with a generated request ID (e.g. `id-slRc7Ma...`)
+           rather than the actual `next` redirect URL.
+        2. When the user returns from the IdP, djangosaml2's `LogoutView` attempts
+           to use this `RelayState` as the literal URL to redirect to.
+        3. Because the `RelayState` ID is not a valid URL, djangosaml2's strict URL
+           validation rejects it and forces a fallback to the `LOGOUT_REDIRECT_URL`.
+
+        To circumvent this, we capture the `next` URL in the session during logout
+        initiation. Here, we pop it back out, wait for djangosaml2 to predictably
+        fail and yield the fallback URL, and then replace it with our desired `next`
+        destination (provided it passes security checks).
+        """
+        next_path = request.session.pop("saml2_logout_next_path", None)
+        if next_path and isinstance(response, HttpResponseRedirect):
+            fallback_url = resolve_url(getattr(settings, "LOGOUT_REDIRECT_URL", "/"))
+            if response.url == fallback_url:
+                if is_safe_redirect_url(request, next_path):
+                    return HttpResponseRedirect(next_path)
+        return response
+
+    def get(self, request, *args, **kwargs):
+        response = super().get(request, *args, **kwargs)
+        return self._handle_response(request, response)
+
+    def post(self, request, *args, **kwargs):
+        response = super().post(request, *args, **kwargs)
+        return self._handle_response(request, response)
 
 
 class SuomiFiMetadataView(MetadataView):


### PR DESCRIPTION
YJDH-609.

Fix Suomi.fi logout redirection by stashing 'next' URL in session

Resolved an issue where the SAML Single Logout (SLO) flow would incorrectly redirect users back to the API root (/) instead of the requested 'next' URL.

Root Cause:
The underlying djangosaml2/pysaml2 libraries use the SAML 'RelayState' parameter to track request state. During the logout flow, this parameter is populated with a generated request ID (e.g. 'id-slRc7Ma...') rather than the destination URL. When the user returns from the IdP, djangosaml2's strict URL validation rejects this ID string as a literal URL, causing a fallback to the default LOGOUT_REDIRECT_URL.

Changes:
- HelsinkiSaml2LogoutView: Updated to capture the 'next' parameter and stash it in the user's session before initiating the SAML request to the IdP.
- HelsinkiSaml2LogoutServiceView: Implemented a new callback view that intercepts the final IdP response. It restores the 'next' URL from the session to override the library's default fallback behavior.
- urls.py: Explicitly registered the saml2_ls and saml2_ls_post endpoints to ensure our custom service view shadows the default djangosaml2 implementation.
- Documentation: Added detailed docstrings explaining the "Entry Door" (Initiator) and "Return Door" (Callback) architecture.

Testing:
- Added unit tests to verify session stashing and recovery logic.
- Implemented an integration test replicating the full two-step logout flow.
- Verified that open redirect protection (is_safe_redirect_url) is maintained.