### PR TITLE
feat(ks,shared): use persistent Suomi.fi usernames

### DIFF
--- a/.github/workflows/ks-backend-ci.yml
+++ b/.github/workflows/ks-backend-ci.yml
@@ -20,4 +20,8 @@ jobs:
       postgres-major-version: 17
       working-directory: ./backend/kesaseteli
       extra-commands: |
+        echo 'DEBUG=1' >> .env.kesaseteli-backend
+        echo 'ENCRYPTION_KEY=f164ec6bd6fbc4aef5647abc15199da0f9badcc1d2127bde2087ae0d794a9a0b' >> .env.kesaseteli-backend
+        echo 'SOCIAL_SECURITY_NUMBER_HASH_KEY=ee235e39ebc238035a6264c063dd829d4b6d2270604b57ee1f463e676ec44669' >> .env.kesaseteli-backend
+
         sudo apt-get install xmlsec1 libsasl2-dev libssl-dev

--- a/backend/docker/kesaseteli.Dockerfile
+++ b/backend/docker/kesaseteli.Dockerfile
@@ -77,7 +77,10 @@ COPY --chown=default:root /kesaseteli/ /app/
 # when spinning up the container
 RUN git config --system --add safe.directory /app
 
-RUN SECRET_KEY="only-used-for-collectstatic" python manage.py collectstatic
+RUN SECRET_KEY="only-used-for-collectstatic" \
+    ENCRYPTION_KEY="only-used-for-collectstatic" \
+    SOCIAL_SECURITY_NUMBER_HASH_KEY="only-used-for-collectstatic" \
+    python manage.py collectstatic
 
 USER default
 

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -9,6 +9,7 @@ import environ
 import saml2
 import saml2.saml
 import sentry_sdk
+from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from saml2.sigver import get_xmlsec_binary
@@ -100,13 +101,10 @@ env = environ.Env(
     # Random 32 bytes AES key, for testing purpose only, DO NOT use it value in
     # staging/production
     # Always override this value from env variables
-    ENCRYPTION_KEY=(
-        str,
-        "f164ec6bd6fbc4aef5647abc15199da0f9badcc1d2127bde2087ae0d794a9a0b",
-    ),
+    ENCRYPTION_KEY=(str, ""),
     SOCIAL_SECURITY_NUMBER_HASH_KEY=(
         str,
-        "ee235e39ebc238035a6264c063dd829d4b6d2270604b57ee1f463e676ec44669",
+        "",
     ),
     ELASTICSEARCH_APP_AUDIT_LOG_INDEX=(str, "kesaseteli_audit_log"),
     ELASTICSEARCH_HOST=(str, ""),
@@ -171,6 +169,8 @@ SECRET_KEY = env.str("SECRET_KEY")
 if DEBUG and not SECRET_KEY:
     SECRET_KEY = "xxx"
 ENCRYPTION_KEY = env.str("ENCRYPTION_KEY")
+if not ENCRYPTION_KEY:
+    raise ImproperlyConfigured("ENCRYPTION_KEY must be set.")
 SOCIAL_SECURITY_NUMBER_HASH_KEY = env.str("SOCIAL_SECURITY_NUMBER_HASH_KEY")
 ENABLE_ADMIN = env.bool("ENABLE_ADMIN")
 AD_ADMIN_GROUP_NAME = env.str("AD_ADMIN_GROUP_NAME")
@@ -181,6 +181,11 @@ VTJ_USERNAME = env.str("VTJ_USERNAME")
 VTJ_PASSWORD = env.str("VTJ_PASSWORD")
 VTJ_TIMEOUT = env.int("VTJ_TIMEOUT")
 NEXT_PUBLIC_ENABLE_SUOMIFI = env("NEXT_PUBLIC_ENABLE_SUOMIFI")
+
+if NEXT_PUBLIC_ENABLE_SUOMIFI and not SOCIAL_SECURITY_NUMBER_HASH_KEY:
+    raise ImproperlyConfigured(
+        "SOCIAL_SECURITY_NUMBER_HASH_KEY must be set when Suomi.fi is enabled."
+    )
 EXCEL_DOWNLOAD_BATCH_SIZE = env.int("EXCEL_DOWNLOAD_BATCH_SIZE")
 
 DB_PREFIX = {
@@ -469,13 +474,14 @@ ADFS_CONTROLLER_GROUP_UUIDS = env.list("ADFS_CONTROLLER_GROUP_UUIDS")
 # Suomi.fi (djangosaml2)
 
 SAML_ATTRIBUTE_MAPPING = {
+    "nationalIdentificationNumber": ("username",),
     "givenName": ("first_name",),
     "sn": ("last_name",),
 }
 SAML_SESSION_COOKIE_NAME = "kesaseteli_saml_session"
 SAML_CREATE_UNKNOWN_USER = True
 SAML_DJANGO_USER_MAIN_ATTRIBUTE = "username"
-SAML_USE_NAME_ID_AS_USERNAME = True  # Suomi.fi session ID as username
+SAML_USE_NAME_ID_AS_USERNAME = False  # Use SAML_ATTRIBUTE_MAPPING for username
 SAML_IGNORE_LOGOUT_ERRORS = True
 if env("SAML_ALLOWED_HOSTS", default=None):
     SAML_ALLOWED_HOSTS = env.list("SAML_ALLOWED_HOSTS")

--- a/backend/shared/shared/suomi_fi/auth.py
+++ b/backend/shared/shared/suomi_fi/auth.py
@@ -1,15 +1,24 @@
 import hashlib
 from typing import Any
 
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from djangosaml2.backends import Saml2Backend
 
 
 class SuomiFiSAML2AuthenticationBackend(Saml2Backend):
     def clean_user_main_attribute(self, main_attribute: Any) -> Any:
         """
-        Return hash of Suomi.fi SSO session identifier.
+        Return salted hash of Suomi.fi nationalIdentificationNumber.
 
-        SSO session identifier is over the normal 150 character username limit.
+        This prevents storing the raw national identification number as the username.
         """
-        digest = hashlib.sha3_512(main_attribute.encode()).hexdigest()
+        salt = settings.SOCIAL_SECURITY_NUMBER_HASH_KEY
+
+        if not salt or not salt.strip():
+            raise ImproperlyConfigured(
+                "Required SOCIAL_SECURITY_NUMBER_HASH_KEY is empty."
+            )
+
+        digest = hashlib.sha3_512(f"{salt}{main_attribute}".encode()).hexdigest()
         return super().clean_user_main_attribute(digest)

--- a/backend/shared/shared/suomi_fi/tests/test_auth.py
+++ b/backend/shared/shared/suomi_fi/tests/test_auth.py
@@ -1,0 +1,84 @@
+import hashlib
+import secrets
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from shared.suomi_fi.auth import SuomiFiSAML2AuthenticationBackend
+
+
+@pytest.mark.django_db
+def test_suomifi_auth_backend_hashes_main_attribute(settings):
+    settings.SOCIAL_SECURITY_NUMBER_HASH_KEY = "test_salt"
+
+    backend = SuomiFiSAML2AuthenticationBackend()
+    main_attribute = "010101-123A"
+
+    expected_hash = hashlib.sha3_512(f"test_salt{main_attribute}".encode()).hexdigest()
+
+    cleaned_attribute = backend.clean_user_main_attribute(main_attribute)
+
+    assert cleaned_attribute == expected_hash
+    assert len(cleaned_attribute) == 128  # sha3_512 hexdigest length
+
+
+@pytest.mark.django_db
+def test_suomifi_auth_backend_raises_with_empty_salt(settings):
+    settings.SOCIAL_SECURITY_NUMBER_HASH_KEY = ""
+
+    backend = SuomiFiSAML2AuthenticationBackend()
+    main_attribute = "010101-123A"
+
+    with pytest.raises(
+        ImproperlyConfigured, match="Required SOCIAL_SECURITY_NUMBER_HASH_KEY is empty."
+    ):
+        backend.clean_user_main_attribute(main_attribute)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "salt",
+    [
+        "test-salt-123",
+        secrets.token_hex(16),
+        secrets.token_urlsafe(32),
+    ],
+)
+@pytest.mark.parametrize(
+    "ssn",
+    [
+        "010101-123A",
+        "120202-345B",
+    ],
+)
+def test_suomifi_auth_backend_authenticate_uses_mapped_attribute(settings, salt, ssn):
+    settings.SOCIAL_SECURITY_NUMBER_HASH_KEY = salt
+    settings.SAML_USE_NAME_ID_AS_USERNAME = False
+    settings.SAML_DJANGO_USER_MAIN_ATTRIBUTE = "username"
+
+    backend = SuomiFiSAML2AuthenticationBackend()
+    session_info = {
+        "ava": {
+            "nationalIdentificationNumber": [ssn],
+            "givenName": ["Test"],
+            "sn": ["User"],
+        },
+        "issuer": "https://test-idp.example.com/",
+        "name_id": "irrelevant-because-SAML_USE_NAME_ID_AS_USERNAME-is-False",
+    }
+
+    attribute_mapping = {
+        "nationalIdentificationNumber": ("username",),
+        "givenName": ("first_name",),
+        "sn": ("last_name",),
+    }
+
+    user = backend.authenticate(
+        None, session_info=session_info, attribute_mapping=attribute_mapping
+    )
+
+    assert user is not None
+    expected_username = hashlib.sha3_512(f"{salt}{ssn}".encode()).hexdigest()
+    assert user.username == expected_username
+    assert user.first_name == "Test"
+    assert user.last_name == "User"


### PR DESCRIPTION
YJDH-883.

# Issue description

The current implementation of the Employer UI uses the transient NameID from Suomi.fi as the Django username (SAML_USE_NAME_ID_AS_USERNAME = True). Because transient identifiers are session-specific, a new Django User object is created for every single login session.

Consequences:

- Duplicate User Objects: Every time an employer logs in, they are treated as a completely new user.
- Data Fragmentation: Drafts and user-linked data created in one session become inaccessible in subsequent sessions.
- Inefficiency: The system accumulates "ghost" user records that cannot be linked back to the actual individual.

# Sources & References

The following technical specifications and documentation were used to analyze the issue and design the solution:
- SAML 2.0 Core Standard: OASIS SAML v2.0 Standard (saml-core-2.0-os) for the definition of NameID formats (transient vs persistent).
- Suomi.fi Interface Description: Rajapintakuvaus - Suomi.fi-tunnistus regarding attribute-based identification and the use of the oid attribute.
- Library Documentation: Djangosaml2 Documentation for configuring attribute mapping and username handling.

Internal Analysis:
- SAML Metadata analysis of the "Kesäseteli" service.
- Database sampling of existing "Jirin" users.
- HAR (HTTP Archive) trace analysis of the dev-auth process.

# Proposed Solution

The fix involves switching the identification logic from the session-based NameID to a persistent attribute:

- Disable SAML_USE_NAME_ID_AS_USERNAME.
- Map nationalIdentificationNumber to the Django username via SAML_ATTRIBUTE_MAPPING.
- Security: Implement salting for the username field to ensure that sensitive data (SSN/hetu) is not stored in plain text while remaining persistent across sessions.