### PR TITLE
fix(benefit): pdf viewer copy fix

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -123,7 +123,7 @@ COPY --chown=default:root --from=staticbuilder app/next.config.js ./
 COPY --chown=default:root --from=staticbuilder app/shared/src/server/next-server.js shared/src/server/
 
 # Copy public directory
-COPY --chown=default:root $PROJECT/$FOLDER/public $PROJECT/$FOLDER/public
+COPY --chown=default:root --from=staticbuilder app/$PROJECT/$FOLDER/public $PROJECT/$FOLDER/public
 
 ENV NEXT_TELEMETRY_DISABLED 1
 


### PR DESCRIPTION
## Description :sparkles:

pdf.worker.min.mjs is copied in yarn build phase, but Docker copies public from repository. Fixed Dockerfile to use staticbuilder source.

[HL-1783](https://helsinkisolutionoffice.atlassian.net/browse/HL-1783)

[HL-1783]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ