### PR TITLE
YJDH-843 | Kesäseteli backend: Add user showable serial number search to Django admin

### DIFF
--- a/backend/kesaseteli/applications/admin.py
+++ b/backend/kesaseteli/applications/admin.py
@@ -35,6 +35,35 @@ TARGET_GROUP_CHOICES_DICT = dict(get_target_group_choices())
 LOGGER = logging.getLogger(__name__)
 
 
+class SerialNumberDecodingSearchMixin:
+    """
+    Mixin for adding decoding of base32 encoded youth summer voucher serial numbers
+    before searching with it. The values in the database are decoded values, so
+    searching with the decoded values is needed to find something.
+    """
+
+    def get_search_results(self, request, queryset, search_term):
+        """ """
+        search_term = search_term.strip()
+        try:
+            # If the search term could be a randomly generated encoded serial number,
+            # try to decode it and search with the decoded value instead:
+            if (
+                "-" in search_term
+                and len(search_term)
+                >= YouthSummerVoucher.MIN_RAND_SERIAL_NUMBER_STR_LEN
+            ):
+                decoded_search_term = str(
+                    YouthSummerVoucher.decode_user_showable_serial_number(search_term)
+                )
+                return super().get_search_results(
+                    request, queryset, decoded_search_term
+                )
+        except ValueError:  # Invalid checksum or format
+            pass
+        return super().get_search_results(request, queryset, search_term)
+
+
 class SummerVoucherConfigurationAdminForm(forms.ModelForm):
     target_group = forms.MultipleChoiceField(
         choices=get_target_group_choices(),
@@ -488,10 +517,13 @@ class YouthApplicationAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
         return False
 
 
-class YouthSummerVoucherAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
+class YouthSummerVoucherAdmin(
+    AuditlogAdminViewAccessLogMixin, SerialNumberDecodingSearchMixin, admin.ModelAdmin
+):
     list_display = [
         "id",
         "summer_voucher_serial_number",
+        "user_showable_serial_number",
         "target_group_display",
         "birthdate",
         "youth_application_link",
@@ -518,6 +550,7 @@ class YouthSummerVoucherAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin)
     autocomplete_fields = [
         "youth_application",
     ]
+    readonly_fields = ["user_showable_serial_number"]
     actions = ["resend_voucher"]
 
     def get_queryset(self, request):
@@ -703,10 +736,13 @@ class EmployerApplicationAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin
         )
 
 
-class EmployerSummerVoucherAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
+class EmployerSummerVoucherAdmin(
+    AuditlogAdminViewAccessLogMixin, SerialNumberDecodingSearchMixin, admin.ModelAdmin
+):
     list_display = [
         "id",
         "youth_summer_voucher_id",
+        "summer_voucher_serial_number",
         "_obsolete_unclean_serial_number",
         "has_migrated_obsolete_serial_number",
         "target_group_display",

--- a/backend/kesaseteli/applications/models.py
+++ b/backend/kesaseteli/applications/models.py
@@ -904,6 +904,9 @@ class YouthSummerVoucher(TimeStampedModel, UUIDModel):
     # existing sequential values in production were in range [1, 30k) in May 2026.
     MIN_RAND_SERIAL_NUM = 100_000
 
+    # Minimum string length of encoded randomly generated serial numbers,
+    MIN_RAND_SERIAL_NUMBER_STR_LEN = 7  # Length of encoded MIN_RAND_SERIAL_NUM
+
     # Inclusive upper limit for randomly generated serial numbers,
     # using maximum value that fits base32 encoded with checksum & dashes in 15 chars:
     # >>> base32_lib.encode(2**50-1, split_every=3, checksum=True) == "zzz-zzz-zzz-z89"

--- a/backend/kesaseteli/applications/tests/test_employer_summer_voucher_admin.py
+++ b/backend/kesaseteli/applications/tests/test_employer_summer_voucher_admin.py
@@ -2,7 +2,9 @@ import pytest
 from django.contrib.admin.sites import AdminSite
 from django.test import RequestFactory
 
-from applications.admin import EmployerSummerVoucherAdmin
+from applications.admin import (
+    EmployerSummerVoucherAdmin,
+)
 from applications.models import EmployerSummerVoucher
 from common.tests.factories import EmployerSummerVoucherFactory
 
@@ -70,3 +72,33 @@ def test_get_queryset(employer_summer_voucher_admin):
     request = RequestFactory().get("/")
     qs = employer_summer_voucher_admin.get_queryset(request)
     assert qs.filter(pk=voucher.pk).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "serial_number, search_term",
+    [
+        (9999, "9999"),  # sequential number, stringified as-is
+        (100_000, "31n-022"),  # base32 encoded, decoded to "100000" before searching
+        (123456789012345, "3g9-230-vqv-s62"),  # base32 encoded → decoded
+    ],
+)
+def test_serial_number_search(
+    employer_summer_voucher_admin, serial_number: int, search_term
+):
+    """
+    Test that searching with a serial number (in both sequential and base32 encoded forms)
+    returns the correct voucher.
+    """
+    _smaller, voucher, _larger = (
+        EmployerSummerVoucherFactory(
+            youth_summer_voucher__summer_voucher_serial_number=serial_number + diff
+        )
+        for diff in (-1, 0, 1)
+    )
+    request = RequestFactory().get("/")
+
+    result_qs, _ = employer_summer_voucher_admin.get_search_results(
+        request, EmployerSummerVoucher.objects.all(), search_term
+    )
+    assert list(result_qs.values_list("pk", flat=True)) == [voucher.pk]

--- a/backend/kesaseteli/applications/tests/test_models.py
+++ b/backend/kesaseteli/applications/tests/test_models.py
@@ -256,6 +256,52 @@ def test_employer_summer_voucher_summer_voucher_serial_number_setter_with_match(
     )
 
 
+@pytest.mark.parametrize(
+    "input_serial_number, expected_result",
+    [
+        # Previously used sequentially generated serial numbers in range [1, 100k):
+        (1, "1"),
+        (1234, "1234"),
+        (99_999, "99999"),
+        # Randomly generated base32 encoded serial numbers with integer values >=100k:
+        (100_000, "31n-022"),
+        (123456789012345, "3g9-230-vqv-s62"),
+        (2**50 - 1, "zzz-zzz-zzz-z89"),
+    ],
+)
+def test_youth_summer_voucher_get_user_showable_serial_number(
+    input_serial_number: int, expected_result: str
+):
+    """
+    Test that YouthSummerVoucher.get_user_showable_serial_number encodes serial numbers
+    as expected.
+    """
+    assert (
+        YouthSummerVoucher.get_user_showable_serial_number(input_serial_number)
+        == expected_result
+    )
+
+
+def test_youth_summer_voucher_encoded_serial_number_lengths():
+    """
+    Test that youth summer vouchers' sequential and randomly generated serial numbers
+    are distinguishable unambiguously in their encoded format simply by their string lengths.
+    """
+    encoded_min_rand_serial_number = YouthSummerVoucher.get_user_showable_serial_number(
+        YouthSummerVoucher.MIN_RAND_SERIAL_NUM
+    )
+    max_sequential_serial_number = YouthSummerVoucher.MIN_RAND_SERIAL_NUM - 1
+    assert (
+        encoded_min_rand_serial_number == "31n-022"
+    )  # Should have been base32 encoded
+    assert YouthSummerVoucher.MIN_RAND_SERIAL_NUMBER_STR_LEN == len(
+        encoded_min_rand_serial_number
+    )
+    assert YouthSummerVoucher.MIN_RAND_SERIAL_NUMBER_STR_LEN > len(
+        str(max_sequential_serial_number)
+    )
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "possibly_matching_serial_numbers, input_serial_number",

--- a/backend/kesaseteli/applications/tests/test_youth_summer_voucher_admin.py
+++ b/backend/kesaseteli/applications/tests/test_youth_summer_voucher_admin.py
@@ -101,3 +101,61 @@ def test_get_queryset(youth_summer_voucher_admin):
     request = RequestFactory().get("/")
     qs = youth_summer_voucher_admin.get_queryset(request)
     assert qs.filter(pk=voucher.pk).exists()
+
+
+@pytest.mark.parametrize(
+    "search_term, expected_term",
+    [
+        # Unchanged search terms:
+        ("Test text", "Test text"),  # Normal text
+        ("9999", "9999"),  # sequential, no dash
+        ("31n-023", "31n-023"),  # invalid checksum → ValueError caught
+        # Changed search terms:
+        ("31n-022", "100000"),  # base32 encoded → decoded
+        ("3g9-230-vqv-s62", "123456789012345"),  # base32 encoded → decoded
+    ],
+)
+def test_get_search_results_search_term_modification(
+    youth_summer_voucher_admin, search_term, expected_term
+):
+    """
+    Test that YouthSummerVoucherAdmin.get_search_results calls the super class's
+    version with the search term modified/unmodified as expected.
+    """
+    request = RequestFactory().get("/")
+    queryset = YouthSummerVoucher.objects.none()
+
+    with patch(
+        "django.contrib.admin.ModelAdmin.get_search_results",
+        return_value=(queryset, False),
+    ) as mock_super:
+        youth_summer_voucher_admin.get_search_results(request, queryset, search_term)
+        mock_super.assert_called_once_with(request, queryset, expected_term)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "serial_number, search_term",
+    [
+        (9999, "9999"),  # sequential number, stringified as-is
+        (100_000, "31n-022"),  # base32 encoded, decoded to "100000" before searching
+        (123456789012345, "3g9-230-vqv-s62"),  # base32 encoded → decoded
+    ],
+)
+def test_serial_number_search(
+    youth_summer_voucher_admin, serial_number: int, search_term
+):
+    """
+    Test that searching with a serial number (in both sequential and base32 encoded forms)
+    returns the correct voucher.
+    """
+    _smaller, voucher, _larger = (
+        YouthSummerVoucherFactory(summer_voucher_serial_number=serial_number + diff)
+        for diff in (-1, 0, 1)
+    )
+    request = RequestFactory().get("/")
+
+    result_qs, _ = youth_summer_voucher_admin.get_search_results(
+        request, YouthSummerVoucher.objects.all(), search_term
+    )
+    assert list(result_qs.values_list("pk", flat=True)) == [voucher.pk]

--- a/backend/kesaseteli/common/tests/factories.py
+++ b/backend/kesaseteli/common/tests/factories.py
@@ -718,9 +718,9 @@ class YouthSummerVoucherFactory(
         AcceptedYouthApplicationFactory, youth_summer_voucher=None
     )
     # NOTE: Difference from production use:
-    # - This does not generate a gapless sequence
+    # - This does not generate a gapless sequence for old sequential values
     summer_voucher_serial_number = factory.Faker(
-        "pyint", min_value=1, max_value=(2**63) - 1
+        "pyint", min_value=1, max_value=YouthSummerVoucher.MAX_RAND_SERIAL_NUM
     )
 
     class Meta:


### PR DESCRIPTION
## Description :sparkles:

### Kesäseteli backend: Add user showable serial number search to Django admin

also:
- add some tests
- show user readable serial numbers in django admin

## Related

[YJDH-843](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-843)

## Testing :alembic:

## Screenshots :camera_flash:

### Youth summer voucher list view in Django admin

<img width="1302" height="833" alt="image" src="https://github.com/user-attachments/assets/fc7da38e-4e81-4f87-89bf-8eb90e01acac" />

### Youth summer voucher detail view in Django admin

#### Sequential number (<100k), not base32 encoded

<img width="1223" height="1091" alt="image" src="https://github.com/user-attachments/assets/aa1cb14f-b2be-44cf-99a6-94dc05baf03b" />

#### Randomly generated number, (≥100k), base32 encoded

<img width="1191" height="1061" alt="image" src="https://github.com/user-attachments/assets/7c7f160d-1dec-4aab-83a0-f82aac924b03" />

### Employer summer voucher list view in Django admin

<img width="1319" height="671" alt="image" src="https://github.com/user-attachments/assets/3ff2bc45-2363-40f2-99d9-ceacebdd5aa0" />

### Employer summer voucher detail view in Django admin

#### Sequential number (<100k), not base32 encoded

<img width="1238" height="352" alt="image" src="https://github.com/user-attachments/assets/2162c1d6-a574-4fac-84e7-c75ce7fa89db" />

#### Randomly generated number, (≥100k), base32 encoded

<img width="1237" height="351" alt="image" src="https://github.com/user-attachments/assets/16c15474-af3b-4cac-8844-a0f6988429d5" />

## Additional notes :spiral_notepad:


[YJDH-843]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ