### PR TITLE
fix(benefit): apprenticeship decoupling and other fixes

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -769,6 +769,11 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
         ):
             data["association_immediate_manager_check"] = None
 
+    def _normalize_pay_subsidy_granted(self, pay_subsidy_granted, data):
+        data["pay_subsidy_granted"] = PaySubsidyGranted.NOT_GRANTED
+        data["pay_subsidy_percent"] = None
+        data["additional_pay_subsidy_percent"] = None
+
     def _validate_de_minimis_aid_set(
         self,
         company,

--- a/backend/benefit/applications/models.py
+++ b/backend/benefit/applications/models.py
@@ -690,6 +690,7 @@ class Application(UUIDModel, TimeStampedModel, DurationMixin):
                 ApplicationBatchStatus.DECIDED_ACCEPTED,
                 ApplicationBatchStatus.DECIDED_REJECTED,
                 ApplicationBatchStatus.SENT_TO_TALPA,
+                ApplicationBatchStatus.PARTIALLY_SENT_TO_TALPA,
                 ApplicationBatchStatus.COMPLETED,
             ]
         else:

--- a/backend/benefit/applications/services/ahjo_decision_service.py
+++ b/backend/benefit/applications/services/ahjo_decision_service.py
@@ -51,9 +51,9 @@ def replace_decision_template_placeholders(
             ),
             benefit_date_range=f"{start_date_str} - {end_date_str}",
             benefit_instalment1_range=benefit_instalment1_range,
-            benefit_instalment1_sum=benefit_instalment1_sum,
+            benefit_instalment1_sum=int(benefit_instalment1_sum),
             benefit_instalment2_range=benefit_instalment2_range,
-            benefit_instalment2_sum=benefit_instalment2_sum,
+            benefit_instalment2_sum=int(benefit_instalment2_sum),
         )
     except AhjoDecisionError as e:
         raise ValueError(f"Error in preparing the decision proposal template: {e}")

--- a/backend/benefit/applications/tests/test_ahjo_decisions.py
+++ b/backend/benefit/applications/tests/test_ahjo_decisions.py
@@ -39,8 +39,8 @@ def test_replace_accepted_decision_template_placeholders(
 
     assert range_1 in replaced_template
     assert range_2 in replaced_template
-    assert (str(sum_1) + " euroa") in replaced_template
-    assert (str(sum_2) + " euroa") in replaced_template
+    assert (str(int(sum_1)) + " euroa") in replaced_template
+    assert (str(int(sum_2)) + " euroa") in replaced_template
 
 
 @pytest.mark.django_db

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/SecondInstalmentListItem.tsx
@@ -16,7 +16,7 @@ import {
   $Avatar,
   $DataColumn,
   $DataHeader,
-  $DataValue,
+  $DataValue, $ItemActions,
   $ItemContent,
   $ListItem,
   $ListItemWrapper,
@@ -86,7 +86,8 @@ const SecondInstalmentListItem: React.FC<SecondInstalmentListItemProps> = ({
               </$StatusText>
             </$StatusDataValue>
           </$StatusDataColumn>
-
+        </$ItemContent>
+        <$ItemActions>
           <$DataColumn>
             <Button
               iconStart={<IconPen />}
@@ -99,7 +100,7 @@ const SecondInstalmentListItem: React.FC<SecondInstalmentListItemProps> = ({
               {t(`${translationBase}.secondInstalments.button`)}
             </Button>
           </$DataColumn>
-        </$ItemContent>
+        </$ItemActions>
       </$ListItem>
     </$ListItemWrapper>
   );

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/utils/validation.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/utils/validation.ts
@@ -82,6 +82,7 @@ export const getValidationSchema = (
           },
         }),
     [APPLICATION_FIELDS_STEP1_KEYS.COMPANY_NUMBER_OF_EMPLOYEES]: Yup.string()
+      .nullable()
       .matches(/^\d+$/, t(VALIDATION_MESSAGE_KEYS.NUMBER_INVALID))
       .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
     [APPLICATION_FIELDS_STEP1_KEYS.COMPANY_BUSINESS_BRIEF]: Yup.string()

--- a/frontend/benefit/handler/browser-tests/pages/1-new-application.testcafe.ts
+++ b/frontend/benefit/handler/browser-tests/pages/1-new-application.testcafe.ts
@@ -92,7 +92,6 @@ test('Fill form and submit', async (t: TestController) => {
     form.employee.otherExpenses
   );
 
-  await t.click('[for="paySubsidyGranted.granted"]');
   await t.click('[for="apprenticeshipProgramTrue"]');
 
   await t.typeText(
@@ -103,7 +102,6 @@ test('Fill form and submit', async (t: TestController) => {
   await uploadFileAttachment(t, '#upload_attachment_full_application');
   await uploadFileAttachment(t, '#upload_attachment_employment_contract');
   await uploadFileAttachment(t, '#upload_attachment_education_contract');
-  await uploadFileAttachment(t, '#upload_attachment_pay_subsidy_decision');
 
   /**
    * Click through all applicant terms.

--- a/frontend/benefit/handler/browser-tests/pages/2-edit-application.testcafe.ts
+++ b/frontend/benefit/handler/browser-tests/pages/2-edit-application.testcafe.ts
@@ -121,7 +121,6 @@ test('Open form and edit fields, then submit', async (t: TestController) => {
     form.employee.otherExpenses
   );
 
-  await t.click('[for="paySubsidyGranted.null"]');
 
   await clearAndFill(
     t,

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/FormContent.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/FormContent.tsx
@@ -1,6 +1,5 @@
 import { APPLICATION_START_DATE_WITHIN_MONTHS } from 'benefit/applicant/src/constants';
 import {
-  APPLICATION_FIELD_KEYS,
   APPLICATION_START_DATE,
 } from 'benefit/handler/constants';
 import { useAlertBeforeLeaving } from 'benefit/handler/hooks/useAlertBeforeLeaving';
@@ -40,7 +39,6 @@ import {
 import Heading from 'shared/components/forms/heading/Heading';
 import FormSection from 'shared/components/forms/section/FormSection';
 import {
-  $Grid,
   $GridCell,
 } from 'shared/components/forms/section/FormSection.sc';
 import { BenefitAttachment } from 'shared/types/attachment';
@@ -537,135 +535,46 @@ const FormContent: React.FC<Props> = ({
         </>
       </FormSection>
       <FormSection header={t(`${translationsBase}.headings.employment2`)}>
-        <$GridCell $colSpan={8}>
+        <$GridCell $colSpan={3} $colStart={1}>
           <SelectionGroup
-            id={fields.paySubsidyGranted.name}
-            label={fields.paySubsidyGranted.label}
+            label={fields.apprenticeshipProgram.label}
+            id={fields.apprenticeshipProgram.name}
             direction="vertical"
             required
-            errorText={getErrorMessage(fields.paySubsidyGranted.name)}
+            errorText={getErrorMessage(fields.apprenticeshipProgram.name)}
           >
             <$RadioButton
-              id={`${fields.paySubsidyGranted.name}.${PAY_SUBSIDY_GRANTED.GRANTED}`}
-              name={fields.paySubsidyGranted.name}
-              value={PAY_SUBSIDY_GRANTED.GRANTED}
+              id={`${fields.apprenticeshipProgram.name}False`}
+              name={fields.apprenticeshipProgram.name}
+              value="false"
               label={t(
-                `${translationsBase}.fields.${fields.paySubsidyGranted.name}.granted`
+                `${translationsBase}.fields.${fields.apprenticeshipProgram.name}.no`
               )}
-              onBlur={formik.handleBlur}
               onChange={() => {
                 formik.setFieldValue(
-                  fields.paySubsidyGranted.name,
-                  PAY_SUBSIDY_GRANTED.GRANTED
-                );
-                formik.setFieldValue(
-                  APPLICATION_FIELD_KEYS.APPRENTICESHIP_PROGRAM,
-                  null
+                  fields.apprenticeshipProgram.name,
+                  false
                 );
               }}
-              checked={
-                formik.values.paySubsidyGranted === PAY_SUBSIDY_GRANTED.GRANTED
-              }
+              checked={formik.values.apprenticeshipProgram === false}
             />
             <$RadioButton
-              id={`${fields.paySubsidyGranted.name}.${PAY_SUBSIDY_GRANTED.GRANTED_AGED}`}
-              name={fields.paySubsidyGranted.name}
-              value={PAY_SUBSIDY_GRANTED.GRANTED_AGED}
+              id={`${fields.apprenticeshipProgram.name}True`}
+              name={fields.apprenticeshipProgram.name}
+              value="true"
               label={t(
-                `${translationsBase}.fields.${fields.paySubsidyGranted.name}.grantedAged`
+                `${translationsBase}.fields.${fields.apprenticeshipProgram.name}.yes`
               )}
-              onBlur={formik.handleBlur}
               onChange={() => {
                 formik.setFieldValue(
-                  fields.paySubsidyGranted.name,
-                  PAY_SUBSIDY_GRANTED.GRANTED_AGED
-                );
-                formik.setFieldValue(
-                  APPLICATION_FIELD_KEYS.APPRENTICESHIP_PROGRAM,
-                  null
+                  fields.apprenticeshipProgram.name,
+                  true
                 );
               }}
-              checked={
-                formik.values.paySubsidyGranted ===
-                PAY_SUBSIDY_GRANTED.GRANTED_AGED
-              }
-            />
-            <$RadioButton
-              id={`${fields.paySubsidyGranted.name}.null`}
-              name={fields.paySubsidyGranted.name}
-              value={PAY_SUBSIDY_GRANTED.NOT_GRANTED}
-              label={t(
-                `${translationsBase}.fields.${fields.paySubsidyGranted.name}.notGranted`
-              )}
-              onBlur={formik.handleBlur}
-              onChange={() => {
-                formik.setFieldValue(
-                  fields.paySubsidyGranted.name,
-                  PAY_SUBSIDY_GRANTED.NOT_GRANTED
-                );
-              }}
-              checked={
-                formik.values.paySubsidyGranted ===
-                PAY_SUBSIDY_GRANTED.NOT_GRANTED
-              }
+              checked={formik.values.apprenticeshipProgram === true}
             />
           </SelectionGroup>
         </$GridCell>
-        {TRUTHY_SUBSIDIES.has(
-          formik.values.paySubsidyGranted as PAY_SUBSIDY_GRANTED
-        ) && (
-          <$GridCell
-            as={$Grid}
-            $colSpan={12}
-            css={`
-              row-gap: ${theme.spacing.xl};
-              padding-left: ${theme.spacing.s};
-              margin-top: ${theme.spacing.s};
-              border-left: 10px solid ${theme.colors.silver};
-            `}
-          >
-            <$GridCell $colSpan={3} $colStart={1}>
-              <SelectionGroup
-                label={fields.apprenticeshipProgram.label}
-                id={fields.apprenticeshipProgram.name}
-                direction="vertical"
-                required
-                errorText={getErrorMessage(fields.apprenticeshipProgram.name)}
-              >
-                <$RadioButton
-                  id={`${fields.apprenticeshipProgram.name}False`}
-                  name={fields.apprenticeshipProgram.name}
-                  value="false"
-                  label={t(
-                    `${translationsBase}.fields.${fields.apprenticeshipProgram.name}.no`
-                  )}
-                  onChange={() => {
-                    formik.setFieldValue(
-                      fields.apprenticeshipProgram.name,
-                      false
-                    );
-                  }}
-                  checked={formik.values.apprenticeshipProgram === false}
-                />
-                <$RadioButton
-                  id={`${fields.apprenticeshipProgram.name}True`}
-                  name={fields.apprenticeshipProgram.name}
-                  value="true"
-                  label={t(
-                    `${translationsBase}.fields.${fields.apprenticeshipProgram.name}.yes`
-                  )}
-                  onChange={() => {
-                    formik.setFieldValue(
-                      fields.apprenticeshipProgram.name,
-                      true
-                    );
-                  }}
-                  checked={formik.values.apprenticeshipProgram === true}
-                />
-              </SelectionGroup>
-            </$GridCell>
-          </$GridCell>
-        )}
       </FormSection>
       <FormSection
         header={t(`${translationsBase}.headings.employment4`)}

--- a/frontend/benefit/handler/src/components/applicationForm/utils/validation.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/utils/validation.ts
@@ -16,7 +16,6 @@ import {
   EMPLOYEE_KEYS,
   MAX_MONTHLY_PAY,
   ORGANIZATION_TYPES,
-  PAY_SUBSIDY_GRANTED,
   VALIDATION_MESSAGE_KEYS,
 } from 'benefit-shared/constants';
 import {
@@ -209,23 +208,9 @@ export const getValidationSchema = (
       Yup.string(),
     [APPLICATION_FIELD_KEYS.OTHER_FINANCIAL_SUPPORT_FOR_EMPLOYMENT]:
       Yup.boolean().nullable().required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
-    [APPLICATION_FIELD_KEYS.PAY_SUBSIDY_GRANTED]: Yup.mixed().oneOf(
-      Object.values(PAY_SUBSIDY_GRANTED),
-      t(VALIDATION_MESSAGE_KEYS.INVALID)
-    ),
     [APPLICATION_FIELD_KEYS.APPRENTICESHIP_PROGRAM]: Yup.boolean()
       .nullable()
-      .when(APPLICATION_FIELD_KEYS.PAY_SUBSIDY_GRANTED, {
-        is: (value?: PAY_SUBSIDY_GRANTED) =>
-          value &&
-          [
-            PAY_SUBSIDY_GRANTED.GRANTED,
-            PAY_SUBSIDY_GRANTED.GRANTED_AGED,
-          ].includes(value),
-        then: Yup.boolean()
-          .nullable()
-          .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
-      }),
+      .required(t(VALIDATION_MESSAGE_KEYS.REQUIRED)),
     [APPLICATION_FIELD_KEYS.ROLE_OF_EMPLOYEE_IN_ORGANIZATION]: Yup.string()
       .trim()
       .max(

--- a/frontend/benefit/handler/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/handler/src/hooks/useFormActions.tsx
@@ -11,7 +11,6 @@ import {
   APPLICATION_STATUSES,
   BENEFIT_TYPES,
   PAY_SUBSIDY_GRANTED,
-  PAY_SUBSIDY_OPTIONS,
 } from 'benefit-shared/constants';
 import {
   ApplicationData,
@@ -318,7 +317,6 @@ const useFormActions = (
     const employee: Employee | undefined = currentValues?.employee ?? undefined;
 
     const {
-      paySubsidyGranted,
       startDate,
       endDate,
       apprenticeshipProgram,
@@ -328,11 +326,6 @@ const useFormActions = (
       paySubsidies,
       companyNumberOfEmployees,
     } = currentValues;
-
-    const paySubsidyPercent =
-      paySubsidyGranted === PAY_SUBSIDY_GRANTED.NOT_GRANTED
-        ? null
-        : PAY_SUBSIDY_OPTIONS[0];
 
     if (employee) {
       employee.commissionAmount = employee.commissionAmount
@@ -354,7 +347,8 @@ const useFormActions = (
 
     const normalizedValues = {
       ...currentValues,
-      paySubsidyPercent,
+      paySubsidyGranted: PAY_SUBSIDY_GRANTED.NOT_GRANTED,
+      paySubsidyPercent: null,
       deMinimisAid: deMinimisAids.length > 0,
       employee: employee || {},
       startDate: startDate
@@ -366,10 +360,7 @@ const useFormActions = (
       paperApplicationDate: paperApplicationDate
         ? convertToBackendDateFormat(parseDate(paperApplicationDate))
         : undefined,
-      apprenticeshipProgram:
-        paySubsidyGranted === PAY_SUBSIDY_GRANTED.NOT_GRANTED
-          ? null
-          : apprenticeshipProgram,
+      apprenticeshipProgram,
       companyNumberOfEmployees:
         companyNumberOfEmployees === ''
           ? null

--- a/frontend/shared/browser-tests/page-models/PageComponent.ts
+++ b/frontend/shared/browser-tests/page-models/PageComponent.ts
@@ -44,13 +44,13 @@ abstract class PageComponent {
   );
 
   protected constructor(datatestId?: string) {
-    this.componentSelector = this.screen.findByTestId(
-      datatestId ?? MAIN_CONTENT_ID
+    this.componentSelector = Selector(
+      `[data-testid="${datatestId ?? MAIN_CONTENT_ID}"]`
     );
     this.component = this.within(this.componentSelector);
   }
 
-  loadingSpinners = this.screen.findAllByTestId('hidden-loading-indicator');
+  loadingSpinners = Selector('[data-testid="hidden-loading-indicator"]');
 
   public async isLoadingSpinnerNoMorePresent(timeout?: number): Promise<void> {
     return (
@@ -67,7 +67,7 @@ abstract class PageComponent {
    */
   public async isLoaded(timeout?: number): Promise<void> {
     await this.isLoadingSpinnerNoMorePresent(timeout);
-    return this.expect(this.componentSelector);
+    return this.expect(this.componentSelector, timeout);
   }
 
   /** expectation utility */
@@ -76,10 +76,12 @@ abstract class PageComponent {
     selector: Selector | SelectorPromise,
     timeout?: number
   ): Promise<void> {
+    const exists = await selector.exists;
+
     return (
       t
         // eslint-disable-next-line security/detect-non-literal-fs-filename
-        .expect(selector.exists)
+        .expect(exists)
         .ok(await getErrorMessage(t), { timeout })
     );
   }
@@ -88,10 +90,12 @@ abstract class PageComponent {
     selector: Selector | SelectorPromise,
     timeout?: number
   ): Promise<void> {
+    const exists = await selector.exists;
+
     return (
       t
         // eslint-disable-next-line security/detect-non-literal-fs-filename
-        .expect(selector.exists)
+        .expect(exists)
         .notOk(await getErrorMessage(t), { timeout })
     );
   }


### PR DESCRIPTION
## Description :sparkles:

* Apprenticeship was coupled with pay subsidy. Setting pay subsidy to null and remove coupling from UI.
* List of applications with second instalment in REQUESTED status was improperly formatted. Fixed formatting.
* Applications partially sent to TALPA were shown in HANDLING state. Fixed.
* Instalment amounts in handler decision texts contained decimals. Fixed to use integers only.
* Fixed ugly error message of company number of employees

## Contextx

[HL-1767](https://helsinkisolutionoffice.atlassian.net/browse/HL-1767)
[HL-1745](https://helsinkisolutionoffice.atlassian.net/browse/HL-1745)
[HL-1816](https://helsinkisolutionoffice.atlassian.net/browse/HL-1816)
[HL-1817](https://helsinkisolutionoffice.atlassian.net/browse/HL-1817)
[HL-1819](https://helsinkisolutionoffice.atlassian.net/browse/HL-1819)

## Testing :alembic:

TestCafe tests were modified for apprenticeship decoupling
Visual checking of integers and second instalment formatting.


[HL-1767]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-1745]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-1816]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HL-1819]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HL-1817]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ