### PR TITLE
refactor(ks,shared): add API error ignoring to Sentry config

### DIFF
--- a/frontend/shared/sentry-config.js
+++ b/frontend/shared/sentry-config.js
@@ -1,16 +1,87 @@
 import * as Sentry from '@sentry/nextjs';
 import maskGDPRData from 'shared/utils/mask-gdpr-data';
 
-export default function sentryConfig() {
+// List of API errors to ignore in Sentry (mapped by URL pattern and HTTP status code)
+const DEFAULT_IGNORED_API_ERRORS = [
+  // 401 Unauthorized from /oidc/userinfo is expected when a user is not logged in yet (e.g. landing/login page)
+  { url: '/oidc/userinfo', status: 401 },
+];
+
+/**
+ * Parse a string value to a floating point number.
+ * If the value is not a valid number, returns the fallback value.
+ */
+const parseSampleRate = (value, fallback) => {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+/**
+ * Configure Sentry with error handling, trace sampling, session replay, and custom ignore rules.
+ *
+ * @param {Array<{ url?: string | RegExp; status?: number }> | Array<{ url?: string | RegExp; errorMessage?: string }>} [ignoredApiErrors] - List of API errors to ignore in Sentry
+ */
+export default function sentryConfig(
+  ignoredApiErrors = DEFAULT_IGNORED_API_ERRORS
+) {
+  /**
+   * A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry.
+   * (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
+   * Either this or tracesSampler must be defined to enable tracing.
+   *
+   * @see https://develop.sentry.dev/sdk/performance/
+   *
+   * NOTE: Don't mix up with sampleRate (without traces prefix).
+   * See https://docs.sentry.io/concepts/key-terms/sample-rates/#error-events
+   */
+  const tracesSampleRate = parseSampleRate(
+    process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
+    1
+  );
+
+  const tracePropagationTargets = (
+    process.env.NEXT_PUBLIC_SENTRY_TRACE_PROPAGATION_TARGETS || ''
+  )
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const replaysSessionSampleRate = parseSampleRate(
+    process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE,
+    0
+  );
+
+  const replaysOnErrorSampleRate = parseSampleRate(
+    process.env.NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE,
+    0
+  );
+
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || '',
     environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'development',
+    release: process.env.NEXT_PUBLIC_RELEASE,
     attachStacktrace: true,
     maxBreadcrumbs:
       Number(process.env.NEXT_PUBLIC_SENTRY_MAX_BREADCRUMBS) || 100,
+    integrations: [
+      ...(typeof window !== 'undefined' &&
+      typeof Sentry.browserTracingIntegration === 'function'
+        ? [Sentry.browserTracingIntegration()]
+        : []),
+      ...(typeof window !== 'undefined' &&
+      typeof Sentry.replayIntegration === 'function'
+        ? [Sentry.replayIntegration()]
+        : []),
+    ],
     // Adjust this value in production, or use tracesSampler for greater control
     // @see https://develop.sentry.dev/sdk/performance/
-    tracesSampleRate: 1,
+    tracesSampleRate,
+    tracePropagationTargets,
+    replaysSessionSampleRate,
+    replaysOnErrorSampleRate,
     beforeBreadcrumb(breadcrumb) {
       return {
         ...breadcrumb,
@@ -18,7 +89,59 @@ export default function sentryConfig() {
         data: maskGDPRData(breadcrumb.data),
       };
     },
-    beforeSend(event) {
+    /**
+     * Filter out certain events before they are sent to Sentry.
+     * Mask GDPR data from events.
+     */
+    beforeSend(event, hint) {
+      const error = hint?.originalException;
+      if (error) {
+        const url = error.config?.url || error.request?.responseURL || '';
+        const status =
+          error.response?.status ?? error.status ?? error.statusCode;
+
+        const isIgnored = ignoredApiErrors.some((ignored) => {
+          if (!ignored.url) {
+            return false;
+          }
+
+          // Is there an ignore rule for this url?
+          const urlMatches =
+            typeof ignored.url === 'string'
+              ? url.includes(ignored.url)
+              : ignored.url instanceof RegExp && ignored.url.test(url);
+
+          if (!urlMatches) {
+            return false;
+          }
+
+          // Does the ignore rule include status code and/or error message?
+          const hasStatus =
+            ignored.status !== undefined && ignored.status !== null;
+          const hasErrorMessage =
+            ignored.errorMessage !== undefined && ignored.errorMessage !== null;
+
+          if (!hasStatus && !hasErrorMessage) {
+            return false;
+          }
+
+          const statusMatches = !hasStatus || status === ignored.status;
+
+          const errorMessageMatches =
+            !hasErrorMessage ||
+            (() => {
+              const msg =
+                error.message || (typeof error === 'string' ? error : '');
+              return msg.includes(ignored.errorMessage);
+            })();
+
+          return statusMatches && errorMessageMatches;
+        });
+
+        if (isIgnored) {
+          return null;
+        }
+      }
       return maskGDPRData(event);
     },
   });

--- a/frontend/shared/src/__tests__/sentry-config.test.ts
+++ b/frontend/shared/src/__tests__/sentry-config.test.ts
@@ -1,0 +1,536 @@
+/* eslint-disable simple-import-sort/imports */
+import * as Sentry from '@sentry/nextjs';
+import sentryConfig from '../../sentry-config';
+/* eslint-enable simple-import-sort/imports */
+
+jest.mock('@sentry/nextjs', () => ({
+  init: jest.fn(),
+  browserTracingIntegration: jest.fn(),
+  replayIntegration: jest.fn(),
+}));
+
+describe('sentryConfig', () => {
+  let beforeSend: (
+    event: Sentry.Event,
+    hint?: Sentry.EventHint
+  ) => Sentry.Event | null | PromiseLike<Sentry.Event | null>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sentryConfig();
+    const initSpy = Sentry.init as jest.Mock;
+    const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+    beforeSend = config.beforeSend as typeof beforeSend;
+  });
+
+  it('should initialize Sentry and register beforeSend', () => {
+    const initSpy = Sentry.init as jest.Mock;
+    expect(initSpy).toHaveBeenCalled();
+    expect(typeof beforeSend).toBe('function');
+  });
+
+  it('should not ignore standard events without exceptions', () => {
+    const event: Sentry.Event = { message: 'Normal log message' };
+    const result = beforeSend(event);
+    expect(result).toEqual(event);
+  });
+
+  it('should ignore errors with matching URL and status code', () => {
+    const event: Sentry.Event = { message: 'Error' };
+    const hint: Sentry.EventHint = {
+      originalException: {
+        config: { url: '/oidc/userinfo' },
+        response: { status: 401 },
+      },
+    };
+    const result = beforeSend(event, hint);
+    expect(result).toBeNull();
+  });
+
+  it('should ignore errors with matching URL and status code 0', () => {
+    sentryConfig([{ url: '/oidc/userinfo', status: 0 }]);
+    const initSpy = Sentry.init as jest.Mock;
+    const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+    const config = lastCall?.[0] as Sentry.BrowserOptions;
+    const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+    const event: Sentry.Event = { message: 'Error' };
+    const hint: Sentry.EventHint = {
+      originalException: {
+        config: { url: '/oidc/userinfo' },
+        response: { status: 0 },
+      },
+    };
+    const result = customBeforeSend(event, hint);
+    expect(result).toBeNull();
+  });
+
+  it('should NOT ignore errors with matching URL but a different status code (e.g. 500)', () => {
+    const event: Sentry.Event = { message: 'Error' };
+    const hint: Sentry.EventHint = {
+      originalException: {
+        config: { url: '/oidc/userinfo' },
+        response: { status: 500 },
+      },
+    };
+    const result = beforeSend(event, hint);
+    expect(result).toEqual(event);
+  });
+
+  describe('custom ignoredApiErrors settings', () => {
+    it('should NOT ignore errors matching status code if URL is not specified in the ignore rule', () => {
+      sentryConfig([{ status: 401 }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Error' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/some/other/url' },
+          response: { status: 401 },
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toEqual(event);
+    });
+
+    it('should NOT ignore errors when status code and error message are not specified in the ignore rule (matching URL only)', () => {
+      sentryConfig([{ url: '/oidc/userinfo' }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Error' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/oidc/userinfo' },
+          response: { status: 500 },
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toEqual(event);
+    });
+
+    it('should ignore errors when the URL string matches as a substring (in the middle of a URL)', () => {
+      sentryConfig([{ url: '/oidc/userinfo', status: 401 }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Error' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: {
+            url: 'https://example.com/api/v1/oidc/userinfo/details?param=1',
+          },
+          response: { status: 401 },
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toBeNull();
+    });
+
+    it('should ignore errors when status matches error status code and URL matches', () => {
+      sentryConfig([{ url: '/custom-url', status: 403 }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Error' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/custom-url' },
+          response: { status: 403 },
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toBeNull();
+    });
+
+    it('should NOT ignore errors when error message is specified in the ignore rule but URL is not specified', () => {
+      sentryConfig([{ errorMessage: 'timeout' }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Request timeout' };
+      const hint: Sentry.EventHint = {
+        originalException: new Error('Request timeout exceeded'),
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toEqual(event);
+    });
+
+    it('should ignore errors when error message contains specified errorMessage and URL matches', () => {
+      sentryConfig([{ url: '/oidc/userinfo', errorMessage: 'timeout' }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Request timeout' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/oidc/userinfo' },
+          message: 'Request timeout exceeded',
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toBeNull();
+    });
+
+    it('should ignore errors when url matches specified RegExp and status matches', () => {
+      sentryConfig([{ url: /\/oidc\/userinfo.*/, status: 401 }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Error' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/oidc/userinfo?foo=bar' },
+          response: { status: 401 },
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toBeNull();
+    });
+
+    it('should NOT ignore errors when url does not match specified RegExp even if status matches', () => {
+      sentryConfig([{ url: /\/oidc\/userinfo$/, status: 401 }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Error' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/oidc/userinfo/extra' },
+          response: { status: 401 },
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toEqual(event);
+    });
+
+    it('should NOT ignore errors when error message does not contain specified errorMessage even if URL matches RegExp', () => {
+      sentryConfig([{ url: /\/oidc\/userinfo.*/, errorMessage: 'timeout' }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Connection refused' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/oidc/userinfo?param=1' },
+          message: 'Connection refused',
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toEqual(event);
+    });
+
+    it('should ignore errors when error message contains specified errorMessage and URL matches RegExp', () => {
+      sentryConfig([{ url: /\/oidc\/userinfo.*/, errorMessage: 'timeout' }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Request timeout' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/oidc/userinfo?param=1' },
+          message: 'Request timeout exceeded',
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toBeNull();
+    });
+
+    it('should NOT ignore errors when error message does not contain specified errorMessage even if URL matches', () => {
+      sentryConfig([{ url: '/oidc/userinfo', errorMessage: 'timeout' }]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Connection refused' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/oidc/userinfo' },
+          message: 'Connection refused',
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toEqual(event);
+    });
+
+    it('should ignore errors when URL, status, and errorMessage all match (invalid JSDoc/JavaScript configuration)', () => {
+      sentryConfig([
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error - Testing invalid JavaScript/JSDoc configuration containing both status and errorMessage
+        { url: '/api/v1', status: 502, errorMessage: 'Bad Gateway' },
+      ]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: '502 Error' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/api/v1/users' },
+          response: { status: 502 },
+          message: 'Error: Bad Gateway received',
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toBeNull();
+    });
+
+    it('should NOT ignore errors when URL and status match but errorMessage does not match (invalid JSDoc/JavaScript configuration)', () => {
+      sentryConfig([
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error - Testing invalid JavaScript/JSDoc configuration containing both status and errorMessage
+        { url: '/api/v1', status: 502, errorMessage: 'Bad Gateway' },
+      ]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: '502 Error' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/api/v1/users' },
+          response: { status: 502 },
+          message: 'Error: Internal Server Error',
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toEqual(event);
+    });
+
+    it('should NOT ignore errors when rule has no properties defined', () => {
+      sentryConfig([{}]);
+      const initSpy = Sentry.init as jest.Mock;
+      const lastCall = initSpy.mock.calls[initSpy.mock.calls.length - 1];
+      const config = lastCall?.[0] as Sentry.BrowserOptions;
+      const customBeforeSend = config.beforeSend as typeof beforeSend;
+
+      const event: Sentry.Event = { message: 'Error' };
+      const hint: Sentry.EventHint = {
+        originalException: {
+          config: { url: '/api/v1/users' },
+          response: { status: 500 },
+          message: 'Internal Error',
+        },
+      };
+      const result = customBeforeSend(event, hint);
+      expect(result).toEqual(event);
+    });
+  });
+
+  describe('tracePropagationTargets config', () => {
+    let originalEnv: string | undefined;
+
+    beforeAll(() => {
+      originalEnv = process.env.NEXT_PUBLIC_SENTRY_TRACE_PROPAGATION_TARGETS;
+    });
+
+    afterAll(() => {
+      if (originalEnv === undefined) {
+        delete process.env.NEXT_PUBLIC_SENTRY_TRACE_PROPAGATION_TARGETS;
+      } else {
+        process.env.NEXT_PUBLIC_SENTRY_TRACE_PROPAGATION_TARGETS = originalEnv;
+      }
+    });
+
+    it('should result in empty tracePropagationTargets when env var is unset', () => {
+      delete process.env.NEXT_PUBLIC_SENTRY_TRACE_PROPAGATION_TARGETS;
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.tracePropagationTargets).toEqual([]);
+    });
+
+    it('should result in empty tracePropagationTargets when env var is an empty string', () => {
+      process.env.NEXT_PUBLIC_SENTRY_TRACE_PROPAGATION_TARGETS = '';
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.tracePropagationTargets).toEqual([]);
+    });
+
+    it('should correctly parse comma-separated targets and ignore empty values', () => {
+      process.env.NEXT_PUBLIC_SENTRY_TRACE_PROPAGATION_TARGETS =
+        'https://api.example.com,,https://localhost:8000';
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.tracePropagationTargets).toEqual([
+        'https://api.example.com',
+        'https://localhost:8000',
+      ]);
+    });
+
+    it('should trim whitespace from targets', () => {
+      process.env.NEXT_PUBLIC_SENTRY_TRACE_PROPAGATION_TARGETS =
+        '  https://api.example.com , https://localhost:8000  ';
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.tracePropagationTargets).toEqual([
+        'https://api.example.com',
+        'https://localhost:8000',
+      ]);
+    });
+  });
+
+  describe('tracesSampleRate config', () => {
+    let originalEnv: string | undefined;
+
+    beforeAll(() => {
+      originalEnv = process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE;
+    });
+
+    afterAll(() => {
+      if (originalEnv === undefined) {
+        delete process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE;
+      } else {
+        process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE = originalEnv;
+      }
+    });
+
+    it('should use 1 when NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE is unset', () => {
+      delete process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE;
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.tracesSampleRate).toBe(1);
+    });
+
+    it('should use the valid value when NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE is between 0 and 1', () => {
+      process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE = '0.5';
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.tracesSampleRate).toBe(0.5);
+    });
+
+    it('should fallback to 1 when NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE is invalid (NaN)', () => {
+      process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE = 'invalid';
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.tracesSampleRate).toBe(1);
+    });
+
+    it('should parse negative values directly', () => {
+      process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE = '-0.1';
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.tracesSampleRate).toBe(-0.1);
+    });
+
+    it('should parse values greater than 1 directly', () => {
+      process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE = '1.1';
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.tracesSampleRate).toBe(1.1);
+    });
+  });
+
+  describe('replays sample rates config', () => {
+    let originalSessionRate: string | undefined;
+    let originalErrorRate: string | undefined;
+
+    beforeAll(() => {
+      originalSessionRate =
+        process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE;
+      originalErrorRate =
+        process.env.NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE;
+    });
+
+    afterAll(() => {
+      if (originalSessionRate === undefined) {
+        delete process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE;
+      } else {
+        process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE =
+          originalSessionRate;
+      }
+      if (originalErrorRate === undefined) {
+        delete process.env.NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE;
+      } else {
+        process.env.NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE =
+          originalErrorRate;
+      }
+    });
+
+    it('should fallback to 0 when sample rate env vars are unset', () => {
+      delete process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE;
+      delete process.env.NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE;
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.replaysSessionSampleRate).toBe(0);
+      expect(config.replaysOnErrorSampleRate).toBe(0);
+    });
+
+    it('should parse replays sample rates even if they are out of bounds', () => {
+      process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE = '1.5';
+      process.env.NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE = '-0.5';
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.replaysSessionSampleRate).toBe(1.5);
+      expect(config.replaysOnErrorSampleRate).toBe(-0.5);
+    });
+
+    it('should fallback to 0 when replays sample rates are NaN', () => {
+      process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE = 'invalid';
+      process.env.NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE =
+        'not-a-number';
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.replaysSessionSampleRate).toBe(0);
+      expect(config.replaysOnErrorSampleRate).toBe(0);
+    });
+
+    it('should parse valid sample rates correctly', () => {
+      process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE = '0.25';
+      process.env.NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE = '0.8';
+      jest.clearAllMocks();
+      sentryConfig();
+      const initSpy = Sentry.init as jest.Mock;
+      const config = initSpy.mock.calls[0]?.[0] as Sentry.BrowserOptions;
+      expect(config.replaysSessionSampleRate).toBe(0.25);
+      expect(config.replaysOnErrorSampleRate).toBe(0.8);
+    });
+  });
+});

--- a/frontend/shared/src/utils/cookieConsentSettings.ts
+++ b/frontend/shared/src/utils/cookieConsentSettings.ts
@@ -106,11 +106,13 @@ type GetCookieConsentSiteSettingsOptions = {
   optionalGroups?: OptionalGroups;
 };
 
+const KESASETELI_SITE_NAME = 'Kesäseteli';
+
 const DEFAULT_SITE_NAMES_BY_APP: Record<CookieConsentApp, LocalizedSiteName> = {
   kesaseteli: {
-    fi: 'Kesäseteli',
-    sv: 'Kesäseteli',
-    en: 'Kesäseteli',
+    fi: KESASETELI_SITE_NAME,
+    sv: KESASETELI_SITE_NAME,
+    en: KESASETELI_SITE_NAME,
   },
   benefit: {
     fi: 'Helsinki-lisä',


### PR DESCRIPTION
YJDH-759.

Ignore expected 401 Unauthorized errors from /oidc/userinfo in Sentry to prevent logs pollution. Parameterize sentryConfig to accept a list of ignored errors, facilitating custom exclusions in the future.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced error tracking: configurable suppression of API errors with a default rule for 401 on the OIDC userinfo endpoint. Breadcrumbs and report data are GDPR-masked. Ignore rules only apply when their matching criteria (URL, status and/or error-message) are satisfied.
  * Added parsing and sensible defaults for trace/replay sampling and trace-propagation targets via environment variables.

* **Tests**
  * Added comprehensive tests for ignored-error matching semantics and env-driven sampling/propagation parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->