### PR TITLE
fix(shared): prevent leave confirmation prompt on dummy/hash links

### DIFF
--- a/frontend/shared/src/hooks/__tests__/useLeaveConfirm.utils.test.ts
+++ b/frontend/shared/src/hooks/__tests__/useLeaveConfirm.utils.test.ts
@@ -43,6 +43,21 @@ describe('useLeaveConfirm.utils', () => {
       anchor.href = 'http://localhost/other';
       expect(isInternalLink(anchor)).toBe(true);
     });
+
+    it('should return false for links starting with #', () => {
+      const anchor = document.createElement('a');
+      anchor.setAttribute('href', '#');
+      expect(isInternalLink(anchor)).toBe(false);
+
+      const anchor2 = document.createElement('a');
+      anchor2.setAttribute('href', '#some-section');
+      expect(isInternalLink(anchor2)).toBe(false);
+    });
+
+    it('should return false if href is missing', () => {
+      const anchor = document.createElement('a');
+      expect(isInternalLink(anchor)).toBe(false);
+    });
   });
 
   describe('isBypassUrl', () => {

--- a/frontend/shared/src/hooks/useLeaveConfirm.utils.ts
+++ b/frontend/shared/src/hooks/useLeaveConfirm.utils.ts
@@ -30,6 +30,10 @@ export const getPathWithoutHash = (p: string): string => p.split('#')[0];
  * @returns True if the link is internal.
  */
 export const isInternalLink = (anchor: HTMLAnchorElement): boolean => {
+  const href = anchor.getAttribute('href');
+  if (!href || href.startsWith('#')) {
+    return false;
+  }
   try {
     const url = new URL(anchor.href, window.location.href);
     const isInternal = url.origin === window.location.origin;


### PR DESCRIPTION
YJDH-897.

Prevent the leave confirmation warning prompt from triggering when clicking on page-local hash links (e.g. href="#") or anchors without an href.

In the employer UI, attachments use anchor elements with href="#" for opening and removing attachments. Previously, the global capturing click listener intercepted these clicks as internal page navigations. This was caused by a mismatch between the browser location (which includes the locale prefix, e.g. /fi/) and the locale-agnostic Router.asPath.

Fix this by returning false in isInternalLink for anchors starting with "#" or missing href. Added unit tests to cover these cases.