### PR TITLE
Improve DVV error handling

### DIFF
--- a/backend/kesaseteli/applications/api/v1/exceptions.py
+++ b/backend/kesaseteli/applications/api/v1/exceptions.py
@@ -1,0 +1,13 @@
+from django.utils.translation import gettext_lazy as _
+from rest_framework.exceptions import APIException
+
+
+class VTJServiceUnavailableError(APIException):
+    """Raised when the VTJ (Population Information System) REST API is unreachable."""
+
+    status_code = 503
+    default_detail = _(
+        "Population Information System is temporarily unavailable. "
+        "Please try again later."
+    )
+    default_code = "vtj_service_unavailable"

--- a/backend/kesaseteli/applications/services.py
+++ b/backend/kesaseteli/applications/services.py
@@ -3,6 +3,7 @@ import logging
 from typing import Optional, TYPE_CHECKING
 
 import jsonpath_ng
+import sentry_sdk
 from auditlog.models import LogEntry
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -10,8 +11,10 @@ from django.template import Context, Template
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import get_template
 from requests import ReadTimeout
+from requests.exceptions import RequestException
 
 import applications.target_groups
+from applications.api.v1.exceptions import VTJServiceUnavailableError
 from applications.enums import (
     APPLICATION_LANGUAGE_CHOICES,
     EmailTemplateType,
@@ -397,9 +400,13 @@ class VTJService:
                 )
             return mock_vtj_person_id_query_not_found_content()
 
-        vtj_data = VTJClient().get_personal_info(
-            application.social_security_number, end_user
-        )
+        try:
+            vtj_data = VTJClient().get_personal_info(
+                application.social_security_number, end_user
+            )
+        except (RequestException, ValueError) as e:
+            sentry_sdk.capture_exception(e)
+            raise VTJServiceUnavailableError() from e
         return json.dumps(vtj_data)
 
     @classmethod

--- a/backend/kesaseteli/applications/tests/test_applications_auth_logging.py
+++ b/backend/kesaseteli/applications/tests/test_applications_auth_logging.py
@@ -6,6 +6,7 @@ from django.test import override_settings, RequestFactory
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from resilient_logger.models import ResilientLogEntry
 
+from applications.api.v1.exceptions import VTJServiceUnavailableError
 from applications.services import VTJService
 from common.tests.factories import (
     DuplicateAllowingUserFactory,
@@ -67,7 +68,7 @@ def test_fetch_vtj_json_logs_vtj_query_failure_on_api_error():
         "shared.vtj.vtj_client.requests.post",
         side_effect=RequestsConnectionError("Connection refused"),
     ):
-        with pytest.raises(RequestsConnectionError):
+        with pytest.raises(VTJServiceUnavailableError):
             VTJService.fetch_vtj_json(application, end_user=end_user)
 
     entry = ResilientLogEntry.objects.last()
@@ -127,3 +128,17 @@ def test_on_user_logged_out_logs_logout():
     assert entry is not None
     assert entry.context["event_type"] == AuthEventType.LOGOUT
     assert entry.context["user_id"] == str(user.pk)
+
+
+@override_settings(
+    NEXT_PUBLIC_MOCK_FLAG=False,
+    NEXT_PUBLIC_DISABLE_VTJ=False,
+    VTJ_USERNAME="",
+    VTJ_PASSWORD="",
+    VTJ_PERSONAL_ID_QUERY_URL="",
+)
+def test_fetch_vtj_json_raises_service_unavailable_on_value_error():
+    """ValueError due to missing VTJ settings should be caught and raise VTJServiceUnavailableError."""
+    application = YouthApplicationFactory()
+    with pytest.raises(VTJServiceUnavailableError):
+        VTJService.fetch_vtj_json(application, end_user="test-handler-uuid")

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -2820,3 +2820,58 @@ def test_youth_application_fetch_employee_data_uses_fuzzy_match(
             last_name=last_name, full_name=employee_name
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+@override_settings(
+    NEXT_PUBLIC_MOCK_FLAG=False,
+    NEXT_PUBLIC_DISABLE_VTJ=False,
+    VTJ_USERNAME="u",
+    VTJ_PASSWORD="p",
+    VTJ_TIMEOUT=30,
+    VTJ_PERSONAL_ID_QUERY_URL="https://example.com/vtj",
+)
+def test_create_youth_application_returns_503_on_vtj_request_exception(api_client):
+    """POST /youth-applications/ → 503 when VTJ is unreachable."""
+    from requests.exceptions import ConnectionError as RequestsConnectionError
+
+    app = InactiveNoNeedAdditionalInfoYouthApplicationFactory.build()
+    data = YouthApplicationSerializer(app).data
+
+    with mock.patch(
+        "shared.vtj.vtj_client.requests.post",
+        side_effect=RequestsConnectionError("VTJ down"),
+    ):
+        with mock.patch("sentry_sdk.capture_exception") as mock_capture:
+            response = api_client.post(get_list_url(), data)
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert response.data["detail"].code == "vtj_service_unavailable"
+    mock_capture.assert_called_once()
+
+
+@pytest.mark.django_db
+@override_settings(
+    NEXT_PUBLIC_MOCK_FLAG=False,
+    NEXT_PUBLIC_DISABLE_VTJ=False,
+    VTJ_USERNAME="u",
+    VTJ_PASSWORD="p",
+    VTJ_TIMEOUT=30,
+    VTJ_PERSONAL_ID_QUERY_URL="https://example.com/vtj",
+)
+def test_retrieve_youth_application_returns_503_on_vtj_request_exception(staff_client):
+    """GET /youth-applications/{pk}/ → 503 when VTJ is unreachable."""
+    from requests.exceptions import ConnectionError as RequestsConnectionError
+
+    app = AwaitingManualProcessingYouthApplicationFactory.create()
+
+    with mock.patch(
+        "shared.vtj.vtj_client.requests.post",
+        side_effect=RequestsConnectionError("VTJ down"),
+    ):
+        with mock.patch("sentry_sdk.capture_exception") as mock_capture:
+            response = staff_client.get(get_detail_url(pk=app.pk))
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert response.data["detail"].code == "vtj_service_unavailable"
+    mock_capture.assert_called_once()


### PR DESCRIPTION
Bases on #4070. 

> NOTE: First run as based on main, so the CI checks are triggered.

YJDH-541.

Send RequestException to Sentry, but raise it as VTJServiceUnavailableError.

