### PR TITLE
Fix sonarcloud properties and naming

### DIFF
--- a/backend/kesaseteli/sonar-project.properties
+++ b/backend/kesaseteli/sonar-project.properties
@@ -5,4 +5,4 @@ sonar.sources=.
 sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.test.inclusions=**/tests/**/*
-sonar.exclusions=**/migrations/*
+sonar.exclusions=**/migrations/**/*,**/.venv/**/*,**/venv/**/*,**/.pytest_cache/**/*,**/.ruff_cache/**/*,**/__pycache__/**/*

--- a/backend/kesaseteli/sonar-project.properties
+++ b/backend/kesaseteli/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectKey=City-of-Helsinki_yjdh-kesaseteli-api
+sonar.projectName=Kesäseteli API
 sonar.organization=city-of-helsinki
 sonar.sources=.
 sonar.python.version=3.12

--- a/frontend/kesaseteli/employer/sonar-project.properties
+++ b/frontend/kesaseteli/employer/sonar-project.properties
@@ -5,7 +5,6 @@ sonar.javascript.lcov.reportPaths = ./coverage/lcov.info
 sonar.sources = src
 sonar.inclusions=src/**/*
 sonar.exclusions = \
-	**/__tests__/**, \
 	**/__mocks__/**, \
 	/browser-tests/**, \
 	**/*.sc.ts, \

--- a/frontend/kesaseteli/employer/sonar-project.properties
+++ b/frontend/kesaseteli/employer/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectKey = City-of-Helsinki_yjdh-kesaseteli-employer
+sonar.projectName=Kesäseteli Employer UI
 sonar.organization = city-of-helsinki
 sonar.javascript.lcov.reportPaths = ./coverage/lcov.info
 sonar.sources = src

--- a/frontend/kesaseteli/handler/sonar-project.properties
+++ b/frontend/kesaseteli/handler/sonar-project.properties
@@ -5,7 +5,6 @@ sonar.javascript.lcov.reportPaths = ./coverage/lcov.info
 sonar.sources = src
 sonar.inclusions=src/**/*
 sonar.exclusions = \
-	**/__tests__/**, \
 	**/__mocks__/**, \
 	/browser-tests/**, \
 	**/*.sc.ts, \

--- a/frontend/kesaseteli/handler/sonar-project.properties
+++ b/frontend/kesaseteli/handler/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectKey = City-of-Helsinki_yjdh-kesaseteli-handler
+sonar.projectName=Kesäseteli Handler UI
 sonar.organization = city-of-helsinki
 sonar.javascript.lcov.reportPaths = ./coverage/lcov.info
 sonar.sources = src

--- a/frontend/kesaseteli/shared/sonar-project.properties
+++ b/frontend/kesaseteli/shared/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectKey = City-of-Helsinki_yjdh-kesaseteli-shared
+sonar.projectName=Kesäseteli Shared
 sonar.organization = city-of-helsinki
 sonar.javascript.lcov.reportPaths = ./coverage/lcov.info
 sonar.sources = src

--- a/frontend/kesaseteli/shared/sonar-project.properties
+++ b/frontend/kesaseteli/shared/sonar-project.properties
@@ -3,4 +3,17 @@ sonar.projectName=Kesäseteli Shared
 sonar.organization = city-of-helsinki
 sonar.javascript.lcov.reportPaths = ./coverage/lcov.info
 sonar.sources = src
-sonar.exclusions=**/__tests__/**,**/__mocks__/**,/browser-tests/**
+sonar.inclusions=src/**/*
+sonar.exclusions = \
+	**/__mocks__/**, \
+	/browser-tests/**, \
+	**/*.sc.ts, \
+	src/types/**/*, \
+	src/utils/test-utils/**/*
+
+sonar.test.inclusions= \
+  src/**/__tests__/**/*, \
+  src/**/*.test.js, \
+  src/**/*.test.ts, \
+  src/**/*.test.jsx, \
+  src/**/*.test.tsx

--- a/frontend/kesaseteli/youth/sonar-project.properties
+++ b/frontend/kesaseteli/youth/sonar-project.properties
@@ -5,7 +5,6 @@ sonar.javascript.lcov.reportPaths = ./coverage/lcov.info
 sonar.sources = src
 sonar.inclusions=src/**/*
 sonar.exclusions = \
-	**/__tests__/**, \
 	**/__mocks__/**, \
 	/browser-tests/**, \
 	**/*.sc.ts, \

--- a/frontend/kesaseteli/youth/sonar-project.properties
+++ b/frontend/kesaseteli/youth/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectKey = City-of-Helsinki_yjdh-kesaseteli-youth
+sonar.projectName=Kesäseteli Youth UI
 sonar.organization = city-of-helsinki
 sonar.javascript.lcov.reportPaths = ./coverage/lcov.info
 sonar.sources = src


### PR DESCRIPTION
YJDH-771.

Add sonar clound project names to fix a repeating "yjdh" name in projects listing.

The sonar.exclusions should not be used to completely wipe out your tests
folder. Instead, SonarCloud has a dedicated property for defining what
counts as a test file: sonar.test.inclusions.