### PR TITLE
ci(ks): ignore text:S8565 from sonar report

### DIFF
--- a/backend/kesaseteli/sonar-project.properties
+++ b/backend/kesaseteli/sonar-project.properties
@@ -5,4 +5,11 @@ sonar.sources=.
 sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.test.inclusions=**/tests/**/*
-sonar.exclusions=**/migrations/**/*,**/.venv/**/*,**/venv/**/*,**/.pytest_cache/**/*,**/.ruff_cache/**/*,**/__pycache__/**/*
+sonar.exclusions=**/migrations/**/*,**/.venv/**/*,**/venv/**/*,**/.pytest_cache/**/*,**/.ruff_cache/**/*,**/__pycache__/**/*,**/templates/admin/**/*,**/templates/email/**/*
+
+# Ignore rule text:S8565 ("Python dependency lock file should be committed to source control")
+# because we use pip-compile (generating requirements.txt) and cannot use a lock file (like uv.lock)
+# due to the editable install of our local shared dependency (-e file:../shared).
+sonar.issue.ignore.multicriteria=lockfile
+sonar.issue.ignore.multicriteria.lockfile.ruleKey=text:S8565
+sonar.issue.ignore.multicriteria.lockfile.resourceKey=**/pyproject.toml,**/requirements*.txt,**/requirements*.in


### PR DESCRIPTION
YJDH-771.

Ignore rule text:S8565 ("Python dependency lock file should be committed to source control") because we use pip-compile (generating requirements.txt) and cannot use a lock file (like uv.lock) due to the editable install of our local shared dependency (-e file:../shared).

See the issue https://sonarcloud.io/project/issues?issues=AZ5kaPfiPrjWNqpoXuzC&open=AZ5kaPfiPrjWNqpoXuzC&id=City-of-Helsinki_yjdh-kesaseteli-api&tab=code&context=other

NOTE: requirements.txt cannot have hashes, because there is internal shared-package (with `-e file:../shared`).

Also exclude the email and admin template files from sonar report, because sonar just don't understand how the Django template system works.