### PR TITLE
test(ks,handler): improve test coverage

### DIFF
--- a/frontend/kesaseteli/handler/src/__tests__/create-application-without-ssn.test.tsx
+++ b/frontend/kesaseteli/handler/src/__tests__/create-application-without-ssn.test.tsx
@@ -1,0 +1,111 @@
+// Integration test: Verifies configuration loading, form interactions with userEvent, and successful form submission using nock
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import expectToGetSummerVoucherConfiguration from 'kesaseteli/handler/__tests__/utils/backend/expectToGetSummerVoucherConfiguration';
+import CreateApplicationWithoutSsnPage from 'kesaseteli/handler/pages/create-application-without-ssn';
+import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
+import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
+import mockRouter from 'next-router-mock';
+import nock from 'nock';
+import React from 'react';
+
+jest.mock('shared/hooks/useGoToPage', () => ({
+  __esModule: true,
+  default:
+    () =>
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    (pagePath = '/', operation: 'push' | 'replace' = 'push') => {
+      const normalizedPath = pagePath.startsWith('/')
+        ? pagePath
+        : `/${pagePath}`;
+      void mockRouter[operation](`/fi${normalizedPath}`);
+    },
+}));
+
+const API_BASE_TEST_URL = 'https://localhost:8000';
+
+describe('CreateApplicationWithoutSsnPage (Integration)', () => {
+  let originalMockFlag: string | undefined;
+
+  beforeAll(() => {
+    nock.disableNetConnect();
+    originalMockFlag = process.env.NEXT_PUBLIC_MOCK_FLAG;
+    process.env.NEXT_PUBLIC_MOCK_FLAG = '1';
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+    process.env.NEXT_PUBLIC_MOCK_FLAG = originalMockFlag;
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+    expectToGetSummerVoucherConfiguration();
+    mockRouter.setCurrentUrl('/create-application-without-ssn');
+  });
+
+  it('renders target groups, handles form interaction, validation error, and successful submission', async () => {
+    const user = userEvent.setup();
+    const mockCreatedResponse = {
+      id: 'mock-uuid-999',
+      status: 'submitted',
+    };
+
+    renderComponent(<CreateApplicationWithoutSsnPage />);
+
+    // Wait for target groups configurations to load
+    const targetGroupRadioFi = await screen.findByLabelText(
+      /sample target group 1/i
+    );
+    expect(targetGroupRadioFi).toBeInTheDocument();
+
+    const firstNameInput = screen.getByLabelText(/etunimi/i);
+    const lastNameInput = screen.getByLabelText(/sukunimi/i);
+    const birthdateInput = screen.getByLabelText(/syntymäpäivä/i);
+    const postcode = screen.getByLabelText(/postinumero/i);
+    const schoolInput = screen.getByLabelText(/koulu/i);
+    const phoneInput = screen.getByLabelText(/puhelinnumero/i);
+    const emailInput = screen.getByLabelText(/sähköpostiosoite/i);
+    const additionalInfoInput = screen.getByLabelText(/lisätiedot/i);
+    const homeMunicipalityInput = screen.getByLabelText(/kotikunta/i);
+    const sendButton = screen.getByRole('button', { name: /lähetä tiedot/i });
+
+    // Select language & target group
+    await user.click(screen.getByLabelText(/englanti/i));
+    await user.click(targetGroupRadioFi);
+
+    // Type fields
+    await user.type(firstNameInput, 'John');
+    await user.type(lastNameInput, 'Doe');
+    await user.type(birthdateInput, '15.05.2008');
+    await user.type(postcode, '00100');
+    await user.type(schoolInput, 'Helsingin peruskoulu');
+    await user.type(phoneInput, '+358401234567');
+    await user.type(emailInput, 'john.doe@example.com');
+    await user.type(additionalInfoInput, 'I have no SSN');
+    await user.type(homeMunicipalityInput, 'Helsinki');
+
+    nock(API_BASE_TEST_URL)
+      .post(BackendEndpoint.CREATE_YOUTH_APPLICATION_WITHOUT_SSN, {
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john.doe@example.com',
+        school: 'Helsingin peruskoulu',
+        phone_number: '+358401234567',
+        postcode: '00100',
+        language: 'en',
+        non_vtj_birthdate: '2008-05-15',
+        non_vtj_home_municipality: 'Helsinki',
+        additional_info_description: 'I have no SSN',
+        target_group: 'target_group_1',
+      })
+      .reply(200, mockCreatedResponse);
+
+    // Click submit
+    await user.click(sendButton);
+
+    await waitFor(() => {
+      expect(mockRouter.asPath).toContain('/thankyou?id=mock-uuid-999');
+    });
+  });
+});

--- a/frontend/kesaseteli/handler/src/components/footer/__tests__/Footer.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/footer/__tests__/Footer.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
+import React from 'react';
+
+import Footer from '../Footer';
+
+describe('Footer', () => {
+  it('renders footer contents and has no accessibility violations', async () => {
+    renderComponent(<Footer />);
+    const footer = screen.getByRole('contentinfo');
+    expect(footer).toBeInTheDocument();
+    expect(screen.getByText(/helsingin kaupunki/i)).toBeInTheDocument();
+    expect(await axe(footer)).toHaveNoViolations();
+  });
+});

--- a/frontend/kesaseteli/handler/src/components/form/__tests__/Inputs.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/__tests__/Inputs.test.tsx
@@ -1,0 +1,152 @@
+import { act, screen, waitFor } from '@testing-library/react';
+import type { ApplicationWithoutSsnFormData } from 'kesaseteli/handler/types/application-without-ssn-types';
+import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
+import React from 'react';
+import { FormProvider, useForm, UseFormReturn } from 'react-hook-form';
+
+import DateInput from '../DateInput';
+import Field from '../Field';
+import SelectionGroup from '../SelectionGroup';
+import TextInput from '../TextInput';
+
+const TestForm: React.FC<{
+  children: (
+    methods: UseFormReturn<ApplicationWithoutSsnFormData>
+  ) => React.ReactNode;
+}> = ({ children }) => {
+  const methods = useForm<ApplicationWithoutSsnFormData>({
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      nonVtjBirthdate: '',
+      language: undefined,
+      school: '',
+      postcode: '',
+      phoneNumber: '',
+      email: '',
+      additionalInfoDescription: '',
+      nonVtjHomeMunicipality: '',
+    },
+  });
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(() => {})}>{children(methods)}</form>
+    </FormProvider>
+  );
+};
+
+describe('Form Inputs', () => {
+  describe('Field', () => {
+    it('renders with value', () => {
+      renderComponent(
+        <Field id="test-field" type="vtjInfo.name" value="John Doe" />
+      );
+      expect(screen.getByText(/john doe/i)).toBeInTheDocument();
+    });
+
+    it('renders hyphen if value is missing/falsy', () => {
+      renderComponent(<Field id="test-field" type="vtjInfo.name" value="" />);
+      expect(screen.getByText(/-/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('TextInput', () => {
+    it('renders and supports helper formats', () => {
+      renderComponent(
+        <TestForm>
+          {() => <TextInput id="firstName" helperFormat="A-Z" />}
+        </TestForm>
+      );
+      expect(screen.getByLabelText(/etunimi/i)).toBeInTheDocument();
+    });
+
+    it('displays custom pattern errors with helper format', async () => {
+      let formMethods!: UseFormReturn<ApplicationWithoutSsnFormData>;
+      renderComponent(
+        <TestForm>
+          {(methods) => {
+            formMethods = methods;
+            return <TextInput id="firstName" helperFormat="A-Z" />;
+          }}
+        </TestForm>
+      );
+
+      await act(async () => {
+        formMethods.setError('firstName', {
+          type: 'pattern',
+          message: 'Virheellinen muoto',
+        });
+      });
+
+      expect(
+        screen.getByText(/virheellinen muoto. käytä muotoa: a-z/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('DateInput', () => {
+    it('renders date input base', () => {
+      renderComponent(
+        <TestForm>
+          {() => <DateInput id="nonVtjBirthdate" validation={{}} />}
+        </TestForm>
+      );
+      expect(screen.getByLabelText(/syntymäpäivä/i)).toBeInTheDocument();
+    });
+
+    it('sets custom error type messages for pattern/required errors', async () => {
+      let formMethods!: UseFormReturn<ApplicationWithoutSsnFormData>;
+      renderComponent(
+        <TestForm>
+          {(methods) => {
+            formMethods = methods;
+            return (
+              <DateInput id="nonVtjBirthdate" validation={{ required: true }} />
+            );
+          }}
+        </TestForm>
+      );
+
+      await act(async () => {
+        formMethods.setError('nonVtjBirthdate', { type: 'required' });
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /tieto puuttuu tai on virheellinen. käytä muotoa p.k.vvvv/i
+          )
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('SelectionGroup', () => {
+    it('renders selection options', () => {
+      renderComponent(
+        <TestForm>
+          {() => <SelectionGroup id="language" values={['en', 'fi', 'sv']} />}
+        </TestForm>
+      );
+      expect(screen.getByLabelText(/englanti/i)).toBeInTheDocument();
+    });
+
+    it('displays error text when selection group has an error', async () => {
+      let formMethods!: UseFormReturn<ApplicationWithoutSsnFormData>;
+      renderComponent(
+        <TestForm>
+          {(methods) => {
+            formMethods = methods;
+            return <SelectionGroup id="language" values={['en', 'fi', 'sv']} />;
+          }}
+        </TestForm>
+      );
+
+      await act(async () => {
+        formMethods.setError('language', { type: 'required' });
+      });
+
+      expect(screen.getByText(/valitse jokin vaihtoehto/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/kesaseteli/handler/src/components/form/__tests__/SubmitErrorSummary.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/__tests__/SubmitErrorSummary.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from '@testing-library/react';
+import type { SubmitError } from 'kesaseteli/handler/hooks/application/useHandleApplicationWithoutSsnSubmit';
+import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import SubmitErrorSummary from '../SubmitErrorSummary';
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const methods = useForm({
+    defaultValues: {},
+  });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+describe('SubmitErrorSummary', () => {
+  it('renders validation errors when error type is validation_error', () => {
+    const error: SubmitError = {
+      type: 'validation_error',
+      errorFields: ['first_name', 'email'],
+    };
+
+    renderComponent(
+      <Wrapper>
+        <SubmitErrorSummary error={error} />
+      </Wrapper>
+    );
+
+    expect(
+      screen.getByText(/hups! jokin tiedoista ei ole oikein/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/etunimi, sähköpostiosoite/i)).toBeInTheDocument();
+  });
+
+  it('renders the error label when error type is null', () => {
+    const error = {
+      type: null,
+      errorFields: [],
+    };
+
+    renderComponent(
+      <Wrapper>
+        <SubmitErrorSummary error={error} />
+      </Wrapper>
+    );
+
+    expect(
+      screen.getByText(/hups! jokin tiedoista ei ole oikein/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/kesaseteli/handler/src/components/form/__tests__/VtjRawData.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/__tests__/VtjRawData.test.tsx
@@ -1,0 +1,43 @@
+import { screen } from '@testing-library/react';
+import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
+import { fakeActivatedYouthApplication } from 'kesaseteli-shared/__tests__/utils/fake-objects';
+import React from 'react';
+
+import VtjRawData from '../VtjRawData';
+
+describe('VtjRawData', () => {
+  it('renders accordion and displays non-omitted raw JSON data', () => {
+    const application = fakeActivatedYouthApplication({
+      encrypted_handler_vtj_json: {
+        Henkilo: {
+          NykyinenSukunimi: { Sukunimi: 'Testinen' },
+          Henkilotunnus: {
+            '@voimassaolokoodi': '1',
+            '#text': '010101-123A',
+          },
+        },
+      },
+    });
+
+    renderComponent(
+      <VtjRawData data={application.encrypted_handler_vtj_json} />
+    );
+
+    // Verify accordion header button
+    expect(
+      screen.getByRole('button', { name: /näytä kaikki raakadata/i })
+    ).toBeInTheDocument();
+
+    // Verify raw JSON stringified contents
+    const preElement = screen.getByText(
+      (content, element) =>
+        element?.tagName.toLowerCase() === 'pre' && content.includes('Testinen')
+    );
+    expect(preElement).toBeInTheDocument();
+    expect(preElement).toHaveTextContent(/010101-123A/);
+
+    // Ensure keys starting with '@' are omitted
+    expect(preElement).not.toHaveTextContent(/@voimassaolokoodi/);
+    expect(preElement).toHaveTextContent(/#text/);
+  });
+});

--- a/frontend/kesaseteli/handler/src/hooks/application/__tests__/useApplicationWithoutSsnFormField.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/application/__tests__/useApplicationWithoutSsnFormField.test.tsx
@@ -1,0 +1,146 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+
+import useApplicationWithoutSsnFormField from '../useApplicationWithoutSsnFormField';
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const methods = useForm({
+    defaultValues: {
+      firstName: 'John',
+      language: '',
+    },
+  });
+  return (
+    <FormProvider {...methods}>
+      <input {...methods.register('firstName')} />
+      <input {...methods.register('language')} />
+      {children}
+    </FormProvider>
+  );
+};
+
+describe('useApplicationWithoutSsnFormField', () => {
+  it('should return form field handlers and handle updates', () => {
+    const { result } = renderHook(
+      () => useApplicationWithoutSsnFormField<string>('firstName'),
+      { wrapper: Wrapper }
+    );
+
+    expect(result.current.fieldName).toBe('firstName');
+    expect(result.current.defaultLabel).toBe('Etunimi');
+    expect(result.current.getValue()).toBe('John');
+
+    act(() => {
+      result.current.setValue('Jane');
+    });
+    expect(result.current.getValue()).toBe('Jane');
+
+    act(() => {
+      result.current.clearValue();
+    });
+    expect(result.current.getValue()).toBe('');
+
+    act(() => {
+      result.current.watch();
+    });
+
+    expect(result.current.hasError()).toBe(false);
+    expect(result.current.getError()).toBeUndefined();
+    expect(result.current.getErrorText()).toBeUndefined();
+
+    // Verify trigger and setFocus can be invoked
+    act(() => {
+      void result.current.trigger();
+      result.current.setFocus();
+    });
+  });
+
+  it('handles field errors correctly', () => {
+    const { result, rerender } = renderHook(
+      () => {
+        const formContext = useFormContext();
+        void formContext.formState.errors;
+        return useApplicationWithoutSsnFormField<string>('firstName');
+      },
+      { wrapper: Wrapper }
+    );
+
+    act(() => {
+      result.current.setError({ type: 'required', message: 'Tieto puuttuu' });
+    });
+    rerender();
+
+    expect(result.current.hasError()).toBe(true);
+    expect(result.current.getError()?.type).toBe('required');
+    expect(result.current.getErrorText()).toBe('Tieto puuttuu');
+
+    act(() => {
+      result.current.clearErrors();
+    });
+    rerender();
+    expect(result.current.hasError()).toBe(false);
+  });
+
+  it('resolves error texts without error message for language field', () => {
+    const { result, rerender } = renderHook(
+      () => {
+        const formContext = useFormContext();
+        void formContext.formState.errors;
+        return useApplicationWithoutSsnFormField<string>('language');
+      },
+      { wrapper: Wrapper }
+    );
+
+    act(() => {
+      result.current.setError({ type: 'required' });
+    });
+    rerender();
+
+    expect(result.current.getErrorText()).toBe('Valitse jokin vaihtoehto');
+  });
+
+  describe('resolves error texts without error message for other fields', () => {
+    it.each([
+      {
+        field: 'firstName',
+        type: 'required',
+        expected: 'Tieto puuttuu tai on virheellinen',
+      },
+      {
+        field: 'email',
+        type: 'pattern',
+        expected: 'Syöttämäsi tieto on virheellistä muotoa',
+      },
+      {
+        field: 'phoneNumber',
+        type: 'maxLength',
+        expected: 'Syöttämäsi tieto on liian pitkä',
+      },
+      {
+        field: 'nonVtjBirthdate',
+        type: 'validate',
+        expected: 'Syöttämäsi tieto on virheellistä muotoa',
+      },
+    ] as const)(
+      'returns correct error text for field "$field" and error type "$type"',
+      ({ field, type, expected }) => {
+        const { result, rerender } = renderHook(
+          () => {
+            const formContext = useFormContext();
+            void formContext.formState.errors;
+            return useApplicationWithoutSsnFormField<string>(field);
+          },
+          { wrapper: Wrapper }
+        );
+
+        act(() => {
+          result.current.setError({ type });
+        });
+        rerender();
+
+        expect(result.current.getErrorText()).toBe(expected);
+      }
+    );
+  });
+});

--- a/frontend/kesaseteli/handler/src/hooks/application/__tests__/useGetApplicationWithoutSsnFormFieldLabel.test.ts
+++ b/frontend/kesaseteli/handler/src/hooks/application/__tests__/useGetApplicationWithoutSsnFormFieldLabel.test.ts
@@ -1,0 +1,12 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useGetApplicationWithoutSsnFormFieldLabel from '../useGetApplicationWithoutSsnFormFieldLabel';
+
+describe('useGetApplicationWithoutSsnFormFieldLabel', () => {
+  it('should return translation key for firstName field', () => {
+    const { result } = renderHook(() =>
+      useGetApplicationWithoutSsnFormFieldLabel('firstName')
+    );
+    expect(result.current).toBe('Etunimi');
+  });
+});

--- a/frontend/kesaseteli/handler/src/hooks/application/__tests__/useHandleApplicationWithoutSsnSubmit.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/application/__tests__/useHandleApplicationWithoutSsnSubmit.test.tsx
@@ -1,0 +1,130 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { fakeCreatedYouthApplication } from 'kesaseteli-shared/__tests__/utils/fake-objects';
+import mockRouter from 'next-router-mock';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import useErrorHandler from 'shared/hooks/useErrorHandler';
+
+import useHandleApplicationWithoutSsnSubmit from '../useHandleApplicationWithoutSsnSubmit';
+
+jest.mock('shared/hooks/useErrorHandler', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUseErrorHandler = useErrorHandler as jest.Mock;
+const mockErrorHandler = jest.fn();
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const methods = useForm();
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+describe('useHandleApplicationWithoutSsnSubmit', () => {
+  beforeEach(() => {
+    mockRouter.setCurrentUrl('/');
+    mockUseErrorHandler.mockReturnValue(mockErrorHandler);
+    jest.clearAllMocks();
+  });
+
+  it('handles success correctly with mock integrations', () => {
+    const originalEnv = process.env.NEXT_PUBLIC_MOCK_FLAG;
+    process.env.NEXT_PUBLIC_MOCK_FLAG = '1';
+    try {
+      const { result } = renderHook(
+        () => useHandleApplicationWithoutSsnSubmit(),
+        {
+          wrapper: Wrapper,
+        }
+      );
+
+      const application = fakeCreatedYouthApplication({
+        id: 'uuid-123',
+        status: 'submitted',
+      });
+
+      act(() => {
+        result.current.handleSaveSuccess(application);
+      });
+
+      expect(mockRouter.asPath).toBe('/fi/thankyou?id=uuid-123');
+      expect(result.current.submitError).toBeUndefined();
+    } finally {
+      process.env.NEXT_PUBLIC_MOCK_FLAG = originalEnv;
+    }
+  });
+
+  it('handles success correctly with real integrations', () => {
+    const originalEnv = process.env.NEXT_PUBLIC_MOCK_FLAG;
+    process.env.NEXT_PUBLIC_MOCK_FLAG = '0';
+    try {
+      const { result } = renderHook(
+        () => useHandleApplicationWithoutSsnSubmit(),
+        {
+          wrapper: Wrapper,
+        }
+      );
+
+      const application = fakeCreatedYouthApplication({
+        id: 'uuid-123',
+        status: 'submitted',
+      });
+
+      act(() => {
+        result.current.handleSaveSuccess(application);
+      });
+
+      expect(mockRouter.asPath).toBe('/fi/thankyou');
+      expect(result.current.submitError).toBeUndefined();
+    } finally {
+      process.env.NEXT_PUBLIC_MOCK_FLAG = originalEnv;
+    }
+  });
+
+  it('handles validation error response correctly', () => {
+    const { result } = renderHook(
+      () => useHandleApplicationWithoutSsnSubmit(),
+      {
+        wrapper: Wrapper,
+      }
+    );
+
+    const mockValidationError = {
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: {
+          first_name: ['Tieto puuttuu'],
+        },
+      },
+    };
+
+    act(() => {
+      result.current.handleErrorResponse(mockValidationError);
+    });
+
+    expect(result.current.submitError).toEqual({
+      type: 'validation_error',
+      errorFields: ['first_name'],
+    });
+    expect(mockErrorHandler).not.toHaveBeenCalled();
+  });
+
+  it('handles generic error response correctly', () => {
+    const { result } = renderHook(
+      () => useHandleApplicationWithoutSsnSubmit(),
+      {
+        wrapper: Wrapper,
+      }
+    );
+
+    const error = new Error('Some unexpected error');
+
+    act(() => {
+      result.current.handleErrorResponse(error);
+    });
+
+    expect(mockErrorHandler).toHaveBeenCalledWith(error);
+    expect(result.current.submitError).toBeUndefined();
+  });
+});

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useCreateYouthApplicationWithoutSsnQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useCreateYouthApplicationWithoutSsnQuery.test.tsx
@@ -1,0 +1,86 @@
+// Integration test: Verifies request payloads are mapped correctly and endpoints are called using nock
+import { renderHook } from '@testing-library/react-hooks';
+import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
+import nock from 'nock';
+import React from 'react';
+import { QueryClientProvider } from 'react-query';
+import createAxiosTestContext from 'shared/__tests__/utils/create-axios-test-context';
+import createReactQueryTestClient from 'shared/__tests__/utils/react-query/create-react-query-test-client';
+import BackendAPIProvider from 'shared/backend-api/BackendAPIProvider';
+
+import useCreateYouthApplicationWithoutSsnQuery from '../useCreateYouthApplicationWithoutSsnQuery';
+
+const API_BASE_TEST_URL = 'http://kesaseteli-api';
+
+describe('useCreateYouthApplicationWithoutSsnQuery (Integration)', () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
+  const axios = createAxiosTestContext(API_BASE_TEST_URL);
+  const queryClient = createReactQueryTestClient(axios, API_BASE_TEST_URL);
+
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <BackendAPIProvider baseURL={API_BASE_TEST_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </BackendAPIProvider>
+  );
+
+  beforeEach(() => {
+    queryClient.clear();
+    nock.cleanAll();
+    jest.clearAllMocks();
+  });
+
+  it('correctly maps and posts application without ssn data', async () => {
+    const mockCreatedResponse = {
+      id: 'test-uuid-123',
+      status: 'submitted',
+    };
+
+    const formData = {
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john.doe@example.com',
+      school: 'Test School',
+      phoneNumber: '+358401234567',
+      postcode: '00100',
+      language: 'fi' as const,
+      nonVtjBirthdate: '2008-05-15',
+      nonVtjHomeMunicipality: 'Helsinki',
+      additionalInfoDescription: 'Some test info',
+      targetGroup: 'test-target-group-id',
+    };
+
+    nock(API_BASE_TEST_URL)
+      .post(BackendEndpoint.CREATE_YOUTH_APPLICATION_WITHOUT_SSN, {
+        first_name: formData.firstName,
+        last_name: formData.lastName,
+        email: formData.email,
+        school: formData.school,
+        phone_number: formData.phoneNumber,
+        postcode: formData.postcode,
+        language: formData.language,
+        non_vtj_birthdate: formData.nonVtjBirthdate,
+        non_vtj_home_municipality: formData.nonVtjHomeMunicipality,
+        additional_info_description: formData.additionalInfoDescription,
+        target_group: formData.targetGroup,
+      })
+      .reply(200, mockCreatedResponse);
+
+    const { result, waitFor } = renderHook(
+      () => useCreateYouthApplicationWithoutSsnQuery(),
+      { wrapper }
+    );
+
+    result.current.mutate(formData);
+
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data).toEqual(mockCreatedResponse);
+    expect(nock.isDone()).toBe(true);
+  });
+});

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useLogin.test.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useLogin.test.ts
@@ -1,0 +1,16 @@
+import { renderHook } from '@testing-library/react-hooks';
+import mockRouter from 'next-router-mock';
+
+import useLogin from '../useLogin';
+
+describe('useLogin', () => {
+  it('redirects to login URL on trigger', async () => {
+    mockRouter.setCurrentUrl('/');
+    const { result } = renderHook(() => useLogin());
+
+    await result.current();
+
+    expect(mockRouter.asPath).toContain('/login');
+    expect(mockRouter.asPath).toContain('lang=fi');
+  });
+});

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useLogout.test.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useLogout.test.ts
@@ -1,0 +1,15 @@
+import { renderHook } from '@testing-library/react-hooks';
+import mockRouter from 'next-router-mock';
+
+import useLogout from '../useLogout';
+
+describe('useLogout', () => {
+  it('redirects to logout URL on trigger', async () => {
+    mockRouter.setCurrentUrl('/');
+    const { result } = renderHook(() => useLogout());
+
+    await result.current();
+
+    expect(mockRouter.asPath).toContain('/logout');
+  });
+});

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useSummerVoucherConfigurationQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useSummerVoucherConfigurationQuery.test.tsx
@@ -1,0 +1,87 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
+import nock from 'nock';
+import React from 'react';
+import { QueryClientProvider } from 'react-query';
+import createAxiosTestContext from 'shared/__tests__/utils/create-axios-test-context';
+import createReactQueryTestClient from 'shared/__tests__/utils/react-query/create-react-query-test-client';
+import BackendAPIProvider from 'shared/backend-api/BackendAPIProvider';
+import useErrorHandler from 'shared/hooks/useErrorHandler';
+
+import useSummerVoucherConfigurationQuery from '../useSummerVoucherConfigurationQuery';
+
+const API_BASE_TEST_URL = 'http://kesaseteli-api';
+
+const mockConfigurationData = [
+  {
+    year: new Date().getFullYear(),
+    voucher_value_in_euros: 300,
+    min_work_compensation_in_euros: 400,
+    min_work_hours: 18,
+    target_groups: [],
+  },
+];
+
+jest.mock('shared/hooks/useErrorHandler', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUseErrorHandler = useErrorHandler as jest.Mock;
+const mockErrorHandler = jest.fn();
+
+describe('useSummerVoucherConfigurationQuery', () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
+  const axios = createAxiosTestContext(API_BASE_TEST_URL);
+  const queryClient = createReactQueryTestClient(axios, API_BASE_TEST_URL);
+
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <BackendAPIProvider baseURL={API_BASE_TEST_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </BackendAPIProvider>
+  );
+
+  beforeEach(() => {
+    queryClient.clear();
+    nock.cleanAll();
+    mockUseErrorHandler.mockReturnValue(mockErrorHandler);
+    jest.clearAllMocks();
+  });
+
+  it('returns configuration successfully', async () => {
+    nock(API_BASE_TEST_URL)
+      .get(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)
+      .reply(200, mockConfigurationData);
+
+    const { result, waitFor } = renderHook(
+      () => useSummerVoucherConfigurationQuery(),
+      { wrapper }
+    );
+
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data).toEqual(mockConfigurationData);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('calls useErrorHandler on error', async () => {
+    nock(API_BASE_TEST_URL)
+      .get(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)
+      .reply(500);
+
+    const { result, waitFor } = renderHook(
+      () => useSummerVoucherConfigurationQuery(),
+      { wrapper }
+    );
+
+    await waitFor(() => result.current.isError);
+    expect(mockErrorHandler).toHaveBeenCalled();
+    expect(nock.isDone()).toBe(true);
+  });
+});

--- a/frontend/kesaseteli/handler/src/utils/__tests__/application-without-ssn.utils.test.ts
+++ b/frontend/kesaseteli/handler/src/utils/__tests__/application-without-ssn.utils.test.ts
@@ -1,0 +1,14 @@
+import { TFunction } from 'next-i18next';
+
+import { getApplicationWithoutSsnFormFieldLabel } from '../application-without-ssn.utils';
+
+describe('getApplicationWithoutSsnFormFieldLabel', () => {
+  it('should call t with the correct translation path key', () => {
+    const t = jest.fn((key: string) => key) as unknown as TFunction;
+    const label = getApplicationWithoutSsnFormFieldLabel(t, 'firstName');
+    expect(t).toHaveBeenCalledWith(
+      'common:applicationWithoutSsn.form.inputs.firstName'
+    );
+    expect(label).toBe('common:applicationWithoutSsn.form.inputs.firstName');
+  });
+});

--- a/frontend/kesaseteli/handler/src/utils/__tests__/type-guards.test.ts
+++ b/frontend/kesaseteli/handler/src/utils/__tests__/type-guards.test.ts
@@ -1,0 +1,44 @@
+import { isApplicationWithoutSsnValidationError } from '../type-guards';
+
+describe('isApplicationWithoutSsnValidationError', () => {
+  it('should return false for non-axios errors', () => {
+    expect(isApplicationWithoutSsnValidationError(new Error('error'))).toBe(
+      false
+    );
+    expect(isApplicationWithoutSsnValidationError(null)).toBe(false);
+    expect(isApplicationWithoutSsnValidationError({})).toBe(false);
+  });
+
+  it('should return false for axios errors with status other than 400', () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 500,
+        data: { first_name: ['Error'] },
+      },
+    };
+    expect(isApplicationWithoutSsnValidationError(error)).toBe(false);
+  });
+
+  it('should return false for axios errors with status 400 but no matching keys', () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: { invalid_key: ['Error'] },
+      },
+    };
+    expect(isApplicationWithoutSsnValidationError(error)).toBe(false);
+  });
+
+  it('should return true for axios errors with status 400 and matching keys', () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: { first_name: ['This field is required'] },
+      },
+    };
+    expect(isApplicationWithoutSsnValidationError(error)).toBe(true);
+  });
+});


### PR DESCRIPTION
YJDH-772.

Add some simple tests to code that is still missing some.

In Kesäseteli Handlers UI, `yarn test:coverage` reports:

```
-----------------------------------------------|---------|----------|---------|---------|-------------------
File                                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------------------------|---------|----------|---------|---------|-------------------
All files                                      |   96.61 |    86.26 |   94.82 |   96.71 |                   
 __tests__/utils/backend                       |   85.71 |    85.71 |   81.81 |   86.11 |                   
  backend-nocks.ts                             |   82.85 |    85.71 |      80 |   83.33 | 28-35             
  expectToGetSummerVoucherConfiguration.ts     |     100 |      100 |     100 |     100 |                   
 __tests__/utils/components                    |   96.96 |    83.33 |     100 |   96.87 |                   
  get-index-page-api.ts                        |   96.55 |    83.33 |     100 |   96.49 | 53,204            
  render-page.tsx                              |     100 |      100 |     100 |     100 |                   
 __tests__/utils/i18n                          |     100 |      100 |     100 |     100 |                   
  get-handler-translations-api.ts              |     100 |      100 |     100 |     100 |                   
 components/footer                             |     100 |      100 |     100 |     100 |                   
  Footer.tsx                                   |     100 |      100 |     100 |     100 |                   
 components/form                               |   96.61 |    89.75 |    92.5 |   96.81 |                   
  ActionButtons.tsx                            |     100 |      100 |     100 |     100 |                   
  CreateApplicationWithoutSsnForm.tsx          |   89.65 |    77.27 |      80 |    92.3 | 148-150           
  DateInput.tsx                                |     100 |       95 |     100 |     100 | 85                
  Field.tsx                                    |     100 |      100 |     100 |     100 |                   
  HandlerForm.tsx                              |     100 |    87.71 |     100 |     100 | 81,98,120-135,169 
  SelectionGroup.tsx                           |   93.75 |    83.33 |     100 |   93.33 | 52                
  SubmitErrorSummary.tsx                       |   90.47 |      100 |     100 |      90 | 41-42             
  TextInput.tsx                                |   94.44 |    92.85 |     100 |   94.11 | 58                
  VtjErrorMessage.tsx                          |     100 |      100 |     100 |     100 |                   
  VtjErrorNotification.tsx                     |     100 |      100 |     100 |     100 |                   
  VtjInfo.tsx                                  |   94.73 |     91.3 |      50 |   94.44 | 72                
  VtjRawData.tsx                               |     100 |      100 |      75 |     100 |                   
 components/header                             |     100 |       75 |     100 |     100 |                   
  Header.tsx                                   |     100 |       75 |     100 |     100 | 42                
 constants                                     |     100 |      100 |     100 |     100 |                   
  data-mappings.ts                             |     100 |      100 |     100 |     100 |                   
  vtj-exceptions.ts                            |     100 |      100 |     100 |     100 |                   
 hooks/application                             |     100 |    94.73 |     100 |     100 |                   
  useApplicationWithoutSsnFormField.ts         |     100 |    88.88 |     100 |     100 | 37                
  useGetApplicationWithoutSsnFormFieldLabel.ts |     100 |      100 |     100 |     100 |                   
  useHandleApplicationWithoutSsnSubmit.ts      |     100 |      100 |     100 |     100 |                   
 hooks/backend                                 |   97.46 |    85.71 |   93.33 |   97.22 |                   
  useCompleteYouthApplicationQuery.ts          |   93.33 |       60 |     100 |   92.85 | 37                
  useCreateYouthApplicationWithoutSsnQuery.ts  |     100 |      100 |     100 |     100 |                   
  useLogin.ts                                  |     100 |      100 |     100 |     100 |                   
  useLogout.ts                                 |     100 |      100 |     100 |     100 |                   
  useSummerVoucherConfigurationQuery.ts        |     100 |      100 |     100 |     100 |                   
  useUserQuery.ts                              |   91.66 |      100 |      50 |    90.9 | 23                
  useYouthApplicationQuery.ts                  |     100 |      100 |     100 |     100 |                   
 utils                                         |   97.14 |    82.23 |     100 |   96.96 |                   
  application-without-ssn.utils.ts             |     100 |      100 |     100 |     100 |                   
  map-vtj-data.ts                              |   96.29 |    82.22 |     100 |   96.15 | 82                
  type-guards.ts                               |     100 |    82.35 |     100 |     100 | 11-14             
-----------------------------------------------|---------|----------|---------|---------|-------------------
Test Suites: 17 passed, 17 total
Tests:       79 passed, 79 total
Snapshots:   0 total
Time:        24.866 s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering youth application submission without personal ID and successful redirect to thank-you page
  * Added accessibility test for the footer content
  * Added tests for form inputs, validation messages, error summary display, and raw data viewing
  * Added tests for login/logout flows and backend integration behavior (create/submission, config fetching)
  * Added utility and type-guard tests for form field labels and validation detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->