### PR TITLE
YJDH-843 | Kesäseteli backend: Add use of randomly generated voucher serial numbers

### DIFF
--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -314,7 +314,7 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
         if not serial_number:
             return
 
-        voucher = self._get_youth_summer_voucher(serial_number)
+        voucher = YouthSummerVoucher.get_voucher_with_serial_number(serial_number)
         if not voucher:
             return
 
@@ -324,19 +324,6 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
         self._validate_voucher_usage(
             voucher, application=self._get_application_context()
         )
-
-    def _get_youth_summer_voucher(
-        self, serial_number: str
-    ) -> Optional[YouthSummerVoucher]:
-        """
-        Safely fetch the YouthSummerVoucher by serial number.
-        """
-        try:
-            return YouthSummerVoucher.objects.get(
-                summer_voucher_serial_number=int(serial_number)
-            )
-        except (ValueError, TypeError, YouthSummerVoucher.DoesNotExist):
-            return None
 
     def _validate_voucher_employee_name(
         self, voucher: YouthSummerVoucher, user_provided_name: str
@@ -986,10 +973,10 @@ class YouthApplicationExcelExportSerializer(serializers.ModelSerializer):
     def to_local_year(value: datetime) -> int:
         return timezone.localdate(value).year
 
-    def get_summer_voucher_serial_number(self, obj: YouthApplication) -> Optional[int]:
+    def get_summer_voucher_serial_number(self, obj: YouthApplication) -> str | None:
         if not obj.has_youth_summer_voucher:
             return None
-        return obj.youth_summer_voucher.summer_voucher_serial_number
+        return obj.youth_summer_voucher.user_showable_serial_number
 
     def get_birth_year(self, obj: YouthApplication) -> int:
         try:

--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -314,7 +314,7 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
         if not serial_number:
             return
 
-        voucher = YouthSummerVoucher.get_voucher_with_serial_number(serial_number)
+        voucher = YouthSummerVoucher.objects.get_by_serial_number(serial_number)
         if not voucher:
             return
 

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -272,7 +272,9 @@ class YouthApplicationViewSet(ModelViewSet):
                 request.data.get("employer_summer_voucher_id", "")
             )
             employee_name = str(request.data.get("employee_name", "")).strip()
-            voucher_number = int(request.data.get("summer_voucher_serial_number", ""))
+            voucher_number = str(
+                request.data.get("summer_voucher_serial_number", "")
+            ).strip()
         except (KeyError, ValueError, TypeError):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
@@ -282,14 +284,12 @@ class YouthApplicationViewSet(ModelViewSet):
         if employer_summer_vouchers.count() != 1:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        try:
-            youth_summer_voucher = YouthSummerVoucher.objects.get(
-                summer_voucher_serial_number=voucher_number
-            )
-        except YouthSummerVoucher.DoesNotExist:
-            youth_application = None
-        else:
-            youth_application = youth_summer_voucher.youth_application
+        youth_summer_voucher = YouthSummerVoucher.get_voucher_with_serial_number(
+            voucher_number
+        )
+        youth_application = (
+            youth_summer_voucher.youth_application if youth_summer_voucher else None
+        )
 
         found_match = youth_application and is_last_name_fuzzy_match_in_full_name(
             last_name=youth_application.last_name, full_name=employee_name

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -284,7 +284,7 @@ class YouthApplicationViewSet(ModelViewSet):
         if employer_summer_vouchers.count() != 1:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        youth_summer_voucher = YouthSummerVoucher.get_voucher_with_serial_number(
+        youth_summer_voucher = YouthSummerVoucher.objects.get_by_serial_number(
             voucher_number
         )
         youth_application = (

--- a/backend/kesaseteli/applications/migrations/0059_remove_sequence_model.py
+++ b/backend/kesaseteli/applications/migrations/0059_remove_sequence_model.py
@@ -1,0 +1,31 @@
+"""
+This migration removes the sequences.sequence model created by django-sequences v3.0
+package's migrations:
+- https://github.com/aaugustin/django-sequences/tree/3.0/src/sequences/migrations
+"""
+
+from django.db import migrations
+
+
+def delete_sequences_sequence_model(apps, schema_editor):
+    try:
+        Sequence = apps.get_model("sequences", "Sequence")
+    except LookupError:
+        # If running migrations to a new database without django-sequences
+        # package being in INSTALLED_APPS anymore, the Sequence model won't be found.
+        # In that case just skip the deletion since the model doesn't exist.
+        return
+    schema_editor.delete_model(Sequence)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("applications", "0058_employerapplication_bank_address_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            delete_sequences_sequence_model,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -1,17 +1,18 @@
 import json
 import logging
+import secrets
 from datetime import date, datetime, timedelta
 from email.mime.image import MIMEImage
 from pathlib import Path
 from typing import Optional
 from urllib.parse import quote, urljoin
 
-import sequences
+import base32_lib
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import MinValueValidator
-from django.db import models, transaction
+from django.db import IntegrityError, models, transaction
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone, translation
@@ -562,12 +563,25 @@ class YouthApplication(LockForUpdateMixin, TimeStampedModel, UUIDModel):
             return False
         return True
 
-    @transaction.atomic  # Needed for django-sequences serial number handling
     def create_youth_summer_voucher(self) -> "YouthSummerVoucher":
-        return YouthSummerVoucher.objects.create(
-            youth_application=self,
-            summer_voucher_serial_number=YouthSummerVoucher.get_next_serial_number(),
-        )
+        """
+        Creates youth summer voucher for this youth application if it doesn't have one.
+        :return: New youth summer voucher for this youth application, or existing one if
+            it already has one.
+        :raises RuntimeError: if unable to allocate a serial number for the voucher
+        """
+        if self.has_youth_summer_voucher:
+            return self.youth_summer_voucher
+        for _i in range(YouthSummerVoucher.SERIAL_NUM_ALLOCATION_TRY_COUNT_LIMIT):
+            try:
+                with transaction.atomic():
+                    return YouthSummerVoucher.objects.create(
+                        youth_application=self,
+                        summer_voucher_serial_number=YouthSummerVoucher.get_random_serial_number(),
+                    )
+            except IntegrityError:
+                continue  # Serial number collision → retry with new number
+        raise RuntimeError("Unable to allocate serial number for youth summer voucher")
 
     @property
     def is_handled(self) -> bool:
@@ -867,8 +881,34 @@ class YouthSummerVoucherManager(models.Manager):
 class YouthSummerVoucher(TimeStampedModel, UUIDModel):
     objects = YouthSummerVoucherManager()
 
-    _SERIAL_NUMBER_SEQUENCE_NAME = "youth_summer_voucher_serial_numbers"
-    SERIAL_NUMBER_SEQUENCE_INITIAL_VALUE = 1
+    # Inclusive lower limit for randomly generated serial numbers,
+    # existing sequential values in production were in range [1, 30k) in May 2026.
+    MIN_RAND_SERIAL_NUM = 100_000
+
+    # Inclusive upper limit for randomly generated serial numbers,
+    # using maximum value that fits base32 encoded with checksum & dashes in 15 chars:
+    # >>> base32_lib.encode(2**50-1, split_every=3, checksum=True) == "zzz-zzz-zzz-z89"
+    # >>> base32_lib.encode(2**50, split_every=3, checksum=True) == "100-000-000-008-6"
+    MAX_RAND_SERIAL_NUM = (2**50) - 1
+
+    # The maximum count of randomly generated serial numbers
+    RAND_SERIAL_NUM_RANGE_LEN = MAX_RAND_SERIAL_NUM - MIN_RAND_SERIAL_NUM + 1
+
+    # How many times at maximum to try to allocate a new serial number
+    # until give up and raise an exception instead?
+    #
+    # Needed because of possible collisions when randomly selecting serial numbers.
+    #
+    # Basically this is completely safe with 10 retries. Why? Read below:
+    #
+    # If 1% of the random serial number range RAND_SERIAL_NUMBER_RANGE_LEN is used,
+    # which is ~10**13 ~= 1000 times the people on Earth in May 2026 (~=8_300M),
+    # the probability that a new randomly selected serial number collides
+    # with an existing one is 1%. Trying 10 times with such probability gives
+    # 0.01**10 = (10**-2)**10 = 10**-20 probability that all 10 tries collide.
+    # This is practically impossible given enough entropy in the random generation
+    # (The secrets library used generates cryptographically strong random numbers).
+    SERIAL_NUM_ALLOCATION_TRY_COUNT_LIMIT = 10
 
     youth_application = models.OneToOneField(
         YouthApplication,
@@ -890,15 +930,88 @@ class YouthSummerVoucher(TimeStampedModel, UUIDModel):
         return self.youth_application.get_target_group_display()
 
     @staticmethod
-    def get_next_serial_number() -> int:
-        return sequences.get_next_value(
-            sequence_name=YouthSummerVoucher._SERIAL_NUMBER_SEQUENCE_NAME,
-            initial_value=YouthSummerVoucher.SERIAL_NUMBER_SEQUENCE_INITIAL_VALUE,
+    def get_random_serial_number() -> int:
+        """
+        Get a randomly generated summer voucher serial number.
+        :return: A randomly generated summer voucher serial number.
+        """
+        return YouthSummerVoucher.MIN_RAND_SERIAL_NUM + secrets.randbelow(
+            YouthSummerVoucher.RAND_SERIAL_NUM_RANGE_LEN
         )
 
     @staticmethod
-    def get_last_used_serial_number() -> Optional[int]:
-        return sequences.get_last_value(YouthSummerVoucher._SERIAL_NUMBER_SEQUENCE_NAME)
+    def get_user_showable_serial_number(serial_number: int) -> str:
+        """
+        Get a user-showable version of the given serial number by encoding it
+        using base32 encoding with checksum and splitting it every 3 chars with dash,
+        except for old sequential serial numbers that are returned as-is as strings.
+
+        Example with new randomly generated serial number:
+        >>> YouthSummerVoucher.get_user_showable_serial_number(123456) == "3rj-076"
+
+        Example with old sequentially generated serial number (<_MIN_RAND_SERIAL_NUM):
+        >>> YouthSummerVoucher.get_user_showable_serial_number(98_765) == "98765"
+        """
+        if serial_number < YouthSummerVoucher.MIN_RAND_SERIAL_NUM:
+            # Return previously used sequentially generated serial numbers
+            # without encoding for backwards compatibility
+            return str(serial_number)
+        # Return current randomly generated serial numbers base32 encoded with checksum
+        return base32_lib.encode(serial_number, split_every=3, checksum=True)
+
+    @property
+    def user_showable_serial_number(self) -> str:
+        """
+        A user-showable version of this youth summer voucher's serial number.
+        """
+        return YouthSummerVoucher.get_user_showable_serial_number(
+            self.summer_voucher_serial_number
+        )
+
+    @staticmethod
+    def decode_user_showable_serial_number(serial_number) -> int:
+        """
+        Decode the given user-showable serial number back to an integer by
+        removing dashes and decoding using base32 encoding with checksum,
+        or parsing it as an integer if it's a previously used sequential serial number.
+
+        Example with new randomly generated serial number:
+        >>> YouthSummerVoucher.decode_user_showable_serial_number("3rj-076") == 123456
+
+        Example with old sequentially generated serial number (<_MIN_RAND_SERIAL_NUM):
+        >>> YouthSummerVoucher.decode_user_showable_serial_number("98765") == 98765
+
+        :raises ValueError: if base32 format is incorrect or its checksum is invalid
+        """
+        cleaned_num: str = str(serial_number).strip()
+        if (
+            cleaned_num.isdigit()
+            and int(cleaned_num) < YouthSummerVoucher.MIN_RAND_SERIAL_NUM
+        ):
+            return int(cleaned_num)
+        return base32_lib.decode(cleaned_num, checksum=True)
+
+    @staticmethod
+    def get_voucher_with_serial_number(serial_number) -> "YouthSummerVoucher | None":
+        """
+        Get the youth summer voucher with the given serial number, which can be a
+        previously used sequential serial number or a user-showable serial number in
+        base32 encoding with checksum.
+
+        :return: Youth summer voucher with given serial number, or None if not found.
+        """
+        try:
+            decoded_num: int = YouthSummerVoucher.decode_user_showable_serial_number(
+                serial_number
+            )
+        except ValueError:
+            return None  # Invalid format or checksum
+        try:
+            return YouthSummerVoucher.objects.get(
+                summer_voucher_serial_number=decoded_num
+            )
+        except YouthSummerVoucher.DoesNotExist:
+            return None
 
     @property
     def year(self) -> int:
@@ -1074,7 +1187,7 @@ class YouthSummerVoucher(TimeStampedModel, UUIDModel):
             context = {
                 "first_name": self.youth_application.first_name,
                 "last_name": self.youth_application.last_name,
-                "summer_voucher_serial_number": self.summer_voucher_serial_number,
+                "summer_voucher_serial_number": self.user_showable_serial_number,
                 "postcode": self.youth_application.postcode,
                 "school": self.youth_application.school,
                 "phone_number": self.youth_application.phone_number,
@@ -1108,7 +1221,7 @@ class YouthSummerVoucher(TimeStampedModel, UUIDModel):
             )
 
     def __str__(self):
-        return str(self.summer_voucher_serial_number)
+        return self.user_showable_serial_number
 
     class Meta:
         verbose_name = _("youth summer voucher")
@@ -1412,16 +1525,18 @@ class EmployerSummerVoucher(TimeStampedModel, UUIDModel):
         when it was a CharField, now reads from the real foreign key relation
         to YouthSummerVoucher.
 
-        :return: Value of youth_summer_voucher_id as a string, if it is not None,
-            otherwise the value of _obsolete_unclean_serial_number (This may be
-            non-empty string in historical data, but should be empty string in
-            newer data).
+        :return: Value of youth_summer_voucher_id as a user-showable serial number,
+            if it is not None, otherwise value of _obsolete_unclean_serial_number
+            (This may be non-empty string in historical data, but should be empty string
+            in newer data).
         """
         if self.youth_summer_voucher_id is None:
             # Fallback to obsolete unclean serial number for historical data,
             # and for newer data this should be an empty string.
             return self._obsolete_unclean_serial_number
-        return str(self.youth_summer_voucher_id)
+        return YouthSummerVoucher.get_user_showable_serial_number(
+            self.youth_summer_voucher_id
+        )
 
     @summer_voucher_serial_number.setter
     def summer_voucher_serial_number(self, value) -> None:
@@ -1431,12 +1546,15 @@ class EmployerSummerVoucher(TimeStampedModel, UUIDModel):
         but now sets the real foreign key relation based on the given value.
 
         Sets youth_summer_voucher to the YouthSummerVoucher instance found
-        with the given summer_voucher_serial_number value converted to int.
+        with the given summer_voucher_serial_number value decoded with
+        YouthSummerVoucher.get_voucher_with_serial_number function.
 
-        If no match is found, or value is None or not convertible to int,
+        If no match is found, or value is None or not decoded successfully,
         sets youth_summer_voucher to None.
 
-        :param value: Value to set the youth_summer_voucher_id foreign key to.
+        :param value: Value to use to set the youth_summer_voucher_id foreign key.
+            Can be base32 encoded integer value with checksum or previously used
+            sequential serial number integer value as an int or string, or None.
         :raises TypeError: if value is not str, int or None
         """
         # Explicitly disallow bool, which is a subclass of int
@@ -1444,13 +1562,11 @@ class EmployerSummerVoucher(TimeStampedModel, UUIDModel):
             raise TypeError(
                 f"summer_voucher_serial_number must be str/int/None, not {type(value)}"
             )
-        try:
-            self.youth_summer_voucher = YouthSummerVoucher.objects.get(
-                summer_voucher_serial_number=int(value)
-            )
-        except (ValueError, TypeError, YouthSummerVoucher.DoesNotExist):
-            # Not convertible to int or no matching YouthSummerVoucher found.
-            self.youth_summer_voucher = None
+        self.youth_summer_voucher = (
+            None
+            if value is None
+            else YouthSummerVoucher.get_voucher_with_serial_number(value)
+        )
 
     @property
     def value_in_euros(self) -> int:

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -867,6 +867,25 @@ class YouthApplication(LockForUpdateMixin, TimeStampedModel, UUIDModel):
 
 
 class YouthSummerVoucherQuerySet(models.QuerySet):
+    def get_by_serial_number(self, serial_number) -> "YouthSummerVoucher | None":
+        """
+        Get the youth summer voucher with the given serial number, which can be a
+        previously used sequential serial number or a user-showable serial number in
+        base32 encoding with checksum.
+
+        :return: Youth summer voucher with given serial number, or None if not found.
+        """
+        try:
+            decoded_num: int = YouthSummerVoucher.decode_user_showable_serial_number(
+                serial_number
+            )
+        except ValueError:
+            return None  # Invalid format or checksum
+        try:
+            return self.get(summer_voucher_serial_number=decoded_num)
+        except YouthSummerVoucher.DoesNotExist:
+            return None
+
     def select_youth_application(self):
         return self.select_related("youth_application")
 
@@ -879,7 +898,7 @@ class YouthSummerVoucherManager(models.Manager):
 
 
 class YouthSummerVoucher(TimeStampedModel, UUIDModel):
-    objects = YouthSummerVoucherManager()
+    objects = YouthSummerVoucherManager.from_queryset(YouthSummerVoucherQuerySet)()
 
     # Inclusive lower limit for randomly generated serial numbers,
     # existing sequential values in production were in range [1, 30k) in May 2026.
@@ -990,28 +1009,6 @@ class YouthSummerVoucher(TimeStampedModel, UUIDModel):
         ):
             return int(cleaned_num)
         return base32_lib.decode(cleaned_num, checksum=True)
-
-    @staticmethod
-    def get_voucher_with_serial_number(serial_number) -> "YouthSummerVoucher | None":
-        """
-        Get the youth summer voucher with the given serial number, which can be a
-        previously used sequential serial number or a user-showable serial number in
-        base32 encoding with checksum.
-
-        :return: Youth summer voucher with given serial number, or None if not found.
-        """
-        try:
-            decoded_num: int = YouthSummerVoucher.decode_user_showable_serial_number(
-                serial_number
-            )
-        except ValueError:
-            return None  # Invalid format or checksum
-        try:
-            return YouthSummerVoucher.objects.get(
-                summer_voucher_serial_number=decoded_num
-            )
-        except YouthSummerVoucher.DoesNotExist:
-            return None
 
     @property
     def year(self) -> int:
@@ -1547,7 +1544,7 @@ class EmployerSummerVoucher(TimeStampedModel, UUIDModel):
 
         Sets youth_summer_voucher to the YouthSummerVoucher instance found
         with the given summer_voucher_serial_number value decoded with
-        YouthSummerVoucher.get_voucher_with_serial_number function.
+        YouthSummerVoucher.objects.get_by_serial_number function.
 
         If no match is found, or value is None or not decoded successfully,
         sets youth_summer_voucher to None.
@@ -1565,7 +1562,7 @@ class EmployerSummerVoucher(TimeStampedModel, UUIDModel):
         self.youth_summer_voucher = (
             None
             if value is None
-            else YouthSummerVoucher.get_voucher_with_serial_number(value)
+            else YouthSummerVoucher.objects.get_by_serial_number(value)
         )
 
     @property

--- a/backend/kesaseteli/applications/tests/test_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_applications_api.py
@@ -175,7 +175,7 @@ def test_update_summer_voucher(api_client, application, summer_voucher):
         != new_youth_summer_voucher.summer_voucher_serial_number
     )
     data["summer_vouchers"][0]["summer_voucher_serial_number"] = str(
-        new_youth_summer_voucher.summer_voucher_serial_number
+        new_youth_summer_voucher.user_showable_serial_number
     )
     data["summer_vouchers"][0]["employee_name"] = (
         new_youth_summer_voucher.youth_application.name
@@ -188,7 +188,7 @@ def test_update_summer_voucher(api_client, application, summer_voucher):
 
     assert response.status_code == 200
     assert response.data["summer_vouchers"][0]["summer_voucher_serial_number"] == str(
-        new_youth_summer_voucher.summer_voucher_serial_number
+        new_youth_summer_voucher.user_showable_serial_number
     )
     # Make sure that the summer voucher ID stays the same
     assert response.data["summer_vouchers"][0]["id"] == str(summer_voucher_id)

--- a/backend/kesaseteli/applications/tests/test_employer_summer_voucher_validation.py
+++ b/backend/kesaseteli/applications/tests/test_employer_summer_voucher_validation.py
@@ -79,9 +79,7 @@ class TestEmployerApplicationValidation:
         youth_app = active_voucher.youth_application
 
         new_voucher_data = {
-            "summer_voucher_serial_number": str(
-                active_voucher.summer_voucher_serial_number
-            ),
+            "summer_voucher_serial_number": active_voucher.user_showable_serial_number,
             "employee_name": f"{youth_app.first_name} {youth_app.last_name}",
             "employee_phone_number": "0401234567",
             "employment_postcode": "00100",
@@ -111,13 +109,13 @@ class TestEmployerApplicationValidation:
         voucher, _ = YouthSummerVoucher.objects.get_or_create(
             youth_application=youth_application,
             defaults={
-                "summer_voucher_serial_number": YouthSummerVoucher.get_next_serial_number()
+                "summer_voucher_serial_number": YouthSummerVoucher.get_random_serial_number()
             },
         )
 
         data = EmployerApplicationSerializer(application).data
         new_voucher_data = {
-            "summer_voucher_serial_number": str(voucher.summer_voucher_serial_number),
+            "summer_voucher_serial_number": voucher.user_showable_serial_number,
             "employee_name": f"{youth_application.first_name} {youth_application.last_name}",
             "employee_phone_number": "0401234567",
             "employment_postcode": "00100",
@@ -152,9 +150,7 @@ class TestEmployerApplicationValidation:
         youth_app = active_voucher.youth_application
 
         new_voucher_data = {
-            "summer_voucher_serial_number": str(
-                active_voucher.summer_voucher_serial_number
-            ),
+            "summer_voucher_serial_number": active_voucher.user_showable_serial_number,
             "employee_name": f"{youth_app.first_name} {youth_app.last_name}",
             "employee_phone_number": "0401234567",
             "employment_postcode": "00100",

--- a/backend/kesaseteli/applications/tests/test_excel_export.py
+++ b/backend/kesaseteli/applications/tests/test_excel_export.py
@@ -478,12 +478,12 @@ def test_youth_excel_download_content(staff_client):  # noqa: C901
             elif source_field.endswith("application_year"):
                 assert int(output_value) == localdate(app.created_at).year
             elif source_field == "summer_voucher_serial_number":
-                if output_value is None:
+                if not output_value:
                     assert not app.has_youth_summer_voucher
                 else:
                     assert (
-                        int(output_value)
-                        == app.youth_summer_voucher.summer_voucher_serial_number
+                        output_value
+                        == app.youth_summer_voucher.user_showable_serial_number
                     )
             elif source_field == "birth_year":
                 assert int(output_value) == app.birthdate.year

--- a/backend/kesaseteli/applications/tests/test_models.py
+++ b/backend/kesaseteli/applications/tests/test_models.py
@@ -5,10 +5,9 @@ from email.mime.image import MIMEImage
 from typing import List
 from unittest import mock
 
+import base32_lib
 import pytest
 from django.core import mail
-from django.db import transaction
-from django.db.utils import IntegrityError
 from django.test import override_settings
 from freezegun import freeze_time
 
@@ -16,7 +15,6 @@ from applications.enums import EmployerApplicationStatus
 from applications.models import EmployerSummerVoucher, YouthSummerVoucher
 from common.tests.factories import (
     AttachmentFactory,
-    AwaitingManualProcessingYouthApplicationFactory,
     EmployerApplicationFactory,
     EmployerSummerVoucherFactory,
     YouthSummerVoucherFactory,
@@ -92,30 +90,75 @@ def test_employer_summer_voucher_submitted_at(year):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "obsolete_serial_number", ["", "Testing", "Even more ABC123 testing!"]
+    "summer_voucher_serial_number",
+    [1, 1234, 99_999, 100_000, 123456789012345, 2**50 - 1],
 )
 def test_employer_summer_voucher_summer_voucher_serial_number_property(
+    summer_voucher_serial_number: int,
+):
+    """
+    Test that EmployerSummerVoucher.summer_voucher_serial_number property
+    returns the linked YouthSummerVoucher's user_showable_serial_number.
+    """
+    employer_voucher = EmployerSummerVoucherFactory(
+        youth_summer_voucher__summer_voucher_serial_number=summer_voucher_serial_number
+    )
+    assert (
+        employer_voucher.youth_summer_voucher.summer_voucher_serial_number
+        == summer_voucher_serial_number
+    )
+    assert (
+        employer_voucher.summer_voucher_serial_number
+        == employer_voucher.youth_summer_voucher.user_showable_serial_number
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "summer_voucher_serial_number, expected_user_showable_serial_number",
+    [
+        # Previously used sequentially generated serial numbers in range [1, 100k):
+        (1, "1"),
+        (1234, "1234"),
+        (99_999, "99999"),
+        # Randomly generated base32 encoded serial numbers with integer values >=100k:
+        (100_000, "31n-022"),
+        (123456789012345, "3g9-230-vqv-s62"),
+        (2**50 - 1, "zzz-zzz-zzz-z89"),
+    ],
+)
+def test_youth_summer_voucher_user_showable_serial_number_property(
+    summer_voucher_serial_number: int, expected_user_showable_serial_number: str
+):
+    """
+    Test that YouthSummerVoucher.user_showable_serial_number property matches
+    the expected encoding.
+    """
+    youth_summer_voucher = YouthSummerVoucherFactory(
+        summer_voucher_serial_number=summer_voucher_serial_number
+    )
+    assert (
+        youth_summer_voucher.user_showable_serial_number
+        == expected_user_showable_serial_number
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "obsolete_serial_number", ["", "Testing", "Even more ABC123 testing!"]
+)
+def test_employer_summer_voucher_summer_voucher_serial_number_property_fallback(
     obsolete_serial_number,
 ):
     """
     Test that EmployerSummerVoucher.summer_voucher_serial_number property
-    returns the linked YouthSummerVoucher's summer_voucher_serial_number as
-    string, or if it doesn't exist falls back to _obsolete_unclean_serial_number.
+    returns _obsolete_unclean_serial_number if not linked to a YouthSummerVoucher.
     """
     employer_voucher = EmployerSummerVoucherFactory(
-        _obsolete_unclean_serial_number=obsolete_serial_number
+        youth_summer_voucher=None,
+        _obsolete_unclean_serial_number=obsolete_serial_number,
     )
-    assert employer_voucher.youth_summer_voucher is not None
-    assert (
-        employer_voucher.youth_summer_voucher.summer_voucher_serial_number is not None
-    )
-    # Serial number should be the linked youth summer voucher's serial number as string
-    assert employer_voucher.summer_voucher_serial_number == str(
-        employer_voucher.youth_summer_voucher.summer_voucher_serial_number
-    )
-    # Serial number should fall back to _obsolete_unclean_serial_number
-    # if no linked youth summer voucher
-    employer_voucher.youth_summer_voucher = None
+    assert employer_voucher.youth_summer_voucher is None
     assert employer_voucher.summer_voucher_serial_number == obsolete_serial_number
 
 
@@ -130,6 +173,9 @@ def test_employer_summer_voucher_summer_voucher_serial_number_property(
         "00001",
         "99999",
         "  1234    ",
+        "31n-022",
+        "3g9-230-vqv-s62",
+        "zzz-zzz-zzz-z89",
         -1,
         1,
         12345,
@@ -155,24 +201,38 @@ def test_employer_summer_voucher_summer_voucher_serial_number_setter_without_mat
     # serial number should result in no linked youth summer voucher
     assert not YouthSummerVoucher.objects.exists()
     employer_voucher.summer_voucher_serial_number = serial_number
-    assert employer_voucher.summer_voucher_serial_number == ""
+    assert employer_voucher.youth_summer_voucher is None
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "input_serial_number",
+    "serial_number_as_int, user_inputted_serial_number",
     [
-        "12345",
-        "00001",
-        "99999",
-        "  1234    ",
-        1,
-        12345,
-        99999,
+        # Previously used sequentially generated serial numbers in range [1, 100k):
+        (1, "1"),
+        (1, 1),
+        (1, "00001"),
+        (1234, "1234"),
+        (1234, "  001234   "),
+        (1234, 1234),
+        (99_999, "99999"),
+        (99_999, 99999),
+        # Randomly generated base32 encoded serial numbers with integer values >=100k:
+        (100_000, "31n-022"),
+        (100_000, "3in-o22"),  # Allowed char variations
+        (100_000, "3IN-O22"),  # Allowed char variations
+        (100_000, "  31n022  "),
+        (123456789012345, "3g9-230-vqv-s62"),
+        (123456789012345, " -3---g9230v-q-v-s62  "),
+        (123456789012345, "3G923ovQVS62"),  # Allowed char variation
+        (2**50 - 1, "zzz-zzz-zzz-z89"),
+        # Non-numeric base32 encoded serial numbers with checksum still match even if <100k:
+        (12, "c62"),
+        (1034, "10a03"),
     ],
 )
 def test_employer_summer_voucher_summer_voucher_serial_number_setter_with_match(
-    input_serial_number: str | int,
+    serial_number_as_int: int, user_inputted_serial_number: str | int
 ):
     """
     Test the EmployerSummerVoucher.summer_voucher_serial_number property's setter
@@ -182,16 +242,85 @@ def test_employer_summer_voucher_summer_voucher_serial_number_setter_with_match(
     EmployerSummerVoucher.objects.all().delete()
     YouthSummerVoucher.objects.all().delete()
 
-    expected_serial_number = int(input_serial_number)
-    YouthSummerVoucherFactory(summer_voucher_serial_number=expected_serial_number)
+    YouthSummerVoucherFactory(summer_voucher_serial_number=serial_number_as_int)
     employer_voucher = EmployerSummerVoucherFactory(
         _obsolete_unclean_serial_number="", youth_summer_voucher=None
     )
 
-    assert employer_voucher.summer_voucher_serial_number == ""
+    assert employer_voucher.youth_summer_voucher is None
+    employer_voucher.summer_voucher_serial_number = user_inputted_serial_number
+    assert employer_voucher.youth_summer_voucher is not None
+    assert (
+        employer_voucher.youth_summer_voucher.summer_voucher_serial_number
+        == serial_number_as_int
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "possibly_matching_serial_numbers, input_serial_number",
+    [
+        ([], "I am not a number"),  # Not base32 encoded nor an integer
+        (
+            [
+                123,
+                base32_lib.decode("123", checksum=False),
+            ],
+            "#123",
+        ),  # Otherwise valid but contains invalid character
+        (
+            [
+                base32_lib.decode("c", checksum=False),
+            ],
+            "c",
+        ),  # Base32 encoded 12 without checksum → invalid
+        (
+            [
+                base32_lib.decode("31n-023", checksum=False),
+            ],
+            "31n-023",
+        ),  # Base32 encoded value with invalid checksum
+        (
+            [
+                base32_lib.decode("31n-022", checksum=False),
+                base32_lib.decode("31n-022", checksum=True),
+            ],
+            "31n-022$",
+        ),  # Otherwise valid but contains invalid character
+        (
+            [
+                base32_lib.decode("3g9-230-vqv-s62", checksum=False),
+                base32_lib.decode("3g9-230-vqv-s62", checksum=True),
+            ],
+            "3g9-230-vqv-s62-",
+        ),  # Otherwise valid but trailing dash is invalid
+    ],
+)
+def test_employer_summer_voucher_summer_voucher_serial_number_setter_with_invalid_input(
+    possibly_matching_serial_numbers: list[int], input_serial_number: str
+):
+    """
+    Test the EmployerSummerVoucher.summer_voucher_serial_number property's setter
+    with invalid serial number inputs.
+
+    :possibly_matching_serial_numbers: list of serial numbers that could possibly match
+        the input_serial_number if it were decoded/interpreted in a more lenient way.
+    :input_serial_number: input serial number invalid in some way
+    """
+    # Clear existing vouchers for a clean slate
+    EmployerSummerVoucher.objects.all().delete()
+    YouthSummerVoucher.objects.all().delete()
+
+    # Create youth summer vouchers for the possibly matching serial numbers
+    for serial_number in possibly_matching_serial_numbers:
+        YouthSummerVoucherFactory(summer_voucher_serial_number=serial_number)
+    employer_voucher = EmployerSummerVoucherFactory(
+        _obsolete_unclean_serial_number="", youth_summer_voucher=None
+    )
+
+    # Try to set the serial number and test that it does not find a match
     employer_voucher.summer_voucher_serial_number = input_serial_number
-    assert employer_voucher.summer_voucher_serial_number == str(expected_serial_number)
-    assert employer_voucher.youth_summer_voucher_id == expected_serial_number
+    assert employer_voucher.youth_summer_voucher is None
 
 
 @pytest.mark.django_db
@@ -206,190 +335,6 @@ def test_employer_summer_voucher_summer_voucher_serial_number_setter_exception(
     employer_voucher = EmployerSummerVoucherFactory()
     with pytest.raises(TypeError):
         employer_voucher.summer_voucher_serial_number = serial_number
-
-
-@pytest.mark.django_db()
-def test_youth_summer_voucher_get_last_used_serial_number():
-    assert YouthSummerVoucher.objects.count() == 0
-    assert YouthSummerVoucher.get_last_used_serial_number() is None
-    for _ in range(1, 10):
-        summer_voucher = AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-        assert YouthSummerVoucher.get_last_used_serial_number() is not None
-        assert (
-            YouthSummerVoucher.get_last_used_serial_number()
-            == summer_voucher.summer_voucher_serial_number
-        )
-
-
-@pytest.mark.django_db()
-def test_youth_summer_voucher_first_serial_number():
-    assert YouthSummerVoucher.objects.count() == 0
-    summer_voucher = (
-        AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-    )
-    assert (
-        summer_voucher.summer_voucher_serial_number
-        == YouthSummerVoucher.SERIAL_NUMBER_SEQUENCE_INITIAL_VALUE
-    )
-
-
-@pytest.mark.django_db()
-def test_youth_summer_voucher_sequentiality():
-    assert YouthSummerVoucher.objects.count() == 0
-    for ordinal_number in range(1, 10):
-        summer_voucher = AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-        assert YouthSummerVoucher.objects.count() == ordinal_number
-        assert YouthSummerVoucher.objects.last() == summer_voucher
-        assert summer_voucher.summer_voucher_serial_number == ordinal_number
-
-
-@pytest.mark.django_db()
-def test_youth_summer_voucher_sequentiality_duplicate_create():
-    assert YouthSummerVoucher.objects.count() == 0
-
-    app_1 = AwaitingManualProcessingYouthApplicationFactory()
-    app_1.create_youth_summer_voucher()
-    assert YouthSummerVoucher.objects.count() == 1
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
-
-    with pytest.raises(IntegrityError):
-        app_1.create_youth_summer_voucher()
-    assert YouthSummerVoucher.objects.count() == 1
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
-
-    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-    assert YouthSummerVoucher.objects.count() == 2
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 2
-
-    assert sorted(
-        YouthSummerVoucher.objects.values_list(
-            "summer_voucher_serial_number", flat=True
-        )
-    ) == list(range(1, 3))
-
-
-@pytest.mark.django_db()
-def test_youth_summer_voucher_sequentiality_failing_transaction():
-    assert YouthSummerVoucher.objects.count() == 0
-
-    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-    assert YouthSummerVoucher.objects.count() == 1
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
-
-    with transaction.atomic():
-        AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-        AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-        transaction.set_rollback(True)
-
-    assert YouthSummerVoucher.objects.count() == 1
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
-
-    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-    assert YouthSummerVoucher.objects.count() == 2
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 2
-
-    assert sorted(
-        YouthSummerVoucher.objects.values_list(
-            "summer_voucher_serial_number", flat=True
-        )
-    ) == list(range(1, 3))
-
-
-@pytest.mark.django_db()
-def test_youth_summer_voucher_sequentiality_failing_nested_transaction():
-    assert YouthSummerVoucher.objects.count() == 0
-
-    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-    assert YouthSummerVoucher.objects.count() == 1
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
-
-    with transaction.atomic():
-        AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-        with transaction.atomic():
-            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-            transaction.set_rollback(True)
-
-    assert YouthSummerVoucher.objects.count() == 2
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 2
-
-    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-    assert YouthSummerVoucher.objects.count() == 3
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 3
-
-    assert sorted(
-        YouthSummerVoucher.objects.values_list(
-            "summer_voucher_serial_number", flat=True
-        )
-    ) == list(range(1, 4))
-
-
-@pytest.mark.django_db()
-def test_youth_summer_voucher_sequentiality_failing_nested_transactions():
-    assert YouthSummerVoucher.objects.count() == 0
-
-    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-    assert YouthSummerVoucher.objects.count() == 1
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
-
-    with transaction.atomic():
-        AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-        with transaction.atomic():
-            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-            transaction.set_rollback(True)
-        transaction.set_rollback(True)
-
-    assert YouthSummerVoucher.objects.count() == 1
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
-
-    AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-    assert YouthSummerVoucher.objects.count() == 2
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 2
-
-    assert sorted(
-        YouthSummerVoucher.objects.values_list(
-            "summer_voucher_serial_number", flat=True
-        )
-    ) == list(range(1, 3))
-
-
-@pytest.mark.django_db()
-def test_youth_summer_voucher_sequentiality_complex_transaction_nesting():
-    assert YouthSummerVoucher.objects.count() == 0
-
-    def create_youth_summer_vouchers(count: int):
-        for _ in range(count):
-            AwaitingManualProcessingYouthApplicationFactory().create_youth_summer_voucher()
-
-    create_youth_summer_vouchers(count=1)
-    assert YouthSummerVoucher.objects.count() == 1
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 1
-
-    with transaction.atomic():
-        create_youth_summer_vouchers(count=3)
-        with transaction.atomic():
-            create_youth_summer_vouchers(count=5)
-            with transaction.atomic():
-                create_youth_summer_vouchers(count=7)
-                with transaction.atomic():
-                    create_youth_summer_vouchers(count=9)
-                    with transaction.atomic():
-                        create_youth_summer_vouchers(count=11)
-                transaction.set_rollback(True)
-
-    assert YouthSummerVoucher.objects.count() == 9
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 9
-
-    create_youth_summer_vouchers(count=1)
-    assert YouthSummerVoucher.objects.count() == 10
-    assert YouthSummerVoucher.objects.last().summer_voucher_serial_number == 10
-
-    assert sorted(
-        YouthSummerVoucher.objects.values_list(
-            "summer_voucher_serial_number", flat=True
-        )
-    ) == list(range(1, 11))
 
 
 @pytest.mark.django_db
@@ -498,3 +443,47 @@ def test_youth_summer_voucher_helsinki_logo(language, expected_logo_from_file):
     expected_logo_mime_image = MIMEImage(expected_logo_content)
 
     assert logo_mime_image.get_payload() == expected_logo_mime_image.get_payload()
+
+
+def test_get_random_serial_number():
+    """
+    Test the YouthSummerVoucher.get_random_serial_number generates numbers in the correct range
+    at least remotely randomly. Not rigorous randomness test, but a test for gross failures.
+    """
+    sample_size = 10_000
+    serial_numbers = [
+        YouthSummerVoucher.get_random_serial_number() for _ in range(sample_size)
+    ]
+
+    # Test for correct range
+    assert all(
+        YouthSummerVoucher.MIN_RAND_SERIAL_NUM
+        <= serial_number
+        <= YouthSummerVoucher.MAX_RAND_SERIAL_NUM
+        for serial_number in serial_numbers
+    )
+
+    # No duplicates: at least a single collision in a ~2**50 range with 10k samples
+    # is approximately 1-math.exp(-k*(k-1)/(2*n)) likely where
+    # k=10_000, n=YouthSummerVoucher.RAND_SERIAL_NUM_RANGE_LEN, i.e. ~1/22M chance.
+    # See https://en.wikipedia.org/wiki/Birthday_problem for the formula derivation.
+    assert len(set(serial_numbers)) == sample_size
+
+    # Split range into buckets and verify that each bucket gets roughly as many numbers
+    num_buckets = 10
+    bucket_size = YouthSummerVoucher.RAND_SERIAL_NUM_RANGE_LEN // num_buckets
+    buckets = [0] * num_buckets
+    for n in serial_numbers:
+        bucket_index = min(
+            (n - YouthSummerVoucher.MIN_RAND_SERIAL_NUM) // bucket_size, num_buckets - 1
+        )
+        buckets[bucket_index] += 1
+
+    expected_per_bucket = 1000
+    # Allowed error of ±180 should be at least as improbable as the earlier check i.e. ~1/22M:
+    allowed_error = 180
+
+    assert all(abs(count - expected_per_bucket) <= allowed_error for count in buckets)
+    assert (
+        sum(buckets) == sample_size
+    )  # Sanity check that the buckets sum up to the total

--- a/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
+++ b/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
@@ -1352,14 +1352,24 @@ def test_youth_application_fetch_employee_data(user_client):
 
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 @pytest.mark.django_db
-def test_youth_application_fetch_employee_data_success_writes_audit_log(user_client):
+@pytest.mark.parametrize(
+    "serial_number_as_int, user_input_serial_number",
+    [
+        (123, 123),
+        (456, "456"),
+        (100_000, "31n-022"),
+    ],
+)
+def test_youth_application_fetch_employee_data_success_writes_audit_log(
+    user_client, serial_number_as_int: int, user_input_serial_number: int | str
+):
     employer_summer_voucher = EmployerSummerVoucherFactory(
         application=EmployerApplicationFactory()
     )
     youth_application = AcceptedYouthApplicationFactory(
         first_name="Franklin",
         last_name="Doe",
-        youth_summer_voucher__summer_voucher_serial_number=123,
+        youth_summer_voucher__summer_voucher_serial_number=serial_number_as_int,
     )
     url = reverse("v1:youthapplication-fetch-employee-data")
     log_entry_count_before = LogEntry.objects.count()
@@ -1368,7 +1378,7 @@ def test_youth_application_fetch_employee_data_success_writes_audit_log(user_cli
         data={
             "employer_summer_voucher_id": str(employer_summer_voucher.id),
             "employee_name": "Peter Doe",
-            "summer_voucher_serial_number": 123,
+            "summer_voucher_serial_number": user_input_serial_number,
         },
     )
     assert LogEntry.objects.count() == log_entry_count_before + 1
@@ -1387,7 +1397,7 @@ def test_youth_application_fetch_employee_data_success_writes_audit_log(user_cli
         "parameters": {
             "employer_summer_voucher_id": str(employer_summer_voucher.id),
             "employee_name": "Peter Doe",
-            "summer_voucher_serial_number": 123,
+            "summer_voucher_serial_number": str(user_input_serial_number),
         },
     }
 
@@ -1424,7 +1434,7 @@ def test_youth_application_fetch_employee_data_not_found_writes_audit_log(user_c
         "parameters": {
             "employer_summer_voucher_id": str(employer_summer_voucher.id),
             "employee_name": "Teppo Testaaja",
-            "summer_voucher_serial_number": 123456789,
+            "summer_voucher_serial_number": "123456789",
         },
     }
 

--- a/backend/kesaseteli/applications/tests/test_serial_number_allocation.py
+++ b/backend/kesaseteli/applications/tests/test_serial_number_allocation.py
@@ -1,0 +1,75 @@
+from unittest.mock import patch
+
+import pytest
+
+from applications.models import YouthApplication, YouthSummerVoucher
+from common.tests.factories import (
+    AcceptableYouthApplicationFactory,
+    YouthSummerVoucherFactory,
+)
+
+
+@pytest.mark.django_db
+def test_create_youth_summer_voucher_normal_success():
+    """
+    Test that YouthSummerVoucher.create_youth_summer_voucher
+    succeeds 100 times in row without any serial number collisions.
+    """
+    for _i in range(100):
+        with patch.object(
+            YouthSummerVoucher,
+            "get_random_serial_number",
+            wraps=YouthSummerVoucher.get_random_serial_number,
+        ) as mock_get_random_serial_number:
+            assert (
+                AcceptableYouthApplicationFactory().create_youth_summer_voucher()
+                is not None
+            )
+            mock_get_random_serial_number.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_create_youth_summer_voucher_succeeds_after_9_collisions():
+    """
+    Test that YouthSummerVoucher.create_youth_summer_voucher succeeds if
+    a serial number collision happens 9 times in row, which is the maximum allowed
+    before raising an exception.
+    """
+    youth_application: YouthApplication = AcceptableYouthApplicationFactory()
+    existing_voucher = YouthSummerVoucherFactory(
+        summer_voucher_serial_number=YouthSummerVoucher.MIN_RAND_SERIAL_NUM + 123456
+    )
+    colliding_num = existing_voucher.summer_voucher_serial_number
+    free_num = colliding_num + 1
+
+    side_effects = [colliding_num] * 9 + [free_num]
+    with patch.object(
+        YouthSummerVoucher, "get_random_serial_number", side_effect=side_effects
+    ):
+        voucher = youth_application.create_youth_summer_voucher()
+
+    assert voucher.summer_voucher_serial_number == free_num
+
+
+@pytest.mark.django_db
+def test_create_youth_summer_voucher_fails_after_10_collisions():
+    """
+    Test that YouthSummerVoucher.create_youth_summer_voucher fails if
+    a serial number collision happens 10 times in row, which is minimum
+    amount of collisions that causes the method to raise an exception.
+    """
+    youth_application: YouthApplication = AcceptableYouthApplicationFactory()
+    existing_voucher = YouthSummerVoucherFactory(
+        summer_voucher_serial_number=YouthSummerVoucher.MIN_RAND_SERIAL_NUM + 123456
+    )
+    colliding_num = existing_voucher.summer_voucher_serial_number
+
+    side_effects = [colliding_num] * 10
+    with patch.object(
+        YouthSummerVoucher, "get_random_serial_number", side_effect=side_effects
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="Unable to allocate serial number for youth summer voucher",
+        ):
+            youth_application.create_youth_summer_voucher()

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -96,7 +96,7 @@ MANDATORY_YOUTH_SUMMER_VOUCHER_FIELDS_IN_VOUCHER_EMAIL = [
     "min_work_compensation_with_euro_sign",
     "min_work_hours",
     "summer_job_period_localized_string",
-    "summer_voucher_serial_number",
+    "user_showable_serial_number",
     "voucher_value_with_euro_sign",
     "year",
 ]
@@ -2233,11 +2233,6 @@ def test_youth_applications_accept_acceptable(
         )
         assert acceptable_youth_application.has_youth_summer_voucher
         assert YouthSummerVoucher.objects.count() == old_youth_summer_voucher_count + 1
-        assert YouthSummerVoucher.get_last_used_serial_number() is not None
-        assert (
-            acceptable_youth_application.youth_summer_voucher.summer_voucher_serial_number
-            == YouthSummerVoucher.get_last_used_serial_number()
-        )
         youth_voucher_audit_event, youth_app_audit_event = LogEntry.objects.all()[:2]
         # Created the youth summer voucher:
         assert youth_voucher_audit_event.action == LogEntry.Action.CREATE
@@ -2317,11 +2312,6 @@ def test_youth_applications_accept_acceptable__vtj_disabled(
     assert acceptable_youth_application.encrypted_handler_vtj_json is None
     assert acceptable_youth_application.has_youth_summer_voucher
     assert YouthSummerVoucher.objects.count() == old_youth_summer_voucher_count + 1
-    assert YouthSummerVoucher.get_last_used_serial_number() is not None
-    assert (
-        acceptable_youth_application.youth_summer_voucher.summer_voucher_serial_number
-        == YouthSummerVoucher.get_last_used_serial_number()
-    )
 
 
 @pytest.mark.django_db
@@ -2808,9 +2798,7 @@ def test_youth_application_fetch_employee_data_uses_fuzzy_match(
     employer_summer_voucher = EmployerSummerVoucherFactory(
         youth_summer_voucher__youth_application__last_name=last_name,
     )
-    serial_number = (
-        employer_summer_voucher.youth_summer_voucher.summer_voucher_serial_number
-    )
+    serial_number = employer_summer_voucher.summer_voucher_serial_number
     url = reverse("v1:youthapplication-fetch-employee-data")
     data = {
         "employer_summer_voucher_id": str(employer_summer_voucher.id),

--- a/backend/kesaseteli/kesaseteli/auditlog_settings.py
+++ b/backend/kesaseteli/kesaseteli/auditlog_settings.py
@@ -30,7 +30,6 @@ AUDITLOG_EXCLUDE_TRACKING_MODELS = (
     "applications.historicalyouthsummervoucher",  # to be removed completely
     "audit_log.auditlogentry",  # no double audit logging
     "contenttypes.contenttype",  # system model
-    "sequences.sequence",  # system model
     "sessions.session",  # auth model
 )
 

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -264,7 +264,6 @@ INSTALLED_APPS = [
     "mozilla_django_oidc",
     "django_extensions",
     "django_auth_adfs",
-    "sequences.apps.SequencesConfig",
     "auditlog",
     "auditlog_extra",
     # shared apps

--- a/backend/kesaseteli/requirements.in
+++ b/backend/kesaseteli/requirements.in
@@ -1,4 +1,5 @@
 -e file:../shared
+base32-lib@https://github.com/inveniosoftware/base32-lib/archive/254311bba7aaa7e5b9e0e364adfdb7c057e252d2.zip
 django-auditlog
 django-auditlog-extra@https://github.com/City-of-Helsinki/django-auditlog-extra/archive/24978fc884355e8d210016dac2e58b8c7d4b701a.zip
 django-auth-adfs
@@ -8,7 +9,6 @@ django-extensions
 django-filter
 django-localflavor
 django-searchable-encrypted-fields
-django-sequences
 django-storages[azure]
 django~=5.2
 djangorestframework

--- a/backend/kesaseteli/requirements.txt
+++ b/backend/kesaseteli/requirements.txt
@@ -18,6 +18,8 @@ azure-core==1.38.2
     #   django-storages
 azure-storage-blob==12.28.0
     # via django-storages
+base32-lib @ https://github.com/inveniosoftware/base32-lib/archive/254311bba7aaa7e5b9e0e364adfdb7c057e252d2.zip
+    # via -r requirements.in
 certifi==2026.1.4
     # via
     #   elasticsearch
@@ -51,7 +53,6 @@ django==5.2.14
     #   django-filter
     #   django-localflavor
     #   django-searchable-encrypted-fields
-    #   django-sequences
     #   django-storages
     #   djangorestframework
     #   djangosaml2
@@ -80,8 +81,6 @@ django-filter==25.2
 django-localflavor==5.0
     # via -r requirements.in
 django-searchable-encrypted-fields==0.2.1
-    # via -r requirements.in
-django-sequences==3.0
     # via -r requirements.in
 django-storages[azure]==1.14.6
     # via -r requirements.in


### PR DESCRIPTION
## Description :sparkles:

### Kesäseteli backend: Add use of randomly generated voucher serial numbers

Also remove `django-sequences` completely as now unused and unnecessary.

## Related

[YJDH-843](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-843)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-843]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ