### PR TITLE
ci(ks): ignore text:S8565 from sonar report

### DIFF
--- a/backend/kesaseteli/sonar-project.properties
+++ b/backend/kesaseteli/sonar-project.properties
@@ -12,4 +12,4 @@ sonar.exclusions=**/migrations/**/*,**/.venv/**/*,**/venv/**/*,**/.pytest_cache/
 # due to the editable install of our local shared dependency (-e file:../shared).
 sonar.issue.ignore.multicriteria=lockfile
 sonar.issue.ignore.multicriteria.lockfile.ruleKey=text:S8565
-sonar.issue.ignore.multicriteria.lockfile.resourceKey=**/pyproject.toml,**/requirements*.txt,**/requirements*.in
+sonar.issue.ignore.multicriteria.lockfile.resourceKey=**/*


### PR DESCRIPTION
YJDH-771.

2nd try: Now ignoring it globally.

Ignore rule text:S8565 ("Python dependency lock file should be committed to source control") because we use pip-compile (generating requirements.txt) and cannot use a lock file (like uv.lock) due to the editable install of our local shared dependency (-e file:../shared).
