### PR TITLE
fix(ks): create structured resilient log of auth events

### DIFF
--- a/backend/kesaseteli/applications/tests/test_applications_auth_logging.py
+++ b/backend/kesaseteli/applications/tests/test_applications_auth_logging.py
@@ -42,9 +42,12 @@ def test_fetch_vtj_json_logs_vtj_query():
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.VTJ_QUERY
-    assert entry.context["end_user"] == end_user
-    assert entry.context["social_security_number"] == application.social_security_number
+    assert entry.context["operation"] == AuthEventType.VTJ_QUERY
+    assert entry.context["actor"]["user_id"] == end_user
+    assert (
+        entry.context["target"]["social_security_number"]
+        == application.social_security_number
+    )
     assert entry.context["query_type"] == VtjQueryType.PERSONAL_DATA_QUERY
     assert entry.context["success"] is True
     assert entry.context["request_id"] is not None
@@ -73,9 +76,12 @@ def test_fetch_vtj_json_logs_vtj_query_failure_on_api_error():
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.VTJ_QUERY
-    assert entry.context["end_user"] == end_user
-    assert entry.context["social_security_number"] == application.social_security_number
+    assert entry.context["operation"] == AuthEventType.VTJ_QUERY
+    assert entry.context["actor"]["user_id"] == end_user
+    assert (
+        entry.context["target"]["social_security_number"]
+        == application.social_security_number
+    )
     assert entry.context["success"] is False
     assert entry.context["request_id"] is not None
     assert "Connection refused" in entry.context["error"]
@@ -113,8 +119,8 @@ def test_on_user_logged_in_logs_login():
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.LOGIN
-    assert entry.context["user_id"] == str(user.pk)
+    assert entry.context["operation"] == AuthEventType.LOGIN
+    assert entry.context["actor"]["user_id"] == str(user.pk)
 
 
 @override_settings(ENABLE_AUTH_LOGGING=True)
@@ -126,8 +132,8 @@ def test_on_user_logged_out_logs_logout():
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.LOGOUT
-    assert entry.context["user_id"] == str(user.pk)
+    assert entry.context["operation"] == AuthEventType.LOGOUT
+    assert entry.context["actor"]["user_id"] == str(user.pk)
 
 
 @override_settings(

--- a/backend/kesaseteli/companies/tests/test_company_auth_logging.py
+++ b/backend/kesaseteli/companies/tests/test_company_auth_logging.py
@@ -42,8 +42,8 @@ def test_get_or_create_company_logs_mandate_query(api_client, requests_mock):
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.MANDATE_QUERY
-    assert entry.context["company_identifier"] == "1234567-8"
+    assert entry.context["operation"] == AuthEventType.MANDATE_QUERY
+    assert entry.context["target"]["company_identifier"] == "1234567-8"
     assert entry.context["success"] is True
 
 
@@ -70,6 +70,6 @@ def test_get_or_create_company_logs_mandate_query_failure_on_api_error(
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.MANDATE_QUERY
+    assert entry.context["operation"] == AuthEventType.MANDATE_QUERY
     assert entry.context["success"] is False
     assert "Connection refused" in entry.context["error"]

--- a/backend/kesaseteli/kesaseteli/AUTH_LOGGING.md
+++ b/backend/kesaseteli/kesaseteli/AUTH_LOGGING.md
@@ -47,8 +47,8 @@ The retained records must make the following facts recoverable after the fact:
 
 | Requirement | Logged field |
 |---|---|
-| Who acted (representative / *puolesta-asioija*) | `user_id` |
-| On whose behalf (principal company) | `company_identifier` (Y-tunnus) |
+| Who acted (representative / *puolesta-asioija*) | `actor.user_id` |
+| On whose behalf (principal company) | `target.company_identifier` (Y-tunnus), `target.company_name` |
 | When the query was made | Timestamp recorded automatically by `django-resilient-logger` |
 | When the response was received | Timestamp recorded automatically by `django-resilient-logger` |
 | What roles / authorizations were returned | `roles`, `query_complete` |
@@ -67,14 +67,14 @@ queries made to the Population Information System. Logs must be retained for
 
 | Requirement | Logged field |
 |---|---|
-| Who made the query (person level) | `end_user` |
-| What data was queried | `social_security_number`, `query_type` |
+| Who made the query (person level) | `actor.user_id` |
+| What data was queried | `target.social_security_number`, `query_type` |
 | When the query was made | Timestamp recorded automatically by `django-resilient-logger` |
 | Whether the query succeeded | `success` |
 
 Reference: https://dvv.fi/vtjkysely-rajapinta
 
-## Log entry structure
+## Log entry structure (context)
 
 ### LOGIN
 
@@ -82,8 +82,13 @@ Written on every successful Suomi.fi SAML2 authentication.
 
 ```json
 {
-  "event_type": "LOGIN",
-  "user_id": "<Django user PK>",
+  "operation": "LOGIN",
+  "actor": {
+    "user_id": "<Django user PK>"
+  },
+  "target": {
+    "user_id": "<Django user PK>"
+  },
   "auth_backend": "shared.suomi_fi.auth.SuomiFiSAML2AuthenticationBackend",
   "ip_address": "1.2.3.4"
 }
@@ -95,8 +100,13 @@ Written on every manual or SAML Single Logout (SLO).
 
 ```json
 {
-  "event_type": "LOGOUT",
-  "user_id": "<Django user PK>",
+  "operation": "LOGOUT",
+  "actor": {
+    "user_id": "<Django user PK>"
+  },
+  "target": {
+    "user_id": "<Django user PK>"
+  },
   "ip_address": "1.2.3.4"
 }
 ```
@@ -107,13 +117,19 @@ Written after a successful Suomi.fi Valtuudet API call.
 
 ```json
 {
-  "event_type": "MANDATE_QUERY",
-  "user_id": "<Django user PK>",
-  "company_identifier": "1234567-8",
-  "company_name": "Example Oy",
+  "operation": "MANDATE_QUERY",
+  "actor": {
+    "user_id": "<Django user PK>"
+  },
+  "target": {
+    "user_id": "<Django user PK>",
+    "company_identifier": "1234567-8",
+    "company_name": "Example Oy"
+  },
   "roles": ["NIMKO"],
   "query_complete": true,
-  "success": true
+  "success": true,
+  "request_id": "req-123"
 }
 ```
 
@@ -123,10 +139,16 @@ Written when the Suomi.fi Valtuudet API call raises a `RequestException`.
 
 ```json
 {
-  "event_type": "MANDATE_QUERY",
-  "user_id": "<Django user PK>",
+  "operation": "MANDATE_QUERY",
+  "actor": {
+    "user_id": "<Django user PK>"
+  },
+  "target": {
+    "user_id": "<Django user PK>"
+  },
   "success": false,
-  "error": "Connection refused"
+  "error": "Connection refused",
+  "request_id": "req-123"
 }
 ```
 
@@ -136,11 +158,16 @@ Written after a successful VTJ personal information query.
 
 ```json
 {
-  "event_type": "VTJ_QUERY",
-  "end_user": "<handler UUID or user PK>",
-  "social_security_number": "010101-123N",
+  "operation": "VTJ_QUERY",
+  "actor": {
+    "user_id": "<handler UUID or 'system'>"
+  },
+  "target": {
+    "social_security_number": "010101-123N"
+  },
   "query_type": "PERUSSANOMA 1",
-  "success": true
+  "success": true,
+  "request_id": "req-vtj-123"
 }
 ```
 
@@ -150,12 +177,17 @@ Written when the VTJ API call raises a `RequestException`.
 
 ```json
 {
-  "event_type": "VTJ_QUERY",
-  "end_user": "<handler UUID or user PK>",
-  "social_security_number": "010101-123N",
+  "operation": "VTJ_QUERY",
+  "actor": {
+    "user_id": "<handler UUID or 'system'>"
+  },
+  "target": {
+    "social_security_number": "010101-123N"
+  },
   "query_type": "PERUSSANOMA 1",
   "success": false,
-  "error": "Connection refused"
+  "error": "Connection refused",
+  "request_id": "req-vtj-123"
 }
 ```
 

--- a/backend/kesaseteli/kesaseteli/auth_logging.py
+++ b/backend/kesaseteli/kesaseteli/auth_logging.py
@@ -105,9 +105,10 @@ SYSTEM_USER = "system"
 class AuthEventType(StrEnum):
     """Stable string identifiers for auth event types stored in log entry context.
 
-    These values are written to the ``event_type`` field of every
-    ``ResilientLogEntry`` produced by this module and will appear verbatim in
-    Elasticsearch. Do not rename existing members without a data migration.
+    These values are written to the ``operation`` field of every
+    ``ResilientLogEntry`` context produced by this module and will appear verbatim in
+    Elasticsearch as ``audit_event.operation``. Do not rename existing members
+    without a data migration.
     """
 
     LOGIN = "LOGIN"
@@ -169,12 +170,14 @@ def log_login_event(request, user):
             user (e.g. ``shared.suomi_fi.auth.SuomiFiSAML2AuthenticationBackend``
             for Suomi.fi SAML2 logins).
     """
-    ResilientLogSource.create(
+    user_id = str(user.pk)
+    ResilientLogSource.create_structured(
         level=logging.INFO,
         message=AuthEventMessage.LOGIN,
-        context={
-            "event_type": AuthEventType.LOGIN,
-            "user_id": str(user.pk),
+        operation=AuthEventType.LOGIN,
+        actor={"user_id": user_id},
+        target={"user_id": user_id},
+        extra={
             "auth_backend": getattr(user, "backend", "unknown"),
             "ip_address": request.META.get("REMOTE_ADDR"),
         },
@@ -191,12 +194,14 @@ def log_logout_event(request, user):
         request: The current Django ``HttpRequest``.
         user: The Django ``User`` instance that is logging out.
     """
-    ResilientLogSource.create(
+    user_id = str(user.pk) if user else "unknown"
+    ResilientLogSource.create_structured(
         level=logging.INFO,
         message=AuthEventMessage.LOGOUT,
-        context={
-            "event_type": AuthEventType.LOGOUT,
-            "user_id": str(user.pk) if user else "unknown",
+        operation=AuthEventType.LOGOUT,
+        actor={"user_id": user_id},
+        target={"user_id": user_id},
+        extra={
             "ip_address": request.META.get("REMOTE_ADDR"),
         },
     )
@@ -220,18 +225,23 @@ def on_suomifi_mandate_queried(
         request_id: The unique ID generated for the API query.
         organization_roles: The dict returned by the API containing roles.
     """
-    user = getattr(request, "user", None)
     if not request_id:
         raise ValueError("Missing request_id in suomifi_mandate_queried signal.")
 
-    ResilientLogSource.create(
+    user = getattr(request, "user", None)
+    user_id = str(user.pk) if user and user.is_authenticated else None
+
+    ResilientLogSource.create_structured(
         level=logging.INFO,
         message=AuthEventMessage.MANDATE_QUERY,
-        context={
-            "event_type": AuthEventType.MANDATE_QUERY,
-            "user_id": str(user.pk) if user and user.is_authenticated else None,
-            "company_identifier": organization_roles.get("identifier"),
+        actor={"user_id": user_id},
+        operation=AuthEventType.MANDATE_QUERY,
+        target={
+            "user_id": user_id,
             "company_name": organization_roles.get("name"),
+            "company_identifier": organization_roles.get("identifier"),
+        },
+        extra={
             "request_id": request_id,
             "roles": organization_roles.get("roles", []),
             "query_complete": organization_roles.get("complete"),
@@ -255,13 +265,14 @@ def on_suomifi_mandate_query_failed(sender, request, request_id, error, **kwargs
         error: The exception that caused the failure.
     """
     user = getattr(request, "user", None)
-
-    ResilientLogSource.create(
+    user_id = str(user.pk) if user and user.is_authenticated else None
+    ResilientLogSource.create_structured(
         level=logging.WARNING,
+        operation=AuthEventType.MANDATE_QUERY,
         message=AuthEventMessage.MANDATE_QUERY_FAILED,
-        context={
-            "event_type": AuthEventType.MANDATE_QUERY,
-            "user_id": str(user.pk) if user and user.is_authenticated else None,
+        actor={"user_id": user_id},
+        target={"user_id": user_id},
+        extra={
             "request_id": request_id,
             "success": False,
             "error": str(error),
@@ -284,13 +295,13 @@ def on_vtj_queried(sender, end_user, social_security_number, request_id=None, **
         social_security_number: The Finnish personal identity code queried.
         request_id: The unique ID generated for the query.
     """
-    ResilientLogSource.create(
+    ResilientLogSource.create_structured(
         level=logging.INFO,
         message=AuthEventMessage.VTJ_QUERY,
-        context={
-            "event_type": AuthEventType.VTJ_QUERY,
-            "end_user": end_user or SYSTEM_USER,
-            "social_security_number": social_security_number,
+        operation=AuthEventType.VTJ_QUERY,
+        actor={"user_id": str(end_user or SYSTEM_USER)},
+        target={"social_security_number": social_security_number},
+        extra={
             "query_type": VtjQueryType.PERSONAL_DATA_QUERY,
             "success": True,
             "request_id": request_id,
@@ -316,13 +327,13 @@ def on_vtj_query_failed(
         error: The exception that caused the failure.
         request_id: The unique ID generated for the query.
     """
-    ResilientLogSource.create(
+    ResilientLogSource.create_structured(
         level=logging.WARNING,
         message=AuthEventMessage.VTJ_QUERY_FAILED,
-        context={
-            "event_type": AuthEventType.VTJ_QUERY,
-            "end_user": end_user or SYSTEM_USER,
-            "social_security_number": social_security_number,
+        operation=AuthEventType.VTJ_QUERY,
+        actor={"user_id": str(end_user or SYSTEM_USER)},
+        target={"social_security_number": social_security_number},
+        extra={
             "query_type": VtjQueryType.PERSONAL_DATA_QUERY,
             "success": False,
             "error": str(error),

--- a/backend/kesaseteli/kesaseteli/tests/test_auth_logging.py
+++ b/backend/kesaseteli/kesaseteli/tests/test_auth_logging.py
@@ -33,8 +33,9 @@ def test_log_login_event_creates_entry(user):
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.LOGIN
-    assert entry.context["user_id"] == str(user.pk)
+    assert entry.context["operation"] == AuthEventType.LOGIN
+    assert entry.context["actor"]["user_id"] == str(user.pk)
+    assert entry.context["target"]["user_id"] == str(user.pk)
     assert entry.context["ip_address"] == "1.2.3.4"
     assert entry.context["auth_backend"] == "django.contrib.auth.backends.ModelBackend"
     assert entry.level == logging.INFO
@@ -60,10 +61,11 @@ def test_log_mandate_query_creates_entry(user):
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.MANDATE_QUERY
-    assert entry.context["user_id"] == str(user.pk)
-    assert entry.context["company_identifier"] == "1234567-8"
-    assert entry.context["company_name"] == "Test Oy"
+    assert entry.context["operation"] == AuthEventType.MANDATE_QUERY
+    assert entry.context["actor"]["user_id"] == str(user.pk)
+    assert entry.context["target"]["user_id"] == str(user.pk)
+    assert entry.context["target"]["company_identifier"] == "1234567-8"
+    assert entry.context["target"]["company_name"] == "Test Oy"
     assert entry.context["roles"] == ["NIMKO"]
     assert entry.context["query_complete"] is True
     assert entry.context["success"] is True
@@ -86,7 +88,9 @@ def test_log_mandate_query_failure_creates_entry(user):
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.MANDATE_QUERY
+    assert entry.context["operation"] == AuthEventType.MANDATE_QUERY
+    assert entry.context["actor"]["user_id"] == str(user.pk)
+    assert entry.context["target"]["user_id"] == str(user.pk)
     assert entry.context["success"] is False
     assert entry.context["request_id"] == "req-123"
     assert "Connection refused" in entry.context["error"]
@@ -103,7 +107,9 @@ def test_user_logged_in_signal_creates_login_entry(user):
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.LOGIN
+    assert entry.context["operation"] == AuthEventType.LOGIN
+    assert entry.context["actor"]["user_id"] == str(user.pk)
+    assert entry.context["target"]["user_id"] == str(user.pk)
     assert entry.context["ip_address"] == "10.0.0.1"
 
 
@@ -132,9 +138,9 @@ def test_log_vtj_query_creates_entry():
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.VTJ_QUERY
-    assert entry.context["end_user"] == "handler-uuid-123"
-    assert entry.context["social_security_number"] == "010101-123N"
+    assert entry.context["operation"] == AuthEventType.VTJ_QUERY
+    assert entry.context["actor"]["user_id"] == "handler-uuid-123"
+    assert entry.context["target"]["social_security_number"] == "010101-123N"
     assert entry.context["query_type"] == VtjQueryType.PERSONAL_DATA_QUERY
     assert entry.context["success"] is True
     assert entry.context["request_id"] == "req-vtj-123"
@@ -155,9 +161,9 @@ def test_log_vtj_query_failure_creates_entry():
 
     entry = ResilientLogEntry.objects.last()
     assert entry is not None
-    assert entry.context["event_type"] == AuthEventType.VTJ_QUERY
-    assert entry.context["end_user"] == "handler-uuid-123"
-    assert entry.context["social_security_number"] == "010101-123N"
+    assert entry.context["operation"] == AuthEventType.VTJ_QUERY
+    assert entry.context["actor"]["user_id"] == "handler-uuid-123"
+    assert entry.context["target"]["social_security_number"] == "010101-123N"
     assert entry.context["query_type"] == VtjQueryType.PERSONAL_DATA_QUERY
     assert entry.context["success"] is False
     assert entry.context["request_id"] == "req-vtj-123-failed"
@@ -224,7 +230,7 @@ def test_vtj_queried_empty_end_user_defaults_to_system():
         request_id="req-vtj-123",
     )
     entry = ResilientLogEntry.objects.last()
-    assert entry.context["end_user"] == "system"
+    assert entry.context["actor"]["user_id"] == "system"
 
 
 @override_settings(ENABLE_AUTH_LOGGING=True)
@@ -237,4 +243,4 @@ def test_vtj_query_failed_empty_end_user_defaults_to_system():
         request_id="req-vtj-123-failed",
     )
     entry = ResilientLogEntry.objects.last()
-    assert entry.context["end_user"] == "system"
+    assert entry.context["actor"]["user_id"] == "system"


### PR DESCRIPTION
YJDH-838.

Use `ResilientLogSource.create_structured` instead of `ResilientLogSource.create`. This leads to a more consistent log entries accross the indices in ElasticSearch.