### PR TITLE
deps(kesaseteli): migrate database driver to psycopg v3

### DIFF
--- a/backend/kesaseteli/README.md
+++ b/backend/kesaseteli/README.md
@@ -38,7 +38,7 @@ Prerequisites:
 * Run `pip install -r requirements.txt`
 * Run `pip install -r requirements-dev.txt` (development requirements)
 
-**Known issues:** `psycopg2` installation often fails on macOS. Try to install it with `brew install postgresql` and then run `pip install psycopg2`, or for a more permanent but not so good solution, try `pip install psycopg2-binary`.
+**Note on Database Drivers:** This project uses `psycopg` (v3) with the `[binary]` extension. This handles the PostgreSQL client library (`libpq`) requirements automatically for most platforms, including macOS (even with architecture mismatches), Windows, and Linux. No manual installation of `libpq` is usually required.
 
 ### Database
 

--- a/backend/kesaseteli/requirements.in
+++ b/backend/kesaseteli/requirements.in
@@ -20,7 +20,7 @@ jsonpath-ng
 mozilla-django-oidc
 pillow
 polyleven
-psycopg2
+psycopg[binary]
 python-stdnum>=1.19
 requests
 sentry-sdk

--- a/backend/kesaseteli/requirements.txt
+++ b/backend/kesaseteli/requirements.txt
@@ -130,8 +130,10 @@ polyleven==0.11.0
     # via -r requirements.in
 prompt-toolkit==3.0.52
     # via ipython
-psycopg2==2.9.11
+psycopg[binary]==3.3.4
     # via -r requirements.in
+psycopg-binary==3.3.4
+    # via psycopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -183,6 +185,7 @@ typing-extensions==4.15.0
     # via
     #   azure-core
     #   azure-storage-blob
+    #   psycopg
 urllib3==2.6.3
     # via
     #   django-auth-adfs


### PR DESCRIPTION
YJDH-640 YJDH-894.

- Replaced psycopg2 with psycopg[binary] (v3) to resolve macOS installation and architecture mismatch issues.
- Updated requirements.in and regenerated requirements.txt.
- Updated README.md with guidance on v3 database driver requirements.