### PR TITLE
HL-1781 | Use azure blob with SAS-token using custom storage

### DIFF
--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -122,9 +122,9 @@ env = environ.Env(
     ADFS_CONTROLLER_GROUP_UUIDS=(list, []),
     DEFAULT_FILE_STORAGE=(str, "django.core.files.storage.FileSystemStorage"),
     AZURE_ACCOUNT_NAME=(str, ""),
-    AZURE_ACCOUNT_KEY=(str, ""),
+    AZURE_BLOB_STORAGE_SAS_TOKEN=(str, ""),
     AZURE_CONTAINER=(str, ""),
-    AZURE_URL_EXPIRATION_SECS=(int, 900),
+    AZURE_URL_EXPIRATION_SECS=(int, None),
     MINIMUM_WORKING_HOURS_PER_WEEK=(int, 18),
     AUDIT_LOG_ORIGIN=(str, "helsinki-benefit-api"),
     AUDIT_LOG_ENV=(str, ""),
@@ -608,7 +608,7 @@ STORAGES = {
     },
 }
 AZURE_ACCOUNT_NAME = env("AZURE_ACCOUNT_NAME")
-AZURE_ACCOUNT_KEY = env("AZURE_ACCOUNT_KEY")
+AZURE_SAS_TOKEN = env("AZURE_BLOB_STORAGE_SAS_TOKEN")
 AZURE_CONTAINER = env("AZURE_CONTAINER")
 AZURE_URL_EXPIRATION_SECS = env(
     "AZURE_URL_EXPIRATION_SECS"

--- a/backend/benefit/helsinkibenefit/tests/test_storage.py
+++ b/backend/benefit/helsinkibenefit/tests/test_storage.py
@@ -1,0 +1,47 @@
+from unittest.mock import patch
+
+import pytest
+from storages.backends.azure_storage import AzureStorage
+
+from helsinkibenefit.utils.storage import AzureStorageWithoutQuerystringAuth
+
+SAS_URL = (
+    "https://myaccount.blob.core.windows.net/mycontainer/myfile.jpg"
+    "?sv=2021-06-08&se=2026-01-01T00%3A00%3A00Z&sr=b&sp=r&sig=FAKESIG"
+)
+CLEAN_URL = "https://myaccount.blob.core.windows.net/mycontainer/myfile.jpg"
+
+
+def _make_storage(model=AzureStorageWithoutQuerystringAuth, **overrides):
+    kwargs = dict(
+        account_name="myaccount",
+        sas_token="FAKESAS",
+        azure_container="mycontainer",
+        expiration_secs=3600,
+    )
+    kwargs.update(overrides)
+    return model(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "model, expected_url",
+    [
+        (AzureStorage, SAS_URL),
+        (AzureStorageWithoutQuerystringAuth, CLEAN_URL),
+    ],
+)
+@patch.object(AzureStorage, "url", return_value=SAS_URL)
+def test_url_querystring_auth(mock_url, model, expected_url):
+    storage = _make_storage(model=model)
+    result = storage.url("myfile.jpg")
+
+    assert result == expected_url
+
+
+@patch.object(AzureStorage, "url", return_value=SAS_URL)
+def test_url_querystring_auth_false_no_query_string_in_parent_url(mock_url):
+    storage = _make_storage()
+    result = storage.url("myfile.jpg")
+
+    assert result == CLEAN_URL
+    assert "?" not in result

--- a/backend/benefit/helsinkibenefit/utils/storage.py
+++ b/backend/benefit/helsinkibenefit/utils/storage.py
@@ -1,0 +1,15 @@
+from urllib.parse import urlparse, urlunparse
+
+from storages.backends.azure_storage import AzureStorage
+
+
+class AzureStorageWithoutQuerystringAuth(AzureStorage):
+    """
+    Extends AzureStorage to strip the SAS token from URLs, matching the
+    behaviour of the S3 and GCS backends in django-storages with querystring_auth=False.
+    """
+
+    def url(self, name, expire=None, parameters=None, mode="r"):
+        sas_url = super().url(name, expire=expire, parameters=parameters, mode=mode)
+        parsed_url = urlparse(sas_url)
+        return urlunparse(parsed_url._replace(query=""))


### PR DESCRIPTION
Using azure blob storage with django-storages the token is put in the return url. This adds custom storage class to handle that url is clear from the token (like is in aws and gc).


Refs: HL-1781