### PR TITLE
HL-1806 | Add download endpoint to api for terms and display api download links in django admin

### DIFF
--- a/backend/benefit/applications/admin.py
+++ b/backend/benefit/applications/admin.py
@@ -50,7 +50,18 @@ class AttachmentInline(admin.StackedInline):
     model = Attachment
     fk_name = "application"
     extra = 0
-    readonly_fields = ("created_at",)
+    readonly_fields = ("created_at", "download_link")
+
+    def download_link(self, obj):
+        if obj.pk and obj.application_id:
+            url = reverse(
+                "v1:handler-application-download-attachment",
+                kwargs={"pk": obj.application_id, "attachment_pk": obj.pk},
+            )
+            return format_html('<a href="{}" target="_blank">Download</a>', url)
+        return "-"
+
+    download_link.short_description = "Download URL"
 
 
 class ApplicationAlterationInline(admin.StackedInline):
@@ -223,6 +234,29 @@ class ApplicationLogEntryAdmin(admin.ModelAdmin):
     search_fields = ["application__id"]
 
 
+class AttachmentAdmin(admin.ModelAdmin):
+    list_display = [
+        "id",
+        "attachment_type",
+        "content_type",
+        "application",
+        "download_link",
+    ]
+    readonly_fields = ["created_at", "download_link"]
+    search_fields = ["id", "application__id"]
+
+    def download_link(self, obj):
+        if obj.pk and obj.application_id:
+            url = reverse(
+                "v1:handler-application-download-attachment",
+                kwargs={"pk": obj.application_id, "attachment_pk": obj.pk},
+            )
+            return format_html('<a href="{}" target="_blank">Download</a>', url)
+        return "-"
+
+    download_link.short_description = "Download URL"
+
+
 class EmployeeAdmin(admin.ModelAdmin):
     exclude = ("encrypted_social_security_number", "social_security_number")
     list_display = [
@@ -240,7 +274,7 @@ admin.site.register(Application, ApplicationAdmin)
 admin.site.register(ApplicationBatch, ApplicationBatchAdmin)
 admin.site.register(DeMinimisAid)
 admin.site.register(Employee, EmployeeAdmin)
-admin.site.register(Attachment)
+admin.site.register(Attachment, AttachmentAdmin)
 admin.site.register(ApplicationBasis, ApplicationBasisAdmin)
 admin.site.register(ApplicationLogEntry, ApplicationLogEntryAdmin)
 admin.site.register(AhjoSetting, AhjoSettingAdmin)

--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 from decimal import ROUND_DOWN, Decimal
 from typing import List
 
+from azure.core.exceptions import ResourceNotFoundError
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core import exceptions
@@ -472,7 +473,10 @@ class BaseApplicationViewSet(AuditLoggingModelViewSet):
                 Operation.READ,
                 attachment,
             )
-            return FileResponse(attachment.attachment_file)
+            try:
+                return FileResponse(attachment.attachment_file)
+            except (OSError, ResourceNotFoundError):
+                return self._attachment_not_found()
         else:
             return self._attachment_not_found()
 

--- a/backend/benefit/helsinkibenefit/urls.py
+++ b/backend/benefit/helsinkibenefit/urls.py
@@ -25,7 +25,10 @@ from applications.api.v1.ahjo_integration_views import (
     AhjoDecisionCallbackView,
 )
 from applications.api.v1.ahjo_setting_views import AhjoSettingDetailView
-from applications.api.v1.deminimis_integration_views import DeMinimisCallbackView, DeMinimisIntegrationView
+from applications.api.v1.deminimis_integration_views import (
+    DeMinimisCallbackView,
+    DeMinimisIntegrationView,
+)
 from applications.api.v1.power_bi_integration_views import PowerBiIntegrationView
 from applications.api.v1.review_state_views import ReviewStateView
 from applications.api.v1.search_views import SearchView
@@ -42,7 +45,7 @@ from messages.views import (
     HandlerMessageViewSet,
     HandlerNoteViewSet,
 )
-from terms.api.v1.views import ApproveTermsOfServiceView
+from terms.api.v1.views import ApproveTermsOfServiceView, TermsPdfDownloadView
 from users.api.v1.views import CurrentUserView, UserOptionsView
 
 router = routers.DefaultRouter()
@@ -129,7 +132,6 @@ urlpatterns = [
         DeMinimisCallbackView.as_view(),
         name="deminimis_callback_url",
     ),
-
     path(
         "v1/decision-proposal-sections/",
         DecisionProposalTemplateSectionList.as_view(),
@@ -150,6 +152,11 @@ urlpatterns = [
     path("v1/", include(applicant_app_router.urls)),
     path("v1/", include(handler_app_router.urls)),
     path("v1/terms/approve_terms_of_service/", ApproveTermsOfServiceView.as_view()),
+    path(
+        "v1/terms/<uuid:terms_id>/download/<str:language>/",
+        TermsPdfDownloadView.as_view(),
+        name="terms-pdf-download",
+    ),
     path("v1/company/", GetUsersOrganizationView.as_view()),
     path("v1/company/search/<str:name>/", SearchOrganisationsView.as_view()),
     path("v1/company/get/<str:business_id>/", GetOrganisationByIdView.as_view()),

--- a/backend/benefit/terms/api/v1/serializers.py
+++ b/backend/benefit/terms/api/v1/serializers.py
@@ -1,5 +1,6 @@
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
+from rest_framework.reverse import reverse
 
 from terms.models import (
     ApplicantConsent,
@@ -25,6 +26,28 @@ class TermsSerializer(serializers.ModelSerializer):
         many=True,
         read_only=True,
     )
+    terms_pdf_fi = serializers.SerializerMethodField()
+    terms_pdf_en = serializers.SerializerMethodField()
+    terms_pdf_sv = serializers.SerializerMethodField()
+
+    def _pdf_download_url(self, obj, language):
+        if not getattr(obj, f"terms_pdf_{language}"):
+            return None
+        request = self.context.get("request")
+        return reverse(
+            "terms-pdf-download",
+            kwargs={"terms_id": obj.id, "language": language},
+            request=request,
+        )
+
+    def get_terms_pdf_fi(self, obj):
+        return self._pdf_download_url(obj, "fi")
+
+    def get_terms_pdf_en(self, obj):
+        return self._pdf_download_url(obj, "en")
+
+    def get_terms_pdf_sv(self, obj):
+        return self._pdf_download_url(obj, "sv")
 
     class Meta:
         model = Terms

--- a/backend/benefit/terms/api/v1/views.py
+++ b/backend/benefit/terms/api/v1/views.py
@@ -1,18 +1,21 @@
+from azure.core.exceptions import ResourceNotFoundError
 from django.conf import settings
+from django.core.exceptions import SuspiciousFileOperation
+from django.http import FileResponse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema
-from rest_framework import serializers
+from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from common.permissions import BFIsApplicant
+from common.permissions import BFIsApplicant, BFIsAuthenticated
 from terms.api.v1.serializers import (
     ApproveTermsSerializer,
     TermsOfServiceApprovalSerializer,
 )
-from terms.models import TermsOfServiceApproval
+from terms.models import Terms, TermsOfServiceApproval
 from users.utils import get_company_from_request
 
 
@@ -58,8 +61,44 @@ class ApproveTermsOfServiceView(APIView):
             # Set the TOS approval flag to session
             request.session[settings.TERMS_OF_SERVICE_SESSION_KEY] = True
             request.session.save()
-            return Response(TermsOfServiceApprovalSerializer(approval).data)
+            return Response(
+                TermsOfServiceApprovalSerializer(
+                    approval, context={"request": request}
+                ).data
+            )
         else:
             raise ValidationError(
                 _("The terms of service should only be approved once")
             )
+
+
+class TermsPdfDownloadView(APIView):
+    permission_classes = [BFIsAuthenticated]
+
+    LANGUAGE_FIELD_MAP = {
+        "fi": "terms_pdf_fi",
+        "en": "terms_pdf_en",
+        "sv": "terms_pdf_sv",
+    }
+
+    def get(self, request, terms_id, language):
+        if language not in self.LANGUAGE_FIELD_MAP:
+            return Response(
+                {"detail": "Invalid language. Use fi, en or sv."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            terms = Terms.objects.get(pk=terms_id)
+        except Terms.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        pdf_file = getattr(terms, self.LANGUAGE_FIELD_MAP[language])
+        if not pdf_file:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            file_handle = pdf_file.open()
+        except (SuspiciousFileOperation, OSError, ResourceNotFoundError):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return FileResponse(file_handle, content_type="application/pdf")

--- a/backend/benefit/terms/tests/test_terms_pdf_download.py
+++ b/backend/benefit/terms/tests/test_terms_pdf_download.py
@@ -1,0 +1,114 @@
+import uuid
+
+import pytest
+from django.core.files.base import ContentFile
+from django.urls import reverse
+from rest_framework.test import APIRequestFactory
+
+from terms.api.v1.serializers import TermsSerializer
+from terms.enums import TermsType
+from terms.tests.factories import TermsFactory
+
+PDF_CONTENT = b"%PDF-1.4 fake pdf content for testing"
+
+
+def get_download_url(terms_id, language):
+    return reverse(
+        "terms-pdf-download",
+        kwargs={"terms_id": terms_id, "language": language},
+    )
+
+
+@pytest.fixture
+def terms_with_pdfs():
+    terms = TermsFactory(terms_type=TermsType.TERMS_OF_SERVICE)
+    terms.terms_pdf_fi.save("terms_fi.pdf", ContentFile(PDF_CONTENT), save=True)
+    terms.terms_pdf_en.save("terms_en.pdf", ContentFile(PDF_CONTENT), save=True)
+    terms.terms_pdf_sv.save("terms_sv.pdf", ContentFile(PDF_CONTENT), save=True)
+    yield terms
+    terms.terms_pdf_fi.delete(save=False)
+    terms.terms_pdf_en.delete(save=False)
+    terms.terms_pdf_sv.delete(save=False)
+
+
+@pytest.fixture
+def terms_without_pdfs():
+    terms = TermsFactory(
+        terms_type=TermsType.TERMS_OF_SERVICE,
+        terms_pdf_fi="",
+        terms_pdf_en="",
+        terms_pdf_sv="",
+    )
+    return terms
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("language", ["fi", "en", "sv"])
+def test_terms_pdf_download_applicant(api_client, terms_with_pdfs, language):
+    response = api_client.get(get_download_url(terms_with_pdfs.id, language))
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/pdf"
+    assert b"".join(response.streaming_content) == PDF_CONTENT
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("language", ["fi", "en", "sv"])
+def test_terms_pdf_download_handler(handler_api_client, terms_with_pdfs, language):
+    response = handler_api_client.get(get_download_url(terms_with_pdfs.id, language))
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/pdf"
+
+
+@pytest.mark.django_db
+def test_terms_pdf_download_unauthenticated(anonymous_client, terms_with_pdfs):
+    response = anonymous_client.get(get_download_url(terms_with_pdfs.id, "fi"))
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_terms_pdf_download_invalid_language(api_client, terms_with_pdfs):
+    response = api_client.get(get_download_url(terms_with_pdfs.id, "de"))
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_terms_pdf_download_nonexistent_terms(api_client):
+    response = api_client.get(get_download_url(uuid.uuid4(), "fi"))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_terms_pdf_download_missing_pdf(api_client, terms_without_pdfs):
+    response = api_client.get(get_download_url(terms_without_pdfs.id, "fi"))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_terms_serializer_returns_proxy_urls(api_client, terms_with_pdfs):
+    """PDF fields in the serializer should return proxy download URLs, not blob storage URLs."""
+    factory = APIRequestFactory()
+    request = factory.get("/")
+    request.user = api_client.handler._force_user
+
+    serializer = TermsSerializer(terms_with_pdfs, context={"request": request})
+    data = serializer.data
+
+    for lang in ("fi", "en", "sv"):
+        field = f"terms_pdf_{lang}"
+        assert data[field] is not None
+        assert f"/v1/terms/{terms_with_pdfs.id}/download/{lang}/" in data[field]
+        assert "blob" not in data[field]
+        assert "?" not in data[field]
+
+
+@pytest.mark.django_db
+def test_terms_serializer_returns_none_for_missing_pdf(api_client, terms_without_pdfs):
+    factory = APIRequestFactory()
+    request = factory.get("/")
+    request.user = api_client.handler._force_user
+
+    serializer = TermsSerializer(terms_without_pdfs, context={"request": request})
+    data = serializer.data
+
+    for lang in ("fi", "en", "sv"):
+        assert data[f"terms_pdf_{lang}"] is None


### PR DESCRIPTION
The blob storage access has changed so that the direct urls does not work anymore and every file needs to be accessed through the REST API. 
This adds:
 - api download links to application attachments to django admin 
 - download endpoint to for the terms to api

In Django Admin application's attachments can be opened from the Download-link.
The link in the filename does not work.

<img width="587" height="535" alt="image" src="https://github.com/user-attachments/assets/a9039c67-957d-4e8c-8385-961f90d5c12c" />

Refs: HL-1806