### PR TITLE
fix: handle possible ValidationError with AuditLoggingModelViewSet

### DIFF
--- a/backend/shared/shared/audit_log/tests/test_viewsets.py
+++ b/backend/shared/shared/audit_log/tests/test_viewsets.py
@@ -1,0 +1,26 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from shared.audit_log.viewsets import AuditLoggingModelViewSet
+
+User = get_user_model()
+
+
+class DummyAuditLoggingModelViewSet(AuditLoggingModelViewSet):
+    queryset = User.objects.all()
+
+
+@pytest.mark.django_db
+def test_get_target_object_returns_user_with_uuid_pk_string(user):
+    viewset = DummyAuditLoggingModelViewSet()
+    viewset.kwargs = {"pk": str(user.pk)}
+
+    assert viewset._get_target_object() == user
+
+
+@pytest.mark.django_db
+def test_get_target_object_returns_none_for_invalid_uuid_pk_string():
+    viewset = DummyAuditLoggingModelViewSet()
+    viewset.kwargs = {"pk": "not-a-uuid"}
+
+    assert viewset._get_target_object() is None

--- a/backend/shared/shared/audit_log/viewsets.py
+++ b/backend/shared/shared/audit_log/viewsets.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Model
 from django.db.models.base import ModelBase
@@ -139,11 +140,16 @@ class AuditLoggingModelViewSet(ModelViewSet):
     def _get_target_object(self):
         lookup_value = self.kwargs.get(self.lookup_field, None)
         if lookup_value is not None:
-            return (
-                self._unfiltered_queryset()
-                .filter(**{self.lookup_field: lookup_value})
-                .first()
-            )
+            try:
+                return (
+                    self._unfiltered_queryset()
+                    .filter(**{self.lookup_field: lookup_value})
+                    .first()
+                )
+            except ValidationError:
+                # Converting the lookup value to the type of lookup field failed
+                return None
+
         else:
             return None
 


### PR DESCRIPTION
This PR fixes an issue when an audit log is being created where e.g. a random string into UUID field would cause a `ValidationError` when trying to retrieve the target object.

Refs: HL-1797
