### PR TITLE
fix(ks): fetch target group translations with current locale

### DIFF
--- a/frontend/kesaseteli/shared/src/hooks/__tests__/useSummerVoucherConfigurationQuery.test.tsx
+++ b/frontend/kesaseteli/shared/src/hooks/__tests__/useSummerVoucherConfigurationQuery.test.tsx
@@ -9,6 +9,7 @@ import useSummerVoucherConfigurationQuery from '../useSummerVoucherConfiguration
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import SummerVoucherConfiguration from 'kesaseteli-shared/types/summer-voucher-configuration';
 import useErrorHandler from 'shared/hooks/useErrorHandler';
+import useLocale from 'shared/hooks/useLocale';
 
 const API_BASE_TEST_URL = 'http://kesaseteli-api';
 
@@ -47,8 +48,11 @@ jest.mock('shared/hooks/useErrorHandler', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('shared/hooks/useLocale', () => jest.fn());
+
 const mockUseTranslation = useTranslation as jest.Mock;
 const mockUseErrorHandler = useErrorHandler as jest.Mock;
+const mockUseLocale = useLocale as jest.Mock;
 const mockErrorHandler = jest.fn();
 
 describe('useSummerVoucherConfigurationQuery', () => {
@@ -86,8 +90,13 @@ describe('useSummerVoucherConfigurationQuery', () => {
     mockUseTranslation.mockReturnValue({
       i18n: { language: firstLang },
     });
+    mockUseLocale.mockReturnValue(firstLang);
 
-    nock(API_BASE_TEST_URL)
+    nock(API_BASE_TEST_URL, {
+      reqheaders: {
+        'accept-language': firstLang,
+      },
+    })
       .get(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)
       .reply(200, languageDataMock[firstLang]);
 
@@ -106,6 +115,7 @@ describe('useSummerVoucherConfigurationQuery', () => {
       mockUseTranslation.mockReturnValue({
         i18n: { language: lang },
       });
+      mockUseLocale.mockReturnValue(lang);
 
       nock(API_BASE_TEST_URL, {
         reqheaders: {
@@ -127,6 +137,7 @@ describe('useSummerVoucherConfigurationQuery', () => {
     mockUseTranslation.mockReturnValue({
       i18n: { language: languages[0] },
     });
+    mockUseLocale.mockReturnValue(languages[0]);
 
     nock(API_BASE_TEST_URL)
       .get(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)

--- a/frontend/kesaseteli/shared/src/hooks/useSummerVoucherConfigurationQuery.ts
+++ b/frontend/kesaseteli/shared/src/hooks/useSummerVoucherConfigurationQuery.ts
@@ -1,19 +1,25 @@
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import SummerVoucherConfiguration from 'kesaseteli-shared/types/summer-voucher-configuration';
-import { useTranslation } from 'next-i18next';
 import { useQuery, UseQueryResult } from 'react-query';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 import useErrorHandler from 'shared/hooks/useErrorHandler';
+import useLocale from 'shared/hooks/useLocale';
 
 const useSummerVoucherConfigurationQuery = (): UseQueryResult<
   SummerVoucherConfiguration[]
 > => {
   const { axios, handleResponse } = useBackendAPI();
-  const { i18n } = useTranslation();
+  const locale = useLocale();
   return useQuery(
-    [BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION, i18n.language],
+    [BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION, locale],
     () =>
-      handleResponse(axios.get(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)),
+      handleResponse(
+        axios.get(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION, {
+          headers: {
+            'Accept-Language': locale,
+          },
+        })
+      ),
     {
       staleTime: Infinity,
       onError: useErrorHandler(),


### PR DESCRIPTION
YJDH-864.

<img width="1087" height="934" alt="image" src="https://github.com/user-attachments/assets/1a13c20a-25f8-4b0e-8281-20ece7a91f19" />

<img width="1084" height="933" alt="image" src="https://github.com/user-attachments/assets/e6e568ad-f067-4254-a374-5857dedb5ecb" />

<img width="1081" height="940" alt="image" src="https://github.com/user-attachments/assets/7e5f6cf9-78f0-48e9-bac9-78a8e2abb439" />
