### PR TITLE
fix(benefit): apprenticeship cannot be changed

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/useApplicationFormStep2.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/useApplicationFormStep2.ts
@@ -185,11 +185,9 @@ const useApplicationFormStep2 = (
   const clearPaySubsidyValues = React.useCallback((): void => {
     void setFieldValue(fields.paySubsidyPercent.name, null);
     void setFieldValue(fields.additionalPaySubsidyPercent.name, null);
-    void setFieldValue(fields.apprenticeshipProgram.name, null);
   }, [
     fields.paySubsidyPercent.name,
     fields.additionalPaySubsidyPercent.name,
-    fields.apprenticeshipProgram.name,
     setFieldValue,
   ]);
 

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/useApplicationFormStep5.ts
@@ -5,7 +5,6 @@ import { useTranslation } from 'benefit/applicant/i18n';
 import { getApplicationStepString } from 'benefit/applicant/utils/common';
 import {
   APPLICATION_STATUSES,
-  PAY_SUBSIDY_GRANTED,
 } from 'benefit-shared/constants';
 import { Application, ApplicationData } from 'benefit-shared/types/application';
 import { useRouter } from 'next/router';
@@ -106,10 +105,7 @@ const useApplicationFormStep5 = (
       {
         ...application,
         ...submitFields,
-        apprenticeshipProgram:
-          application?.paySubsidyGranted === PAY_SUBSIDY_GRANTED.NOT_GRANTED
-            ? null
-            : application?.apprenticeshipProgram,
+        apprenticeshipProgram: application?.apprenticeshipProgram,
         trainingCompensations: application?.apprenticeshipProgram
           ? application?.trainingCompensations
           : [],

--- a/frontend/benefit/applicant/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/applicant/src/hooks/useFormActions.tsx
@@ -165,10 +165,7 @@ const useFormActions = (application: Partial<Application>): FormActions => {
       endDate: endDate
         ? convertToBackendDateFormat(parseDate(endDate))
         : undefined,
-      apprenticeshipProgram:
-        paySubsidyGranted !== PAY_SUBSIDY_GRANTED.NOT_GRANTED
-          ? apprenticeshipProgram
-          : null,
+      apprenticeshipProgram,
     };
 
     // Use context on first step, otherwise pass data from backend


### PR DESCRIPTION
## Description

Removed normalization functionalities for apprenticeship program to allow for editing
modifying the apprenticeship status when requested for additional information by
the handler.

## Motivation and context

Apprenticeship cannot be changed in the APPLICANT UI
if an application is set to be modified by the handler. 

[HL-1766](https://helsinkisolutionoffice.atlassian.net/browse/HL-1766)

## Testing

E2E testing requires using both HANDLER and APPLICANT, therefore tested by hand.

[HL-1766]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ