### PR TITLE
test(ks,youth): improve test coverage for youth UI

### DIFF
--- a/frontend/kesaseteli/youth/src/__tests__/additional_info.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/additional_info.test.tsx
@@ -196,6 +196,48 @@ describe('frontend/kesaseteli/youth/src/pages/additional_info.tsx', () => {
         },
         SLOW_JEST_TIMEOUT
       );
+
+      it(
+        `redirects to 500 -error page when backend returns unexpected error on submit`,
+        async () => {
+          expectToGetSummerVoucherConfigurationFromBackend();
+          expectToGetYouthApplicationStatus(APPLICATION_ID, {
+            status: 'additional_information_requested',
+          });
+          const spyPush = jest.fn();
+          renderPage(AdditionalInfoPage, {
+            query: { id: APPLICATION_ID },
+            push: spyPush,
+          });
+          const { additional_info_description, additional_info_user_reasons } =
+            fakeAdditionalInfoApplication();
+          const additionalInfoPageApi =
+            getAdditionalInfoPageApi(APPLICATION_ID);
+          await additionalInfoPageApi.expectations.formIsPresent();
+          await additionalInfoPageApi.actions.clickAndSelectReasonsFromDropdown(
+            additional_info_user_reasons
+          );
+          await additionalInfoPageApi.actions.inputDescription(
+            additional_info_description
+          );
+          await additionalInfoPageApi.actions.clickSendButton(500);
+          await waitFor(() =>
+            expect(spyPush).toHaveBeenCalledWith(
+              `/${DEFAULT_LANGUAGE}/500`,
+              undefined,
+              { shallow: false }
+            )
+          );
+        },
+        SLOW_JEST_TIMEOUT
+      );
+
+      it('throws an error if clicking send button without application id', async () => {
+        const additionalInfoPageApi = getAdditionalInfoPageApi();
+        await expect(
+          additionalInfoPageApi.actions.clickSendButton()
+        ).rejects.toThrow('you forgot to give application id');
+      });
     });
   });
 });

--- a/frontend/kesaseteli/youth/src/__tests__/index.validation.test.tsx
+++ b/frontend/kesaseteli/youth/src/__tests__/index.validation.test.tsx
@@ -224,7 +224,9 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
         );
 
         await Promise.all(
-          validFields.map(async (field) => indexPageApi.expectations.textInputIsValid(field))
+          validFields.map(async (field) =>
+            indexPageApi.expectations.textInputIsValid(field)
+          )
         );
       });
       it('shows invalid unlisted school field when unlistedSchool in the error repsonse', async () => {
@@ -248,6 +250,30 @@ describe('frontend/kesaseteli/youth/src/pages/index.tsx', () => {
           'unlistedSchool',
           'pattern'
         );
+      });
+    });
+
+    describe('getIndexPageApi helper edge cases', () => {
+      it('handles selectedSchool combobox correctly in textInputIsValid helper', async () => {
+        expectToGetSchoolsFromBackend();
+        renderPage(YouthIndex);
+        const indexPageApi = getIndexPageApi();
+        await indexPageApi.expectations.pageIsLoaded();
+        // Verify helper routes 'selectedSchool' combobox to selectedSchoolIsValid() instead of text input checks
+        await indexPageApi.expectations.textInputIsValid('selectedSchool');
+      });
+
+      it('exercises selectTargetGroup with label and handles missing radio buttons', async () => {
+        expectToGetSchoolsFromBackend();
+        renderPage(YouthIndex);
+        const indexPageApi = getIndexPageApi();
+        await indexPageApi.expectations.pageIsLoaded();
+
+        await indexPageApi.actions.selectTargetGroup(/9th graders/i);
+
+        await expect(
+          indexPageApi.actions.selectTargetGroup('non-existent-label')
+        ).rejects.toThrow();
       });
     });
   });

--- a/frontend/kesaseteli/youth/src/components/youth-form/__tests__/SchoolSelection.test.tsx
+++ b/frontend/kesaseteli/youth/src/components/youth-form/__tests__/SchoolSelection.test.tsx
@@ -7,13 +7,6 @@ import { FormProvider, useForm } from 'react-hook-form';
 import theme from 'shared/styles/theme';
 import { ThemeProvider } from 'styled-components';
 
-jest.mock('next-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-    i18n: { language: 'fi' },
-  }),
-}));
-
 jest.mock('kesaseteli/youth/hooks/backend/useSchoolListQuery');
 
 type YouthFormDataForTest = {
@@ -50,14 +43,14 @@ const renderSchoolSelection = (): ReturnType<typeof render> => {
 
 const getSchoolSelector = (): HTMLElement => {
   const byCombobox = screen.queryByRole('combobox', {
-    name: /selectedschool/i,
+    name: /koulu/i,
   });
 
   if (byCombobox) {
     return byCombobox;
   }
 
-  const byButton = screen.queryByRole('button', { name: /selectedschool/i });
+  const byButton = screen.queryByRole('button', { name: /koulu/i });
 
   if (byButton) {
     return byButton;

--- a/frontend/kesaseteli/youth/src/components/youth-form/__tests__/SubmitErrorSummary.test.tsx
+++ b/frontend/kesaseteli/youth/src/components/youth-form/__tests__/SubmitErrorSummary.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { SubmitError } from 'kesaseteli/youth/hooks/useHandleYouthApplicationSubmit';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import theme from 'shared/styles/theme';
+import { ThemeProvider } from 'styled-components';
+
+import SubmitErrorSummary from '../SubmitErrorSummary';
+
+const renderWithForm = (
+  testChildren: React.ReactNode
+): ReturnType<typeof render> => {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const methods = useForm({
+      defaultValues: {},
+    });
+    return (
+      <ThemeProvider theme={theme}>
+        <FormProvider {...methods}>{children}</FormProvider>
+      </ThemeProvider>
+    );
+  };
+  return render(testChildren as React.ReactElement, { wrapper: Wrapper });
+};
+
+describe('SubmitErrorSummary', () => {
+  it('renders recheck error notification', () => {
+    const error: SubmitError = {
+      type: 'please_recheck_data',
+      errorFields: [],
+    };
+    renderWithForm(<SubmitErrorSummary error={error} />);
+    expect(
+      screen.getByText(
+        'Tarkistathan, että olet kirjoittanut nimesi ja henkilötunnuksesi kuten ne ovat Kela-kortissasi.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders validation error notification with error fields', () => {
+    const error: SubmitError = {
+      type: 'validation_error',
+      errorFields: ['first_name', 'last_name'],
+    };
+    renderWithForm(<SubmitErrorSummary error={error} />);
+    expect(
+      screen.getByText('Tarkista seuraavat kentät: Etunimi, Sukunimi')
+    ).toBeInTheDocument();
+  });
+
+  it('renders ErrorSummary wrapper with null content when error.type is null', () => {
+    const error: SubmitError = {
+      type: null,
+      errorFields: [],
+    };
+    renderWithForm(<SubmitErrorSummary error={error} />);
+    expect(
+      screen.getByText('Hups! Jokin tiedoista ei ole oikein')
+    ).toBeInTheDocument();
+  });
+
+  it('throws an error for unknown types due to assertUnreachable', () => {
+    const error = {
+      type: 'unknown_type' as unknown as SubmitError['type'],
+      errorFields: [],
+    };
+
+    /* eslint-disable no-console */
+    // Silence error log of assertUnreachable
+    const originalConsoleError = console.error;
+    console.error = jest.fn();
+
+    try {
+      expect(() => {
+        renderWithForm(<SubmitErrorSummary error={error} />);
+      }).toThrow('Unknown submit error type: unknown_type');
+    } finally {
+      console.error = originalConsoleError;
+      /* eslint-enable no-console */
+    }
+  });
+});

--- a/frontend/kesaseteli/youth/src/components/youth-form/__tests__/TargetGroupSelection.test.tsx
+++ b/frontend/kesaseteli/youth/src/components/youth-form/__tests__/TargetGroupSelection.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import useRegisterInput from 'kesaseteli/youth/hooks/useRegisterInput';
+import { useCurrentYearSummerVoucherConfig } from 'kesaseteli-shared/hooks/useCurrentYearSummerVoucherConfig';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import theme from 'shared/styles/theme';
+import { ThemeProvider } from 'styled-components';
+
+import TargetGroupSelection from '../TargetGroupSelection';
+
+jest.mock('kesaseteli-shared/hooks/useCurrentYearSummerVoucherConfig');
+jest.mock('kesaseteli/youth/hooks/useRegisterInput');
+
+const renderWithForm = (
+  testChildren: React.ReactNode
+): ReturnType<typeof render> => {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const methods = useForm({
+      defaultValues: {
+        target_group: '',
+      },
+    });
+    return (
+      <ThemeProvider theme={theme}>
+        <FormProvider {...methods}>{children}</FormProvider>
+      </ThemeProvider>
+    );
+  };
+  return render(testChildren as React.ReactElement, { wrapper: Wrapper });
+};
+
+describe('TargetGroupSelection', () => {
+  beforeEach(() => {
+    (useRegisterInput as jest.Mock).mockReturnValue(() => ({
+      id: 'target_group',
+      label: 'Target Group',
+      registerOptions: { required: true },
+    }));
+  });
+
+  it('renders loading text when config is loading', () => {
+    (useCurrentYearSummerVoucherConfig as jest.Mock).mockReturnValue({
+      query: { isLoading: true, isError: false },
+      currentConfiguration: undefined,
+    });
+
+    renderWithForm(<TargetGroupSelection />);
+    expect(
+      screen.getByText('Ladataan kohtaa luokka / koulutusaste...')
+    ).toBeInTheDocument();
+  });
+
+  it('renders error message when config fails', () => {
+    (useCurrentYearSummerVoucherConfig as jest.Mock).mockReturnValue({
+      query: { isLoading: false, isError: true },
+      currentConfiguration: undefined,
+    });
+
+    renderWithForm(<TargetGroupSelection />);
+    expect(
+      screen.getByText(
+        'Luokkaa / koulutusastetta ei pystytty lataamaan. Hakemuksen täyttäminen ei ole tällä hetkellä mahdollista.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders select group when target groups are loaded successfully', () => {
+    (useCurrentYearSummerVoucherConfig as jest.Mock).mockReturnValue({
+      query: { isLoading: false, isError: false },
+      currentConfiguration: {
+        target_groups: [
+          { id: 'target_group_1', name: 'Target Group 1' },
+          { id: 'target_group_2', name: 'Target Group 2' },
+        ],
+      },
+    });
+
+    renderWithForm(<TargetGroupSelection />);
+    expect(
+      screen.getByRole('group', { name: /Target Group/ })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Target Group 1')).toBeInTheDocument();
+  });
+});

--- a/frontend/kesaseteli/youth/src/hooks/__tests__/useHandleYouthApplicationSubmit.test.tsx
+++ b/frontend/kesaseteli/youth/src/hooks/__tests__/useHandleYouthApplicationSubmit.test.tsx
@@ -1,0 +1,159 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import {
+  isYouthApplicationCreationError,
+  isYouthApplicationValidationError,
+} from 'kesaseteli/youth/utils/type-guards';
+import { useRouter } from 'next/router';
+import { useFormContext } from 'react-hook-form';
+import useErrorHandler from 'shared/hooks/useErrorHandler';
+import useGoToPage from 'shared/hooks/useGoToPage';
+import useLocale from 'shared/hooks/useLocale';
+
+import useHandleYouthApplicationSubmit from '../useHandleYouthApplicationSubmit';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+jest.mock('shared/hooks/useLocale', () => jest.fn());
+jest.mock('shared/hooks/useGoToPage', () => jest.fn());
+jest.mock('shared/hooks/useErrorHandler', () => jest.fn());
+jest.mock('react-hook-form', () => ({
+  useFormContext: jest.fn(),
+}));
+// eslint-disable-next-line unicorn/consistent-function-scoping
+jest.mock('shared/hooks/useGdprMaskedFormValues', () => () => ({}));
+jest.mock('kesaseteli/youth/utils/type-guards', () => ({
+  isYouthApplicationCreationError: jest.fn(),
+  isYouthApplicationValidationError: jest.fn(),
+}));
+
+describe('useHandleYouthApplicationSubmit', () => {
+  const mockPush = jest.fn();
+  const mockGoToPage = jest.fn();
+  const mockErrorHandler = jest.fn();
+  const mockReset = jest.fn();
+  const mockSetError = jest.fn();
+  const mockGetValues = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+    (useLocale as jest.Mock).mockReturnValue('fi');
+    (useGoToPage as jest.Mock).mockReturnValue(mockGoToPage);
+    (useErrorHandler as jest.Mock).mockReturnValue(mockErrorHandler);
+    (useFormContext as jest.Mock).mockReturnValue({
+      formState: { isDirty: false, isSubmitted: false },
+      setError: mockSetError,
+      getValues: mockGetValues,
+      reset: mockReset,
+    });
+  });
+
+  it('handleSaveSuccess redirects to thankyou page', () => {
+    const { result } = renderHook(() => useHandleYouthApplicationSubmit());
+
+    act(() => {
+      result.current.handleSaveSuccess({ id: '123' } as any);
+    });
+
+    expect(mockGoToPage).toHaveBeenCalledWith('/thankyou');
+  });
+
+  it('handleErrorResponse redirects on specific code errors', () => {
+    jest.mocked(isYouthApplicationCreationError).mockReturnValue(true);
+    const { result } = renderHook(() => useHandleYouthApplicationSubmit());
+
+    const creationError = {
+      response: {
+        data: {
+          code: 'already_assigned',
+        },
+      },
+    };
+
+    act(() => {
+      result.current.handleErrorResponse(creationError);
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/fi/already_assigned');
+  });
+
+  it('handleErrorResponse sets error summary on please_recheck_data', () => {
+    jest.mocked(isYouthApplicationCreationError).mockReturnValue(true);
+    const { result } = renderHook(() => useHandleYouthApplicationSubmit());
+
+    const creationError = {
+      response: {
+        data: {
+          code: 'please_recheck_data',
+        },
+      },
+    };
+
+    act(() => {
+      result.current.handleErrorResponse(creationError);
+    });
+
+    expect(result.current.submitError).toEqual({
+      type: 'please_recheck_data',
+      errorFields: [],
+    });
+    expect(mockReset).toHaveBeenCalled();
+  });
+
+  it('handleErrorResponse asserts unreachable for unknown code', () => {
+    jest.mocked(isYouthApplicationCreationError).mockReturnValue(true);
+    const { result } = renderHook(() => useHandleYouthApplicationSubmit());
+
+    const unknownError = {
+      response: {
+        data: {
+          code: 'unknown_code',
+        },
+      },
+    };
+
+    expect(() => {
+      act(() => {
+        result.current.handleErrorResponse(unknownError);
+      });
+    }).toThrow();
+  });
+
+  it('handleErrorResponse handles validation errors', () => {
+    jest.mocked(isYouthApplicationCreationError).mockReturnValue(false);
+    jest.mocked(isYouthApplicationValidationError).mockReturnValue(true);
+    const { result } = renderHook(() => useHandleYouthApplicationSubmit());
+
+    const valError = {
+      response: {
+        status: 400,
+        data: {
+          first_name: ['Error text'],
+        },
+      },
+    };
+
+    act(() => {
+      result.current.handleErrorResponse(valError);
+    });
+
+    expect(mockSetError).toHaveBeenCalledWith('first_name', {
+      type: 'pattern',
+    });
+    expect(result.current.submitError?.type).toBe('validation_error');
+  });
+
+  it('handleErrorResponse calls default error handler for generic errors', () => {
+    jest.mocked(isYouthApplicationCreationError).mockReturnValue(false);
+    jest.mocked(isYouthApplicationValidationError).mockReturnValue(false);
+    const { result } = renderHook(() => useHandleYouthApplicationSubmit());
+    const genericError = new Error('Generic error');
+
+    act(() => {
+      result.current.handleErrorResponse(genericError);
+    });
+
+    expect(mockErrorHandler).toHaveBeenCalledWith(genericError);
+  });
+});

--- a/frontend/kesaseteli/youth/src/hooks/backend/__tests__/useCreateAdditionalInfoQuery.test.tsx
+++ b/frontend/kesaseteli/youth/src/hooks/backend/__tests__/useCreateAdditionalInfoQuery.test.tsx
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import nock from 'nock';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import BackendAPIProvider from 'shared/backend-api/BackendAPIProvider';
+
+import useCreateAdditionalInfoQuery from '../useCreateAdditionalInfoQuery';
+
+const API_BASE_TEST_URL = 'http://kesaseteli-api';
+
+// eslint-disable-next-line unicorn/consistent-function-scoping
+jest.mock('shared/hooks/useGetLanguage', () => () => () => 'fi');
+jest.mock('shared/hooks/useErrorHandler', () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+describe('useCreateAdditionalInfoQuery', () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <BackendAPIProvider baseURL={API_BASE_TEST_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </BackendAPIProvider>
+  );
+
+  beforeEach(() => {
+    queryClient.clear();
+    nock.cleanAll();
+  });
+
+  it('calls onSuccess when additional info created successfully', async () => {
+    const mockOnSuccess = jest.fn();
+    const applicationId = 'app-123';
+
+    nock(API_BASE_TEST_URL)
+      .post(`/v1/youthapplications/${applicationId}/additional_info/`)
+      .reply(200, { id: 'info-123' });
+
+    const { result, waitFor } = renderHook(
+      () =>
+        useCreateAdditionalInfoQuery(applicationId, {
+          onSuccess: mockOnSuccess,
+        }),
+      { wrapper }
+    );
+
+    act(() => {
+      result.current.mutate({
+        additional_info_user_reasons: ['reason_1'],
+        additional_info_description: 'Description text',
+      } as any);
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(mockOnSuccess).toHaveBeenCalled();
+  });
+});

--- a/frontend/kesaseteli/youth/src/utils/__tests__/type-guards.test.ts
+++ b/frontend/kesaseteli/youth/src/utils/__tests__/type-guards.test.ts
@@ -1,0 +1,110 @@
+import Axios from 'axios';
+
+import {
+  isYouthApplicationCreationError,
+  isYouthApplicationValidationError,
+} from '../type-guards';
+
+describe('type-guards', () => {
+  describe('isYouthApplicationCreationError', () => {
+    it('returns true for youth application creation error', () => {
+      const error = {
+        isAxiosError: true,
+        response: {
+          data: {
+            code: 'already_assigned',
+          },
+        },
+      };
+      jest.spyOn(Axios, 'isAxiosError').mockReturnValueOnce(true);
+      expect(isYouthApplicationCreationError(error)).toBe(true);
+    });
+
+    it('returns false for other errors', () => {
+      const error = new Error('Generic error');
+      jest.spyOn(Axios, 'isAxiosError').mockReturnValueOnce(false);
+      expect(isYouthApplicationCreationError(error)).toBe(false);
+    });
+
+    it('returns false when no response exists', () => {
+      const error = {
+        isAxiosError: true,
+      };
+      jest.spyOn(Axios, 'isAxiosError').mockReturnValueOnce(true);
+      expect(isYouthApplicationCreationError(error)).toBe(false);
+    });
+
+    it('returns false when code is not creation error code', () => {
+      const error = {
+        isAxiosError: true,
+        response: {
+          data: {
+            code: 'unknown_code',
+          },
+        },
+      };
+      jest.spyOn(Axios, 'isAxiosError').mockReturnValueOnce(true);
+      expect(isYouthApplicationCreationError(error)).toBe(false);
+    });
+  });
+
+  describe('isYouthApplicationValidationError', () => {
+    it('returns true when status is 400 and data contains field validation error', () => {
+      const error = {
+        isAxiosError: true,
+        response: {
+          status: 400,
+          data: {
+            first_name: ['Enter a valid value.'],
+          },
+        },
+      };
+      jest.spyOn(Axios, 'isAxiosError').mockReturnValueOnce(true);
+      expect(isYouthApplicationValidationError(error)).toBe(true);
+    });
+
+    it('returns false when status is not 400', () => {
+      const error = {
+        isAxiosError: true,
+        response: {
+          status: 500,
+          data: {},
+        },
+      };
+      jest.spyOn(Axios, 'isAxiosError').mockReturnValueOnce(true);
+      expect(isYouthApplicationValidationError(error)).toBe(false);
+    });
+
+    it('returns false when status is 400 but data does not contain fields', () => {
+      const error = {
+        isAxiosError: true,
+        response: {
+          status: 400,
+          data: {
+            unknown_field: ['Error'],
+          },
+        },
+      };
+      jest.spyOn(Axios, 'isAxiosError').mockReturnValueOnce(true);
+      expect(isYouthApplicationValidationError(error)).toBe(false);
+    });
+
+    it('returns false when status is 400 and data is null/empty', () => {
+      const error = {
+        isAxiosError: true,
+        response: {
+          status: 400,
+          data: null,
+        },
+      };
+      jest.spyOn(Axios, 'isAxiosError').mockReturnValueOnce(true);
+      expect(isYouthApplicationValidationError(error)).toBe(false);
+    });
+
+    it('returns false for other errors', () => {
+      const error = new Error('Generic error');
+      jest.spyOn(Axios, 'isAxiosError').mockReturnValueOnce(false);
+      expect(isYouthApplicationValidationError(error)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
YJDH-772.

Add tests for server backend, i18n loaders,
components, hooks, type guards, and helper edge cases to resolve coverage gaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for form submission behavior, error handling, and validation workflows.
  * Expanded test coverage for form error summary rendering, field selection components, and target group functionality.
  * Introduced comprehensive test suites for application creation operations and utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->