### PR TITLE
YJDH-843 | Kesäseteli employer UI: Remove enforcement of numeric voucher serial numbers

### DIFF
--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
@@ -41,11 +41,10 @@ const useFetchEmployeeDataButtonState = (
   const enableFetchEmployeeDataButton = useCallback((): void => {
     const formDataVoucher = getValues().summer_vouchers[index];
     if (!formDataVoucher) return;
-    const integerStringRegex = /^\s*\d+\s*$/; // Allow leading and trailing whitespace
     setIsFetchEmployeeDataEnabled(
       (formDataVoucher.employee_name?.length ?? 0) > 0 &&
         typeof formDataVoucher.summer_voucher_serial_number === 'string' &&
-        integerStringRegex.test(formDataVoucher.summer_voucher_serial_number)
+        !!formDataVoucher.summer_voucher_serial_number.trim()
     );
   }, [getValues, index]);
 


### PR DESCRIPTION
## Description :sparkles:

### Kesäseteli employer UI: Remove enforcement of numeric voucher serial numbers

Summer voucher serial numbers are no longer always numeric on the frontend side, they can be e.g. "31n-022", "3g9-230-vqv-s62" or "1234". Remove enforcement of numeric voucher serial numbers from the employer UI to allow the use of the new format (e.g. "31n-022").

## Related

[YJDH-843](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-843)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-843]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ