### PR TITLE
fix(ks): use RelayState as logout redirect fallback for suomi-fi

### DIFF
--- a/backend/shared/shared/suomi_fi/tests/test_views.py
+++ b/backend/shared/shared/suomi_fi/tests/test_views.py
@@ -250,6 +250,21 @@ class TestSuomiFiViews:
         assert response.status_code == 302
         assert response.url == next_url
 
+    def test_helsinki_saml2_logout_view_uses_next_as_relay_state(self):
+        factory = RequestFactory()
+        next_url = "https://kesaseteli.dev.hel.ninja/fi"
+        request = factory.get("/saml2/logout/", {"next": next_url})
+        request.session = {}
+
+        view = HelsinkiSaml2LogoutView()
+
+        with mock.patch(
+            "shared.suomi_fi.views.is_safe_redirect_url", return_value=True
+        ):
+            relay_state = view.get_relay_state(request)
+
+        assert relay_state == next_url
+
 
 @pytest.mark.django_db
 class TestSuomiFiViewsHARIntegration:
@@ -409,3 +424,46 @@ class TestSuomiFiViewsHARIntegration:
         assert (
             response.url == self.NEXT_URL_HAR
         )  # not "/" (the pre-fix broken behavior)
+
+    @override_settings(
+        ROOT_URLCONF=_SAML_TEST_URLCONF,
+        LOGOUT_REDIRECT_URL="/",
+        SAML_ALLOWED_HOSTS=[urllib_parse.urlparse(NEXT_URL_HAR).netloc],
+    )
+    def test_har_documented_slo_flow_with_lost_session(self):
+        """
+        Verify that redirection still works even if the session is lost,
+        by relying on RelayState (which now contains the next URL).
+        """
+        clear_url_caches()
+        client = Client()
+
+        # Step 1: IdP sends back the URL in RelayState.
+        # Even if the session is empty, djangosaml2's finish_logout should use RelayState.
+        with mock.patch.object(
+            HelsinkiSaml2LogoutServiceView,
+            "get_state_client",
+            return_value=(mock.MagicMock(), mock.MagicMock()),
+        ):
+            # We mock the standalone finish_logout function in djangosaml2.views
+            # to return the fallback if no RelayState, or the RelayState itself
+            # if it's provided (simulating djangosaml2 behavior).
+            def finish_logout_mock(request, response):
+                from djangosaml2.views import _get_next_path
+
+                next_path = _get_next_path(request)
+                return HttpResponseRedirect(next_path or "/")
+
+            with mock.patch(
+                "djangosaml2.views.finish_logout", side_effect=finish_logout_mock
+            ):
+                response = client.get(
+                    "/saml2/ls/",
+                    {
+                        "SAMLResponse": self.SAML_RESPONSE_HAR,
+                        "RelayState": self.NEXT_URL_HAR,  # URL is in RelayState!
+                    },
+                )
+
+        assert response.status_code == 302
+        assert response.url == self.NEXT_URL_HAR

--- a/backend/shared/shared/suomi_fi/views.py
+++ b/backend/shared/shared/suomi_fi/views.py
@@ -86,17 +86,26 @@ class HelsinkiSaml2LogoutView(LogoutInitView):
     redirecting the user to the IdP (Suomi.fi).
     """
 
-    def get(self, request, *args, **kwargs):
-        # Capture 'next' parameter so it can be used on failure.
-        # RELAY_STATE_PARAM is also checked as a fallback for standard SAML logout.
-        self.next_path = (
+    def get_relay_state(self, request):
+        """
+        Use 'next' path as RelayState so it survives if session is lost.
+        """
+        next_path = (
             request.GET.get(REDIRECT_FIELD_NAME)
             or request.GET.get(RELAY_STATE_PARAM)
             or request.POST.get(RELAY_STATE_PARAM)
         )
-        if self.next_path and is_safe_redirect_url(
-            request, self.next_path, allowed_hosts=settings.SAML_ALLOWED_HOSTS
+        if next_path and is_safe_redirect_url(
+            request, next_path, allowed_hosts=settings.SAML_ALLOWED_HOSTS
         ):
+            return next_path
+        return ""
+
+    def get(self, request, *args, **kwargs):
+        # Capture 'next' parameter so it can be used on failure.
+        # RELAY_STATE_PARAM is also checked as a fallback for standard SAML logout.
+        self.next_path = self.get_relay_state(request)
+        if self.next_path:
             request.session["saml2_logout_next_path"] = self.next_path
 
         return super().get(request, *args, **kwargs)
@@ -134,8 +143,13 @@ class HelsinkiSaml2LogoutServiceView(LogoutView):
     """
 
     def do_logout_service(self, request, data, binding, *args, **kwargs):
+        # Pop next_path from session BEFORE super() calls auth.logout() and flushes it.
         next_path = request.session.pop("saml2_logout_next_path", None)
+
         response = super().do_logout_service(request, data, binding, *args, **kwargs)
+
+        # If next_path was in the session, and the response is a redirect to the default
+        # fallback, replace it with the session-stored next_path.
         if next_path and isinstance(response, HttpResponseRedirect):
             fallback = resolve_url(getattr(settings, "LOGOUT_REDIRECT_URL", "/"))
             if response.url == fallback and is_safe_redirect_url(


### PR DESCRIPTION
YJDH-609.

> a desperate attempt to get logout working after several attempts. Currently it is not possible to test or replicate it on my own machine, so it needs to be tested in a dev environment.