### PR TITLE
test: use example.org when generating emails

### DIFF
--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -130,12 +130,12 @@ class EmployerApplicationFactory(
     street_address = factory.Faker("street_address")
     bank_account_number = factory.Faker("iban")
     contact_person_name = factory.Faker("name")
-    contact_person_email = factory.Faker("email")
+    contact_person_email = factory.Faker("safe_email")
     contact_person_phone_number = factory.Faker("phone_number")
 
     is_separate_invoicer = factory.Faker("boolean")
     invoicer_name = factory.Faker("name")
-    invoicer_email = factory.Faker("email")
+    invoicer_email = factory.Faker("safe_email")
     invoicer_phone_number = factory.Faker("phone_number")
 
     # foreign iban fields
@@ -283,6 +283,8 @@ def determine_school(youth_application) -> str:
 
 
 def get_test_phone_number() -> str:
+    # TODO: PHONE_NUMBER_REGEX should support international phone numbers.
+
     # PHONE_NUMBER_REGEX didn't accept phone numbers starting with (+358) but did with
     # +358 so removing the parentheses to make the generated phone numbers fit it
     return get_faker().phone_number().replace("(+358)", "+358")
@@ -464,7 +466,7 @@ class AbstractYouthApplicationFactory(
     non_vtj_birthdate = None
     school = factory.LazyAttribute(determine_school)
     is_unlisted_school = factory.LazyAttribute(determine_is_unlisted_school)
-    email = factory.Faker("email")
+    email = factory.Faker("safe_email")
     phone_number = factory.LazyFunction(get_test_phone_number)
     postcode = factory.Faker("postcode", locale="fi")
     language = factory.Faker("random_element", elements=get_supported_languages())

--- a/backend/shared/shared/common/tests/factories.py
+++ b/backend/shared/shared/common/tests/factories.py
@@ -9,7 +9,7 @@ class UserFactory(factory.django.DjangoModelFactory):
 
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
-    email = factory.Faker("email")
+    email = factory.Faker("safe_email")
 
     username = factory.Faker("uuid4")
 

--- a/frontend/kesaseteli/shared/src/__tests__/utils/fake-objects.ts
+++ b/frontend/kesaseteli/shared/src/__tests__/utils/fake-objects.ts
@@ -165,7 +165,7 @@ export const fakeYouthApplication = (
       : faker.random.arrayElement(fakeSchools),
     is_unlisted_school,
     phone_number: faker.phone.phoneNumber('+358#########'),
-    email: faker.internet.email(),
+    email: faker.internet.exampleEmail(),
     language: DEFAULT_LANGUAGE,
     target_group: targetGroupForSSN(social_security_number),
     ...override,

--- a/frontend/shared/src/__tests__/utils/FakeObjectFactory.ts
+++ b/frontend/shared/src/__tests__/utils/FakeObjectFactory.ts
@@ -79,7 +79,7 @@ class FakeObjectFactory {
   public fakeContactInfo(): ContactInfo {
     return {
       contact_person_name: faker.name.findName(),
-      contact_person_email: faker.internet.email(),
+      contact_person_email: faker.internet.exampleEmail(),
       contact_person_phone_number: faker.phone.phoneNumber(),
       street_address: faker.address.streetAddress(),
       bank_account_number: 'FI2112345600000785',

--- a/frontend/shared/src/constants.ts
+++ b/frontend/shared/src/constants.ts
@@ -4,6 +4,7 @@ export const INVALID_FIELD_CLASS = 'invalid-field';
 // For the following regex constants, see: frontend/shared/src/__tests__/constants.test.ts
 export const ADDRESS_REGEX = /^([\d (),./A-Za-zÄÅÖäåö-]+)$/;
 export const COMPANY_BANK_ACCOUNT_NUMBER = /^FI\d{16}$/;
+// TODO: PHONE_NUMBER_REGEX should support international phone numbers
 export const PHONE_NUMBER_REGEX =
   // eslint-disable-next-line security/detect-unsafe-regex
   /^((\+358[ -]*)+|(\\(\d{2,3}\\)[ -]*)|(\d{2,4})[ -]*)*?\d{3,4}?[ -]*\d{3,4}?$/;


### PR DESCRIPTION
YJDH-833.

The generated phone numbers and emails can relate to some real contact information. Since Kesäseteli is sending messages via email, at least the emails should be generated so, that they never match a real email.

Kesäseteli nor Benefit do not send SMS messages, so it's better to keep phone number faker as it is, so we get more phone numbers tested.

References:
1. Use safe email from factory boy: https://faker.readthedocs.io/en/master/providers/faker.providers.internet.html#faker.providers.internet.Provider.safe_email
2. Use exampleEmail from js-faker: https://fakerjs.dev/api/internet.html#exampleemail