### PR TITLE
Hl 1782 pdf summary for handler

### DIFF
--- a/backend/benefit/applications/api/v1/application_views.py
+++ b/backend/benefit/applications/api/v1/application_views.py
@@ -73,6 +73,7 @@ from applications.services.applications_power_bi_csv_report import (
 from applications.services.clone_application import clone_application_based_on_other
 from applications.services.generate_application_summary import (
     generate_application_summary_file,
+    generate_handler_application_pdf,
     get_context_for_summary_context,
 )
 from calculator.enums import InstalmentStatus
@@ -1115,6 +1116,18 @@ class HandlerApplicationViewSet(BaseApplicationViewSet):
         return Response(
             status=status.HTTP_400_BAD_REQUEST,
         )
+
+    @action(methods=["GET"], detail=True, url_path="application_pdf")
+    def application_pdf(self, request, pk=None) -> HttpResponse:
+        application = self.get_object()
+        pdf_bytes = generate_handler_application_pdf(application, request)
+        if not pdf_bytes:
+            return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        response = HttpResponse(pdf_bytes, content_type="application/pdf")
+        response["Content-Disposition"] = (
+            f'attachment; filename="application_{application.application_number}.pdf"'
+        )
+        return response
 
     def _create_application_batch(self, status) -> QuerySet[Application]:
         """

--- a/backend/benefit/applications/services/generate_application_summary.py
+++ b/backend/benefit/applications/services/generate_application_summary.py
@@ -1,5 +1,4 @@
 from datetime import date
-from typing import Union
 
 import pdfkit
 from django.template import loader
@@ -36,7 +35,7 @@ def get_context_for_summary_context(application):
     }
 
 
-def generate_application_summary_file(application, request=None) -> Union[bytes, None]:
+def generate_application_summary_file(application, request=None) -> bytes | None:
     def generate_summary_pdf(context) -> bytes:
         template = loader.get_template("application.html")
         rendered_template = template.render(context, request)
@@ -80,7 +79,7 @@ def get_handler_context_for_summary(application):
     return context
 
 
-def generate_handler_application_pdf(application, request=None) -> Union[bytes, None]:
+def generate_handler_application_pdf(application, request=None) -> bytes | None:
     def generate_pdf(context) -> bytes:
         template = loader.get_template("application_handler.html")
         rendered_template = template.render(context, request)

--- a/backend/benefit/applications/services/generate_application_summary.py
+++ b/backend/benefit/applications/services/generate_application_summary.py
@@ -3,6 +3,7 @@ from typing import Union
 
 import pdfkit
 from django.template import loader
+from django.utils import translation
 
 
 def get_context_for_summary_context(application):
@@ -47,6 +48,51 @@ def generate_application_summary_file(application, request=None) -> Union[bytes,
     except Exception as e:
         print(  # noqa: T201
             f"Cannot generate application summary PDF for application {application.id}",
+            e,
+        )
+        return None
+
+
+def get_handler_context_for_summary(application):
+    context = get_context_for_summary_context(application)
+    batch = getattr(application, "batch", None)
+    calculation = getattr(application, "calculation", None)
+    context["batch"] = batch
+    context["calculation"] = calculation
+    context["calculation_rows"] = (
+        calculation.rows.all().order_by("ordering") if calculation else []
+    )
+    context["benefit_total_row"] = (
+        calculation.rows.filter(row_type="helsinki_benefit_total_eur").first()
+        if calculation
+        else None
+    )
+    context["instalments"] = (
+        list(calculation.instalments.order_by("instalment_number"))
+        if calculation
+        else []
+    )
+    context["alterations"] = list(
+        application.alteration_set.exclude(state="cancelled").order_by("created_at")
+    )
+    # Pages 1-4 always; page 5 (Laskelma) only when calculation exists
+    context["total_pages"] = 5 if calculation else 4
+    return context
+
+
+def generate_handler_application_pdf(application, request=None) -> Union[bytes, None]:
+    def generate_pdf(context) -> bytes:
+        template = loader.get_template("application_handler.html")
+        rendered_template = template.render(context, request)
+        return pdfkit.from_string(rendered_template, False, None)
+
+    try:
+        context = get_handler_context_for_summary(application)
+        with translation.override("fi"):
+            return generate_pdf(context)
+    except Exception as e:
+        print(  # noqa: T201
+            f"Cannot generate handler PDF for application {application.id}",
             e,
         )
         return None

--- a/backend/benefit/applications/templates/application.html
+++ b/backend/benefit/applications/templates/application.html
@@ -148,7 +148,7 @@
                 {%endif%}
             </section>
         </article>
-        {% include "footer.html" with page="1" %}
+        {% include "footer.html" with page="1" total="4" %}
 
     </div>
 
@@ -226,7 +226,7 @@
                 {% endif %}
             </section>
         </article>
-        {% include "footer.html" with page="2" %}
+        {% include "footer.html" with page="2" total="4" %}
     </div>
     <div class="page-start"></div>
     <div class="page-wrapper">
@@ -330,7 +330,7 @@
             {% endcomment %}
             </section>
         </article>
-        {% include "footer.html" with page="3" %}
+        {% include "footer.html" with page="3" total="4" %}
 
     </div>
 
@@ -352,7 +352,7 @@
                 {% endfor %}
             </section>
         </article>
-        {% include "footer.html" with page="4" %}
+        {% include "footer.html" with page="4" total="4" %}
     </div>
 </main>
 

--- a/backend/benefit/applications/templates/application_handler.html
+++ b/backend/benefit/applications/templates/application_handler.html
@@ -501,6 +501,5 @@
     </div>
     {% endif %}
 </main>
-</div>
 
 {% endblock %}

--- a/backend/benefit/applications/templates/application_handler.html
+++ b/backend/benefit/applications/templates/application_handler.html
@@ -1,0 +1,506 @@
+{% extends "base.html" %}
+{% block title %}{{ application.application_number }}{% endblock %}
+{% block content %}
+{% load application_extras %}
+{% load i18n %}
+
+<main>
+    <div class="page-wrapper">
+        {% include "header.html" %}
+        <article>
+            <div class="two-col-sections">
+            <section>
+                <h3>{{ _("Employer information") }}</h3>
+                <div class="row">
+                    <div class="label">{{ _("Name of the employer") }}</div>
+                    <div class="value">{{application.company.name}}</div>
+                </div>
+
+                {% if application.company.industry_code %}
+                <div class="row">
+                    <div class="label">TOL-koodi</div>
+                    <div class="value">{{ application.company.industry_code }}{% if application.company.industry %} – {{ application.company.industry }}{% endif %}</div>
+                </div>
+                {% endif %}
+
+                <div class="row">
+                    <div class="label">{{ _("Business ID") }}</div>
+                    <div class="value">{{ application.company.business_id }}</div>
+                </div>
+
+                <div class="row">
+                    <div class="label">{{ _("Street address") }}</div>
+                    <div class="value">{{ application.company.street_address }}<br>{{ application.company.postcode }} {{ application.company.city}}</div>
+                </div>
+
+                {% if application.alternative_company_street_address %}
+                <div class="row">
+                    <div class="label">{{ _("Delivery address") }}</div>
+                    <div class="value">
+                        {{ application.company_department }}<br>
+                        {{ application.alternative_company_street_address }}<br>
+                        {{ application.alternative_company_postcode }} {{ application.alternative_company_city }}
+                    </div>
+                </div>
+                {% endif %}
+
+                <div class="row">
+                    <div class="label">{{ _("Bank account number") }}</div>
+                    <div class="value">{{ application.company_bank_account_number | iban}}</div>
+                </div>
+
+                <div class="row">
+                    <div class="label">{{ _("Number of employees before the employed") }}</div>
+                    <div class="value">{{ application.company_number_of_employees }}</div>
+                </div>
+
+                <div class="row force-column">
+                    <div class="label">{{ _("Is service purchased by city of Helsinki") }}</div>
+                    <div class="value">
+                        {% if application.purchased_service %}
+                        {{ _("Yes") }}
+                        {% else %}
+                        {{ _("No") }}
+                        {%endif%}
+                    </div>
+                </div>
+
+                {% if application.company.organization_type == 'association' %}
+                <div class="row force-column">
+                    <div class="label">{{ _("Does the employer engage in economic activity?") }}</div>
+                    <div class="value">
+                        {% if application.association_has_business_activities %}
+                        {{ _("Yes") }}
+                        {% else %}
+                        {{ _("No") }}
+                        {%endif%}
+                    </div>
+                </div>
+                {% endif %}
+            </section>
+
+            <section>
+                <h3>{{ _("Contact person for the employer") }}</h3>
+                <div>
+                    <div class="row">
+                        <div class="label">{{ _("Name") }}</div>
+                        <div class="value">{{ application.company_contact_person_first_name}} {{ application.company_contact_person_last_name }}</div>
+                    </div>
+                    <div class="row">
+                        <div class="label">{{ _("Telephone") }}</div>
+                        <div class="value">{{ application.company_contact_person_phone_number }}</div>
+                    </div>
+                    <div class="row">
+                        <div class="label">{{ _("Email address") }}</div>
+                        <div class="value">{{ application.company_contact_person_email }}</div>
+                    </div>
+                    <div class="row">
+                        <div class="label">{{ _("Preferred language of communication") }}</div>
+                        <div class="value">{% translate application.applicant_language %}</div>
+                    </div>
+                </div>
+            </section>
+            </div>
+
+            <div class="row force-column">
+                <div class="label">{{ _("Description of employer's business activities") }}</div>
+                <div class="value">{{ application.company_business_brief|linebreaksbr }}</div>
+            </div>
+
+            <section>
+                <h3 id="deminimis-heading">{{ _("De minimis aid received by the employer") }}</h3>
+
+                {% if de_minimis_aid_set %}
+                <table aria-describedby="deminimis-heading">
+                    <thead>
+                        <tr>
+                            <th>{{ _("Granter") }}</th>
+                            <th>{{ _("Amount") }}</th>
+                            <th>{{ _("Date") }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for aid in de_minimis_aid_set %}
+                        <tr>
+                            <td>{{ aid.granter }}</td>
+                            <td>{{ aid.amount | to_euro }}</td>
+                            <td>{{ aid.granted_at | date_fi }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <div class="row force-column" style="margin-top: 10px;">
+                    <div class="label">{{ _("Total") }}</div>
+                    <div class="value">{{ de_minimis_amount | to_euro }}</div>
+                </div>
+                {% else %}
+                <p>{{ _("No, the applicant has not listed any previous de minimis aids.") }}</p>
+                {%endif%}
+            </section>
+            <section>
+                <h3>{{ _("Change negotiations or co-determination negotiations") }}</h3>
+                {% if application.co_operation_negotiations %}
+                <div class="row force-column">
+                    <div class="value">
+                        <p>{{ _("Yes, the organization has ongoing or completed change negotiations within the previous 12 months.") }}</p>
+                    </div>
+                </div>
+                {% else %}
+                <p>{{ _("No, the organization does not have change negotiations in progress or that have ended in the previous 12 months.") }}</p>
+                {% endif %}
+
+                {% if application.co_operation_negotiations %}
+                <div class="row">
+                    <div class="label">{{ _("Describe the situation") }}</div>
+                    <div class="value">{{ application.co_operation_negotiations_description }}</div>
+                </div>
+                {%endif%}
+            </section>
+        </article>
+        {% include "footer.html" with page="1" total=total_pages %}
+    </div>
+
+    <div class="page-start"></div>
+    <div class="page-wrapper">
+        {% include "header.html" %}
+        <article>
+            <div class="two-col-sections">
+            <section>
+                <h3>{{ _("Person to be hired") }}</h3>
+
+                <div class="row">
+                    <div class="label">{{ _("First name") }}</div>
+                    <div class="value">{{ application.employee.first_name }}</div>
+                </div>
+                <div class="row">
+                    <div class="label">{{ _("Last name") }}</div>
+                    <div class="value">{{ application.employee.last_name }}</div>
+                </div>
+                <div class="row">
+                    <div class="label">{{ _("Personal identity code") }}</div>
+                    <div class="value">{{ application.employee.social_security_number }}</div>
+                </div>
+                <div class="row force-column">
+                    <div class="label">{{ _("The subsidised employee's municipality of residence is Helsinki") }}</div>
+                    <div class="value">
+                        {% if application.employee.is_living_in_helsinki %}
+                        {{ _("Yes") }}
+                        {% else %}
+                        {{ _("No") }}
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="row force-column">
+                    <div class="label">{{ _("Are there other employees with pay subsidy") }}</div>
+                    <div class="value">
+                        {% if application.other_subsidised_employed %}
+                        {{ _("Yes") }}
+                        {% else %}
+                        {{ _("No") }}
+                        {%endif%}
+                    </div>
+                </div>
+
+                {% if application.other_subsidised_employed %}
+                <div class="row">
+                    <div class="label">{{ _("Number of other subsidised employees") }}</div>
+                    <div class="value">{{ application.other_subsidised_number }}</div>
+                </div>
+                {% endif %}
+
+                <div class="row force-column">
+                    <div class="label">{{ _("Has other financial support been granted for employment?") }}</div>
+                    <div class="value">
+                        {% if application.other_financial_support_for_employment %}
+                        {{ _("Yes") }}
+                        {% else %}
+                        {{ _("No") }}
+                        {%endif%}
+                    </div>
+                </div>
+
+                {% if application.company.organization_type == 'association' %}
+                <div class="row force-column">
+                    <div class="label">{{ _("Has the person who is being employed been assigned a job supervisor?") }}</div>
+                    <div class="value">
+                        {% if application.association_immediate_manager_check %}
+                        {{ _("Yes") }}
+                        {% else %}
+                        {{ _("No") }}
+                        {%endif%}
+                    </div>
+                </div>
+                {% endif %}
+            </section>
+
+            <section>
+                <h3>{{ _("Employment relationship") }}</h3>
+                <div class="row">
+                    <div class="label">{{ _("Job title") }}</div>
+                    <div class="value">{{ application.employee.job_title }}</div>
+                </div>
+                <div class="row">
+                    <div class="label">{{ _("Working hours per week") }}</div>
+                    <div class="value">{{application.employee.working_hours | dot_to_comma}}</div>
+                </div>
+                <div class="row">
+                    <div class="label">{{ _("Gross salary per month") }}</div>
+                    <div class="value">{{application.employee.monthly_pay | to_euro}}</div>
+                </div>
+                <div class="row">
+                    <div class="label">{{ _("Holiday pay per month") }}</div>
+                    <div class="value">{{ application.employee.vacation_money | to_euro}}</div>
+                </div>
+                <div class="row">
+                    <div class="label">{{ _("Indirect labour costs per month") }}</div>
+                    <div class="value">{{ application.employee.other_expenses | to_euro}}</div>
+                </div>
+                <div class="row">
+                    <div class="label">{{ _("Applicable collective agreement") }}</div>
+                    <div class="value">{{ application.employee.collective_bargaining_agreement }}</div>
+                </div>
+
+                {% if application.association_has_business_activities%}
+                <div class="row">
+                    <div class="label">{{ _("Association has business activities") }}</div>
+                    <div class="value">{{ _("Yes") }}</div>
+                </div>
+                {%endif%}
+
+                <div class="row">
+                    <div class="label">{{ _("Is this an apprenticeship?") }}</div>
+                    <div class="value">{% if application.apprenticeship_program %}{{ _("Yes") }}{% else %}{{ _("No") }}{%endif%}</div>
+                </div>
+
+                <div class="row">
+                    <div class="label">{{ _("Received aid") }}</div>
+                    <div class="value">{% translate application.pay_subsidy_granted %}</div>
+                </div>
+            </section>
+            </div>
+
+            <div class="row force-column">
+                <div class="label">{{ _("A description of how the work tasks of the person hired with the support are related to the organization's operations") }}</div>
+                <div class="value">{{ application.role_of_employee_in_organization|linebreaksbr }}</div>
+            </div>
+
+            <section>
+                <h3>{{ _("Benefit is applied for the period") }}</h3>
+                <div class="row">
+                    <div class="label">{{ _("Applying for dates") }}</div>
+                    <div class="value">{{ application.start_date | date_fi }} - {{ application.end_date | date_fi }}</div>
+                </div>
+            </section>
+        </article>
+        {% include "footer.html" with page="2" total=total_pages %}
+    </div>
+
+    <div class="page-start"></div>
+    <div class="page-wrapper">
+        {% include "header.html" %}
+        <article>
+            <section>
+                <h3>{{ _("Attachments") }}</h3>
+                {% for attachment in attachments %}
+                <div class="row">
+                    <div class="label">{% if application.pay_subsidy_granted == "granted_aged" and attachment.attachment_type == "pay_subsidy_decision" %}{{ _("granted_aged") }}{% else %}{% translate attachment.attachment_type %}{% endif %}</div>
+                    <div class="value">{{ attachment.attachment_file }}</div>
+                </div>
+                {% endfor %}
+            </section>
+        </article>
+        {% include "footer.html" with page="3" total=total_pages %}
+    </div>
+    <div class="page-start"></div>
+    <div class="page-wrapper">
+        {% include "header.html" %}
+        <article>
+            <section>
+                <h3>Käsittelijän yhteenveto</h3>
+
+                {% if application.status == "accepted" %}
+                <div class="row">
+                    <div class="label">Päätös</div>
+                    <div class="value" style="font-weight: 600; color: #007a64;">{{ _("Accepted") }}</div>
+                </div>
+                {% elif application.status == "rejected" %}
+                <div class="row">
+                    <div class="label">Päätös</div>
+                    <div class="value" style="font-weight: 600; color: #b01038;">Hylätty</div>
+                </div>
+                {% endif %}
+
+                {% if application.ahjo_case_id %}
+                <div class="row">
+                    <div class="label">Diaarinumero</div>
+                    <div class="value">{{ application.ahjo_case_id }}</div>
+                </div>
+                {% endif %}
+
+                {% if batch %}
+                <div class="row">
+                    <div class="label">Päätöksen päivämäärä</div>
+                    <div class="value">{{ batch.decision_date | date_fi }}</div>
+                </div>
+                <div class="row">
+                    <div class="label">Päätöksentekijä</div>
+                    <div class="value">{{ batch.decision_maker_name }}</div>
+                </div>
+                <div class="row">
+                    <div class="label">Päätöksentekijän titteli</div>
+                    <div class="value">{{ batch.decision_maker_title }}</div>
+                </div>
+                <div class="row">
+                    <div class="label">Lain kohta</div>
+                    <div class="value">{{ batch.section_of_the_law }}</div>
+                </div>
+                {% endif %}
+                {% if batch and batch.handler %}
+                    <div class="row">
+                        <div class="label">Käsittelijä</div>
+                        <div class="value">{{ batch.handler.first_name }} {{ batch.handler.last_name }}</div>
+                    </div>
+                {% endif %}
+
+            </section>
+
+            {% if batch and batch.p2p_inspector_name %}
+            <section>
+                <h3>Kaksoistarkastus</h3>
+                <div class="row">
+                    <div class="label">Tarkastaja</div>
+                    <div class="value">{{ batch.p2p_inspector_name }}</div>
+                </div>
+                <div class="row">
+                    <div class="label">Tarkastajan sähköposti</div>
+                    <div class="value">{{ batch.p2p_inspector_email }}</div>
+                </div>
+                <div class="row">
+                    <div class="label">Hyväksyjä</div>
+                    <div class="value">{{ batch.p2p_checker_name }}</div>
+                </div>
+            </section>
+            {% endif %}
+
+            {% if benefit_total_row %}
+            <section>
+                <h3>Myönnettävä Helsinki-lisä</h3>
+                <div class="row">
+                    <div class="label">Tukiaika</div>
+                    <div class="value">{{ application.start_date | date_fi }} – {{ application.end_date | date_fi }}</div>
+                </div>
+                <div class="row">
+                    <div class="label">{{ benefit_total_row.description_fi }}</div>
+                    <div class="value" style="font-weight: 600;">{{ benefit_total_row.amount | to_euro }}</div>
+                </div>
+                {% if calculation %}
+                <div class="row force-column">
+                    <div class="label">Myönnetty de minimis -tukena</div>
+                    <div class="value">
+                        {% if calculation.granted_as_de_minimis_aid %}
+                        Kyllä
+                        {% else %}
+                        Ei
+                        {% endif %}
+                    </div>
+                </div>
+                {% endif %}
+            </section>
+            {% endif %}
+
+            {% if instalments %}
+            <section>
+                <h3>Maksuaikataulu</h3>
+                {% for instalment in instalments %}
+                <div class="row">
+                    <div class="label">{% if instalment.instalment_number == 1 %}Ensimmäinen maksuerä{% elif instalment.instalment_number == 2 %}Toinen maksuerä{% else %}Maksuerä {{ instalment.instalment_number }}{% endif %}</div>
+                    <div class="value">{{ instalment.amount | to_euro }}{% if instalment.due_date %} – eräpäivä {{ instalment.due_date | date_fi }}{% endif %}</div>
+                </div>
+                {% endfor %}
+            </section>
+            {% endif %}
+
+            {% if alterations %}
+            <section>
+                <h3>Tukiajan muutokset</h3>
+                {% for alt in alterations %}
+                <div class="row">
+                    <div class="label">Muutostyyppi</div>
+                    <div class="value">{% if alt.alteration_type == "termination" %}Päättyminen{% elif alt.alteration_type == "suspension" %}Keskeytys{% else %}{{ alt.alteration_type }}{% endif %}</div>
+                </div>
+                <div class="row">
+                    <div class="label">Uusi päättymispäivä</div>
+                    <div class="value">{{ alt.end_date | date_fi }}</div>
+                </div>
+                {% if alt.resume_date %}
+                <div class="row">
+                    <div class="label">Työn jatkumispäivä</div>
+                    <div class="value">{{ alt.resume_date | date_fi }}</div>
+                </div>
+                {% endif %}
+                {% if alt.reason %}
+                <div class="row">
+                    <div class="label">Syy</div>
+                    <div class="value">{{ alt.reason }}</div>
+                </div>
+                {% endif %}
+                {% if alt.is_recoverable and alt.recovery_amount %}
+                <div class="row">
+                    <div class="label">Palautettava summa</div>
+                    <div class="value">{{ alt.recovery_amount | to_euro }}</div>
+                </div>
+                <div class="row">
+                    <div class="label">Palautusaika</div>
+                    <div class="value">{{ alt.recovery_start_date | date_fi }} – {{ alt.recovery_end_date | date_fi }}</div>
+                </div>
+                {% endif %}
+                {% if alt.handled_at %}
+                <div class="row">
+                    <div class="label">Käsitelty</div>
+                    <div class="value">{{ alt.handled_at | date_fi }}</div>
+                </div>
+                {% endif %}
+                {% if not forloop.last %}<hr style="margin: 8px 0; border-color: #ccc;">{% endif %}
+                {% endfor %}
+            </section>
+            {% endif %}
+
+        </article>
+        {% include "footer.html" with page="4" total=total_pages %}
+    </div>
+
+    {% if calculation %}
+    <div class="page-start"></div>
+    <div class="page-wrapper">
+        {% include "header.html" %}
+        <article>
+            <section>
+                <h3 id="calculation-heading">Laskelma</h3>
+                {% if calculation_rows %}
+                <table aria-describedby="calculation-heading">
+                    <thead>
+                        <tr>
+                            <th>Kuvaus</th>
+                            <th>Summa</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in calculation_rows %}
+                        <tr>
+                            <td>{{ row.description_fi }}</td>
+                            <td>{{ row.amount | to_euro }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {% endif %}
+            </section>
+        </article>
+        {% include "footer.html" with page="5" total=total_pages %}
+    </div>
+    {% endif %}
+</main>
+</div>
+
+{% endblock %}

--- a/backend/benefit/applications/templates/base.html
+++ b/backend/benefit/applications/templates/base.html
@@ -4,7 +4,7 @@
 <html lang="fi">
     <head>
         <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-        <title>Ahjo pdf</title>
+        <title>{% block title %}Ahjo pdf{% endblock %}</title>
         {% include "style.html" %}
     </head>
     <body>

--- a/backend/benefit/applications/templates/footer.html
+++ b/backend/benefit/applications/templates/footer.html
@@ -3,5 +3,5 @@
     <div class="left-column page-printed-at">
         {{ _("Printed at") }} {{ today }}
     </div>
-    <div class="right-column page-count">{{ page }} / {{ total|default:"3" }}</div>
+    <div class="right-column page-count">{{ page }} / {{ total }}</div>
 </footer>

--- a/backend/benefit/applications/templates/footer.html
+++ b/backend/benefit/applications/templates/footer.html
@@ -3,5 +3,5 @@
     <div class="left-column page-printed-at">
         {{ _("Printed at") }} {{ today }}
     </div>
-    <div class="right-column page-count">{{ page }} / 4</div>
+    <div class="right-column page-count">{{ page }} / {{ total }}</div>
 </footer>

--- a/backend/benefit/applications/templates/footer.html
+++ b/backend/benefit/applications/templates/footer.html
@@ -3,5 +3,5 @@
     <div class="left-column page-printed-at">
         {{ _("Printed at") }} {{ today }}
     </div>
-    <div class="right-column page-count">{{ page }} / {{ total }}</div>
+    <div class="right-column page-count">{{ page }} / {{ total|default:"3" }}</div>
 </footer>

--- a/backend/benefit/applications/templates/style.html
+++ b/backend/benefit/applications/templates/style.html
@@ -191,4 +191,23 @@
         font-size: 1em;
         font-weight: 400;
     }
+
+    .two-col-sections {
+        display: table;
+        width: 100%;
+        table-layout: fixed;
+    }
+
+    .two-col-sections section {
+        display: table-cell;
+        width: 50%;
+        vertical-align: top;
+        padding-right: 16px;
+        box-sizing: border-box;
+    }
+
+    .two-col-sections section:last-child {
+        padding-right: 0;
+        padding-left: 16px;
+    }
 </style>

--- a/backend/benefit/applications/tests/test_applications_api.py
+++ b/backend/benefit/applications/tests/test_applications_api.py
@@ -3381,3 +3381,56 @@ def _create_random_applications():
             Calculation.objects.filter(application__id=application.pk).update(
                 modified_at=random_datetime
             )
+
+
+@pytest.mark.django_db
+@mock.patch(
+    "applications.services.generate_application_summary.pdfkit.from_string",
+    return_value=b"%PDF-1.4 fake",
+)
+def test_handler_application_pdf_accepted(
+    mock_pdf, handler_api_client, application_batch
+):
+    application = application_batch.applications.first()
+    url = reverse(
+        "v1:handler-application-application-pdf",
+        kwargs={"pk": application.pk},
+    )
+    response = handler_api_client.get(url)
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/pdf"
+    assert b"%PDF" in response.content
+    mock_pdf.assert_called_once()
+
+
+@pytest.mark.django_db
+@mock.patch(
+    "applications.services.generate_application_summary.pdfkit.from_string",
+    return_value=b"%PDF-1.4 fake",
+)
+def test_handler_application_pdf_rejected(mock_pdf, handler_api_client):
+    batch = ApplicationBatchFactory(
+        proposal_for_decision="rejected",
+        application_1__status="rejected",
+        application_2__status="rejected",
+    )
+    application = batch.applications.first()
+    url = reverse(
+        "v1:handler-application-application-pdf",
+        kwargs={"pk": application.pk},
+    )
+    response = handler_api_client.get(url)
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/pdf"
+    mock_pdf.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_handler_application_pdf_unauthenticated(anonymous_client, application_batch):
+    application = application_batch.applications.first()
+    url = reverse(
+        "v1:handler-application-application-pdf",
+        kwargs={"pk": application.pk},
+    )
+    response = anonymous_client.get(url)
+    assert response.status_code == 403

--- a/backend/benefit/sonar-project.properties
+++ b/backend/benefit/sonar-project.properties
@@ -5,3 +5,4 @@ sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.test.inclusions=**/tests/**/*
 sonar.exclusions=**/migrations/*,helsinkibenefit/templates/emails/**/*
+sonar.cpd.exclusions=**/templates/application_handler.html

--- a/frontend/benefit/handler/browser-tests/pages/1-new-application.testcafe.ts
+++ b/frontend/benefit/handler/browser-tests/pages/1-new-application.testcafe.ts
@@ -124,12 +124,12 @@ test('Fill form and submit', async (t: TestController) => {
   const submitButton = Selector(buttonSelector).withText(
     fi.applications.actions.send
   );
-  await t.expect(submitButton.visible).ok();
+  await t.expect(submitButton.visible).ok({ timeout: 10000 });
   await t.click(submitButton);
 
   // Form submitted, single application view shown
   const handleButton = Selector(buttonSelector).withText(
     fi.review.actions.handle
   );
-  await t.expect(handleButton.visible).ok();
+  await t.expect(handleButton.visible).ok({ timeout: 10000 });
 });

--- a/frontend/benefit/handler/browser-tests/pages/10-talpa-error-handling.testcafe.ts
+++ b/frontend/benefit/handler/browser-tests/pages/10-talpa-error-handling.testcafe.ts
@@ -56,7 +56,7 @@ test('Handler changes Talpa status to waiting', async (t: TestController) => {
   );
 
   await t.expect(applicationRow.exists).ok();
-  await t.expect(errorTag.visible).ok();
+  await t.expect(errorTag.visible).ok({ timeout: 10000 });
   await t.click(errorTag);
 
   await t
@@ -95,7 +95,7 @@ test('Handler changes Talpa status to paid', async (t: TestController) => {
   );
 
   await t.expect(applicationRow.exists).ok();
-  await t.expect(errorTag.visible).ok();
+  await t.expect(errorTag.visible).ok({ timeout: 10000 });
   await t.click(errorTag);
 
   await t
@@ -112,4 +112,3 @@ test('Handler changes Talpa status to paid', async (t: TestController) => {
   await t.click(Selector('a').withText(fi.header.navigation.archive));
   await t.expect(Selector('td').withText(`Saragossa, Milamassa`).visible).ok();
 });
-

--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1093,6 +1093,11 @@
       "saveAndContinue": "Tallenna ja sulje",
       "backToHandling": "Palauta käsittelyyn",
       "handlingPanel": "Käsittelypaneeli",
+      "downloadPdf": "Download application PDF",
+      "downloadPdfError": {
+        "title": "PDF download failed",
+        "message": "Could not generate the application PDF. Please try again."
+      },
       "search": "Hae arkistosta",
       "cancel": "Peruuta hakemus",
       "clone": "Kopioi hakemus",

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1093,6 +1093,11 @@
       "saveAndContinue": "Tallenna ja sulje",
       "backToHandling": "Palauta käsittelyyn",
       "handlingPanel": "Käsittelypaneeli",
+      "downloadPdf": "Lataa hakemus PDF",
+      "downloadPdfError": {
+        "title": "PDF-lataus epäonnistui",
+        "message": "Hakemuksen PDF-tiedostoa ei voitu luoda. Yritä uudelleen."
+      },
       "search": "Hae arkistosta",
       "cancel": "Peruuta hakemus",
       "clone": "Kopioi hakemus",

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1093,6 +1093,11 @@
       "saveAndContinue": "Tallenna ja sulje",
       "backToHandling": "Palauta käsittelyyn",
       "handlingPanel": "Käsittelypaneeli",
+      "downloadPdf": "Ladda ner ansökan PDF",
+      "downloadPdfError": {
+        "title": "PDF-nedladdning misslyckades",
+        "message": "Det gick inte att skapa PDF-filen för ansökan. Försök igen."
+      },
       "search": "Hae arkistosta",
       "cancel": "Peruuta hakemus",
       "clone": "Kopioi hakemus",

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActionsAhjo.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/HandlingApplicationActionsAhjo.tsx
@@ -8,6 +8,7 @@ import {
 } from 'benefit/handler/hooks/applicationHandling/useHandlingStepper';
 import { useRouterNavigation } from 'benefit/handler/hooks/applicationHandling/useRouterNavigation';
 import useCloneApplicationMutation from 'benefit/handler/hooks/useCloneApplicationMutation';
+import useDownloadApplicationPdf from 'benefit/handler/hooks/useDownloadApplicationPdf';
 import useUpdateCompanyIndustryCode from 'benefit/handler/hooks/useUpdateCompanyIndustryCode';
 import { Application as HandlerApplication } from 'benefit/handler/types/application';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
@@ -18,6 +19,7 @@ import {
   IconArrowLeft,
   IconArrowRight,
   IconCopy,
+  IconDownload,
   IconInfoCircle,
   IconLock,
   IconPen,
@@ -360,6 +362,9 @@ const HandlingApplicationActions: React.FC<Props> = ({
   const { data: clonedData, mutate: cloneApplication } =
     useCloneApplicationMutation();
 
+  const { mutate: downloadPdf, isLoading: isDownloadingPdf } =
+    useDownloadApplicationPdf();
+
   React.useEffect(() => {
     if (clonedData?.id) void router.push(`/application?id=${clonedData.id}`);
   }, [clonedData?.id, router]);
@@ -448,6 +453,19 @@ const HandlingApplicationActions: React.FC<Props> = ({
         >
           {t(`${translationsBase}.handlingPanel`)}
         </Button>
+
+        {application.archived && (
+          <Button
+            onClick={() => application.id && downloadPdf(application.id)}
+            disabled={!application.id}
+            theme={ButtonPresetTheme.Black}
+            variant={ButtonVariant.Secondary}
+            iconStart={<IconDownload />}
+            isLoading={isDownloadingPdf}
+          >
+            {t(`${translationsBase}.downloadPdf`)}
+          </Button>
+        )}
 
         {application.status &&
           process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT !== 'production' &&

--- a/frontend/benefit/handler/src/hooks/__tests__/useDownloadApplicationPdf.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useDownloadApplicationPdf.test.ts
@@ -62,11 +62,14 @@ describe('useDownloadApplicationPdf', () => {
   });
 
   it('triggers a file download with the correct filename on success', () => {
+    jest.useFakeTimers();
     const click = jest.fn();
+    const remove = jest.fn();
     const anchorElement = {
       href: '',
       download: '',
       click,
+      remove,
     } as unknown as HTMLAnchorElement;
     const originalCreateElement = document.createElement.bind(document);
     const createElement = jest
@@ -74,6 +77,9 @@ describe('useDownloadApplicationPdf', () => {
       .mockImplementation((tag: string) =>
         tag === 'a' ? anchorElement : originalCreateElement(tag)
       );
+    const appendSpy = jest
+      .spyOn(document.body, 'append')
+      .mockImplementation(() => {});
 
     // JSDOM does not define URL.createObjectURL/revokeObjectURL, so assign directly
     const createObjectURL = jest.fn(() => 'blob:fake-url');
@@ -92,12 +98,19 @@ describe('useDownloadApplicationPdf', () => {
       new Blob([data], { type: 'application/pdf' })
     );
     expect(anchorElement.download).toBe('hakemus_abc-123.pdf');
+    expect(appendSpy).toHaveBeenCalledWith(anchorElement);
     expect(click).toHaveBeenCalled();
+    expect(remove).toHaveBeenCalled();
+
+    // revokeObjectURL is deferred via setTimeout
+    jest.runAllTimers();
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
 
     createElement.mockRestore();
+    appendSpy.mockRestore();
     URL.createObjectURL = originalCreateObjectURL;
     URL.revokeObjectURL = originalRevokeObjectURL;
+    jest.useRealTimers();
   });
 
   it('shows an error toast on failure', () => {

--- a/frontend/benefit/handler/src/hooks/__tests__/useDownloadApplicationPdf.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useDownloadApplicationPdf.test.ts
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom';
+import '../../../test/i18n/i18n-test';
+
+import { renderHook } from '@testing-library/react-hooks';
+import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { useMutation } from 'react-query';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+import useDownloadApplicationPdf from '../useDownloadApplicationPdf';
+
+jest.mock('react-query', () => ({
+  useMutation: jest.fn(),
+}));
+
+jest.mock('shared/hooks/useBackendAPI', () => jest.fn());
+jest.mock('shared/components/toast/show-error-toast', () => jest.fn());
+
+describe('useDownloadApplicationPdf', () => {
+  const handleResponse = jest.fn();
+  const get = jest.fn();
+  const mutationFn = jest.fn();
+
+  let mutationOptions: {
+    onSuccess?: (data: ArrayBuffer, applicationId: string) => void;
+    onError?: () => void;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useBackendAPI as jest.Mock).mockReturnValue({
+      axios: { get },
+      handleResponse,
+    });
+
+    mutationOptions = {};
+
+    (useMutation as jest.Mock).mockImplementation(
+      (_key, passedMutationFn, options) => {
+        mutationFn.mockImplementation(passedMutationFn);
+        mutationOptions = options;
+        return { mutate: jest.fn() };
+      }
+    );
+  });
+
+  it('calls the correct endpoint with arraybuffer responseType', async () => {
+    const getResponse = {};
+    get.mockReturnValue(getResponse);
+    handleResponse.mockResolvedValue(new ArrayBuffer(0));
+
+    renderHook(() => useDownloadApplicationPdf());
+
+    await mutationFn('abc-123');
+
+    expect(get).toHaveBeenCalledWith(
+      HandlerEndpoint.HANDLER_APPLICATION_PDF('abc-123'),
+      { responseType: 'arraybuffer' }
+    );
+    expect(handleResponse).toHaveBeenCalledWith(getResponse);
+  });
+
+  it('triggers a file download with the correct filename on success', () => {
+    const createObjectURL = jest.fn(() => 'blob:fake-url');
+    const revokeObjectURL = jest.fn();
+    const click = jest.fn();
+    const anchorElement = {
+      href: '',
+      download: '',
+      click,
+    } as unknown as HTMLAnchorElement;
+    const originalCreateElement = document.createElement.bind(document);
+    const createElement = jest
+      .spyOn(document, 'createElement')
+      .mockImplementation((tag: string) =>
+        tag === 'a' ? anchorElement : originalCreateElement(tag)
+      );
+
+    global.URL.createObjectURL = createObjectURL;
+    global.URL.revokeObjectURL = revokeObjectURL;
+
+    renderHook(() => useDownloadApplicationPdf());
+
+    const data = new ArrayBuffer(8);
+    mutationOptions.onSuccess?.(data, 'abc-123');
+
+    expect(createObjectURL).toHaveBeenCalledWith(
+      new Blob([data], { type: 'application/pdf' })
+    );
+    expect(anchorElement.download).toBe('hakemus_abc-123.pdf');
+    expect(click).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
+
+    createElement.mockRestore();
+  });
+
+  it('shows an error toast on failure', () => {
+    renderHook(() => useDownloadApplicationPdf());
+
+    mutationOptions.onError?.();
+
+    expect(showErrorToast).toHaveBeenCalled();
+  });
+});

--- a/frontend/benefit/handler/src/hooks/__tests__/useDownloadApplicationPdf.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useDownloadApplicationPdf.test.ts
@@ -62,8 +62,6 @@ describe('useDownloadApplicationPdf', () => {
   });
 
   it('triggers a file download with the correct filename on success', () => {
-    const createObjectURL = jest.fn(() => 'blob:fake-url');
-    const revokeObjectURL = jest.fn();
     const click = jest.fn();
     const anchorElement = {
       href: '',
@@ -77,8 +75,13 @@ describe('useDownloadApplicationPdf', () => {
         tag === 'a' ? anchorElement : originalCreateElement(tag)
       );
 
-    global.URL.createObjectURL = createObjectURL;
-    global.URL.revokeObjectURL = revokeObjectURL;
+    // JSDOM does not define URL.createObjectURL/revokeObjectURL, so assign directly
+    const createObjectURL = jest.fn(() => 'blob:fake-url');
+    const revokeObjectURL = jest.fn();
+    const originalCreateObjectURL = URL.createObjectURL?.bind(URL);
+    const originalRevokeObjectURL = URL.revokeObjectURL?.bind(URL);
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
 
     renderHook(() => useDownloadApplicationPdf());
 
@@ -93,6 +96,8 @@ describe('useDownloadApplicationPdf', () => {
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
 
     createElement.mockRestore();
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
   });
 
   it('shows an error toast on failure', () => {

--- a/frontend/benefit/handler/src/hooks/useDownloadApplicationPdf.ts
+++ b/frontend/benefit/handler/src/hooks/useDownloadApplicationPdf.ts
@@ -1,0 +1,49 @@
+import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { useTranslation } from 'next-i18next';
+import { useMutation, UseMutationResult } from 'react-query';
+import showErrorToast from 'shared/components/toast/show-error-toast';
+import useBackendAPI from 'shared/hooks/useBackendAPI';
+
+type ApplicationID = string;
+
+const useDownloadApplicationPdf = (): UseMutationResult<
+  ArrayBuffer,
+  Error,
+  ApplicationID
+> => {
+  const { axios, handleResponse } = useBackendAPI();
+  const { t } = useTranslation();
+
+  const handleError = (): void => {
+    showErrorToast(
+      t('common:review.actions.downloadPdfError.title'),
+      t('common:review.actions.downloadPdfError.message')
+    );
+  };
+
+  return useMutation<ArrayBuffer, Error, ApplicationID>(
+    'downloadApplicationPdf',
+    (applicationId: ApplicationID) => {
+      const res = axios.get<ArrayBuffer>(
+        HandlerEndpoint.HANDLER_APPLICATION_PDF(applicationId),
+        { responseType: 'arraybuffer' }
+      );
+
+      return handleResponse<ArrayBuffer>(res);
+    },
+    {
+      onSuccess: (data, applicationId) => {
+        const blob = new Blob([data], { type: 'application/pdf' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `hakemus_${applicationId}.pdf`;
+        a.click();
+        URL.revokeObjectURL(url);
+      },
+      onError: () => handleError(),
+    }
+  );
+};
+
+export default useDownloadApplicationPdf;

--- a/frontend/benefit/handler/src/hooks/useDownloadApplicationPdf.ts
+++ b/frontend/benefit/handler/src/hooks/useDownloadApplicationPdf.ts
@@ -36,10 +36,13 @@ const useDownloadApplicationPdf = (): UseMutationResult<
         const blob = new Blob([data], { type: 'application/pdf' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
+        // eslint-disable-next-line scanjs-rules/assign_to_href
         a.href = url;
         a.download = `hakemus_${applicationId}.pdf`;
+        document.body.append(a);
         a.click();
-        URL.revokeObjectURL(url);
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(url), 0);
       },
       onError: () => handleError(),
     }

--- a/frontend/benefit/shared/src/backend-api/backend-api.ts
+++ b/frontend/benefit/shared/src/backend-api/backend-api.ts
@@ -62,8 +62,9 @@ export const HandlerEndpoint = {
     `${handlerInstalmentBase(id)}`,
   HANDLER_CHANGE_EMPLOYER_ASSURANCE: (id: string) =>
     `${handlerApplicationsBase(id)}change_employer_assurance/`,
-  COMPANY_INDUSTRY_CODE: (id: string) =>
-    `/v1/company/${id}/industry_code/`,
+  HANDLER_APPLICATION_PDF: (id: string) =>
+    `${handlerApplicationsBase(id)}application_pdf/`,
+  COMPANY_INDUSTRY_CODE: (id: string) => `/v1/company/${id}/industry_code/`,
 } as const;
 
 const applicationsBase = (id: string): string =>


### PR DESCRIPTION
## Description :sparkles:
PDF report of application for Handler.
PDF report contains all information of the application and it's handling.
Button to download the report is added to applications that are in the arhieve.


## Issues :bug:
Simple pdf generator does no handle cases were page content does not fit to the page.
Pages and page numbering is predefined.
To avoid problems some page use two columns.
Label text that are not in po-files are hardcoded in finish. The handler application is only in finish.
Those label text are only defined frontend JSON files.

## Testing :alembic:
Unit tests for useDownloadApplicationPdf hook.
Covers three cases:
- correct endpoint/responseType,
- file download trigger on success,
- and error toast on failure.
- 
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Download application PDF” for archived handler applications in the review UI.
  * Implemented a new handler PDF download endpoint that generates a multi-page PDF with employer, employment, attachments, and decision details.
* **Localization**
  * Added localized download label and error messaging (EN/FI/SV) for PDF generation/download failures.
* **Tests**
  * Added API and React hook test coverage for the PDF download flow.
  * Improved browser test reliability with longer visibility timeouts.
* **UI/Template Updates**
  * Updated PDF document title and pagination footer to show correct total page counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->