### PR TITLE
fix(ks,shared): prevent double organization selection loop

### DIFF
--- a/backend/shared/shared/oidc/tests/test_hki_views.py
+++ b/backend/shared/shared/oidc/tests/test_hki_views.py
@@ -4,6 +4,7 @@ import pytest
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
 from django.test import RequestFactory, override_settings
+from django.urls import reverse
 
 from shared.oidc.views.hki_views import HelsinkiOIDCAuthenticationCallbackView
 
@@ -38,3 +39,31 @@ def test_hki_callback_transfers_oidc_next_url():
 
     assert response.status_code == 302
     assert req.session.get("eauth_next_url") == "https://localhost:3000/employer"
+
+
+@pytest.mark.django_db
+@override_settings(
+    NEXT_PUBLIC_MOCK_FLAG=False,
+    OIDC_OP_AUTHORIZATION_ENDPOINT="http://example.com/auth",
+)
+def test_hki_callback_skips_auth_init_url():
+    """
+    Test that the custom `HelsinkiOIDCAuthenticationCallbackView` DOES NOT transfer
+    `oidc_login_next` if it is equal to `eauth_authentication_init`.
+    """
+    factory = RequestFactory()
+    req = factory.get("/")
+    middleware = SessionMiddleware(lambda request: HttpResponse())
+    middleware.process_request(req)
+    req.session.save()
+    req.session["oidc_login_next"] = reverse("eauth_authentication_init")
+
+    view = HelsinkiOIDCAuthenticationCallbackView()
+    view.user = mock.Mock()
+    view.request = req
+
+    with mock.patch("mozilla_django_oidc.views.auth.login"):
+        response = view.login_success()
+
+    assert response.status_code == 302
+    assert "eauth_next_url" not in req.session

--- a/backend/shared/shared/oidc/views/hki_views.py
+++ b/backend/shared/shared/oidc/views/hki_views.py
@@ -70,10 +70,12 @@ class HelsinkiOIDCAuthenticationCallbackView(OIDCAuthenticationCallbackView):
         # `mozilla_django_oidc` validates the explicit `next` parameter against
         # OIDC_REDIRECT_ALLOWED_HOSTS and stores it securely in `oidc_login_next`.
         next_url = self.request.session.get("oidc_login_next")
-        if next_url:
+        eauth_init_url = reverse("eauth_authentication_init")
+
+        if next_url and next_url.rstrip("/") != eauth_init_url.rstrip("/"):
             self.request.session["eauth_next_url"] = next_url
 
-        return HttpResponseRedirect(reverse("eauth_authentication_init"))
+        return HttpResponseRedirect(eauth_init_url)
 
     def login_failure(self):
         url, error_path = self.failure_url.rsplit("/", 1)

--- a/backend/shared/shared/suomi_fi/views.py
+++ b/backend/shared/shared/suomi_fi/views.py
@@ -46,9 +46,13 @@ class SuomiFiAssertionConsumerServiceView(AssertionConsumerServiceView):
         Intercept the validated `RelayState` and manually route the user completely
         through the eAuthorizations pipeline before allowing the final redirect.
         """
+        eauth_init_url = reverse("eauth_authentication_init")
         if relay_state and is_safe_redirect_url(self.request, relay_state):
-            self.request.session["eauth_next_url"] = relay_state
-        return reverse("eauth_authentication_init")
+            # Do not store the eAuthorizations initiation URL as the next URL,
+            # as it would cause a redirect loop.
+            if relay_state.rstrip("/") != eauth_init_url.rstrip("/"):
+                self.request.session["eauth_next_url"] = relay_state
+        return eauth_init_url
 
     def handle_acs_failure(self, request, exception=None, status=403, **kwargs):
         """


### PR DESCRIPTION
YJDH-888.

Skip storing eAuthorizations initiation URL as the next redirect URL in SAML ACS and OIDC callback views. This prevents a circular redirect loop when the default RelayState is used.