### PR TITLE
fix(benefit): update pdf viewer

### DIFF
--- a/frontend/benefit/applicant/src/components/pdfViewer/PdfViewer.tsx
+++ b/frontend/benefit/applicant/src/components/pdfViewer/PdfViewer.tsx
@@ -33,12 +33,15 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ file, scale }) => {
 
   const theme = useTheme();
 
+  const pdfOptions = React.useMemo(() => ({ withCredentials: true }), []);
+
   return (
     <>
       <$ViewerWrapper>
         <Document
           onLoadSuccess={handleDocumentLoadSuccess}
           file={file}
+          options={pdfOptions}
           className="Document"
         >
           <Page pageNumber={currentPage} scale={scale} />


### PR DESCRIPTION
## Description :sparkles:

Change PdfViewer to send credentials when
document is shown.

## Issues :bug:

PDF Viewer gives error 403 Forbidden when trying to access a document
from backend API.

[HL-1783](https://helsinkisolutionoffice.atlassian.net/browse/HL-1783)


[HL-1783]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ