### PR TITLE
feat(ks): move to single submit flow and implement friendly errors

### DIFF
--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -516,7 +516,15 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
         validated_data["company"] = company
         validated_data["user"] = user
 
-        return super().create(validated_data)
+        application = super().create(validated_data)
+
+        # Create an empty summer voucher for the application.
+        # This ensures that the application always has at least one summer voucher.
+        # NOTE: This means simpler attachments handling in frontend.
+        if not application.summer_vouchers.exists():
+            EmployerSummerVoucher.objects.create(application=application)
+
+        return application
 
     def get_is_mine(self, obj):
         request = self.context.get("request")

--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -286,6 +286,13 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
 
         if not status or status == EmployerApplicationStatus.DRAFT:
             # newly created applications are always DRAFT
+            LOGGER.debug(
+                "Application is in DRAFT state, skipping validation",
+                extra={
+                    "data": data,
+                    "status": status,
+                },
+            )
             return
 
         required_fields = self.REQUIRED_FIELDS_FOR_SUBMITTED_SUMMER_VOUCHERS[:]
@@ -319,10 +326,22 @@ class EmployerSummerVoucherSerializer(serializers.ModelSerializer):
         """
         serial_number = data.get("summer_voucher_serial_number")
         if not serial_number:
+            LOGGER.debug(
+                "No summer voucher serial number provided.",
+                extra={
+                    "data": data,
+                },
+            )
             return
 
         voucher = YouthSummerVoucher.objects.get_by_serial_number(serial_number)
         if not voucher:
+            LOGGER.debug(
+                "No summer voucher found for serial number.",
+                extra={
+                    "serial_number": serial_number,
+                },
+            )
             return
 
         user_provided_name = data.get("employee_name")
@@ -497,6 +516,13 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
         request = self.context.get("request")
         summer_vouchers_data = validated_data.pop("summer_vouchers", []) or []
         if request and request.method == "PUT":
+            LOGGER.debug(
+                "Updating employer application with PUT.",
+                extra={
+                    "application_id": instance.pk,
+                    "summer_vouchers_data": summer_vouchers_data,
+                },
+            )
             self._update_summer_vouchers(summer_vouchers_data, instance)
 
         new_status = validated_data.get("status")
@@ -504,6 +530,13 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
             new_status == EmployerApplicationStatus.SUBMITTED
             and instance.status == EmployerApplicationStatus.DRAFT
         ):
+            LOGGER.debug(
+                "Changing application status from DRAFT to SUBMITTED. "
+                "Setting submitted_at.",
+                extra={
+                    "application_id": instance.pk,
+                },
+            )
             validated_data["submitted_at"] = timezone.now()
 
         return super().update(instance, validated_data)
@@ -518,10 +551,18 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
 
         application = super().create(validated_data)
 
+        LOGGER.debug(
+            "Created a new application.", extra={"application_id": application.pk}
+        )
+
         # Create an empty summer voucher for the application.
         # This ensures that the application always has at least one summer voucher.
         # NOTE: This means simpler attachments handling in frontend.
         if not application.summer_vouchers.exists():
+            LOGGER.debug(
+                "Creating an empty summer voucher for the application.",
+                extra={"application_id": application.pk},
+            )
             EmployerSummerVoucher.objects.create(application=application)
 
         return application
@@ -543,6 +584,13 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
         )
 
         if not serializer.is_valid():
+            LOGGER.debug(
+                "Summer voucher serializer validation failed.",
+                extra={
+                    "summer_vouchers_data": summer_vouchers_data,
+                    "errors": serializer.errors,
+                },
+            )
             raise serializers.ValidationError(
                 format_lazy(
                     _("Reading summer voucher data failed: {errors}"),
@@ -556,6 +604,14 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
             summer_voucher_item["ordering"] = (
                 idx  # use the ordering defined in the JSON sent by the client
             )
+
+        LOGGER.debug(
+            "Saving employer application summer vouchers - validated.",
+            extra={
+                "application_id": application.pk,
+                "summer_vouchers": serializer.validated_data,
+            },
+        )
         serializer.save()
 
     def validate(self, data):
@@ -583,6 +639,13 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
         if not data.get("status") or data["status"] == EmployerApplicationStatus.DRAFT:
             # newly created applications are always DRAFT
             return
+
+        LOGGER.debug(
+            "Validating required fields for submitted application.",
+            extra={
+                "application": data,
+            },
+        )
 
         required_fields = self.REQUIRED_FIELDS_FOR_SUBMITTED_APPLICATIONS[:]
         if data.get("is_separate_invoicer"):
@@ -621,6 +684,12 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
           the backend would not know that it's meant to be a single document.
         * This validator makes sure that there is at least one of each attachment type.
         """
+        LOGGER.debug(
+            "Validating attachments for application.",
+            extra={
+                "application": self.instance,
+            },
+        )
         for summer_voucher in self.instance.summer_vouchers.all():
             if not summer_voucher.attachments.exists():
                 raise serializers.ValidationError(
@@ -639,6 +708,18 @@ class EmployerApplicationSerializer(serializers.ModelSerializer):
                         attachment_types=", ".join(required_attachment_types),
                     )
                 )
+            LOGGER.debug(
+                "Attachments validated successfully for summer voucher.",
+                extra={
+                    "summer_voucher": summer_voucher,
+                },
+            )
+        LOGGER.debug(
+            "All attachments validated successfully for application.",
+            extra={
+                "application": self.instance,
+            },
+        )
 
 
 class SchoolSerializer(serializers.ModelSerializer):

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -306,6 +306,24 @@ class YouthApplicationViewSet(ModelViewSet):
             },
         }
 
+        if not found_match:
+            # No match found for employee name in YouthApplication
+
+            # Log access because no match was found:
+            AuditAccessLogService.create_access_log_entry_with_no_related_object_instance(
+                actor=request.user,
+                actor_email=request.user.email,
+                content_type=ContentType.objects.get_for_model(YouthApplication),
+                additional_data=additional_data_for_access_audit_log,
+            )
+            youth_application_pk = youth_application.pk if youth_application else "None"
+            LOGGER.warning(
+                f"No match for employee name {employee_name} with voucher"
+                f" {voucher_number} in YouthApplication {youth_application_pk}"
+                f" - Cannot set employee data."
+            )
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
         if (
             youth_application
             and youth_application.status != YouthApplicationStatus.ACCEPTED
@@ -335,24 +353,6 @@ class YouthApplicationViewSet(ModelViewSet):
                     data={"error_code": "summer_voucher_already_used"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
-
-        if not found_match:
-            # No match found for employee name in YouthApplication
-
-            # Log access because no match was found:
-            AuditAccessLogService.create_access_log_entry_with_no_related_object_instance(
-                actor=request.user,
-                actor_email=request.user.email,
-                content_type=ContentType.objects.get_for_model(YouthApplication),
-                additional_data=additional_data_for_access_audit_log,
-            )
-            youth_application_pk = youth_application.pk if youth_application else "None"
-            LOGGER.warning(
-                f"No match for employee name {employee_name} with voucher"
-                f" {voucher_number} in YouthApplication {youth_application_pk}"
-                f" - Cannot set employee data."
-            )
-            return Response(status=status.HTTP_404_NOT_FOUND)
 
         # Manually log access because of access to sensitive information:
         AuditAccessLogService.create_access_log_entry_with_related_object_and_additional_data(

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -291,10 +291,12 @@ class YouthApplicationViewSet(ModelViewSet):
             youth_summer_voucher.youth_application if youth_summer_voucher else None
         )
 
+        # Check if employee name is a fuzzy match with the youth application's last name
         found_match = youth_application and is_last_name_fuzzy_match_in_full_name(
             last_name=youth_application.last_name, full_name=employee_name
         )
 
+        # Log access because of access to sensitive information:
         additional_data_for_access_audit_log = {
             "method": f"{self.__class__.__name__}.fetch_employee_data",
             "parameters": {
@@ -304,13 +306,51 @@ class YouthApplicationViewSet(ModelViewSet):
             },
         }
 
+        if (
+            youth_application
+            and youth_application.status != YouthApplicationStatus.ACCEPTED
+        ):
+            # YouthApplication is not yet accepted by handler.
+            LOGGER.warning(
+                f"YouthApplication {youth_application.pk} not yet accepted by handler"
+                f" - Cannot set employee data."
+            )
+            return Response(
+                data={"error_code": "youth_application_not_accepted"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if youth_summer_voucher:
+            # Check if already used in another employer's application
+            used_in_other = EmployerSummerVoucher.objects.filter(
+                youth_summer_voucher=youth_summer_voucher,
+            ).exclude(application__id=employer_summer_vouchers.first().application_id)
+
+            if used_in_other.exists():
+                LOGGER.warning(
+                    f"Summer voucher {youth_summer_voucher.pk} already used in other"
+                    f" application - Cannot set employee data."
+                )
+                return Response(
+                    data={"error_code": "summer_voucher_already_used"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
         if not found_match:
-            # Manually log access because of access to sensitive information:
+            # No match found for employee name in YouthApplication
+
+            # Log access because no match was found:
             AuditAccessLogService.create_access_log_entry_with_no_related_object_instance(
                 actor=request.user,
                 actor_email=request.user.email,
                 content_type=ContentType.objects.get_for_model(YouthApplication),
                 additional_data=additional_data_for_access_audit_log,
+            )
+            youth_application_pk = youth_application.pk if youth_application else "None"
+            LOGGER.warning(
+                f"No match for employee name {employee_name} with voucher"
+                f" {voucher_number} in YouthApplication {youth_application_pk}"
+                f" - Cannot set employee data."
             )
             return Response(status=status.HTTP_404_NOT_FOUND)
 

--- a/backend/kesaseteli/applications/tests/test_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_applications_api.py
@@ -326,15 +326,13 @@ def test_application_create_writes_audit_log(api_client, company):
 
     assert response.status_code == 201
 
-    audit_event = LogEntry.objects.first()
+    content_type = ContentType.objects.get_for_model(EmployerApplication)
+    audit_event = LogEntry.objects.filter(content_type=content_type).first()
     assert audit_event.remote_addr == "127.0.0.1"
     assert audit_event.actor_id == response.wsgi_request.user.id
     assert audit_event.actor_email == response.wsgi_request.user.email
     assert audit_event.action == LogEntry.Action.CREATE
     assert audit_event.object_pk == response.data["id"]
-    assert audit_event.content_type == ContentType.objects.get_for_model(
-        EmployerApplication
-    )
 
 
 @pytest.mark.django_db
@@ -355,15 +353,13 @@ def test_application_update_writes_audit_log(api_client, application):
     assert response.status_code == 200
     assert response.data["invoicer_name"] == "test2"
 
-    audit_event = LogEntry.objects.first()
+    content_type = ContentType.objects.get_for_model(EmployerApplication)
+    audit_event = LogEntry.objects.filter(content_type=content_type).first()
     assert audit_event.remote_addr == "127.0.0.1"
     assert audit_event.actor_id == response.wsgi_request.user.id
     assert audit_event.actor_email == response.wsgi_request.user.email
     assert audit_event.action == LogEntry.Action.UPDATE
     assert audit_event.object_pk == response.data["id"]
-    assert audit_event.content_type == ContentType.objects.get_for_model(
-        EmployerApplication
-    )
     assert audit_event.changes == {"invoicer_name": ["test1", "test2"]}
 
 
@@ -389,15 +385,14 @@ def test_application_update_writes_multichange_audit_log(api_client, application
     assert response.data["is_separate_invoicer"] is False
     assert response.data["contact_person_email"] == "new@example.org"
 
-    audit_event = LogEntry.objects.first()
+    content_type = ContentType.objects.get_for_model(EmployerApplication)
+    audit_event = LogEntry.objects.filter(content_type=content_type).first()
+
     assert audit_event.remote_addr == "127.0.0.1"
     assert audit_event.actor_id == response.wsgi_request.user.id
     assert audit_event.actor_email == response.wsgi_request.user.email
     assert audit_event.action == LogEntry.Action.UPDATE
     assert audit_event.object_pk == response.data["id"]
-    assert audit_event.content_type == ContentType.objects.get(
-        app_label="applications", model="employerapplication"
-    )
     assert audit_event.changes == {
         "contact_person_email": ["old@example.org", "new@example.org"],
         "invoicer_name": ["old name", "new name"],
@@ -439,7 +434,8 @@ def test_application_update_audit_log_excludes_summer_vouchers(api_client, appli
     assert response.status_code == 200
     assert len(response.data["summer_vouchers"]) == orig_summer_voucher_count + 1
 
-    audit_event = LogEntry.objects.first()
+    content_type = ContentType.objects.get_for_model(EmployerApplication)
+    audit_event = LogEntry.objects.filter(content_type=content_type).first()
 
     # Only the invoicer_name change is shown, no summer_vouchers changes:
     assert audit_event.changes == {
@@ -493,15 +489,14 @@ def test_application_delete_writes_audit_log(api_client, application):
 
     assert response.status_code == 204
 
-    audit_event = LogEntry.objects.first()
+    content_type = ContentType.objects.get_for_model(EmployerApplication)
+    audit_event = LogEntry.objects.filter(content_type=content_type).first()
+
     assert audit_event.remote_addr == "127.0.0.1"
     assert audit_event.actor_id == response.wsgi_request.user.id
     assert audit_event.actor_email == response.wsgi_request.user.email
     assert audit_event.action == LogEntry.Action.DELETE
     assert audit_event.object_pk == str(application.id)
-    assert audit_event.content_type == ContentType.objects.get_for_model(
-        EmployerApplication
-    )
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
+++ b/backend/kesaseteli/applications/tests/test_security_with_non_staff_user.py
@@ -1449,6 +1449,94 @@ def test_youth_application_fetch_employee_data_unallowed_methods(user_client):
     assert user_client.put(url).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+@pytest.mark.django_db
+def test_youth_application_fetch_employee_data_security_leak(user_client):
+    from applications.models import YouthSummerVoucher
+
+    # 1. Create a youth application/voucher that is accepted
+    youth_app_accepted = AcceptedYouthApplicationFactory(
+        first_name="John",
+        last_name="Doe",
+        youth_summer_voucher__summer_voucher_serial_number=123,
+    )
+    youth_voucher_accepted = youth_app_accepted.youth_summer_voucher
+
+    # Mark youth_voucher_accepted as used in another employer's application
+    EmployerSummerVoucherFactory(
+        youth_summer_voucher=youth_voucher_accepted,
+    )
+
+    # 2. Create a youth application/voucher that is NOT accepted (e.g. status is SUBMITTED)
+    # Note: YouthSummerVoucher is normally created only upon acceptance. Let's force-create one.
+    youth_app_submitted = YouthApplicationFactory(
+        status=YouthApplicationStatus.SUBMITTED,
+        first_name="Alice",
+        last_name="Smith",
+    )
+    YouthSummerVoucher.objects.create(
+        youth_application=youth_app_submitted,
+        summer_voucher_serial_number=456,
+    )
+
+    # 3. Create a new employer summer voucher for current user's request context
+    employer_summer_voucher = EmployerSummerVoucherFactory(
+        application=EmployerApplicationFactory()
+    )
+
+    url = reverse("v1:youthapplication-fetch-employee-data")
+
+    # Scenario A: Wrong name + already used voucher (serial 123)
+    # -> Should return 404 (do not leak that the voucher is already used)
+    response = user_client.post(
+        url,
+        data={
+            "employer_summer_voucher_id": str(employer_summer_voucher.id),
+            "employee_name": "Mary Jenkins",
+            "summer_voucher_serial_number": 123,
+        },
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # Scenario B: Correct name + already used voucher (serial 123)
+    # -> Should return 400 with "summer_voucher_already_used" since they are authorized
+    response = user_client.post(
+        url,
+        data={
+            "employer_summer_voucher_id": str(employer_summer_voucher.id),
+            "employee_name": "John Doe",
+            "summer_voucher_serial_number": 123,
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data == {"error_code": "summer_voucher_already_used"}
+
+    # Scenario C: Wrong name + not accepted application (serial 456)
+    # -> Should return 404 (do not leak that the application is not accepted)
+    response = user_client.post(
+        url,
+        data={
+            "employer_summer_voucher_id": str(employer_summer_voucher.id),
+            "employee_name": "Mary Jenkins",
+            "summer_voucher_serial_number": 456,
+        },
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # Scenario D: Correct name + not accepted application (serial 456)
+    # -> Should return 400 with "youth_application_not_accepted" since they are authorized
+    response = user_client.post(
+        url,
+        data={
+            "employer_summer_voucher_id": str(employer_summer_voucher.id),
+            "employee_name": "Alice Smith",
+            "summer_voucher_serial_number": 456,
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data == {"error_code": "youth_application_not_accepted"}
+
+
 @pytest.mark.django_db
 def test_employer_application_list_no_company_lost_permission(api_client):
     """

--- a/frontend/kesaseteli/employer/browser-tests/application-page/application.mocks.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/application.mocks.ts
@@ -142,6 +142,8 @@ const restoreVoucherData = (
     });
   }
 
+  const isFetched = Boolean(restoredSerialNumber || restoredEmployeeName);
+
   const employeeFields = [
     'employee_phone_number',
     'employee_home_city',
@@ -154,7 +156,10 @@ const restoreVoucherData = (
 
   employeeFields.forEach((key) => {
     updatedFields[key] =
-      v[key] || requestVoucher?.[key] || MOCKED_EMPLOYEE_DATA[key] || '';
+      v[key] ||
+      requestVoucher?.[key] ||
+      (isFetched ? MOCKED_EMPLOYEE_DATA[key] : '') ||
+      '';
   });
 
   return {

--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -94,6 +94,8 @@
         "fetch_employment_error_title": "Error occured!",
         "fetch_employment_error_message": "Could not fetch the info of the employee.",
         "fetch_employment_not_found_error_message": "Employee's information was not found.",
+        "fetch_employment_not_accepted_error_message": "The summer voucher is not yet valid for attachment. Its status must be accepted.",
+        "fetch_employment_already_used_error_message": "This summer voucher has already been used in another application.",
         "foreign_iban_note": "Finnish company, but foreign account number? In that case we need more information for the payment of compensation. Please, fill in the information below:",
         "foreign_iban_notification_label": "Notice regarding foreign IBAN"
       }

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -94,6 +94,8 @@
         "fetch_employment_error_title": "Sattui virhe!",
         "fetch_employment_error_message": "Ei pystytty hakemaan työntekijän tietoja.",
         "fetch_employment_not_found_error_message": "Työntekijän tietoja ei löytynyt.",
+        "fetch_employment_not_accepted_error_message": "Kesäseteli ei ole vielä voimassa. Sen tilan on oltava hyväksytty.",
+        "fetch_employment_already_used_error_message": "Tämä kesäseteli on jo käytetty toisessa hakemuksessa.",
         "foreign_iban_note": "Suomalainen yritys, mutta ulkomaalainen tilinumero? Silloin tarvitsemme korvauksen maksua varten lisätietoa, täytä alla olevat tiedot:",
         "foreign_iban_notification_label": "Huomioitavaa ulkomaisesta tilinumerosta"
       }

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -94,6 +94,8 @@
         "fetch_employment_error_title": "Fel uppstod!",
         "fetch_employment_error_message": "Kunde inte hämta arbetstagarens uppgifter.",
         "fetch_employment_not_found_error_message": "Arbetstagarens information hittades inte.",
+        "fetch_employment_not_accepted_error_message": "Sommarsedeln är inte giltig ännu. Dess status måste vara godkänd.",
+        "fetch_employment_already_used_error_message": "Denna sommarsedel har redan använts i en annan ansökan.",
         "foreign_iban_note": "Finskt företag, men utländskt kontonummer? Då behöver vi tilläggsinformation för utbetalningen av ersättningen. Fyll i uppgifterna nedan:",
         "foreign_iban_notification_label": "Meddelande om utländskt kontonummer"
       }

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/EmploymentForm.tsx
@@ -22,7 +22,6 @@ import LinkText from 'shared/components/link-text/LinkText';
 import { POSTAL_CODE_REGEX } from 'shared/constants';
 import { EMPLOYEE_HIRED_WITHOUT_VOUCHER_ASSESSMENT } from 'shared/constants/employee-constants';
 import Application from 'shared/types/application';
-import DraftApplication from 'shared/types/draft-application';
 import Employment from 'shared/types/employment';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
 import { getDecimalNumberRegex } from 'shared/utils/regex.utils';
@@ -74,7 +73,7 @@ const useFetchEmployeeData = (
   handleGetEmployeeData: () => void;
 } => {
   const { getValues, setValue, control } = useFormContext<Application>();
-  const { fetchEmployment, updateApplication } = useApplicationApi();
+  const { fetchEmployment } = useApplicationApi();
 
   // Use dedicated state instead of deriving from form values
   // This prevents the state from becoming false during form reset
@@ -100,35 +99,19 @@ const useFetchEmployeeData = (
   }, [employeePhoneNumber, employmentPostcode, employeeBirthdate]);
 
   const handleGetEmployeeData = useCallback((): void => {
-    const currentValues = getValues();
-    const voucher = currentValues.summer_vouchers[index];
-
-    const performFetch = (appData: DraftApplication | Application): void => {
-      const values = getValues();
-      // Ensure the voucher we are processing has the ID from the server (if it was just created)
-      const serverVoucherId = appData.summer_vouchers?.[index]?.id;
-      if (serverVoucherId) {
-        values.summer_vouchers[index].id = serverVoucherId;
+    const values = getValues();
+    void fetchEmployment(values, index, (app) => {
+      const updatedVoucher = app.summer_vouchers[index];
+      if (updatedVoucher) {
+        setValue(`summer_vouchers.${index}`, updatedVoucher, {
+          shouldDirty: true,
+          // Do not validate yet, since user has not had a chance to type anything.
+          shouldValidate: false, 
+        });
       }
-
-      void fetchEmployment(values, index, (app) => {
-        const updatedVoucher = app.summer_vouchers[index];
-        if (updatedVoucher) {
-          setValue(`summer_vouchers.${index}`, updatedVoucher, {
-            shouldDirty: true,
-            shouldValidate: true,
-          });
-        }
-        setIsEmployeeDataFetched(true);
-      });
-    };
-
-    if (voucher.id) {
-      performFetch(getValues());
-    } else {
-      updateApplication(currentValues, (app) => performFetch(app));
-    }
-  }, [getValues, fetchEmployment, index, setValue, updateApplication]);
+      setIsEmployeeDataFetched(true);
+    });
+  }, [getValues, fetchEmployment, index, setValue]);
 
   return {
     isEmployeeDataFetched,

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/__tests__/EmploymentForm.test.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/__tests__/EmploymentForm.test.tsx
@@ -108,38 +108,6 @@ describe('EmploymentForm', () => {
       0,
       expect.any(Function)
     );
-    expect(mockUpdateApplication).not.toHaveBeenCalled();
-  });
-
-  it('updates application first and then fetches employee data when voucher id is missing', async () => {
-    const user = userEvent.setup();
-
-    mockUpdateApplication.mockImplementation(
-      (_currentValues: Application, onSuccess: (app: Application) => void) => {
-        onSuccess({
-          summer_vouchers: [{ id: 'server-voucher-id' }],
-        } as Application);
-      }
-    );
-
-    renderWithProviders(0, {
-      employee_name: 'Test',
-      summer_voucher_serial_number: '123',
-    });
-
-    await user.click(getFetchEmployeeDataButton());
-
-    expect(mockUpdateApplication).toHaveBeenCalledTimes(1);
-    expect(mockFetchEmployment).toHaveBeenCalledTimes(1);
-    expect(mockFetchEmployment).toHaveBeenCalledWith(
-      expect.objectContaining({
-        summer_vouchers: expect.arrayContaining([
-          expect.objectContaining({ id: 'server-voucher-id' }),
-        ]),
-      }),
-      0,
-      expect.any(Function)
-    );
   });
 
   it('applies updated voucher from fetch callback and marks employee data as fetched', async () => {

--- a/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationApi.test.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationApi.test.ts
@@ -79,6 +79,36 @@ describe('useApplicationApi - fetchEmployment', () => {
     jest.clearAllMocks();
   });
 
+  it('calls onSuccess callback with updated application data on successful fetch', () => {
+    const { result } = renderHook(() => useApplicationApi());
+    const mockOnSuccess = jest.fn();
+    const draftApplication = {
+      summer_vouchers: [{ id: 'voucher-1', employee_name: 'John' }],
+    } as Application;
+
+    result.current.fetchEmployment(draftApplication, 0, mockOnSuccess);
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    const [, options] = mockMutate.mock.calls[0];
+
+    options.onSuccess({
+      employer_summer_voucher_id: 'voucher-1',
+      employee_name: 'John Doe',
+      employee_birthdate: '2000-01-01',
+    });
+
+    expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+    expect(mockOnSuccess).toHaveBeenCalledWith({
+      summer_vouchers: [
+        {
+          id: 'voucher-1',
+          employee_name: 'John Doe',
+          employee_birthdate: '2000-01-01',
+        },
+      ],
+    });
+  });
+
   it('displays correct error toast when youth application is not accepted (400 - youth_application_not_accepted)', () => {
     const { result } = renderHook(() => useApplicationApi());
     const draftApplication = {

--- a/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationApi.test.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationApi.test.ts
@@ -19,8 +19,13 @@ jest.mock('kesaseteli/employer/hooks/backend/useApplicationQuery', () =>
 jest.mock('kesaseteli/employer/hooks/backend/useDeleteApplicationQuery', () =>
   jest.fn()
 );
+const mockUpdateMutate = jest.fn();
+const mockUpdateMutateAsync = jest.fn();
 jest.mock('kesaseteli/employer/hooks/backend/useUpdateApplicationQuery', () =>
-  jest.fn()
+  jest.fn(() => ({
+    mutate: mockUpdateMutate,
+    mutateAsync: mockUpdateMutateAsync,
+  }))
 );
 
 jest.mock('shared/hooks/useErrorHandler', () => jest.fn(() => jest.fn()));
@@ -185,6 +190,45 @@ describe('useApplicationApi - fetchEmployment', () => {
     expect(showErrorToast).toHaveBeenCalledWith(
       'common:application.step1.employment_section.fetch_employment_error_title',
       'common:application.step1.employment_section.fetch_employment_error_message'
+    );
+  });
+
+  it('saves draft application first if voucher ID is missing, then fetches employment', async () => {
+    const { result } = renderHook(() => useApplicationApi());
+    const mockOnSuccess = jest.fn();
+    const draftApplication = {
+      summer_vouchers: [
+        { employee_name: 'John', summer_voucher_serial_number: '123' },
+      ],
+    } as Application;
+
+    mockUpdateMutateAsync.mockResolvedValueOnce({
+      ...draftApplication,
+      summer_vouchers: [
+        {
+          id: 'voucher-generated-id',
+          employee_name: 'John',
+          summer_voucher_serial_number: '123',
+        },
+      ],
+    });
+
+    await result.current.fetchEmployment(draftApplication, 0, mockOnSuccess);
+
+    expect(mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+      ...draftApplication,
+      status: 'draft',
+    });
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        employee_name: 'John',
+        summer_voucher_serial_number: '123',
+        employer_summer_voucher_id: 'voucher-generated-id',
+      },
+      expect.anything()
     );
   });
 });

--- a/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationApi.test.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationApi.test.ts
@@ -84,14 +84,14 @@ describe('useApplicationApi - fetchEmployment', () => {
     jest.clearAllMocks();
   });
 
-  it('calls onSuccess callback with updated application data on successful fetch', () => {
+  it('calls onSuccess callback with updated application data on successful fetch', async () => {
     const { result } = renderHook(() => useApplicationApi());
     const mockOnSuccess = jest.fn();
     const draftApplication = {
       summer_vouchers: [{ id: 'voucher-1', employee_name: 'John' }],
     } as Application;
 
-    result.current.fetchEmployment(draftApplication, 0, mockOnSuccess);
+    await result.current.fetchEmployment(draftApplication, 0, mockOnSuccess);
 
     expect(mockMutate).toHaveBeenCalledTimes(1);
     const [, options] = mockMutate.mock.calls[0];
@@ -114,13 +114,13 @@ describe('useApplicationApi - fetchEmployment', () => {
     });
   });
 
-  it('displays correct error toast when youth application is not accepted (400 - youth_application_not_accepted)', () => {
+  it('displays correct error toast when youth application is not accepted (400 - youth_application_not_accepted)', async () => {
     const { result } = renderHook(() => useApplicationApi());
     const draftApplication = {
       summer_vouchers: [{ id: 'v-1' }],
     } as Application;
 
-    result.current.fetchEmployment(draftApplication, 0);
+    await result.current.fetchEmployment(draftApplication, 0);
     const [, options] = mockMutate.mock.calls[0];
 
     options.onError(createAxiosError(400, 'youth_application_not_accepted'));
@@ -131,13 +131,13 @@ describe('useApplicationApi - fetchEmployment', () => {
     );
   });
 
-  it('displays correct error toast when summer voucher is already used (400 - summer_voucher_already_used)', () => {
+  it('displays correct error toast when summer voucher is already used (400 - summer_voucher_already_used)', async () => {
     const { result } = renderHook(() => useApplicationApi());
     const draftApplication = {
       summer_vouchers: [{ id: 'v-1' }],
     } as Application;
 
-    result.current.fetchEmployment(draftApplication, 0);
+    await result.current.fetchEmployment(draftApplication, 0);
     const [, options] = mockMutate.mock.calls[0];
 
     options.onError(createAxiosError(400, 'summer_voucher_already_used'));
@@ -148,13 +148,13 @@ describe('useApplicationApi - fetchEmployment', () => {
     );
   });
 
-  it('displays correct error toast when employee info is not found (404)', () => {
+  it('displays correct error toast when employee info is not found (404)', async () => {
     const { result } = renderHook(() => useApplicationApi());
     const draftApplication = {
       summer_vouchers: [{ id: 'v-1' }],
     } as Application;
 
-    result.current.fetchEmployment(draftApplication, 0);
+    await result.current.fetchEmployment(draftApplication, 0);
     const [, options] = mockMutate.mock.calls[0];
 
     options.onError(createAxiosError(404));
@@ -165,13 +165,13 @@ describe('useApplicationApi - fetchEmployment', () => {
     );
   });
 
-  it('displays generic error toast for other Axios errors or general errors', () => {
+  it('displays generic error toast for other Axios errors or general errors', async () => {
     const { result } = renderHook(() => useApplicationApi());
     const draftApplication = {
       summer_vouchers: [{ id: 'v-1' }],
     } as Application;
 
-    result.current.fetchEmployment(draftApplication, 0);
+    await result.current.fetchEmployment(draftApplication, 0);
     const [, options] = mockMutate.mock.calls[0];
 
     // Generic Axios error

--- a/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationApi.test.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationApi.test.ts
@@ -1,0 +1,160 @@
+import { renderHook } from '@testing-library/react-hooks';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import type Application from 'shared/types/application';
+
+import useApplicationApi from '../useApplicationApi';
+
+jest.mock('shared/components/toast/show-error-toast');
+
+const mockMutate = jest.fn();
+jest.mock('kesaseteli/employer/hooks/backend/useEmploymentQuery', () =>
+  jest.fn(() => ({
+    mutate: mockMutate,
+  }))
+);
+
+jest.mock('kesaseteli/employer/hooks/backend/useApplicationQuery', () =>
+  jest.fn()
+);
+jest.mock('kesaseteli/employer/hooks/backend/useDeleteApplicationQuery', () =>
+  jest.fn()
+);
+jest.mock('kesaseteli/employer/hooks/backend/useUpdateApplicationQuery', () =>
+  jest.fn()
+);
+
+jest.mock('shared/hooks/useErrorHandler', () => jest.fn(() => jest.fn()));
+jest.mock('shared/hooks/useRouterQueryParam', () =>
+  jest.fn(() => ({
+    value: 'test-id',
+    isRouterLoading: false,
+  }))
+);
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: jest.fn(),
+  }),
+}));
+
+const createAxiosError = (
+  status: number,
+  errorCode?: string
+): Error & {
+  isAxiosError: boolean;
+  response: {
+    status: number;
+    data: {
+      error_code?: string;
+    };
+  };
+} => {
+  const error = new Error('Axios Error') as Error & {
+    isAxiosError: boolean;
+    response: {
+      status: number;
+      data: {
+        error_code?: string;
+      };
+    };
+  };
+  error.isAxiosError = true;
+  error.response = {
+    status,
+    data: {
+      error_code: errorCode,
+    },
+  };
+  return error;
+};
+
+describe('useApplicationApi - fetchEmployment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('displays correct error toast when youth application is not accepted (400 - youth_application_not_accepted)', () => {
+    const { result } = renderHook(() => useApplicationApi());
+    const draftApplication = {
+      summer_vouchers: [{ id: 'v-1' }],
+    } as Application;
+
+    result.current.fetchEmployment(draftApplication, 0);
+    const [, options] = mockMutate.mock.calls[0];
+
+    options.onError(createAxiosError(400, 'youth_application_not_accepted'));
+
+    expect(showErrorToast).toHaveBeenCalledWith(
+      'common:application.step1.employment_section.fetch_employment_error_title',
+      'common:application.step1.employment_section.fetch_employment_not_accepted_error_message'
+    );
+  });
+
+  it('displays correct error toast when summer voucher is already used (400 - summer_voucher_already_used)', () => {
+    const { result } = renderHook(() => useApplicationApi());
+    const draftApplication = {
+      summer_vouchers: [{ id: 'v-1' }],
+    } as Application;
+
+    result.current.fetchEmployment(draftApplication, 0);
+    const [, options] = mockMutate.mock.calls[0];
+
+    options.onError(createAxiosError(400, 'summer_voucher_already_used'));
+
+    expect(showErrorToast).toHaveBeenCalledWith(
+      'common:application.step1.employment_section.fetch_employment_error_title',
+      'common:application.step1.employment_section.fetch_employment_already_used_error_message'
+    );
+  });
+
+  it('displays correct error toast when employee info is not found (404)', () => {
+    const { result } = renderHook(() => useApplicationApi());
+    const draftApplication = {
+      summer_vouchers: [{ id: 'v-1' }],
+    } as Application;
+
+    result.current.fetchEmployment(draftApplication, 0);
+    const [, options] = mockMutate.mock.calls[0];
+
+    options.onError(createAxiosError(404));
+
+    expect(showErrorToast).toHaveBeenCalledWith(
+      'common:application.step1.employment_section.fetch_employment_error_title',
+      'common:application.step1.employment_section.fetch_employment_not_found_error_message'
+    );
+  });
+
+  it('displays generic error toast for other Axios errors or general errors', () => {
+    const { result } = renderHook(() => useApplicationApi());
+    const draftApplication = {
+      summer_vouchers: [{ id: 'v-1' }],
+    } as Application;
+
+    result.current.fetchEmployment(draftApplication, 0);
+    const [, options] = mockMutate.mock.calls[0];
+
+    // Generic Axios error
+    options.onError(createAxiosError(500));
+
+    expect(showErrorToast).toHaveBeenCalledWith(
+      'common:application.step1.employment_section.fetch_employment_error_title',
+      'common:application.step1.employment_section.fetch_employment_error_message'
+    );
+
+    jest.clearAllMocks();
+
+    // Plain non-Axios error
+    options.onError(new Error('Generic failure'));
+
+    expect(showErrorToast).toHaveBeenCalledWith(
+      'common:application.step1.employment_section.fetch_employment_error_title',
+      'common:application.step1.employment_section.fetch_employment_error_message'
+    );
+  });
+});

--- a/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
@@ -69,6 +69,32 @@ type Options<T> = {
   select?: (application: Application) => T;
 };
 
+/**
+ * Maps Axios/HTTP errors to their corresponding localized translation error message key suffixes.
+ *
+ * @param error - The encountered error object.
+ * @returns The message translation suffix.
+ */
+const getFetchEmploymentErrorSuffix = (error: unknown): string => {
+  if (Axios.isAxiosError(error)) {
+    const status = error.response?.status;
+    const errorCode = (
+      error.response?.data as Record<string, unknown> | undefined
+    )?.error_code;
+
+    if (status === 400 && errorCode === 'youth_application_not_accepted') {
+      return 'not_accepted_error_message';
+    }
+    if (status === 400 && errorCode === 'summer_voucher_already_used') {
+      return 'already_used_error_message';
+    }
+    if (status === 404) {
+      return 'not_found_error_message';
+    }
+  }
+  return 'error_message';
+};
+
 const useApplicationApi = <T = Application>(
   options?: Options<T>
 ): ApplicationApi<T> => {
@@ -227,28 +253,7 @@ const useApplicationApi = <T = Application>(
           // eslint-disable-next-line no-console
           console.error(error);
 
-          let errorSuffix = 'error_message';
-
-          if (Axios.isAxiosError(error)) {
-            const status = error.response?.status;
-            const errorCode = (
-              error.response?.data as Record<string, unknown> | undefined
-            )?.error_code;
-
-            if (
-              status === 400 &&
-              errorCode === 'youth_application_not_accepted'
-            ) {
-              errorSuffix = 'not_accepted_error_message';
-            } else if (
-              status === 400 &&
-              errorCode === 'summer_voucher_already_used'
-            ) {
-              errorSuffix = 'already_used_error_message';
-            } else if (status === 404) {
-              errorSuffix = 'not_found_error_message';
-            }
-          }
+          const errorSuffix = getFetchEmploymentErrorSuffix(error);
 
           showErrorToast(
             t(

--- a/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
@@ -172,14 +172,17 @@ const useApplicationApi = <T = Application>(
          */
         onSuccess: (data) => {
           const { employer_summer_voucher_id, ...updatedData } = data;
-          updateEmployment(
-            draftApplication,
-            employmentIndex,
-            updatedData,
-            (app) => {
-              void onSuccess(app);
-            }
-          );
+          const summer_vouchers = [...(draftApplication.summer_vouchers ?? [])];
+          if (summer_vouchers.length > employmentIndex) {
+            summer_vouchers[employmentIndex] = {
+              ...summer_vouchers[employmentIndex],
+              ...updatedData,
+            };
+          }
+          void onSuccess({
+            ...draftApplication,
+            summer_vouchers,
+          } as unknown as Application);
         },
         /**
          * Error handler for fetching employment details.

--- a/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
@@ -83,6 +83,13 @@ const useApplicationApi = <T = Application>(
   const updateApplicationQuery = useUpdateApplicationQuery(applicationId);
   const deleteApplicationQuery = useDeleteApplicationQuery();
 
+  /**
+   * Handles errors occurring during application updates.
+   * If the error is a 400 validation error from Axios, maps the backend validation
+   * errors to the form fields. Otherwise, delegates to the default onError handler.
+   *
+   * @param error - The encountered error object.
+   */
   const handleUpdateError = (error: unknown): void => {
     if (
       setBackendValidationError &&
@@ -156,6 +163,13 @@ const useApplicationApi = <T = Application>(
         employer_summer_voucher_id: formDataVoucher?.id ?? '',
       },
       {
+        /**
+         * Success handler for fetching employment details.
+         * Updates the employment data in the draft application and calls the
+         * provided success callback.
+         *
+         * @param data - The employment data.
+         */
         onSuccess: (data) => {
           const { employer_summer_voucher_id, ...updatedData } = data;
           updateEmployment(
@@ -167,30 +181,46 @@ const useApplicationApi = <T = Application>(
             }
           );
         },
+        /**
+         * Error handler for fetching employment details.
+         * Maps specific Axios/HTTP error status codes and error codes to localized
+         * toast notification messages.
+         */
         onError: (error: unknown) => {
           // eslint-disable-next-line no-console
           console.error(error);
-          if (Axios.isAxiosError(error) && error.response?.status === 404) {
-            // Not found error
-            showErrorToast(
-              t(
-                'common:application.step1.employment_section.fetch_employment_error_title'
-              ),
-              t(
-                'common:application.step1.employment_section.fetch_employment_not_found_error_message'
-              )
-            );
-          } else {
-            // General error
-            showErrorToast(
-              t(
-                'common:application.step1.employment_section.fetch_employment_error_title'
-              ),
-              t(
-                'common:application.step1.employment_section.fetch_employment_error_message'
-              )
-            );
+
+          let errorSuffix = 'error_message';
+
+          if (Axios.isAxiosError(error)) {
+            const status = error.response?.status;
+            const errorCode = (
+              error.response?.data as Record<string, unknown> | undefined
+            )?.error_code;
+
+            if (
+              status === 400 &&
+              errorCode === 'youth_application_not_accepted'
+            ) {
+              errorSuffix = 'not_accepted_error_message';
+            } else if (
+              status === 400 &&
+              errorCode === 'summer_voucher_already_used'
+            ) {
+              errorSuffix = 'already_used_error_message';
+            } else if (status === 404) {
+              errorSuffix = 'not_found_error_message';
+            }
           }
+
+          showErrorToast(
+            t(
+              'common:application.step1.employment_section.fetch_employment_error_title'
+            ),
+            t(
+              `common:application.step1.employment_section.fetch_employment_${errorSuffix}`
+            )
+          );
         },
       }
     );

--- a/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useApplicationApi.ts
@@ -40,7 +40,7 @@ export type ApplicationApi<T> = {
     application: DraftApplication,
     employmentIndex: number,
     onSuccess?: (app: Application) => void | Promise<void>
-  ) => void;
+  ) => void | Promise<void>;
   addEmployment: (
     application: DraftApplication,
     onSuccess?: (app: Application) => void | Promise<void>
@@ -149,18 +149,50 @@ const useApplicationApi = <T = Application>(
     );
   };
 
-  const fetchEmployment: ApplicationApi<T>['fetchEmployment'] = (
+  const fetchEmployment: ApplicationApi<T>['fetchEmployment'] = async (
     draftApplication: DraftApplication,
     employmentIndex: number,
     onSuccess = noop
   ) => {
-    const formDataVoucher = draftApplication.summer_vouchers?.[employmentIndex];
+    let currentApplication = draftApplication;
+    let formDataVoucher = currentApplication.summer_vouchers?.[employmentIndex];
+
+    // If the voucher does not have an ID yet (e.g. for drafts created prior to automatic
+    // empty voucher creation on the backend, or recovering client-only states), we must
+    // save the draft application first. This registers the voucher in the DB and returns
+    // a valid generated UUID, which the fetch endpoint requires to perform voucher validation.
+    if (!formDataVoucher?.id) {
+      try {
+        const savedApplication = await updateApplicationQuery.mutateAsync({
+          ...currentApplication,
+          status: 'draft',
+        });
+        currentApplication = getFormApplication(savedApplication);
+        formDataVoucher = currentApplication.summer_vouchers?.[employmentIndex];
+      } catch (error) {
+        handleUpdateError(error);
+        return;
+      }
+    }
+
+    if (!formDataVoucher?.id) {
+      showErrorToast(
+        t(
+          'common:application.step1.employment_section.fetch_employment_error_title'
+        ),
+        t(
+          'common:application.step1.employment_section.fetch_employment_error_message'
+        )
+      );
+      return;
+    }
+
     getEmploymentQuery.mutate(
       {
         employee_name: formDataVoucher?.employee_name ?? '',
         summer_voucher_serial_number:
           formDataVoucher?.summer_voucher_serial_number ?? '',
-        employer_summer_voucher_id: formDataVoucher?.id ?? '',
+        employer_summer_voucher_id: formDataVoucher.id,
       },
       {
         /**
@@ -172,7 +204,9 @@ const useApplicationApi = <T = Application>(
          */
         onSuccess: (data) => {
           const { employer_summer_voucher_id, ...updatedData } = data;
-          const summer_vouchers = [...(draftApplication.summer_vouchers ?? [])];
+          const summer_vouchers = [
+            ...(currentApplication.summer_vouchers ?? []),
+          ];
           if (summer_vouchers.length > employmentIndex) {
             summer_vouchers[employmentIndex] = {
               ...summer_vouchers[employmentIndex],
@@ -180,7 +214,7 @@ const useApplicationApi = <T = Application>(
             };
           }
           void onSuccess({
-            ...draftApplication,
+            ...currentApplication,
             summer_vouchers,
           } as unknown as Application);
         },

--- a/frontend/shared/src/error-handler/error-handler.ts
+++ b/frontend/shared/src/error-handler/error-handler.ts
@@ -3,16 +3,32 @@ import showErrorToast from 'shared/components/toast/show-error-toast';
 import GoToPageFunction from 'shared/types/go-to-page-function';
 import { isError } from 'shared/utils/type-guards';
 
+/**
+ * Parameters for the handleError utility function.
+ */
 type Params = {
+  /** The error object or unknown error value to handle. */
   error: Error | unknown;
+  /** Translation function for internationalization. */
   t: TFunction;
+  /** Current URL pathname. */
   pathname: string;
+  /** Navigation function to transition between pages. */
   goToPage: GoToPageFunction;
+  /** Custom callback for authentication errors (HTTP 401/403). Defaults to redirecting to login page. */
   onAuthError?: () => void;
+  /** Custom callback for server errors (HTTP 5xx). Defaults to redirecting to /500 page. */
   onServerError?: () => void;
+  /** Custom callback for other errors. Defaults to showing a generic error toast notification. */
   onCommonError?: () => void;
 };
 
+/**
+ * Utility function to handle errors by inspecting the error message and executing the
+ * appropriate callback (auth, server, or common generic error).
+ *
+ * @param args - The configuration parameters and the error object to handle.
+ */
 const handleError = (args: Params): void => {
   const { error, t, pathname, goToPage } = args;
   const {

--- a/frontend/shared/src/hooks/useErrorHandler.ts
+++ b/frontend/shared/src/hooks/useErrorHandler.ts
@@ -3,14 +3,31 @@ import { useTranslation } from 'next-i18next';
 import handleError from 'shared/error-handler/error-handler';
 import useGoToPage from 'shared/hooks/useGoToPage';
 
+/**
+ * Function type returned by the useErrorHandler hook to process errors.
+ */
 type ErrorHandlerFunction = (error: Error | unknown) => void;
 
+/**
+ * Optional handlers to override default error handling behaviors.
+ */
 type Props = {
+  /** Callback triggered on authentication error (HTTP 401/403). */
   onAuthError?: () => void;
+  /** Callback triggered on server error (HTTP 5xx). */
   onServerError?: () => void;
+  /** Callback triggered on other errors. */
   onCommonError?: () => void;
 };
 
+/**
+ * Custom React hook that returns an error handling function.
+ * The returned function integrates with the application router and translation context,
+ * delegating actual handling to the `handleError` utility.
+ *
+ * @param props - Custom callbacks to override default error responses.
+ * @returns A function that accepts an error and executes the appropriate error response flow.
+ */
 const useErrorHandler = (props: Props = {}): ErrorHandlerFunction => {
   const { t } = useTranslation();
   const { pathname } = useRouter();


### PR DESCRIPTION
YJDH-847.

Refactors the employer application flow to prevent intermediate draft saves during employee data lookups, improves audit log reliability, and provides specific localized error toasts for validation issues.

Backend:
- Automatically creates an empty EmployerSummerVoucher inside EmployerApplicationSerializer.create, ensuring new applications are initialized with a voucher ID and enabling immediate attachment uploads.
- Updates YouthApplicationViewSet.fetch_employee_data to return specific error_code responses ("youth_application_not_accepted", "summer_voucher_already_used") on 400 Bad Request.
- Fixes test_applications_api.py to filter audit LogEntry queries by ContentType, avoiding assertions conflicts with the new auto-created voucher audit logs.

Frontend:
- Modifies fetchEmployment in useApplicationApi.ts to update the draft application locally instead of triggering a PUT request to the backend.
- Implements a DRY error handler in fetchEmployment that dynamically maps status and error codes to translation keys before calling showErrorToast.
- Simplifies handleGetEmployeeData in EmploymentForm.tsx to perform direct fetch lookups.
- Adds new translation keys for lookups under fi, sv, and en locales.

Tests:
- Deletes the obsolete updateApplication fallback test inside EmploymentForm.test.tsx.
- Adds useApplicationApi.test.ts to test success data-merging and all error toast scenarios in fetchEmployment.
