### PR TITLE
feat(ks): disable youth summer voucher creation and updates in admin

### DIFF
--- a/backend/kesaseteli/applications/admin.py
+++ b/backend/kesaseteli/applications/admin.py
@@ -553,6 +553,14 @@ class YouthSummerVoucherAdmin(
     readonly_fields = ["user_showable_serial_number"]
     actions = ["resend_voucher"]
 
+    def has_add_permission(self, request):
+        """Disable add permission."""
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        """Disable change permission."""
+        return False
+
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("youth_application")
 

--- a/backend/kesaseteli/applications/tests/test_youth_summer_voucher_admin.py
+++ b/backend/kesaseteli/applications/tests/test_youth_summer_voucher_admin.py
@@ -159,3 +159,13 @@ def test_serial_number_search(
         request, YouthSummerVoucher.objects.all(), search_term
     )
     assert list(result_qs.values_list("pk", flat=True)) == [voucher.pk]
+
+
+def test_has_add_permission(youth_summer_voucher_admin):
+    request = RequestFactory().get("/")
+    assert youth_summer_voucher_admin.has_add_permission(request) is False
+
+
+def test_has_change_permission(youth_summer_voucher_admin):
+    request = RequestFactory().get("/")
+    assert youth_summer_voucher_admin.has_change_permission(request) is False


### PR DESCRIPTION
YJDH-865.

Disable the add and change permissions for YouthSummerVoucher in the Django admin site. Admins do not need to create or update youth summer vouchers manually, so disabling these permissions prevents accidental modifications and simplifies the admin interface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Summer voucher records are now read-only in the admin interface and can no longer be added or edited.

* **Tests**
  * Added tests to verify admin permission restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->