### PR TITLE
YJDH-883 | Fix parallel running of shared backend tests

### DIFF
--- a/backend/shared/shared/suomi_fi/tests/test_auth.py
+++ b/backend/shared/shared/suomi_fi/tests/test_auth.py
@@ -1,5 +1,4 @@
 import hashlib
-import secrets
 
 import pytest
 from django.core.exceptions import ImproperlyConfigured
@@ -40,8 +39,8 @@ def test_suomifi_auth_backend_raises_with_empty_salt(settings):
     "salt",
     [
         "test-salt-123",
-        secrets.token_hex(16),
-        secrets.token_urlsafe(32),
+        "0123456789abcdef0123456789abcdef",  # Hex token
+        "L6-testing-testing-6MkVie-interesting-y9YoI",  # URL-safe token
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description :sparkles:

**NOTE**:
- **Only changes** single **test** file in shared backend
- The **suomi_fi** component in shared backend is **only actually used** by **Kesäseteli**

The whole change is just this:
<img width="825" height="644" alt="image" src="https://github.com/user-attachments/assets/f296734c-da7f-4951-8d08-9544b9461f8a" />

### Fix parallel running of shared backend tests

Parallel running of shared backend tests was broken in commit
990e34ea76217b3bc6d92d0e493153aaf957779c where
secrets.token_hex(16) and secrets.token_urlsafe(32) values
were used as test parametrizations in
`test_suomifi_auth_backend_authenticate_uses_mapped_attribute` test.

Broken behavior when when running tests using e.g.
"pytest . -vv --pyargs shared -n 3" in Docker container was:
"Different tests were collected between gw1 and gw0."

Using hardcoded values instead of generated ones fixes parallel running.

## Related

[YJDH-883](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-883) PR #4045 added the shared backend test

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-883]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ