### PR TITLE
Hl 1801 add missing tol code

### DIFF
--- a/backend/benefit/companies/api/v1/serializers.py
+++ b/backend/benefit/companies/api/v1/serializers.py
@@ -19,6 +19,8 @@ class CompanySerializer(serializers.ModelSerializer):
             "city",
             "bank_account_number",
             "organization_type",
+            "industry",
+            "industry_code",
         ]
 
     organization_type = serializers.SerializerMethodField(
@@ -34,3 +36,14 @@ class CompanySerializer(serializers.ModelSerializer):
 class CompanySearchSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=200)
     business_id = serializers.CharField(max_length=20)
+
+
+class UpdateCompanyIndustryCodeSerializer(serializers.Serializer):
+    industry_code = serializers.CharField(max_length=10)
+    industry = serializers.CharField(max_length=255, allow_blank=True, default="")
+
+    def update(self, instance, validated_data):
+        instance.industry_code = validated_data["industry_code"]
+        instance.industry = validated_data["industry"]
+        instance.save(update_fields=["industry_code", "industry"])
+        return instance

--- a/backend/benefit/companies/api/v1/views.py
+++ b/backend/benefit/companies/api/v1/views.py
@@ -13,8 +13,12 @@ from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
 from stdnum.fi import ytunnus
 
-from common.permissions import BFIsAuthenticated, TermsOfServiceAccepted
-from companies.api.v1.serializers import CompanySearchSerializer, CompanySerializer
+from common.permissions import BFIsAuthenticated, BFIsHandler, TermsOfServiceAccepted
+from companies.api.v1.serializers import (
+    CompanySearchSerializer,
+    CompanySerializer,
+    UpdateCompanyIndustryCodeSerializer,
+)
 from companies.models import Company
 from companies.services import (
     get_or_create_organisation_with_business_id,
@@ -118,6 +122,25 @@ class GetUsersOrganizationView(APIView):
         company_data = CompanySerializer(company).data
 
         return Response(company_data)
+
+
+class UpdateCompanyIndustryCodeView(APIView):
+    """Handler-only endpoint to set the industry (TOL) code on a company."""
+
+    permission_classes = [BFIsHandler]
+
+    @transaction.atomic
+    def patch(self, request: HttpRequest, id: str) -> Response:
+        try:
+            company = Company.objects.get(pk=id)
+        except (Company.DoesNotExist, ValueError):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = UpdateCompanyIndustryCodeSerializer(company, data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        serializer.save()
+        return Response(CompanySerializer(company).data)
 
 
 class SearchOrganisationsView(APIView):

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -286,6 +286,30 @@ def test_update_industry_code_non_handler_forbidden(api_client):
     assert response.status_code == 403
 
 
+@pytest.mark.django_db
+def test_update_industry_code_too_long(handler_api_client):
+    from companies.tests.factories import CompanyFactory
+
+    company = CompanyFactory()
+    url = get_industry_code_url(company.pk)
+    response = handler_api_client.patch(url, {"industry_code": "X" * 11}, format="json")
+    assert response.status_code == 400
+    assert "industry_code" in response.data
+
+
+@pytest.mark.django_db
+def test_update_industry_too_long(handler_api_client):
+    from companies.tests.factories import CompanyFactory
+
+    company = CompanyFactory()
+    url = get_industry_code_url(company.pk)
+    response = handler_api_client.patch(
+        url, {"industry_code": "62010", "industry": "A" * 256}, format="json"
+    )
+    assert response.status_code == 400
+    assert "industry" in response.data
+
+
 # ── SearchOrganisationsView ────────────────────────────────────────────────────
 
 

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -1,5 +1,6 @@
 import re
 from copy import deepcopy
+from unittest.mock import patch
 
 import pytest
 from django.conf import settings
@@ -219,3 +220,129 @@ def test_get_company_from_service_bus_and_yrtti_with_fallback_data(
         == YtjOrganizationCode.COMPANY_FORM_CODE_DEFAULT
     )
     assert response.data["company_form"] == "Osakeyhtiö"
+
+
+# ── UpdateCompanyIndustryCodeView ──────────────────────────────────────────────
+
+
+def get_industry_code_url(company_id):
+    return f"/v1/company/{company_id}/industry_code/"
+
+
+@pytest.mark.django_db
+def test_update_industry_code_success(handler_api_client):
+    from companies.tests.factories import CompanyFactory
+
+    company = CompanyFactory()
+    url = get_industry_code_url(company.pk)
+    response = handler_api_client.patch(
+        url,
+        {"industry_code": "62010", "industry": "Computer programming"},
+        format="json",
+    )
+    assert response.status_code == 200
+    company.refresh_from_db()
+    assert company.industry_code == "62010"
+    assert company.industry == "Computer programming"
+
+
+@pytest.mark.django_db
+def test_update_industry_code_missing_field(handler_api_client):
+    from companies.tests.factories import CompanyFactory
+
+    company = CompanyFactory()
+    url = get_industry_code_url(company.pk)
+    response = handler_api_client.patch(url, {"industry_code": ""}, format="json")
+    assert response.status_code == 400
+    assert "industry_code" in response.data
+
+
+@pytest.mark.django_db
+def test_update_industry_code_company_not_found(handler_api_client):
+    import uuid
+
+    url = get_industry_code_url(uuid.uuid4())
+    response = handler_api_client.patch(url, {"industry_code": "62010"}, format="json")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_update_industry_code_unauthenticated(anonymous_client):
+    from companies.tests.factories import CompanyFactory
+
+    company = CompanyFactory()
+    url = get_industry_code_url(company.pk)
+    response = anonymous_client.patch(url, {"industry_code": "62010"}, format="json")
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_update_industry_code_non_handler_forbidden(api_client):
+    from companies.tests.factories import CompanyFactory
+
+    company = CompanyFactory()
+    url = get_industry_code_url(company.pk)
+    response = api_client.patch(url, {"industry_code": "62010"}, format="json")
+    assert response.status_code == 403
+
+
+# ── SearchOrganisationsView ────────────────────────────────────────────────────
+
+
+def get_search_url(name):
+    return f"/v1/company/search/{name}/"
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=True)
+def test_search_organisations_mock(api_client):
+    response = api_client.get(get_search_url("test"))
+    assert response.status_code == 200
+    assert isinstance(response.data, list)
+
+
+@pytest.mark.django_db
+def test_search_organisations_live(api_client):
+    mock_results = [
+        {"name": "Acme Oy", "business_id": "1234567-8"},
+        {"name": "Beta Oy", "business_id": "8765432-1"},
+    ]
+    with patch("companies.services.ServiceBusClient") as mock_sb_cls:
+        mock_sb_cls.return_value.search_companies.return_value = mock_results
+        with patch("companies.services.YRTTIClient") as mock_yrtti_cls:
+            mock_yrtti_cls.return_value.search_associations.return_value = []
+            response = api_client.get(get_search_url("Acme"))
+    assert response.status_code == 200
+    assert len(response.data) == 2
+    business_ids = {item["business_id"] for item in response.data}
+    assert "1234567-8" in business_ids
+
+
+# ── GetOrganisationByIdView ────────────────────────────────────────────────────
+
+
+def get_organisation_by_id_url(business_id):
+    return f"/v1/company/get/{business_id}/"
+
+
+@pytest.mark.django_db
+def test_get_organisation_by_id_invalid_business_id(api_client):
+    response = api_client.get(get_organisation_by_id_url("invalid-id"))
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_get_organisation_by_id_valid(api_client):
+    from companies.tests.factories import CompanyFactory
+
+    business_id = DUMMY_SERVICE_BUS_RESPONSE["GetCompanyResult"]["Company"][
+        "BusinessId"
+    ]
+    company = CompanyFactory(business_id=business_id)
+    with patch(
+        "companies.api.v1.views.get_or_create_organisation_with_business_id",
+        return_value=company,
+    ):
+        response = api_client.get(get_organisation_by_id_url(business_id))
+    assert response.status_code == 200
+    assert response.data["business_id"] == business_id

--- a/backend/benefit/helsinkibenefit/urls.py
+++ b/backend/benefit/helsinkibenefit/urls.py
@@ -39,6 +39,7 @@ from companies.api.v1.views import (
     GetOrganisationByIdView,
     GetUsersOrganizationView,
     SearchOrganisationsView,
+    UpdateCompanyIndustryCodeView,
 )
 from messages.views import (
     ApplicantMessageViewSet,
@@ -160,6 +161,7 @@ urlpatterns = [
     path("v1/company/", GetUsersOrganizationView.as_view()),
     path("v1/company/search/<str:name>/", SearchOrganisationsView.as_view()),
     path("v1/company/get/<str:business_id>/", GetOrganisationByIdView.as_view()),
+    path("v1/company/<str:id>/industry_code/", UpdateCompanyIndustryCodeView.as_view()),
     path("v1/users/me/", CurrentUserView.as_view(), name="users-me"),
     path("v1/users/options/", UserOptionsView.as_view()),
     path(

--- a/frontend/benefit/handler/browser-tests/pages/1-new-application.testcafe.ts
+++ b/frontend/benefit/handler/browser-tests/pages/1-new-application.testcafe.ts
@@ -109,7 +109,9 @@ test('Fill form and submit', async (t: TestController) => {
    * Click through all applicant terms.
    * Assume terms are loaded from fixture default_terms.json using LOAD_DEFAULT_TERMS=1
    */
-  await t.click(Selector('[name="application_consent_0"]'));
+  const firstConsent = Selector('[name="application_consent_0"]');
+  await t.expect(firstConsent.exists).ok({ timeout: 10000 });
+  await t.click(firstConsent);
   await t.click(Selector('[name="application_consent_1"]'));
   await t.click(Selector('[name="application_consent_2"]'));
   await t.click(Selector('[name="application_consent_3"]'));

--- a/frontend/benefit/handler/browser-tests/pages/5-ahjo-process.testcafe.ts
+++ b/frontend/benefit/handler/browser-tests/pages/5-ahjo-process.testcafe.ts
@@ -80,15 +80,16 @@ test('Open form and create a decision proposal', async (t: TestController) => {
   await t.expect(handleButton.visible).ok();
 
   await t.click(Selector('label').withText(fi.review.fields.support));
+  await t.click(
+    Selector('label').withText(fi.review.actions.grantedAsDeminimisAidNo)
+  );
   await t.click(handleButton);
 
   const firstSignerRadio = Selector('[id^="radio-signer-"]')
     .filterVisible()
     .nth(0);
   await t.expect(firstSignerRadio.exists).ok();
-  const firstSignerRadioId = await firstSignerRadio.getAttribute(
-    'id'
-  );
+  const firstSignerRadioId = await firstSignerRadio.getAttribute('id');
   await t.click(Selector(`label[for="${firstSignerRadioId}"]`));
   await t.expect(firstSignerRadio.checked).ok();
 

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1113,6 +1113,7 @@
       "grantedAsDeminimisText": "De minimis",
       "confirm": "Vahvista toimenpide",
       "grantedAsDeminimisAid": "Helsinki-lisä myönnetään de minimis-tukena",
+      "grantedAsDeminimisAidNo": "Helsinki-lisä ei ole hakijalle de minimis-tukea",
       "accepting": "Olet siirtämässä hakemuksen päätösjonoon, jossa sille tehdään myönteinen päätös",
       "rejecting": "Olet siirtämässä hakemuksen päätösjonoon, jossa sille tehdään kielteinen päätös",
       "accept": "Tee myönteinen päätösehdotus",
@@ -1187,7 +1188,10 @@
         "granted": "Palkkatuki",
         "grantedAged": "55-vuotta täyttäneiden työllistämistuki",
         "notGranted": "Työsuhteeseen ei ole myönnetty mitään edeltävää tukea"
-      }
+      },
+      "industryCode": "TOL-koodi (toimialaluokitus)",
+      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
+      "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa"
     },
     "notifications": {
       "editEndDate": "Hakemus avattu muokattavaksi ja lukittuu {{date}}",
@@ -1256,7 +1260,9 @@
           "decisionMakerId": "Päättäjän rooli puuttuu",
           "decisionText": "Päätös ei voi olla tyhjä",
           "signerId": "Allekirjoittaja puuttuu",
-          "justificationText": "Päätöksen perustelu ei voi olla tyhjä"
+          "justificationText": "Päätöksen perustelu ei voi olla tyhjä",
+          "industryCode": "TOL-koodi on pakollinen de minimis -tuessa",
+          "deMinimis": "De minimis -valinta on pakollinen"
         }
       },
       "list": {
@@ -1274,6 +1280,9 @@
         "employeeName": "Työllistettävä",
         "totalAmount": "Myönnettävä tuki yhteensä",
         "grantedAsDeMinimisAid": "Myönnetään de minimis -tukena",
+        "industryCode": "TOL-koodi (toimialaluokitus)",
+        "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
+        "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa",
         "decisionMaker": "Päättäjän rooli"
       },
       "calculationReview": {

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1190,7 +1190,7 @@
         "notGranted": "Työsuhteeseen ei ole myönnetty mitään edeltävää tukea"
       },
       "industryCode": "TOL-koodi (toimialaluokitus)",
-      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
+      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa. Voit kopiodia YTJ:n sivulta koko kohdan Päätoimiala (koodi + selite)",
       "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa"
     },
     "notifications": {
@@ -1281,8 +1281,6 @@
         "totalAmount": "Myönnettävä tuki yhteensä",
         "grantedAsDeMinimisAid": "Myönnetään de minimis -tukena",
         "industryCode": "TOL-koodi (toimialaluokitus)",
-        "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
-        "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa",
         "decisionMaker": "Päättäjän rooli"
       },
       "calculationReview": {

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1190,7 +1190,7 @@
         "notGranted": "Työsuhteeseen ei ole myönnetty mitään edeltävää tukea"
       },
       "industryCode": "TOL-koodi (toimialaluokitus)",
-      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa. Voit kopiodia YTJ:n sivulta koko kohdan Päätoimiala (koodi + selite)",
+      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa. Voit kopioida YTJ:n sivulta koko kohdan Päätoimiala (koodi + selite)",
       "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa"
     },
     "notifications": {

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1263,6 +1263,10 @@
           "justificationText": "Päätöksen perustelu ei voi olla tyhjä",
           "industryCode": "TOL-koodi on pakollinen de minimis -tuessa",
           "deMinimis": "De minimis -valinta on pakollinen"
+        },
+        "industryCodeUpdateFailed": {
+          "label": "TOL-koodin tallennus epäonnistui",
+          "text": "Tarkista TOL-koodi ja yritä uudelleen."
         }
       },
       "list": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1113,6 +1113,7 @@
       "grantedAsDeminimisText": "De minimis",
       "confirm": "Vahvista toimenpide",
       "grantedAsDeminimisAid": "Helsinki-lisä myönnetään de minimis-tukena",
+      "grantedAsDeminimisAidNo": "Helsinki-lisä ei ole hakijalle de minimis-tukea",
       "accepting": "Olet siirtämässä hakemuksen päätösjonoon, jossa sille tehdään myönteinen päätös",
       "rejecting": "Olet siirtämässä hakemuksen päätösjonoon, jossa sille tehdään kielteinen päätös",
       "accept": "Tee myönteinen päätösehdotus",
@@ -1187,7 +1188,10 @@
         "granted": "Palkkatuki",
         "grantedAged": "55-vuotta täyttäneiden työllistämistuki",
         "notGranted": "Työsuhteeseen ei ole myönnetty mitään edeltävää tukea"
-      }
+      },
+      "industryCode": "TOL-koodi (toimialaluokitus)",
+      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
+      "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa"
     },
     "notifications": {
       "editEndDate": "Hakemus avattu muokattavaksi ja lukittuu {{date}}",
@@ -1256,7 +1260,9 @@
           "decisionMakerId": "Päättäjän rooli puuttuu",
           "decisionText": "Päätös ei voi olla tyhjä",
           "signerId": "Allekirjoittaja puuttuu",
-          "justificationText": "Päätöksen perustelu ei voi olla tyhjä"
+          "justificationText": "Päätöksen perustelu ei voi olla tyhjä",
+          "industryCode": "TOL-koodi on pakollinen de minimis -tuessa",
+          "deMinimis": "De minimis -valinta on pakollinen"
         }
       },
       "list": {
@@ -1274,6 +1280,9 @@
         "employeeName": "Työllistettävä",
         "totalAmount": "Myönnettävä tuki yhteensä",
         "grantedAsDeMinimisAid": "Myönnetään de minimis -tukena",
+        "industryCode": "TOL-koodi (toimialaluokitus)",
+        "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
+        "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa",
         "decisionMaker": "Päättäjän rooli"
       },
       "calculationReview": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1190,7 +1190,7 @@
         "notGranted": "Työsuhteeseen ei ole myönnetty mitään edeltävää tukea"
       },
       "industryCode": "TOL-koodi (toimialaluokitus)",
-      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
+      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa. Voit kopiodia YTJ:n sivulta koko kohdan Päätoimiala (koodi + selite)",
       "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa"
     },
     "notifications": {
@@ -1281,8 +1281,6 @@
         "totalAmount": "Myönnettävä tuki yhteensä",
         "grantedAsDeMinimisAid": "Myönnetään de minimis -tukena",
         "industryCode": "TOL-koodi (toimialaluokitus)",
-        "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
-        "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa",
         "decisionMaker": "Päättäjän rooli"
       },
       "calculationReview": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1190,7 +1190,7 @@
         "notGranted": "Työsuhteeseen ei ole myönnetty mitään edeltävää tukea"
       },
       "industryCode": "TOL-koodi (toimialaluokitus)",
-      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa. Voit kopiodia YTJ:n sivulta koko kohdan Päätoimiala (koodi + selite)",
+      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa. Voit kopioida YTJ:n sivulta koko kohdan Päätoimiala (koodi + selite)",
       "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa"
     },
     "notifications": {

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1263,6 +1263,10 @@
           "justificationText": "Päätöksen perustelu ei voi olla tyhjä",
           "industryCode": "TOL-koodi on pakollinen de minimis -tuessa",
           "deMinimis": "De minimis -valinta on pakollinen"
+        },
+        "industryCodeUpdateFailed": {
+          "label": "TOL-koodin tallennus epäonnistui",
+          "text": "Tarkista TOL-koodi ja yritä uudelleen."
         }
       },
       "list": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1113,6 +1113,7 @@
       "grantedAsDeminimisText": "De minimis",
       "confirm": "Vahvista toimenpide",
       "grantedAsDeminimisAid": "Helsinki-lisä myönnetään de minimis-tukena",
+      "grantedAsDeminimisAidNo": "Helsinki-lisä ei ole hakijalle de minimis-tukea",
       "accepting": "Olet siirtämässä hakemuksen päätösjonoon, jossa sille tehdään myönteinen päätös",
       "rejecting": "Olet siirtämässä hakemuksen päätösjonoon, jossa sille tehdään kielteinen päätös",
       "accept": "Tee myönteinen päätösehdotus",
@@ -1187,7 +1188,10 @@
         "granted": "Palkkatuki",
         "grantedAged": "55-vuotta täyttäneiden työllistämistuki",
         "notGranted": "Työsuhteeseen ei ole myönnetty mitään edeltävää tukea"
-      }
+      },
+      "industryCode": "TOL-koodi (toimialaluokitus)",
+      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
+      "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa"
     },
     "notifications": {
       "editEndDate": "Hakemus avattu muokattavaksi ja lukittuu {{date}}",
@@ -1256,7 +1260,9 @@
           "decisionMakerId": "Päättäjän rooli puuttuu",
           "decisionText": "Päätös ei voi olla tyhjä",
           "signerId": "Allekirjoittaja puuttuu",
-          "justificationText": "Päätöksen perustelu ei voi olla tyhjä"
+          "justificationText": "Päätöksen perustelu ei voi olla tyhjä",
+          "industryCode": "TOL-koodi on pakollinen de minimis -tuessa",
+          "deMinimis": "De minimis -valinta on pakollinen"
         }
       },
       "list": {
@@ -1274,6 +1280,9 @@
         "employeeName": "Työllistettävä",
         "totalAmount": "Myönnettävä tuki yhteensä",
         "grantedAsDeMinimisAid": "Myönnetään de minimis -tukena",
+        "industryCode": "TOL-koodi (toimialaluokitus)",
+        "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
+        "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa",
         "decisionMaker": "Päättäjän rooli"
       },
       "calculationReview": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1190,7 +1190,7 @@
         "notGranted": "Työsuhteeseen ei ole myönnetty mitään edeltävää tukea"
       },
       "industryCode": "TOL-koodi (toimialaluokitus)",
-      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
+      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa. Voit kopiodia YTJ:n sivulta koko kohdan Päätoimiala (koodi + selite)",
       "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa"
     },
     "notifications": {
@@ -1281,8 +1281,6 @@
         "totalAmount": "Myönnettävä tuki yhteensä",
         "grantedAsDeMinimisAid": "Myönnetään de minimis -tukena",
         "industryCode": "TOL-koodi (toimialaluokitus)",
-        "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa",
-        "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa",
         "decisionMaker": "Päättäjän rooli"
       },
       "calculationReview": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1190,7 +1190,7 @@
         "notGranted": "Työsuhteeseen ei ole myönnetty mitään edeltävää tukea"
       },
       "industryCode": "TOL-koodi (toimialaluokitus)",
-      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa. Voit kopiodia YTJ:n sivulta koko kohdan Päätoimiala (koodi + selite)",
+      "industryCodeHelper": "Pakollinen yhdistyksen de minimis -tuessa. Voit kopioida YTJ:n sivulta koko kohdan Päätoimiala (koodi + selite)",
       "industryCodeRequired": "TOL-koodi on pakollinen de minimis -tuessa"
     },
     "notifications": {

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1263,6 +1263,10 @@
           "justificationText": "Päätöksen perustelu ei voi olla tyhjä",
           "industryCode": "TOL-koodi on pakollinen de minimis -tuessa",
           "deMinimis": "De minimis -valinta on pakollinen"
+        },
+        "industryCodeUpdateFailed": {
+          "label": "TOL-koodin tallennus epäonnistui",
+          "text": "Tarkista TOL-koodi ja yritä uudelleen."
         }
       },
       "list": {

--- a/frontend/benefit/handler/src/components/applicationReview/CalculationReview.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/CalculationReview.tsx
@@ -107,6 +107,19 @@ const CalculationReview: React.FC<ApplicationReviewStepProps> = ({
                     : t('common:utility.no')}
                 </dd>
               </div>
+              {decisionProposalDraft.grantedAsDeMinimisAid &&
+                (handledApplication?.industryCode ||
+                  company?.industryCode) && (
+                  <div>
+                    <dt>
+                      {t('common:review.decisionProposal.list.industryCode')}
+                    </dt>
+                    <dd>
+                      {handledApplication?.industryCode ||
+                        company?.industryCode}
+                    </dd>
+                  </div>
+                )}
             </>
           )}
           <div style={{ maxWidth: '220px', minWidth: '220px' }}>

--- a/frontend/benefit/handler/src/components/applicationReview/__tests__/CalculationReview.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/__tests__/CalculationReview.test.tsx
@@ -1,0 +1,123 @@
+import { screen } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import AppContext, { AppContextType } from 'benefit/handler/context/AppContext';
+import { HandledAplication } from 'benefit/handler/types/application';
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
+import { Application } from 'benefit-shared/types/application';
+import { axe } from 'jest-axe';
+import noop from 'lodash/noop';
+import React from 'react';
+import theme from 'shared/styles/theme';
+
+import CalculationReview from '../CalculationReview';
+
+const defaultAppContextValue: AppContextType = {
+  isNavigationVisible: false,
+  isFooterVisible: true,
+  isSidebarVisible: false,
+  layoutBackgroundColor: theme.colors.white,
+  handledApplication: null,
+  setIsNavigationVisible: noop,
+  setIsFooterVisible: noop,
+  setLayoutBackgroundColor: noop,
+  setHandledApplication: noop,
+  setIsSidebarVisible: noop,
+};
+
+const buildApplication = (overrides: Partial<Application> = {}): Application =>
+  ({
+    company: { name: 'Test Oy', businessId: '1234567-1' },
+    employee: { firstName: 'Maija', lastName: 'Meikäläinen' },
+    calculation: { rows: [] },
+    decisionProposalDraft: {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+    },
+    ...overrides,
+  } as unknown as Application);
+
+const getComponent = (
+  application: Application,
+  handledApplication: HandledAplication | null
+): ReturnType<typeof renderComponent>['renderResult'] =>
+  renderComponent(
+    <AppContext.Provider
+      value={{ ...defaultAppContextValue, handledApplication }}
+    >
+      <CalculationReview application={application} />
+    </AppContext.Provider>
+  ).renderResult;
+
+describe('CalculationReview', () => {
+  it('should render with no accessibility violations', async () => {
+    const application = buildApplication();
+    const { container } = getComponent(application, null);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should return null when decisionProposalDraft is missing', () => {
+    const application = buildApplication({ decisionProposalDraft: undefined });
+    const { container } = getComponent(application, null);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should show industryCode row when grantedAsDeMinimisAid is true and handledApplication has industryCode', () => {
+    const application = buildApplication();
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+      industryCode: '62010',
+    };
+    getComponent(application, handledApplication);
+    expect(screen.getByText('62010')).toBeInTheDocument();
+  });
+
+  it('should show industryCode from company when handledApplication has none', () => {
+    const application = buildApplication({
+      company: {
+        name: 'Test Oy',
+        businessId: '1234567-1',
+        industryCode: '47111',
+      } as Application['company'],
+    });
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+    };
+    getComponent(application, handledApplication);
+    expect(screen.getByText('47111')).toBeInTheDocument();
+  });
+
+  it('should NOT show industryCode row when grantedAsDeMinimisAid is false', () => {
+    const application = buildApplication({
+      decisionProposalDraft: {
+        status: APPLICATION_STATUSES.ACCEPTED,
+        grantedAsDeMinimisAid: false,
+      },
+    });
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: false,
+      industryCode: '62010',
+    };
+    getComponent(application, handledApplication);
+    // industryCode row should not appear when grantedAsDeMinimisAid is false
+    expect(screen.queryByText('62010')).not.toBeInTheDocument();
+  });
+
+  it('should show REJECTED text when status is REJECTED', () => {
+    const application = buildApplication({
+      decisionProposalDraft: {
+        status: APPLICATION_STATUSES.REJECTED,
+        grantedAsDeMinimisAid: false,
+      },
+    });
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.REJECTED,
+    };
+    getComponent(application, handledApplication);
+    // employee name shows in rejected view
+    expect(screen.getByText('Maija Meikäläinen')).toBeInTheDocument();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActionsAhjo.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActionsAhjo.tsx
@@ -8,6 +8,7 @@ import {
 } from 'benefit/handler/hooks/applicationHandling/useHandlingStepper';
 import { useRouterNavigation } from 'benefit/handler/hooks/applicationHandling/useRouterNavigation';
 import useCloneApplicationMutation from 'benefit/handler/hooks/useCloneApplicationMutation';
+import useUpdateCompanyIndustryCode from 'benefit/handler/hooks/useUpdateCompanyIndustryCode';
 import { Application as HandlerApplication } from 'benefit/handler/types/application';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { Application } from 'benefit-shared/types/application';
@@ -74,6 +75,7 @@ const HandlingApplicationActions: React.FC<Props> = ({
     isConfirmationModalOpen,
     isDoneConfirmationModalOpen,
     handledApplication,
+    setHandledApplication,
     onDoneConfirmation,
   } = useHandlingApplicationActions(application);
 
@@ -93,6 +95,28 @@ const HandlingApplicationActions: React.FC<Props> = ({
   } = useDecisionProposalDraftMutation(application as HandlerApplication);
 
   const [isSavingAndClosing, setIsSavingAndClosing] = React.useState(false);
+  const updateCompanyIndustryCode = useUpdateCompanyIndustryCode();
+
+  const saveIndustryCodeIfNeeded = React.useCallback((): void => {
+    if (
+      stepState.activeStepIndex === 0 &&
+      handledApplication?.grantedAsDeMinimisAid &&
+      handledApplication?.industryCode &&
+      application.company?.id &&
+      !application.company?.industryCode
+    ) {
+      updateCompanyIndustryCode.mutate({
+        companyId: application.company.id,
+        industryCode: handledApplication.industryCode,
+        industry: handledApplication.industryDescription,
+      });
+    }
+  }, [
+    stepState.activeStepIndex,
+    handledApplication,
+    application.company,
+    updateCompanyIndustryCode,
+  ]);
 
   // TODO: This callback is currently unused (dead code). Remove it once
   // index-navigation-on-save behavior is confirmed unnecessary.
@@ -174,6 +198,13 @@ const HandlingApplicationActions: React.FC<Props> = ({
       logEntry:
         (handledApplication?.logEntryComment?.length ?? 0) <= 0 &&
         handledApplication?.status === APPLICATION_STATUSES.REJECTED,
+      deMinimis:
+        handledApplication?.status === APPLICATION_STATUSES.ACCEPTED &&
+        handledApplication?.grantedAsDeMinimisAid === undefined,
+      industryCode:
+        handledApplication?.grantedAsDeMinimisAid === true &&
+        !handledApplication?.industryCode &&
+        !application.company?.industryCode,
       decisionMakerId:
         !handledApplication?.decisionMakerId ||
         handledApplication?.decisionMakerId?.length <= 0,
@@ -192,6 +223,8 @@ const HandlingApplicationActions: React.FC<Props> = ({
       status: '#proccessRejectedRadio',
       calculation: '#endDate',
       logEntry: '#proccessRejectedRadio',
+      deMinimis: '#deminimisYes',
+      industryCode: '#industryCodeInput',
       decisionMakerId: '#radio-decision-maker-0',
       decisionText: '[data-testid="decisionText"]',
       signerId: '[data-testid="decisionText"]',
@@ -237,10 +270,16 @@ const HandlingApplicationActions: React.FC<Props> = ({
     }
 
     const fields = getValidationFields();
+    if (fields.missing.industryCode) {
+      setHandledApplication({ ...handledApplication, industryCodeTouched: true });
+    }
+
     const errorStep1 =
       fields.missing.status ||
       fields.missing.calculation ||
-      fields.missing.logEntry;
+      fields.missing.logEntry ||
+      fields.missing.deMinimis ||
+      fields.missing.industryCode;
 
     let errorStep2 = false;
     if (currentStepIndex > 0) {
@@ -273,6 +312,7 @@ const HandlingApplicationActions: React.FC<Props> = ({
   };
 
   const handleNext = (finishProposal = false): void => {
+    saveIndustryCodeIfNeeded();
     if (finishProposal || stepState.activeStepIndex < 2) {
       updateApplication({
         ...handledApplication,
@@ -286,6 +326,7 @@ const HandlingApplicationActions: React.FC<Props> = ({
   };
 
   const handlePrev = (): void => {
+    saveIndustryCodeIfNeeded();
     updateApplication({
       ...handledApplication,
       reviewStep: Math.max(0, stepState.activeStepIndex),

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActionsAhjo.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActionsAhjo.tsx
@@ -271,7 +271,10 @@ const HandlingApplicationActions: React.FC<Props> = ({
 
     const fields = getValidationFields();
     if (fields.missing.industryCode) {
-      setHandledApplication({ ...handledApplication, industryCodeTouched: true });
+      setHandledApplication({
+        ...handledApplication,
+        industryCodeTouched: true,
+      });
     }
 
     const errorStep1 =

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/__tests__/HandlingApplicationActionsAhjo.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/__tests__/HandlingApplicationActionsAhjo.test.tsx
@@ -1,510 +1,335 @@
-import '@testing-library/jest-dom';
-
-import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { createAlterationApplication } from 'benefit/handler/__tests__/utils/alteration-fixtures';
+import { fireEvent, RenderResult, screen } from '@testing-library/react';
 import renderComponent from 'benefit/handler/__tests__/utils/render-component';
-import { setupUserAndRender } from 'benefit/handler/__tests__/utils/user-render-helper';
+import { useHandlingApplicationActions } from 'benefit/handler/components/applicationReview/actions/handlingApplicationActions/useHandlingApplicationActions';
+import AppContext, { AppContextType } from 'benefit/handler/context/AppContext';
 import useDecisionProposalDraftMutation from 'benefit/handler/hooks/applicationHandling/useDecisionProposalDraftMutation';
 import { useRouterNavigation } from 'benefit/handler/hooks/applicationHandling/useRouterNavigation';
 import useCloneApplicationMutation from 'benefit/handler/hooks/useCloneApplicationMutation';
+import useUpdateCompanyIndustryCode from 'benefit/handler/hooks/useUpdateCompanyIndustryCode';
+import { HandledAplication } from 'benefit/handler/types/application';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
-import { Calculation, Row } from 'benefit-shared/types/application';
-import i18n from 'i18next';
+import { Application } from 'benefit-shared/types/application';
+import noop from 'lodash/noop';
 import { useRouter } from 'next/router';
 import React from 'react';
-import showErrorToast from 'shared/components/toast/show-error-toast';
-import { focusAndScroll } from 'shared/utils/dom.utils';
+import theme from 'shared/styles/theme';
 
-import HandlingApplicationActionsAhjo from '../HandlingApplicationActionsAhjo';
-import { useHandlingApplicationActions } from '../useHandlingApplicationActions';
+import HandlingApplicationActionsAhjo, {
+  Props,
+} from '../HandlingApplicationActionsAhjo';
 
-jest.mock('benefit/handler/hooks/applicationHandling/useRouterNavigation');
 jest.mock(
-  'benefit/handler/hooks/applicationHandling/useDecisionProposalDraftMutation'
+  'benefit/handler/components/applicationReview/actions/handlingApplicationActions/useHandlingApplicationActions',
+  () => ({
+    useHandlingApplicationActions: jest.fn(),
+  })
 );
-jest.mock('benefit/handler/hooks/useCloneApplicationMutation');
-jest.mock('../useHandlingApplicationActions');
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(),
-}));
-jest.mock('shared/components/toast/show-error-toast');
+jest.mock(
+  'benefit/handler/hooks/applicationHandling/useRouterNavigation',
+  () => ({
+    useRouterNavigation: jest.fn(),
+  })
+);
+jest.mock(
+  'benefit/handler/hooks/applicationHandling/useDecisionProposalDraftMutation',
+  () => jest.fn()
+);
+jest.mock('benefit/handler/hooks/useCloneApplicationMutation', () => jest.fn());
+jest.mock('benefit/handler/hooks/useUpdateCompanyIndustryCode', () =>
+  jest.fn()
+);
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('shared/components/toast/show-error-toast', () => jest.fn());
+
+function MockEditAction(): JSX.Element {
+  return <span />;
+}
+function MockSidebar(): JSX.Element {
+  return <span />;
+}
+
+jest.mock(
+  'benefit/handler/components/applicationReview/actions/editAction/EditAction',
+  () => MockEditAction
+);
+jest.mock('benefit/handler/components/sidebar/Sidebar', () => MockSidebar);
 jest.mock('shared/utils/dom.utils', () => ({
   focusAndScroll: jest.fn(),
   focusAndScrollToSelector: jest.fn(),
 }));
 
-const ACTION_LABELS = {
-  close: 'Sulje',
-  saveAndClose: 'Tallenna ja sulje',
-  handlingPanel: 'Käsittelypaneeli',
-  cloneApplication: 'Kopioi hakemus',
-  cancelApplication: 'Peruuta hakemus',
-  previous: 'Edellinen',
-  next: 'Seuraava',
-  send: 'Lähetä',
-} as const;
-
-const t = i18n.t.bind(i18n);
-
-const getActionButton = (label: string): HTMLElement =>
-  screen.getByRole('button', { name: label });
-
-const queryActionButton = (label: string): HTMLElement | null =>
-  screen.queryByRole('button', { name: label });
-
-const getDialogs = (): HTMLElement[] => screen.getAllByRole('dialog');
-
-type HandlingActionsHookValue = ReturnType<
-  typeof useHandlingApplicationActions
->;
-
-type DraftPayload = {
-  reviewStep: number;
-  applicationId: string;
-};
-
-const mockNavigateBack = jest.fn();
-const mockUpdateApplication = jest.fn();
-const mockCloneApplication = jest.fn();
-const mockPush = jest.fn();
-const mockToggleMessagesDrawerVisibility = jest.fn();
-const mockOpenDialog = jest.fn();
-const mockOnDoneConfirmation = jest.fn();
-const originalSentryEnvironment = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT;
-
-const createHandlingApplication = (
-  overrides: Partial<ReturnType<typeof createAlterationApplication>> = {}
-): ReturnType<typeof createAlterationApplication> =>
-  createAlterationApplication({
-    status: APPLICATION_STATUSES.HANDLING,
-    calculation: { rows: [{ id: 'row-1' } as Row] } as Calculation,
-    archived: false,
-    ...overrides,
-  });
-
-const expectDraftMutationPayload = (
-  reviewStep: number,
-  applicationId: string
-): void => {
-  expect(mockUpdateApplication).toHaveBeenCalledWith(
-    expect.objectContaining<DraftPayload>({
-      reviewStep,
-      applicationId,
-    })
-  );
-};
-
-const mockCloneConfirmation = (isConfirmed: boolean): jest.SpyInstance =>
-  jest.spyOn(window, 'confirm').mockReturnValue(isConfirmed);
-
-const createHandledApplication = (overrides = {}): Record<string, unknown> => ({
-  status: APPLICATION_STATUSES.REJECTED,
-  logEntryComment: 'rejection reason',
-  decisionMakerId: 'decision-maker',
-  signerId: 'signer',
-  decisionText: 'Decision text is long enough',
-  justificationText: 'Justification text is long enough',
-  ...overrides,
-});
-
-const createHookMockValue = (
-  overrides: Partial<HandlingActionsHookValue> = {}
-): HandlingActionsHookValue =>
+const buildApplication = (overrides: Partial<Application> = {}): Application =>
   ({
-    t,
-    toggleMessagesDrawerVisibility: mockToggleMessagesDrawerVisibility,
-    openDialog: mockOpenDialog,
-    closeDialog: jest.fn(),
-    closeDoneDialog: jest.fn(),
-    handleCancel: jest.fn(),
-    isMessagesDrawerVisible: false,
-    translationsBase: 'common:review.actions',
-    isConfirmationModalOpen: false,
-    isDoneConfirmationModalOpen: false,
-    handledApplication: createHandledApplication() as never,
-    onDoneConfirmation: mockOnDoneConfirmation,
+    id: 'app-1',
+    status: APPLICATION_STATUSES.HANDLING,
+    startDate: '2026-01-01',
+    endDate: '2026-06-30',
+    company: {
+      id: 'company-1',
+      businessId: '1234567-1',
+      name: 'Test Oy',
+      industryCode: '',
+    },
+    calculation: { rows: [{ id: 'row-1' }] },
     ...overrides,
-  } as HandlingActionsHookValue);
+  } as unknown as Application);
 
-const createStepState = (
-  activeStepIndex = 0
-): { activeStepIndex: number; steps: Record<string, unknown>[] } => ({
-  activeStepIndex,
-  steps: [{}, {}, {}],
+const buildContextValue = (
+  handledApplication: HandledAplication | null = null,
+  setHandledApplication: (app: HandledAplication | null) => void = noop
+): AppContextType => ({
+  isNavigationVisible: false,
+  isFooterVisible: true,
+  isSidebarVisible: false,
+  layoutBackgroundColor: theme.colors.white,
+  handledApplication,
+  setIsNavigationVisible: noop,
+  setIsFooterVisible: noop,
+  setLayoutBackgroundColor: noop,
+  setHandledApplication,
+  setIsSidebarVisible: noop,
 });
 
-const createDefaultTestApplication = (): ReturnType<
-  typeof createHandlingApplication
-> => createHandlingApplication({ id: 'app-123' });
+// A fully valid handledApplication (all step 1 + step 2 fields valid)
+const validHandledApplication: HandledAplication = {
+  status: APPLICATION_STATUSES.ACCEPTED,
+  grantedAsDeMinimisAid: false,
+  decisionMakerId: 'dm-1',
+  signerId: 'signer-1',
+  decisionText: 'Decision text that is long enough',
+  justificationText: 'Justification text that is long enough',
+};
 
-const renderSubject = ({
-  application = createHandlingApplication(),
-  stepState = createStepState(0),
-  stepperDispatch = jest.fn(),
-  isRecalculationRequired = false,
-  isCalculationsErrors = false,
-  isApplicationReadOnly = false,
-}: {
-  application?: ReturnType<typeof createAlterationApplication>;
-  stepState?: ReturnType<typeof createStepState>;
-  stepperDispatch?: jest.Mock;
-  isRecalculationRequired?: boolean;
-  isCalculationsErrors?: boolean;
-  isApplicationReadOnly?: boolean;
-} = {}): ReturnType<typeof renderComponent> =>
-  renderComponent(
-    <HandlingApplicationActionsAhjo
-      application={application}
-      stepState={stepState as never}
-      stepperDispatch={stepperDispatch}
-      isRecalculationRequired={isRecalculationRequired}
-      isCalculationsErrors={isCalculationsErrors}
-      isApplicationReadOnly={isApplicationReadOnly}
-    />,
-    {
-      push: mockPush,
-      query: {},
-    }
-  );
+type MakeComponentOptions = {
+  props?: Partial<Props>;
+  handledApplication?: HandledAplication | null;
+  setHandledApplication?: (app: HandledAplication | null) => void;
+};
+
+const makeComponent = ({
+  props = {},
+  handledApplication = validHandledApplication,
+  setHandledApplication = noop,
+}: MakeComponentOptions = {}): RenderResult => {
+  const defaultStepState = {
+    activeStepIndex: 0,
+    steps: [1, 2, 3] as unknown as Props['stepState']['steps'],
+  };
+  const defaultProps: Props = {
+    application: buildApplication(),
+    stepperDispatch: jest.fn(),
+    stepState: defaultStepState,
+    isRecalculationRequired: false,
+    isCalculationsErrors: false,
+    isApplicationReadOnly: false,
+  };
+
+  return renderComponent(
+    <AppContext.Provider
+      value={buildContextValue(handledApplication, setHandledApplication)}
+    >
+      <HandlingApplicationActionsAhjo {...defaultProps} {...props} />
+    </AppContext.Provider>
+  ).renderResult;
+};
 
 describe('HandlingApplicationActionsAhjo', () => {
+  const mockMutate = jest.fn();
+  const mockNavigateBack = jest.fn();
+  const mockOnDoneConfirmation = jest.fn();
+
+  const setupHookMocks = (
+    handledApplication: HandledAplication = validHandledApplication
+  ): void => {
+    (useHandlingApplicationActions as jest.Mock).mockReturnValue({
+      t: (key: string): string => key,
+      toggleMessagesDrawerVisibility: jest.fn(),
+      openDialog: jest.fn(),
+      closeDialog: jest.fn(),
+      closeDoneDialog: jest.fn(),
+      handleCancel: jest.fn(),
+      isMessagesDrawerVisible: false,
+      translationsBase: 'common:review.actions',
+      isConfirmationModalOpen: false,
+      isDoneConfirmationModalOpen: false,
+      handledApplication,
+      setHandledApplication: noop,
+      onDoneConfirmation: mockOnDoneConfirmation,
+    });
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT = 'development';
 
-    (useHandlingApplicationActions as jest.Mock).mockReturnValue(
-      createHookMockValue()
-    );
+    setupHookMocks();
+
     (useRouterNavigation as jest.Mock).mockReturnValue({
       navigateBack: mockNavigateBack,
     });
     (useDecisionProposalDraftMutation as jest.Mock).mockReturnValue({
+      mutate: mockMutate,
       data: null,
-      mutate: mockUpdateApplication,
       isError: false,
     });
     (useCloneApplicationMutation as jest.Mock).mockReturnValue({
+      mutate: jest.fn(),
       data: null,
-      mutate: mockCloneApplication,
     });
-    (useRouter as jest.Mock).mockReturnValue({
-      push: mockPush,
-      query: {},
+    (useUpdateCompanyIndustryCode as jest.Mock).mockReturnValue({
+      mutate: jest.fn(),
     });
+    (useRouter as jest.Mock).mockReturnValue({ query: {}, push: jest.fn() });
   });
 
-  afterAll(() => {
-    process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT = originalSentryEnvironment;
+  it('renders without crashing', () => {
+    makeComponent();
+    expect(screen.getByText('common:review.actions.close')).toBeInTheDocument();
   });
 
-  it('renders base action buttons', () => {
-    renderSubject();
-
-    expect(getActionButton(ACTION_LABELS.close)).toBeInTheDocument();
-    expect(getActionButton(ACTION_LABELS.saveAndClose)).toBeInTheDocument();
-    expect(getActionButton(ACTION_LABELS.handlingPanel)).toBeInTheDocument();
+  it('renders Next button when application is in HANDLING status', () => {
+    makeComponent();
+    expect(screen.getByText('common:utility.next')).toBeInTheDocument();
   });
 
-  it('calls navigateBack when close is clicked', async () => {
-    const user = setupUserAndRender(() => renderSubject());
-
-    await user.click(getActionButton(ACTION_LABELS.close));
-
-    expect(mockNavigateBack).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls toggleMessagesDrawerVisibility when handling panel is clicked', async () => {
-    const user = setupUserAndRender(() => renderSubject());
-
-    await user.click(getActionButton(ACTION_LABELS.handlingPanel));
-
-    expect(mockToggleMessagesDrawerVisibility).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls cloneApplication when clone is confirmed', async () => {
-    const confirmSpy = mockCloneConfirmation(true);
-    const application = createHandlingApplication({
-      id: 'clone-id-1',
-    });
-
-    const user = setupUserAndRender(() => renderSubject({ application }));
-
-    await user.click(getActionButton(ACTION_LABELS.cloneApplication));
-
-    expect(confirmSpy).toHaveBeenCalledWith(
-      'Haluatko varmasti kloonata tämän hakemuksen?'
-    );
-    expect(mockCloneApplication).toHaveBeenCalledWith('clone-id-1');
-    confirmSpy.mockRestore();
-  });
-
-  it('does not call cloneApplication when clone confirmation is rejected', async () => {
-    const confirmSpy = mockCloneConfirmation(false);
-
-    const user = setupUserAndRender(() =>
-      renderSubject({
-        application: createHandlingApplication({
-          id: 'clone-id-2',
+  it('does not render Next button when application is not in HANDLING status', () => {
+    makeComponent({
+      props: {
+        application: buildApplication({
+          status: APPLICATION_STATUSES.RECEIVED,
         }),
-      })
-    );
-
-    await user.click(getActionButton(ACTION_LABELS.cloneApplication));
-
-    expect(mockCloneApplication).not.toHaveBeenCalled();
-    confirmSpy.mockRestore();
-  });
-
-  it('navigates to cloned application when clonedData.id exists', async () => {
-    (useCloneApplicationMutation as jest.Mock).mockReturnValue({
-      data: { id: 'cloned-app-123' },
-      mutate: mockCloneApplication,
+      },
     });
+    expect(screen.queryByText('common:utility.next')).not.toBeInTheDocument();
+  });
 
-    renderSubject();
+  it('clicking Next calls updateApplication (mutate) when step 0 validation passes', () => {
+    makeComponent();
+    fireEvent.click(screen.getByText('common:utility.next'));
+    expect(mockMutate).toHaveBeenCalled();
+  });
 
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/application?id=cloned-app-123');
+  it('clicking Next is blocked when status is missing (step 0 validation fails)', () => {
+    const noStatus: HandledAplication = {
+      ...validHandledApplication,
+      status: undefined,
+    };
+    setupHookMocks(noStatus);
+    makeComponent({ handledApplication: noStatus });
+    fireEvent.click(screen.getByText('common:utility.next'));
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('step 2 fields (decisionText) do NOT block at step 0', () => {
+    const shortDecisionText: HandledAplication = {
+      ...validHandledApplication,
+      decisionText: 'short', // < 10 chars, invalid for step 2
+      justificationText: 'short',
+    };
+    setupHookMocks(shortDecisionText);
+    makeComponent({
+      props: {
+        stepState: {
+          activeStepIndex: 0,
+          steps: [1, 2, 3] as unknown as Props['stepState']['steps'],
+        },
+      },
+      handledApplication: shortDecisionText,
     });
+    fireEvent.click(screen.getByText('common:utility.next'));
+    // Step 0 should pass because step2 fields are only validated at step > 0
+    expect(mockMutate).toHaveBeenCalled();
   });
 
-  it('dispatches completeStep when draft mutation data contains review_step', async () => {
-    const stepperDispatch = jest.fn();
-
-    (useDecisionProposalDraftMutation as jest.Mock).mockReturnValue({
-      data: { review_step: 4 },
-      mutate: mockUpdateApplication,
-      isError: false,
+  it('step 2 fields (decisionText) block at step 1', () => {
+    const shortDecisionText: HandledAplication = {
+      ...validHandledApplication,
+      decisionText: 'short',
+      justificationText: 'short',
+    };
+    setupHookMocks(shortDecisionText);
+    makeComponent({
+      props: {
+        stepState: {
+          activeStepIndex: 1,
+          steps: [1, 2, 3] as unknown as Props['stepState']['steps'],
+        },
+      },
+      handledApplication: shortDecisionText,
     });
+    fireEvent.click(screen.getByText('common:utility.next'));
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
 
-    renderSubject({ stepperDispatch });
-
-    await waitFor(() => {
-      expect(stepperDispatch).toHaveBeenCalledWith({
-        type: 'completeStep',
-        payload: 2,
-      });
+  it('step 2 fields (empty signerId) block at step 1', () => {
+    const emptySignerId: HandledAplication = {
+      ...validHandledApplication,
+      signerId: '',
+      decisionMakerId: '',
+    };
+    setupHookMocks(emptySignerId);
+    makeComponent({
+      props: {
+        stepState: {
+          activeStepIndex: 1,
+          steps: [1, 2, 3] as unknown as Props['stepState']['steps'],
+        },
+      },
+      handledApplication: emptySignerId,
     });
+    fireEvent.click(screen.getByText('common:utility.next'));
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 
-  it('calls updateApplication from save and close with current review step', async () => {
-    const application = createDefaultTestApplication();
-
-    const user = setupUserAndRender(() => renderSubject({ application }));
-
-    await user.click(getActionButton(ACTION_LABELS.saveAndClose));
-
-    expectDraftMutationPayload(1, 'app-123');
-  });
-
-  it('navigates back after save and close when mutation review step matches current step', async () => {
-    const application = createDefaultTestApplication();
-
-    (useDecisionProposalDraftMutation as jest.Mock).mockReturnValue({
-      data: { review_step: 1 },
-      mutate: mockUpdateApplication,
-      isError: false,
+  it('all valid fields at step 1 allow proceeding', () => {
+    makeComponent({
+      props: {
+        stepState: {
+          activeStepIndex: 1,
+          steps: [1, 2, 3] as unknown as Props['stepState']['steps'],
+        },
+      },
     });
+    fireEvent.click(screen.getByText('common:utility.next'));
+    expect(mockMutate).toHaveBeenCalled();
+  });
 
-    const user = setupUserAndRender(() => renderSubject({ application }));
-
-    await user.click(getActionButton(ACTION_LABELS.saveAndClose));
-
-    await waitFor(() => {
-      expect(mockNavigateBack).toHaveBeenCalledTimes(1);
+  it('industryCode is required when grantedAsDeMinimisAid is true and no company industryCode', () => {
+    const deMinimisNoCode: HandledAplication = {
+      ...validHandledApplication,
+      grantedAsDeMinimisAid: true,
+      industryCode: '',
+    };
+    setupHookMocks(deMinimisNoCode);
+    makeComponent({
+      handledApplication: deMinimisNoCode,
     });
+    fireEvent.click(screen.getByText('common:utility.next'));
+    // industryCode missing → errorStep1 = true → mutate NOT called
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 
-  it('shows calculation error and blocks save when recalculation is required', async () => {
-    const user = setupUserAndRender(() =>
-      renderSubject({ isRecalculationRequired: true })
-    );
-
-    await user.click(getActionButton(ACTION_LABELS.saveAndClose));
-
-    expect(focusAndScroll).toHaveBeenCalledWith('endDate');
-    expect(showErrorToast).toHaveBeenCalledTimes(1);
-    expect(mockUpdateApplication).not.toHaveBeenCalled();
-  });
-
-  it('shows cancel button and calls openDialog when clicked', async () => {
-    const user = setupUserAndRender(() => renderSubject());
-
-    await user.click(getActionButton(ACTION_LABELS.cancelApplication));
-
-    expect(mockOpenDialog).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not show cancel button for ACCEPTED status', () => {
-    renderSubject({
-      application: createHandlingApplication({
-        status: APPLICATION_STATUSES.ACCEPTED,
-      }),
-    });
-
-    expect(
-      queryActionButton(ACTION_LABELS.cancelApplication)
-    ).not.toBeInTheDocument();
-  });
-
-  it('disables cancel button for read-only application without ahjoCaseId', () => {
-    renderSubject({
-      isApplicationReadOnly: true,
-      application: createHandlingApplication({
-        ahjoCaseId: undefined,
-      }),
-    });
-
-    expect(getActionButton(ACTION_LABELS.cancelApplication)).toBeDisabled();
-  });
-
-  it('shows previous button on step > 0 and calls updateApplication on click', async () => {
-    const application = createDefaultTestApplication();
-
-    const user = setupUserAndRender(() =>
-      renderSubject({
-        application,
-        stepState: createStepState(1),
-      })
-    );
-
-    await user.click(getActionButton(ACTION_LABELS.previous));
-
-    expectDraftMutationPayload(1, 'app-123');
-  });
-
-  it('calls updateApplication with next review step when next is clicked on non-final step', async () => {
-    const application = createDefaultTestApplication();
-
-    const user = setupUserAndRender(() =>
-      renderSubject({
-        application,
-        stepState: createStepState(0),
-      })
-    );
-
-    await user.click(getActionButton(ACTION_LABELS.next));
-
-    expectDraftMutationPayload(2, 'app-123');
-  });
-
-  it('filters out step2 validation fields when validating from first step', async () => {
-    (useHandlingApplicationActions as jest.Mock).mockReturnValue(
-      createHookMockValue({
-        handledApplication: null,
-      })
-    );
-
-    renderSubject({
-      application: createHandlingApplication({
-        id: 'app-step-1',
-      }),
-    });
-
-    fireEvent.click(getActionButton(ACTION_LABELS.next));
-
-    await waitFor(() => {
-      expect(showErrorToast).toHaveBeenCalled();
-    });
-
-    const toastMessages = (showErrorToast as jest.Mock).mock.calls.map(
-      (call) => call[1]
-    );
-
-    expect(toastMessages).toContain('Puoltotieto puuttuu');
-    expect(toastMessages).not.toContain('Päätös ei voi olla tyhjä');
-    expect(toastMessages).not.toContain(
-      'Päätöksen perustelu ei voi olla tyhjä'
-    );
-    expect(toastMessages).not.toContain('Allekirjoittaja puuttuu');
-    expect(toastMessages).not.toContain('Päättäjän rooli puuttuu');
-    expect(mockUpdateApplication).not.toHaveBeenCalled();
-  });
-
-  it('calls onDoneConfirmation when send is clicked on final step', async () => {
-    const application = createHandlingApplication();
-
-    (useHandlingApplicationActions as jest.Mock).mockReturnValue(
-      createHookMockValue({
-        handledApplication: createHandledApplication({
-          status: APPLICATION_STATUSES.ACCEPTED,
-        }) as never,
-      })
-    );
-
-    const user = setupUserAndRender(() =>
-      renderSubject({
-        application,
-        stepState: createStepState(2),
-      })
-    );
-
-    await user.click(getActionButton(ACTION_LABELS.send));
-
-    expect(mockOnDoneConfirmation).toHaveBeenCalledTimes(1);
-  });
-
-  it.each([APPLICATION_STATUSES.ACCEPTED, APPLICATION_STATUSES.REJECTED])(
-    'sets router query action to submit and pushes router on final step for %s status',
-    async (status) => {
-      renderSubject({
-        application: createHandlingApplication({
-          status,
+  it('industryCode is not required when company already has an industryCode', () => {
+    const deMinimisWithCompanyCode: HandledAplication = {
+      ...validHandledApplication,
+      grantedAsDeMinimisAid: true,
+      industryCode: '',
+    };
+    setupHookMocks(deMinimisWithCompanyCode);
+    makeComponent({
+      props: {
+        application: buildApplication({
+          company: {
+            id: 'c1',
+            businessId: '123',
+            name: 'Oy',
+            industryCode: '62010',
+          } as Application['company'],
         }),
-        stepState: createStepState(2),
-      });
-
-      await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith(
-          expect.objectContaining({
-            query: expect.objectContaining({ action: 'submit' }),
-          })
-        );
-      });
-    }
-  );
-
-  it('submits done confirmation modal via onSubmit and updates application with finish step', async () => {
-    const application = createHandlingApplication({
-      id: 'app-999',
+      },
+      handledApplication: deMinimisWithCompanyCode,
     });
-
-    (useHandlingApplicationActions as jest.Mock).mockReturnValue(
-      createHookMockValue({
-        isDoneConfirmationModalOpen: true,
-        handledApplication: createHandledApplication({
-          status: APPLICATION_STATUSES.ACCEPTED,
-        }) as never,
-      })
-    );
-
-    const user = setupUserAndRender(() =>
-      renderSubject({
-        application,
-        stepState: createStepState(2),
-      })
-    );
-
-    await user.click(screen.getByTestId('submit'));
-
-    expect(mockUpdateApplication).toHaveBeenCalledWith(
-      expect.objectContaining<DraftPayload>({
-        reviewStep: 4,
-        applicationId: 'app-999',
-      })
-    );
-  });
-
-  it('renders confirmation modals based on hook state', () => {
-    (useHandlingApplicationActions as jest.Mock).mockReturnValue(
-      createHookMockValue({
-        isConfirmationModalOpen: true,
-        isDoneConfirmationModalOpen: true,
-      })
-    );
-
-    renderSubject();
-
-    expect(getDialogs()).toHaveLength(2);
+    fireEvent.click(screen.getByText('common:utility.next'));
+    // Company already has industryCode → not missing → mutate called
+    expect(mockMutate).toHaveBeenCalled();
   });
 });

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/__tests__/HandlingApplicationActionsAhjo.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/__tests__/HandlingApplicationActionsAhjo.test.tsx
@@ -76,7 +76,9 @@ const buildApplication = (overrides: Partial<Application> = {}): Application =>
 
 const buildContextValue = (
   handledApplication: HandledAplication | null = null,
-  setHandledApplication: (app: HandledAplication | null) => void = noop
+  setHandledApplication: React.Dispatch<
+    React.SetStateAction<HandledAplication | null>
+  > = noop
 ): AppContextType => ({
   isNavigationVisible: false,
   isFooterVisible: true,
@@ -103,7 +105,9 @@ const validHandledApplication: HandledAplication = {
 type MakeComponentOptions = {
   props?: Partial<Props>;
   handledApplication?: HandledAplication | null;
-  setHandledApplication?: (app: HandledAplication | null) => void;
+  setHandledApplication?: React.Dispatch<
+    React.SetStateAction<HandledAplication | null>
+  >;
 };
 
 const makeComponent = ({

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/useHandlingApplicationActions.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/useHandlingApplicationActions.ts
@@ -28,6 +28,7 @@ type ExtendedComponentProps = {
   isDoneConfirmationModalOpen: boolean;
   cancelComments: string;
   handledApplication: HandledAplication | null;
+  setHandledApplication: (application: HandledAplication | null) => void;
 };
 
 const useHandlingApplicationActions = (
@@ -119,6 +120,7 @@ const useHandlingApplicationActions = (
     isDoneConfirmationModalOpen,
     cancelComments,
     handledApplication,
+    setHandledApplication,
   };
 };
 

--- a/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/ApplicationProcessingView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/ApplicationProcessingView.tsx
@@ -34,11 +34,6 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
 
   const isNewAhjoMode = useDetermineAhjoMode();
 
-  const handledApplicationRef = React.useRef(handledApplication);
-  React.useEffect(() => {
-    handledApplicationRef.current = handledApplication;
-  }, [handledApplication]);
-
   const needsIndustryCode =
     handledApplication?.grantedAsDeMinimisAid === true &&
     !data?.company?.industryCode;
@@ -299,17 +294,17 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                         spaceIndex === -1
                           ? ''
                           : trimmed.slice(spaceIndex).trim();
-                      setHandledApplication({
-                        ...handledApplication,
+                      setHandledApplication((prev) => ({
+                        ...prev,
                         industryCode: code,
                         industryDescription: description || undefined,
-                      });
+                      }));
                     }}
                     onBlur={() =>
-                      setHandledApplication({
-                        ...handledApplicationRef.current,
+                      setHandledApplication((prev) => ({
+                        ...prev,
                         industryCodeTouched: true,
-                      })
+                      }))
                     }
                     required
                     invalid={

--- a/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/ApplicationProcessingView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/ApplicationProcessingView.tsx
@@ -8,9 +8,7 @@ import { TextArea, TextInput } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $ViewField } from 'shared/components/benefit/summaryView/SummaryView.sc';
-import {
-  $RadioButton,
-} from 'shared/components/forms/fields/Fields.sc';
+import { $RadioButton } from 'shared/components/forms/fields/Fields.sc';
 import {
   $Grid,
   $GridCell,
@@ -35,6 +33,11 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
     React.useContext(AppContext);
 
   const isNewAhjoMode = useDetermineAhjoMode();
+
+  const handledApplicationRef = React.useRef(handledApplication);
+  React.useEffect(() => {
+    handledApplicationRef.current = handledApplication;
+  }, [handledApplication]);
 
   const needsIndustryCode =
     handledApplication?.grantedAsDeMinimisAid === true &&
@@ -231,7 +234,7 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                 </$GridCell>
               )}
             </$Grid>
-            <$Grid style={{ marginTop: theme.spacing.xl}}>
+            <$Grid style={{ marginTop: theme.spacing.xl }}>
               <$GridCell $colSpan={12}>
                 <$ViewField
                   isBold
@@ -257,7 +260,9 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                   id="deminimisNo"
                   name="deminimisRadio"
                   value="no"
-                  label={t(`${translationsBase}.actions.grantedAsDeminimisAidNo`)}
+                  label={t(
+                    `${translationsBase}.actions.grantedAsDeminimisAidNo`
+                  )}
                   checked={handledApplication.grantedAsDeMinimisAid === false}
                   onChange={(value: boolean) => {
                     if (value) toggleGrantedAsDeMinimisAid(false);
@@ -275,17 +280,25 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                     )}
                     value={
                       handledApplication.industryDescription
-                        ? `${handledApplication.industryCode ?? ''} ${handledApplication.industryDescription}`
-                        : (handledApplication.industryCode ?? '')
+                        ? `${handledApplication.industryCode ?? ''} ${
+                            handledApplication.industryDescription
+                          }`
+                        : handledApplication.industryCode ?? ''
                     }
                     // We allow users to input both code and description in the same field to make it easier to
                     // understand which code they are selecting.
                     // We then split the input back to code and description when saving.
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      const raw = e.target.value;
-                      const spaceIndex = raw.indexOf(' ');
-                      const code = spaceIndex === -1 ? raw : raw.slice(0, spaceIndex);
-                      const description = spaceIndex === -1 ? '' : raw.slice(spaceIndex + 1);
+                      const trimmed = e.target.value.trim();
+                      const spaceIndex = trimmed.search(/\s/);
+                      const code =
+                        spaceIndex === -1
+                          ? trimmed
+                          : trimmed.slice(0, spaceIndex).trim();
+                      const description =
+                        spaceIndex === -1
+                          ? ''
+                          : trimmed.slice(spaceIndex).trim();
                       setHandledApplication({
                         ...handledApplication,
                         industryCode: code,
@@ -294,7 +307,7 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                     }}
                     onBlur={() =>
                       setHandledApplication({
-                        ...handledApplication,
+                        ...handledApplicationRef.current,
                         industryCodeTouched: true,
                       })
                     }

--- a/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/ApplicationProcessingView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/ApplicationProcessingView.tsx
@@ -4,12 +4,11 @@ import { useDetermineAhjoMode } from 'benefit/handler/hooks/useDetermineAhjoMode
 import { Application } from 'benefit/handler/types/application';
 import { extractCalculatorRows } from 'benefit/handler/utils/calculator';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
-import { TextArea } from 'hds-react';
+import { TextArea, TextInput } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import { $ViewField } from 'shared/components/benefit/summaryView/SummaryView.sc';
 import {
-  $Checkbox,
   $RadioButton,
 } from 'shared/components/forms/fields/Fields.sc';
 import {
@@ -22,7 +21,6 @@ import { formatFloatToEvenEuros } from 'shared/utils/string.utils';
 import {
   $CalculatorHr,
   $CalculatorTableRow,
-  $FieldHeaderText,
   $HelpText,
   $MainHeader,
   $RadioButtonContainer,
@@ -38,10 +36,15 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
 
   const isNewAhjoMode = useDetermineAhjoMode();
 
-  const toggleGrantedAsDeMinimisAid = (): void => {
+  const needsIndustryCode =
+    handledApplication?.grantedAsDeMinimisAid === true &&
+    !data?.company?.industryCode;
+
+  const toggleGrantedAsDeMinimisAid = (value: boolean): void => {
     setHandledApplication({
       ...handledApplication,
-      grantedAsDeMinimisAid: !handledApplication?.grantedAsDeMinimisAid,
+      grantedAsDeMinimisAid: value,
+      industryCodeTouched: false,
     });
   };
 
@@ -50,7 +53,7 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
       setHandledApplication({
         status: data?.decisionProposalDraft?.status,
         grantedAsDeMinimisAid:
-          !!data?.decisionProposalDraft?.grantedAsDeMinimisAid,
+          data?.decisionProposalDraft?.grantedAsDeMinimisAid ?? undefined,
         logEntryComment: data?.decisionProposalDraft?.logEntryComment,
         justificationText: data?.decisionProposalDraft?.justificationText,
         decisionText: data?.decisionProposalDraft?.decisionText,
@@ -228,22 +231,89 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                 </$GridCell>
               )}
             </$Grid>
-            <$Grid>
+            <$Grid style={{ marginTop: theme.spacing.xl}}>
               <$GridCell $colSpan={12}>
-                <$FieldHeaderText>
+                <$ViewField
+                  isBold
+                  style={{ fontSize: theme.fontSize.heading.s }}
+                >
                   {t(`${translationsBase}.actions.grantedAsDeminimisText`)}
-                </$FieldHeaderText>
+                </$ViewField>
               </$GridCell>
-              <$GridCell $colSpan={12}>
-                <$Checkbox
-                  id="deminimisCheckbox"
-                  name="deminimisCheckbox"
+              <$GridCell $colSpan={12} style={{ marginTop: theme.spacing.xs }}>
+                <$RadioButton
+                  id="deminimisYes"
+                  name="deminimisRadio"
+                  value="yes"
                   label={t(`${translationsBase}.actions.grantedAsDeminimisAid`)}
-                  required
                   checked={handledApplication.grantedAsDeMinimisAid === true}
-                  onChange={toggleGrantedAsDeMinimisAid}
+                  onChange={(value: boolean) => {
+                    if (value) toggleGrantedAsDeMinimisAid(true);
+                  }}
                 />
               </$GridCell>
+              <$GridCell $colSpan={12} style={{ marginTop: theme.spacing.xs2 }}>
+                <$RadioButton
+                  id="deminimisNo"
+                  name="deminimisRadio"
+                  value="no"
+                  label={t(`${translationsBase}.actions.grantedAsDeminimisAidNo`)}
+                  checked={handledApplication.grantedAsDeMinimisAid === false}
+                  onChange={(value: boolean) => {
+                    if (value) toggleGrantedAsDeMinimisAid(false);
+                  }}
+                />
+              </$GridCell>
+              {needsIndustryCode && (
+                <$GridCell $colSpan={6}>
+                  {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
+                  <TextInput
+                    id="industryCodeInput"
+                    label={t(`${translationsBase}.fields.industryCode`)}
+                    helperText={t(
+                      `${translationsBase}.fields.industryCodeHelper`
+                    )}
+                    value={
+                      handledApplication.industryDescription
+                        ? `${handledApplication.industryCode ?? ''} ${handledApplication.industryDescription}`
+                        : (handledApplication.industryCode ?? '')
+                    }
+                    // We allow users to input both code and description in the same field to make it easier to
+                    // understand which code they are selecting.
+                    // We then split the input back to code and description when saving.
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      const raw = e.target.value;
+                      const spaceIndex = raw.indexOf(' ');
+                      const code = spaceIndex === -1 ? raw : raw.slice(0, spaceIndex);
+                      const description = spaceIndex === -1 ? '' : raw.slice(spaceIndex + 1);
+                      setHandledApplication({
+                        ...handledApplication,
+                        industryCode: code,
+                        industryDescription: description || undefined,
+                      });
+                    }}
+                    onBlur={() =>
+                      setHandledApplication({
+                        ...handledApplication,
+                        industryCodeTouched: true,
+                      })
+                    }
+                    required
+                    invalid={
+                      !!handledApplication.industryCodeTouched &&
+                      handledApplication.grantedAsDeMinimisAid === true &&
+                      !handledApplication.industryCode
+                    }
+                    errorText={
+                      !!handledApplication.industryCodeTouched &&
+                      handledApplication.grantedAsDeMinimisAid === true &&
+                      !handledApplication.industryCode
+                        ? t(`${translationsBase}.fields.industryCodeRequired`)
+                        : undefined
+                    }
+                  />
+                </$GridCell>
+              )}
             </$Grid>
           </>
         )}

--- a/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/__tests__/ApplicationProcessingView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/__tests__/ApplicationProcessingView.test.tsx
@@ -147,12 +147,15 @@ describe('ApplicationProcessingView', () => {
     // Simulate pasting the full TOL code + description at once
     fireEvent.change(input, { target: { value: '62010 Ohjelmistot' } });
 
-    expect(setHandledApplication).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        industryCode: '62010',
-        industryDescription: 'Ohjelmistot',
-      })
-    );
+    const updater = setHandledApplication.mock.calls.at(-1)?.[0] as (
+      prev: HandledAplication
+    ) => HandledAplication;
+    expect(typeof updater).toBe('function');
+    const result = updater(handledApplication);
+    expect(result).toMatchObject({
+      industryCode: '62010',
+      industryDescription: 'Ohjelmistot',
+    });
   });
 
   it('should NOT show de minimis section when status is REJECTED', () => {

--- a/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/__tests__/ApplicationProcessingView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/__tests__/ApplicationProcessingView.test.tsx
@@ -1,0 +1,168 @@
+import { fireEvent, RenderResult, screen } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import AppContext, { AppContextType } from 'benefit/handler/context/AppContext';
+import { HandledAplication } from 'benefit/handler/types/application';
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
+import { axe } from 'jest-axe';
+import noop from 'lodash/noop';
+import React from 'react';
+import theme from 'shared/styles/theme';
+
+import ApplicationProcessingView from '../ApplicationProcessingView';
+
+// Finnish labels from public/locales/fi/common.json
+const LABEL_REJECT = 'Ei puolleta';
+const LABEL_ACCEPT = 'Puolletaan';
+const LABEL_DEMINIMIS_YES = 'Helsinki-lisä myönnetään de minimis-tukena';
+const LABEL_DEMINIMIS_NO = 'Helsinki-lisä ei ole hakijalle de minimis-tukea';
+const LABEL_INDUSTRY_CODE = 'TOL-koodi (toimialaluokitus)';
+
+const defaultAppContextValue: AppContextType = {
+  isNavigationVisible: false,
+  isFooterVisible: true,
+  isSidebarVisible: false,
+  layoutBackgroundColor: theme.colors.white,
+  handledApplication: null,
+  setIsNavigationVisible: noop,
+  setIsFooterVisible: noop,
+  setLayoutBackgroundColor: noop,
+  setHandledApplication: noop,
+  setIsSidebarVisible: noop,
+};
+
+const buildAppContext = (
+  handledApplication: HandledAplication | null,
+  setHandledApplication: AppContextType['setHandledApplication'] = noop
+): AppContextType => ({
+  ...defaultAppContextValue,
+  handledApplication,
+  setHandledApplication,
+});
+
+const minimalData = {
+  company: {
+    name: 'Test Oy',
+    businessId: '1234567-1',
+  },
+  calculation: { rows: [] },
+  decisionProposalDraft: {},
+};
+
+const getComponent = (
+  handledApplication: HandledAplication | null,
+  setHandledApplication: AppContextType['setHandledApplication'] = noop,
+  data: Record<string, unknown> = minimalData
+): RenderResult =>
+  renderComponent(
+    <AppContext.Provider
+      value={buildAppContext(handledApplication, setHandledApplication)}
+    >
+      {/* @ts-expect-error: partial application data sufficient for unit testing */}
+      <ApplicationProcessingView data={data} />
+    </AppContext.Provider>
+  ).renderResult;
+
+describe('ApplicationProcessingView', () => {
+  it('should render with no accessibility violations when handledApplication is null', async () => {
+    const { container } = getComponent(null);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should render accept/reject radio buttons', () => {
+    getComponent(null);
+    expect(screen.getByLabelText(LABEL_REJECT)).toBeInTheDocument();
+    expect(screen.getByLabelText(LABEL_ACCEPT)).toBeInTheDocument();
+  });
+
+  it('should show de minimis radio buttons when status is ACCEPTED', () => {
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: undefined,
+    };
+    getComponent(handledApplication);
+    expect(screen.getByLabelText(LABEL_DEMINIMIS_YES)).toBeInTheDocument();
+    expect(screen.getByLabelText(LABEL_DEMINIMIS_NO)).toBeInTheDocument();
+  });
+
+  it('should show TOL code input when ACCEPTED + grantedAsDeMinimisAid is true + no company industryCode', () => {
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+    };
+    const data = {
+      ...minimalData,
+      company: {
+        name: 'Test Oy',
+        businessId: '1234567-1',
+        industryCode: undefined,
+      },
+    };
+    getComponent(handledApplication, noop, data);
+    expect(
+      screen.queryByLabelText(LABEL_INDUSTRY_CODE, { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it('should NOT show TOL code input when company already has industryCode', () => {
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+    };
+    const data = {
+      ...minimalData,
+      company: {
+        name: 'Test Oy',
+        businessId: '1234567-1',
+        industryCode: '62010',
+      },
+    };
+    getComponent(handledApplication, noop, data);
+    expect(
+      screen.queryByLabelText(LABEL_INDUSTRY_CODE, { exact: false })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should parse paste input: first word becomes code, rest becomes description', () => {
+    const setHandledApplication = jest.fn();
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+      industryCode: '',
+      industryDescription: undefined,
+    };
+    const data = {
+      ...minimalData,
+      company: {
+        name: 'Test Oy',
+        businessId: '1234567-1',
+        industryCode: undefined,
+      },
+    };
+    getComponent(handledApplication, setHandledApplication, data);
+
+    const input = screen.getByLabelText(LABEL_INDUSTRY_CODE, { exact: false });
+    expect(input).toBeInTheDocument();
+
+    // Simulate pasting the full TOL code + description at once
+    fireEvent.change(input, { target: { value: '62010 Ohjelmistot' } });
+
+    expect(setHandledApplication).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        industryCode: '62010',
+        industryDescription: 'Ohjelmistot',
+      })
+    );
+  });
+
+  it('should NOT show de minimis section when status is REJECTED', () => {
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.REJECTED,
+      grantedAsDeMinimisAid: false,
+    };
+    getComponent(handledApplication);
+    expect(
+      screen.queryByLabelText(LABEL_DEMINIMIS_YES)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/__tests__/useSalaryBenefitCalculatorData.test.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/__tests__/useSalaryBenefitCalculatorData.test.ts
@@ -1,0 +1,284 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { CALCULATION_SALARY_KEYS } from 'benefit/handler/constants';
+import {
+  Application,
+  TrainingCompensation,
+} from 'benefit-shared/types/application';
+
+import { useSalaryBenefitCalculatorData } from '../useSalaryBenefitCalculatorData';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'test-uuid'),
+}));
+
+jest.mock('benefit/handler/hooks/useHandlerReviewActions', () =>
+  jest.fn(() => ({
+    calculateSalaryBenefit: jest.fn(),
+  }))
+);
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const buildApplication = (overrides: Partial<Application> = {}): Application =>
+  ({
+    id: 'app-1',
+    startDate: '2026-01-01',
+    endDate: '2026-06-30',
+    paySubsidies: [],
+    trainingCompensations: [],
+    calculation: {
+      startDate: '2026-01-01',
+      endDate: '2026-06-30',
+      monthlyPay: '2000',
+      otherExpenses: '100',
+      vacationMoney: '200',
+      stateAidMaxPercentage: 50,
+      overrideMonthlyBenefitAmount: null,
+      overrideMonthlyBenefitAmountComment: '',
+    },
+    ...overrides,
+  } as unknown as Application);
+
+describe('useSalaryBenefitCalculatorData', () => {
+  const setCalculationErrors = jest.fn();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns all expected fields', () => {
+    const application = buildApplication();
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    expect(result.current.formik).toBeDefined();
+    expect(result.current.fields).toBeDefined();
+    expect(result.current.stateAidMaxPercentageOptions).toBeDefined();
+    expect(result.current.isManualCalculator).toBe(false);
+    expect(result.current.newTrainingCompensation).toBeDefined();
+    expect(result.current.dateInputLimits).toBeDefined();
+  });
+
+  it('sets isManualCalculator to true when overrideMonthlyBenefitAmount is set', () => {
+    const application = buildApplication({
+      calculation: {
+        startDate: '2026-01-01',
+        endDate: '2026-06-30',
+        monthlyPay: '2000',
+        otherExpenses: '100',
+        vacationMoney: '200',
+        stateAidMaxPercentage: 50,
+        overrideMonthlyBenefitAmount: '500',
+        overrideMonthlyBenefitAmountComment: 'manual',
+      } as Application['calculation'],
+    });
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    expect(result.current.isManualCalculator).toBe(true);
+  });
+
+  it('stateAidMaxPercentageOptions contains formatted percentage labels', () => {
+    const application = buildApplication();
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    expect(result.current.stateAidMaxPercentageOptions).toEqual(
+      expect.arrayContaining([
+        { label: '50%', value: 50 },
+        { label: '100%', value: 100 },
+      ])
+    );
+  });
+
+  it('getStateAidMaxPercentageSelectValue returns matching option', () => {
+    const application = buildApplication();
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    const val = result.current.getStateAidMaxPercentageSelectValue();
+    expect(val).toEqual({ label: '50%', value: 50 });
+  });
+
+  it('getStateAidMaxPercentageSelectValue returns null when no match', () => {
+    const application = buildApplication({
+      calculation: {
+        ...buildApplication().calculation,
+        stateAidMaxPercentage: 99,
+      } as Application['calculation'],
+    });
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    const val = result.current.getStateAidMaxPercentageSelectValue();
+    expect(val).toBeNull();
+  });
+
+  it('grantedPeriod is calculated from start and end dates', () => {
+    const application = buildApplication();
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    // 6 months difference between 2026-01-01 and 2026-06-30
+    expect(typeof result.current.grantedPeriod).toBe('number');
+  });
+
+  it('addNewTrainingCompensation appends entry with generated id and resets form', async () => {
+    const application = buildApplication();
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    await act(async () => {
+      result.current.setNewTrainingCompensation({
+        id: '',
+        monthlyAmount: '300',
+        startDate: '2026-01-01',
+        endDate: '2026-03-31',
+      });
+    });
+
+    await act(async () => {
+      result.current.addNewTrainingCompensation();
+    });
+
+    const compensations = result.current.formik.values[
+      CALCULATION_SALARY_KEYS.TRAINING_COMPENSATIONS
+    ] as TrainingCompensation[];
+    expect(compensations).toHaveLength(1);
+    expect(compensations[0]).toMatchObject({
+      id: 'test-uuid',
+      monthlyAmount: '300',
+      startDate: '2026-01-01',
+      endDate: '2026-03-31',
+    });
+
+    // newTrainingCompensation is reset
+    expect(result.current.newTrainingCompensation.monthlyAmount).toBe('');
+  });
+
+  it('removeTrainingCompensation removes entry by id', async () => {
+    const application = buildApplication({
+      trainingCompensations: [
+        {
+          id: 'tc-1',
+          monthlyAmount: '100',
+          startDate: '2026-01-01',
+          endDate: '2026-02-28',
+        },
+        {
+          id: 'tc-2',
+          monthlyAmount: '200',
+          startDate: '2026-03-01',
+          endDate: '2026-04-30',
+        },
+      ],
+    });
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    await act(async () => {
+      result.current.removeTrainingCompensation('tc-1');
+    });
+
+    const compensations = result.current.formik.values[
+      CALCULATION_SALARY_KEYS.TRAINING_COMPENSATIONS
+    ] as TrainingCompensation[];
+    expect(compensations).toHaveLength(1);
+    expect(compensations[0].id).toBe('tc-2');
+  });
+
+  it('isDisabledAddTrainingCompensationButton is true when fields are empty', () => {
+    const application = buildApplication();
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    expect(result.current.isDisabledAddTrainingCompensationButton).toBe(true);
+  });
+
+  it('isDisabledAddTrainingCompensationButton becomes false when all fields are filled', async () => {
+    const application = buildApplication();
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    await act(async () => {
+      result.current.setNewTrainingCompensation({
+        id: '',
+        monthlyAmount: '300',
+        startDate: '2026-01-01',
+        endDate: '2026-03-31',
+      });
+    });
+
+    expect(result.current.isDisabledAddTrainingCompensationButton).toBe(false);
+  });
+
+  it('changeCalculatorMode switches to manual mode', async () => {
+    const application = buildApplication();
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    expect(result.current.isManualCalculator).toBe(false);
+
+    await act(async () => {
+      result.current.changeCalculatorMode('manual');
+    });
+
+    expect(result.current.isManualCalculator).toBe(true);
+  });
+
+  it('changeCalculatorMode switches back to auto mode and clears override field', async () => {
+    const application = buildApplication({
+      calculation: {
+        startDate: '2026-01-01',
+        endDate: '2026-06-30',
+        monthlyPay: '2000',
+        otherExpenses: '100',
+        vacationMoney: '200',
+        stateAidMaxPercentage: 50,
+        overrideMonthlyBenefitAmount: '500',
+        overrideMonthlyBenefitAmountComment: 'manual',
+      } as Application['calculation'],
+    });
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    expect(result.current.isManualCalculator).toBe(true);
+
+    await act(async () => {
+      result.current.changeCalculatorMode('auto');
+    });
+
+    expect(result.current.isManualCalculator).toBe(false);
+    expect(
+      result.current.formik.values[
+        CALCULATION_SALARY_KEYS.OVERRIDE_MONTHLY_BENEFIT_AMOUNT
+      ]
+    ).toBeNull();
+  });
+
+  it('dateInputLimits min and max are Date objects', () => {
+    const application = buildApplication();
+    const { result } = renderHook(() =>
+      useSalaryBenefitCalculatorData(application, setCalculationErrors)
+    );
+
+    expect(result.current.dateInputLimits.min).toBeInstanceOf(Date);
+    expect(result.current.dateInputLimits.max).toBeInstanceOf(Date);
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
@@ -224,13 +224,12 @@ const useSalaryBenefitCalculatorData = (
   };
 
   useEffect(() => {
-    if (
+    const allFieldsFilled = Boolean(
       newTrainingCompensation.monthlyAmount &&
-      newTrainingCompensation.startDate &&
-      newTrainingCompensation.endDate
-    )
-      setIsDisabledAddTrainingCompensationButton(false);
-    else setIsDisabledAddTrainingCompensationButton(true);
+        newTrainingCompensation.startDate &&
+        newTrainingCompensation.endDate
+    );
+    setIsDisabledAddTrainingCompensationButton(!allFieldsFilled);
   }, [newTrainingCompensation]);
 
   return {

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/useSalaryBenefitCalculatorData.ts
@@ -37,7 +37,7 @@ type ExtendedComponentProps = {
   };
   grantedPeriod: number;
   stateAidMaxPercentageOptions: OptionType[];
-  getStateAidMaxPercentageSelectValue: () => OptionType | undefined;
+  getStateAidMaxPercentageSelectValue: () => OptionType | null;
   paySubsidyPercentageOptions: OptionType[];
   isManualCalculator: boolean;
   changeCalculatorMode: (mode: 'auto' | 'manual') => true;
@@ -195,10 +195,12 @@ const useSalaryBenefitCalculatorData = (
 
   const { values } = formik;
 
-  const getStateAidMaxPercentageSelectValue = (): OptionType | undefined => {
+  const getStateAidMaxPercentageSelectValue = (): OptionType | null => {
     const { stateAidMaxPercentage } = values;
-    return stateAidMaxPercentageOptions.find(
-      (o) => o.value?.toString() === stateAidMaxPercentage?.toString()
+    return (
+      stateAidMaxPercentageOptions.find(
+        (o) => o.value?.toString() === stateAidMaxPercentage?.toString()
+      ) ?? null
     );
   };
 

--- a/frontend/benefit/handler/src/context/AppContext.tsx
+++ b/frontend/benefit/handler/src/context/AppContext.tsx
@@ -13,7 +13,9 @@ export type AppContextType = {
   setIsNavigationVisible: (value: boolean) => void;
   setIsFooterVisible: (value: boolean) => void;
   setLayoutBackgroundColor: (value: string) => void;
-  setHandledApplication: (handledApplication: HandledAplication | null) => void;
+  setHandledApplication: React.Dispatch<
+    React.SetStateAction<HandledAplication | null>
+  >;
   setIsSidebarVisible: (value: boolean) => void;
 };
 

--- a/frontend/benefit/handler/src/hooks/__tests__/useHandlerReviewActions.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useHandlerReviewActions.test.ts
@@ -1,0 +1,321 @@
+import { renderHook } from '@testing-library/react-hooks';
+import AppContext, { AppContextType } from 'benefit/handler/context/AppContext';
+import { useRouterNavigation } from 'benefit/handler/hooks/applicationHandling/useRouterNavigation';
+import { useApplicationActions } from 'benefit/handler/hooks/useApplicationActions';
+import useUpdateApplicationQuery from 'benefit/handler/hooks/useUpdateApplicationQuery';
+import useUpdateCompanyIndustryCode from 'benefit/handler/hooks/useUpdateCompanyIndustryCode';
+import { HandledAplication } from 'benefit/handler/types/application';
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
+import { Application } from 'benefit-shared/types/application';
+import noop from 'lodash/noop';
+import React from 'react';
+import theme from 'shared/styles/theme';
+
+import useHandlerReviewActions from '../useHandlerReviewActions';
+
+jest.mock('benefit/handler/hooks/useUpdateApplicationQuery', () => jest.fn());
+jest.mock('benefit/handler/hooks/useUpdateCompanyIndustryCode', () =>
+  jest.fn()
+);
+jest.mock('benefit/handler/hooks/useApplicationActions', () => ({
+  useApplicationActions: jest.fn(),
+}));
+jest.mock(
+  'benefit/handler/hooks/applicationHandling/useRouterNavigation',
+  () => ({
+    useRouterNavigation: jest.fn(),
+  })
+);
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string): string => key }),
+}));
+
+const buildApplication = (overrides: Partial<Application> = {}): Application =>
+  ({
+    id: 'app-1',
+    startDate: '2026-01-01',
+    endDate: '2026-06-30',
+    company: { id: 'company-1', businessId: '1234567-1', name: 'Test Oy' },
+    calculation: {
+      startDate: '2026-01-01',
+      endDate: '2026-06-30',
+      monthlyPay: '2000',
+      otherExpenses: '100',
+      vacationMoney: '200',
+      stateAidMaxPercentage: 50,
+      overrideMonthlyBenefitAmount: null,
+      overrideMonthlyBenefitAmountComment: '',
+    },
+    ...overrides,
+  } as unknown as Application);
+
+const buildContextValue = (
+  handledApplication: HandledAplication | null = null
+): AppContextType => ({
+  isNavigationVisible: false,
+  isFooterVisible: true,
+  isSidebarVisible: false,
+  layoutBackgroundColor: theme.colors.white,
+  handledApplication,
+  setIsNavigationVisible: noop,
+  setIsFooterVisible: noop,
+  setLayoutBackgroundColor: noop,
+  setHandledApplication: noop,
+  setIsSidebarVisible: noop,
+});
+
+const makeWrapper =
+  (handledApplication: HandledAplication | null) =>
+  ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      AppContext.Provider,
+      { value: buildContextValue(handledApplication) },
+      children
+    );
+
+describe('useHandlerReviewActions', () => {
+  const mockMutate = jest.fn();
+  const mockUpdateCompanyMutate = jest.fn();
+  const mockUpdateStatus = jest.fn();
+  const mockNavigateBack = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useUpdateApplicationQuery as jest.Mock).mockReturnValue({
+      mutate: mockMutate,
+      error: null,
+    });
+    (useUpdateCompanyIndustryCode as jest.Mock).mockReturnValue({
+      mutate: mockUpdateCompanyMutate,
+    });
+    (useApplicationActions as jest.Mock).mockReturnValue({
+      updateStatus: mockUpdateStatus,
+    });
+    (useRouterNavigation as jest.Mock).mockReturnValue({
+      navigateBack: mockNavigateBack,
+    });
+  });
+
+  it('returns all expected actions', () => {
+    const { result } = renderHook(
+      () => useHandlerReviewActions(buildApplication()),
+      { wrapper: makeWrapper(null) }
+    );
+
+    expect(result.current.onCalculateEmployment).toBeDefined();
+    expect(result.current.onSaveAndClose).toBeDefined();
+    expect(result.current.onDone).toBeDefined();
+    expect(result.current.onCancel).toBeDefined();
+    expect(result.current.calculateSalaryBenefit).toBeDefined();
+  });
+
+  it('onSaveAndClose calls navigateBack', () => {
+    const { result } = renderHook(
+      () => useHandlerReviewActions(buildApplication()),
+      { wrapper: makeWrapper(null) }
+    );
+
+    result.current.onSaveAndClose();
+
+    expect(mockNavigateBack).toHaveBeenCalled();
+  });
+
+  it('onCancel calls updateStatus with the cancelled application status', () => {
+    const { result } = renderHook(
+      () => useHandlerReviewActions(buildApplication()),
+      { wrapper: makeWrapper(null) }
+    );
+
+    const cancelledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.CANCELLED,
+      logEntryComment: 'test reason',
+    };
+
+    result.current.onCancel(cancelledApplication);
+
+    expect(mockUpdateStatus).toHaveBeenCalledWith(
+      APPLICATION_STATUSES.CANCELLED,
+      'test reason',
+      false
+    );
+  });
+
+  it('onCancel does nothing when status is missing', () => {
+    const { result } = renderHook(
+      () => useHandlerReviewActions(buildApplication()),
+      { wrapper: makeWrapper(null) }
+    );
+
+    result.current.onCancel({});
+
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it('onDone calls updateStatus directly when grantedAsDeMinimisAid is false', () => {
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: false,
+    };
+    const { result } = renderHook(
+      () => useHandlerReviewActions(buildApplication()),
+      { wrapper: makeWrapper(handledApplication) }
+    );
+
+    result.current.onDone();
+
+    expect(mockUpdateStatus).toHaveBeenCalledWith(
+      APPLICATION_STATUSES.ACCEPTED,
+      undefined,
+      false
+    );
+    expect(mockUpdateCompanyMutate).not.toHaveBeenCalled();
+  });
+
+  it('onDone calls updateCompanyIndustryCode.mutate when grantedAsDeMinimisAid is true with industryCode', () => {
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+      industryCode: '62010',
+      industryDescription: 'Computer programming',
+    };
+    const application = buildApplication();
+    const { result } = renderHook(() => useHandlerReviewActions(application), {
+      wrapper: makeWrapper(handledApplication),
+    });
+
+    result.current.onDone();
+
+    expect(mockUpdateCompanyMutate).toHaveBeenCalledWith(
+      {
+        companyId: 'company-1',
+        industryCode: '62010',
+        industry: 'Computer programming',
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      })
+    );
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it('onDone does nothing when handledApplication has no status', () => {
+    const handledApplication: HandledAplication = {};
+    const { result } = renderHook(
+      () => useHandlerReviewActions(buildApplication()),
+      { wrapper: makeWrapper(handledApplication) }
+    );
+
+    result.current.onDone();
+
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
+    expect(mockUpdateCompanyMutate).not.toHaveBeenCalled();
+  });
+
+  it('calculateSalaryBenefit calls updateApplicationQuery.mutate', () => {
+    const { result } = renderHook(
+      () => useHandlerReviewActions(buildApplication()),
+      { wrapper: makeWrapper(null) }
+    );
+
+    result.current.calculateSalaryBenefit({
+      startDate: '01.01.2026',
+      endDate: '30.06.2026',
+      monthlyPay: '2000',
+      otherExpenses: '100',
+      vacationMoney: '200',
+      stateAidMaxPercentage: 50,
+      overrideMonthlyBenefitAmount: null,
+      overrideMonthlyBenefitAmountComment: '',
+      paySubsidies: [],
+      trainingCompensations: [],
+    });
+
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it('onCalculateEmployment calls updateApplicationQuery.mutate', () => {
+    const { result } = renderHook(
+      () => useHandlerReviewActions(buildApplication()),
+      { wrapper: makeWrapper(null) }
+    );
+
+    result.current.onCalculateEmployment({
+      startDate: '01.01.2026',
+      endDate: '30.06.2026',
+      monthlyPay: '2000',
+      otherExpenses: '100',
+      vacationMoney: '200',
+      stateAidMaxPercentage: 50,
+      overrideMonthlyBenefitAmount: null,
+      overrideMonthlyBenefitAmountComment: '',
+      paySubsidies: [],
+      trainingCompensations: [],
+    });
+
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it('setCalculationErrors receives 400 error data on client error', () => {
+    const mockSetCalculationErrors = jest.fn();
+    const errorResponse = {
+      response: {
+        status: 422,
+        data: { calculation: { start_date: ['This field is required.'] } },
+      },
+    };
+    (useUpdateApplicationQuery as jest.Mock).mockReturnValue({
+      mutate: mockMutate,
+      error: errorResponse,
+    });
+
+    renderHook(
+      () =>
+        useHandlerReviewActions(buildApplication(), mockSetCalculationErrors),
+      { wrapper: makeWrapper(null) }
+    );
+
+    expect(mockSetCalculationErrors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calculation: expect.any(Object),
+      })
+    );
+  });
+
+  it('setCalculationErrors receives generic error on server error (500)', () => {
+    const mockSetCalculationErrors = jest.fn();
+    const errorResponse = {
+      response: { status: 500, data: {} },
+    };
+    (useUpdateApplicationQuery as jest.Mock).mockReturnValue({
+      mutate: mockMutate,
+      error: errorResponse,
+    });
+
+    renderHook(
+      () =>
+        useHandlerReviewActions(buildApplication(), mockSetCalculationErrors),
+      { wrapper: makeWrapper(null) }
+    );
+
+    expect(mockSetCalculationErrors).toHaveBeenCalledWith(
+      expect.objectContaining({ calculation: expect.any(Object) })
+    );
+  });
+
+  it('setCalculationErrors is cleared when there is no error', () => {
+    const mockSetCalculationErrors = jest.fn();
+    (useUpdateApplicationQuery as jest.Mock).mockReturnValue({
+      mutate: mockMutate,
+      error: null,
+    });
+
+    renderHook(
+      () =>
+        useHandlerReviewActions(buildApplication(), mockSetCalculationErrors),
+      { wrapper: makeWrapper(null) }
+    );
+
+    expect(mockSetCalculationErrors).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/benefit/handler/src/hooks/__tests__/useHandlerReviewActions.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useHandlerReviewActions.test.ts
@@ -191,10 +191,7 @@ describe('useHandlerReviewActions', () => {
         industryCode: '62010',
         industry: 'Computer programming',
       },
-      expect.objectContaining({
-        onSuccess: expect.any(Function),
-        onError: expect.any(Function),
-      })
+      { onSuccess: expect.any(Function) }
     );
     expect(mockUpdateStatus).not.toHaveBeenCalled();
   });

--- a/frontend/benefit/handler/src/hooks/__tests__/useHandlerReviewActions.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useHandlerReviewActions.test.ts
@@ -191,7 +191,7 @@ describe('useHandlerReviewActions', () => {
         industryCode: '62010',
         industry: 'Computer programming',
       },
-      { onSuccess: expect.any(Function) }
+      { onSettled: expect.any(Function) }
     );
     expect(mockUpdateStatus).not.toHaveBeenCalled();
   });
@@ -253,7 +253,7 @@ describe('useHandlerReviewActions', () => {
     expect(mockMutate).toHaveBeenCalled();
   });
 
-  it('setCalculationErrors receives 400 error data on client error', () => {
+  it('setCalculationErrors receives 4xx error data on client error', () => {
     const mockSetCalculationErrors = jest.fn();
     const errorResponse = {
       response: {

--- a/frontend/benefit/handler/src/hooks/__tests__/useUpdateCompanyIndustryCode.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useUpdateCompanyIndustryCode.test.ts
@@ -7,6 +7,13 @@ import useUpdateCompanyIndustryCode from '../useUpdateCompanyIndustryCode';
 
 jest.mock('react-query', () => ({
   useMutation: jest.fn(),
+  useQueryClient: jest.fn().mockReturnValue({
+    invalidateQueries: jest.fn(),
+  }),
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: jest.fn().mockReturnValue({ t: (key: string) => key }),
 }));
 
 jest.mock('shared/hooks/useBackendAPI', () => jest.fn());
@@ -82,7 +89,8 @@ describe('useUpdateCompanyIndustryCode', () => {
 
     expect(useMutation).toHaveBeenCalledWith(
       'updateCompanyIndustryCode',
-      expect.any(Function)
+      expect.any(Function),
+      expect.any(Object)
     );
   });
 });

--- a/frontend/benefit/handler/src/hooks/__tests__/useUpdateCompanyIndustryCode.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useUpdateCompanyIndustryCode.test.ts
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { useMutation } from 'react-query';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+import useUpdateCompanyIndustryCode from '../useUpdateCompanyIndustryCode';
+
+jest.mock('react-query', () => ({
+  useMutation: jest.fn(),
+}));
+
+jest.mock('shared/hooks/useBackendAPI', () => jest.fn());
+
+describe('useUpdateCompanyIndustryCode', () => {
+  const handleResponse = jest.fn();
+  const patch = jest.fn();
+
+  let capturedMutationFn: (variables: {
+    companyId: string;
+    industryCode: string;
+    industry?: string;
+  }) => unknown;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useBackendAPI as jest.Mock).mockReturnValue({
+      axios: { patch },
+      handleResponse,
+    });
+
+    (useMutation as jest.Mock).mockImplementation((_key, mutationFn) => {
+      capturedMutationFn = mutationFn;
+      return { mutate: jest.fn() };
+    });
+  });
+
+  it('calls the correct endpoint with industry_code and industry fields', () => {
+    renderHook(() => useUpdateCompanyIndustryCode());
+
+    handleResponse.mockReturnValue(Promise.resolve({}));
+    patch.mockReturnValue(Promise.resolve({ data: {} }));
+
+    capturedMutationFn({
+      companyId: 'company-123',
+      industryCode: '62010',
+      industry: 'Computer programming activities',
+    });
+
+    expect(patch).toHaveBeenCalledWith(
+      HandlerEndpoint.COMPANY_INDUSTRY_CODE('company-123'),
+      {
+        industry_code: '62010',
+        industry: 'Computer programming activities',
+      }
+    );
+  });
+
+  it('sends empty string for industry when industry is undefined', () => {
+    renderHook(() => useUpdateCompanyIndustryCode());
+
+    handleResponse.mockReturnValue(Promise.resolve({}));
+    patch.mockReturnValue(Promise.resolve({ data: {} }));
+
+    capturedMutationFn({
+      companyId: 'company-456',
+      industryCode: '47111',
+      industry: undefined,
+    });
+
+    expect(patch).toHaveBeenCalledWith(
+      HandlerEndpoint.COMPANY_INDUSTRY_CODE('company-456'),
+      {
+        industry_code: '47111',
+        industry: '',
+      }
+    );
+  });
+
+  it('registers the mutation with the correct key', () => {
+    renderHook(() => useUpdateCompanyIndustryCode());
+
+    expect(useMutation).toHaveBeenCalledWith(
+      'updateCompanyIndustryCode',
+      expect.any(Function)
+    );
+  });
+});

--- a/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
+++ b/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
@@ -3,8 +3,8 @@ import {
   CalculationFormProps,
   HandledAplication,
 } from 'benefit/handler/types/application';
-import { Application, ApplicationData } from 'benefit-shared/types/application';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
+import { Application, ApplicationData } from 'benefit-shared/types/application';
 import { ErrorData } from 'benefit-shared/types/common';
 import camelcaseKeys from 'camelcase-keys';
 import isEmpty from 'lodash/isEmpty';

--- a/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
+++ b/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
@@ -65,7 +65,7 @@ const useHandlerReviewActions = (
           industryCode: handledApplication.industryCode,
           industry: handledApplication.industryDescription,
         },
-        { onSuccess: doUpdateStatus, onError: doUpdateStatus }
+        { onSuccess: doUpdateStatus }
       );
     } else {
       doUpdateStatus();

--- a/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
+++ b/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
@@ -4,6 +4,7 @@ import {
   HandledAplication,
 } from 'benefit/handler/types/application';
 import { Application, ApplicationData } from 'benefit-shared/types/application';
+import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { ErrorData } from 'benefit-shared/types/common';
 import camelcaseKeys from 'camelcase-keys';
 import isEmpty from 'lodash/isEmpty';
@@ -16,6 +17,7 @@ import snakecaseKeys from 'snakecase-keys';
 import { useRouterNavigation } from './applicationHandling/useRouterNavigation';
 import { useApplicationActions } from './useApplicationActions';
 import useUpdateApplicationQuery from './useUpdateApplicationQuery';
+import useUpdateCompanyIndustryCode from './useUpdateCompanyIndustryCode';
 
 interface HandlerReviewActions {
   onCalculateEmployment: (calculator: CalculationFormProps) => void;
@@ -32,6 +34,7 @@ const useHandlerReviewActions = (
   >
 ): HandlerReviewActions => {
   const updateApplicationQuery = useUpdateApplicationQuery();
+  const updateCompanyIndustryCode = useUpdateCompanyIndustryCode();
 
   const { handledApplication } = React.useContext(AppContext);
 
@@ -41,14 +44,38 @@ const useHandlerReviewActions = (
 
   // ACCEPTED, REJECTED
   const onDone = React.useCallback((): void => {
-    if (handledApplication?.status) {
+    if (!handledApplication?.status) return;
+
+    const doUpdateStatus = (): void => {
       updateStatus(
-        handledApplication.status,
+        handledApplication.status as APPLICATION_STATUSES,
         handledApplication.logEntryComment,
         handledApplication.grantedAsDeMinimisAid
       );
+    };
+
+    if (
+      handledApplication.grantedAsDeMinimisAid &&
+      handledApplication.industryCode &&
+      application.company?.id
+    ) {
+      updateCompanyIndustryCode.mutate(
+        {
+          companyId: application.company.id,
+          industryCode: handledApplication.industryCode,
+          industry: handledApplication.industryDescription,
+        },
+        { onSuccess: doUpdateStatus, onError: doUpdateStatus }
+      );
+    } else {
+      doUpdateStatus();
     }
-  }, [handledApplication, updateStatus]);
+  }, [
+    handledApplication,
+    updateStatus,
+    updateCompanyIndustryCode,
+    application,
+  ]);
 
   // CANCELL
   const onCancel = (cancelledApplication: HandledAplication): void => {

--- a/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
+++ b/frontend/benefit/handler/src/hooks/useHandlerReviewActions.ts
@@ -65,7 +65,7 @@ const useHandlerReviewActions = (
           industryCode: handledApplication.industryCode,
           industry: handledApplication.industryDescription,
         },
-        { onSuccess: doUpdateStatus }
+        { onSettled: doUpdateStatus }
       );
     } else {
       doUpdateStatus();

--- a/frontend/benefit/handler/src/hooks/useUpdateCompanyIndustryCode.ts
+++ b/frontend/benefit/handler/src/hooks/useUpdateCompanyIndustryCode.ts
@@ -1,0 +1,30 @@
+import { AxiosError } from 'axios';
+import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { Company } from 'benefit-shared/types/application';
+import { useMutation, UseMutationResult } from 'react-query';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+const useUpdateCompanyIndustryCode = (): UseMutationResult<
+  Company,
+  AxiosError,
+  { companyId: string; industryCode: string; industry?: string }
+> => {
+  const { axios, handleResponse } = useBackendAPI();
+
+  return useMutation<
+    Company,
+    AxiosError,
+    { companyId: string; industryCode: string; industry?: string }
+  >(
+    'updateCompanyIndustryCode',
+    ({ companyId, industryCode, industry }) =>
+      handleResponse<Company>(
+        axios.patch(HandlerEndpoint.COMPANY_INDUSTRY_CODE(companyId), {
+          industry_code: industryCode,
+          industry: industry ?? '',
+        })
+      )
+  );
+};
+
+export default useUpdateCompanyIndustryCode;

--- a/frontend/benefit/handler/src/hooks/useUpdateCompanyIndustryCode.ts
+++ b/frontend/benefit/handler/src/hooks/useUpdateCompanyIndustryCode.ts
@@ -1,7 +1,9 @@
 import { AxiosError } from 'axios';
 import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
 import { Company } from 'benefit-shared/types/application';
-import { useMutation, UseMutationResult } from 'react-query';
+import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+import showErrorToast from 'shared/components/toast/show-error-toast';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 
 const useUpdateCompanyIndustryCode = (): UseMutationResult<
@@ -10,6 +12,8 @@ const useUpdateCompanyIndustryCode = (): UseMutationResult<
   { companyId: string; industryCode: string; industry?: string }
 > => {
   const { axios, handleResponse } = useBackendAPI();
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
 
   return useMutation<
     Company,
@@ -23,7 +27,23 @@ const useUpdateCompanyIndustryCode = (): UseMutationResult<
           industry_code: industryCode,
           industry: industry ?? '',
         })
-      )
+      ),
+    {
+      onSuccess: () => {
+        void queryClient.invalidateQueries('applications');
+        void queryClient.invalidateQueries('application');
+      },
+      onError: (): void => {
+        showErrorToast(
+          t(
+            'common:review.decisionProposal.errors.industryCodeUpdateFailed.label'
+          ),
+          t(
+            'common:review.decisionProposal.errors.industryCodeUpdateFailed.text'
+          )
+        );
+      },
+    }
   );
 };
 

--- a/frontend/benefit/handler/src/types/application.d.ts
+++ b/frontend/benefit/handler/src/types/application.d.ts
@@ -113,6 +113,9 @@ export type HandledAplication = {
   status?: APPLICATION_STATUSES;
   logEntryComment?: string;
   grantedAsDeMinimisAid?: boolean;
+  industryCode?: string;
+  industryDescription?: string;
+  industryCodeTouched?: boolean;
   decisionText?: string;
   justificationText?: string;
   decisionMakerName?: string;

--- a/frontend/benefit/shared/src/backend-api/backend-api.ts
+++ b/frontend/benefit/shared/src/backend-api/backend-api.ts
@@ -61,7 +61,9 @@ export const HandlerEndpoint = {
   HANDLER_INSTALMENT_CHANGE_DATE: (id: string) =>
     `${handlerInstalmentBase(id)}`,
   HANDLER_CHANGE_EMPLOYER_ASSURANCE: (id: string) =>
-    `${handlerApplicationsBase(id)}change_employer_assurance/`
+    `${handlerApplicationsBase(id)}change_employer_assurance/`,
+  COMPANY_INDUSTRY_CODE: (id: string) =>
+    `/v1/company/${id}/industry_code/`,
 } as const;
 
 const applicationsBase = (id: string): string =>

--- a/frontend/benefit/shared/src/types/application.d.ts
+++ b/frontend/benefit/shared/src/types/application.d.ts
@@ -599,6 +599,7 @@ export type Company = {
   city: string;
   bankAccountNumber?: string;
   organizationType: ORGANIZATION_TYPES;
+  industryCode?: string;
 };
 
 export type ApplicationListItemData = {


### PR DESCRIPTION
## Description :sparkles:

Official API's do not provide TOL code for associations. TOL code is needed in de Minimis support reporting to EU.

If benefit for application is approved as de Minimis support, it is check that applicant has TOL code (industry code) in database. If not - handler must add it manually. Handler can copy paste the combination of code and text that one can see in YTJ web page - example:
**Päätoimiala**:   56111 Ruokaravintolat
It is stored to field industry_code and industry in bf_companies_company. (currently industry is not used for anything)
If code storing is failing an error toast is shown, but it does not prevent processing the application. 

The de Minimis question was change to to yes/no type and mandatory. Due to EU reporting it is important to have a proper selection.


## Testing :alembic:
A lot of tests was added to make Sonar happy.
ApplicationProcessingView.test.tsx: 7 tests covering:
accessibility, accept/reject radio buttons,
de minimis radio buttons (ACCEPTED state),
TOL code input visibility (with/without company industryCode),
paste parsing (space-split into code + description),
no de minimis when REJECTED

applicationReview/tests/CalculationReview.test.tsx: 6 tests covering:
accessibility, null return when no draft,
industryCode row shown from handledApplication,
fallback to company.industryCode,
hidden when grantedAsDeMinimisAid=false, REJECTED status view

hooks/tests/useUpdateCompanyIndustryCode.test.ts: 3 tests covering:
correct endpoint + industry_code/industry payload, empty string
fallback when industry is undefined, correct mutation key

file: useSalaryBenefitCalculatorData.ts did not have any tests.
Now there is 16 new ones.

- HandlingApplicationActionsAhjo.tsx
- useHandlerReviewActions.ts
that had no test coverage before. 23 test added.

## Screenshots :camera_flash:
New de Minimis question
<img width="452" height="192" alt="image" src="https://github.com/user-attachments/assets/ae90df21-5254-4783-91f0-2be550504beb" />

TOL code:
<img width="484" height="143" alt="image" src="https://github.com/user-attachments/assets/ed1e6d3f-f6ef-4a53-b709-02aa126f53be" />

Error toast:
<img width="248" height="48" alt="image" src="https://github.com/user-attachments/assets/f9e59b49-74a7-4f99-b2c0-e82d48f8b8c3" />


## Additional notes :spiral_notepad:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Industry code field added and can be saved to companies; required conditionally for de minimis aid decisions
  * De minimis selection switched to Yes/No radio buttons; industry code input shown when needed
  * Handlers can update company industry code from the review flow

* **Localization**
  * Added translations for industry code fields, helper text and error messages (fi/en/sv)

* **Tests**
  * Expanded unit and integration tests covering industry code flows and API updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->