### PR TITLE
feat(ks): display related summer vouchers inline in admin

### DIFF
--- a/backend/kesaseteli/applications/admin.py
+++ b/backend/kesaseteli/applications/admin.py
@@ -517,9 +517,88 @@ class YouthApplicationAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
         return False
 
 
+class YouthEmployerSummerVoucherInline(admin.TabularInline):
+    """
+    Django Admin Inline View for Employer Summer Vouchers
+
+    Display employer summer vouchers in the YouthSummerVoucher admin view.
+    Shows related employer application and voucher details in a tabular format
+    with links to the respective admin pages.
+
+    Features:
+        - Read-only fields to prevent direct modifications
+        - Links to employer application and voucher admin
+        - Shows key employment information
+        - No add/delete permissions
+    """
+
+    model = EmployerSummerVoucher
+    fk_name = "youth_summer_voucher"
+    verbose_name = _("employer summer voucher")
+    verbose_name_plural = _("employer summer vouchers")
+    extra = 0
+    show_change_link = True
+    can_delete = False
+
+    fields = [
+        "employer_summer_voucher_link",
+        "employer_application_link",
+        "company_name",
+        "employment_start_date",
+        "employment_end_date",
+    ]
+    readonly_fields = fields
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("application", "application__company")
+        )
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def employer_summer_voucher_link(self, obj):
+        if not obj.pk or obj._state.adding:
+            return ""
+        url = reverse(
+            "admin:applications_employersummervoucher_change",
+            args=[obj.pk],
+        )
+        return mark_safe(f'<a href="{url}">{obj.pk}</a>')
+
+    employer_summer_voucher_link.short_description = _("employer summer voucher")
+
+    def employer_application_link(self, obj):
+        if not obj.application or obj._state.adding:
+            return ""
+        url = reverse(
+            "admin:applications_employerapplication_change",
+            args=[obj.application.pk],
+        )
+        return mark_safe(f'<a href="{url}">{obj.application.pk}</a>')
+
+    employer_application_link.short_description = _("employer application")
+
+    def company_name(self, obj):
+        if not obj.application or not obj.application.company:
+            return ""
+        return obj.application.company.name
+
+    company_name.short_description = _("company")
+
+
 class YouthSummerVoucherAdmin(
     AuditlogAdminViewAccessLogMixin, SerialNumberDecodingSearchMixin, admin.ModelAdmin
 ):
+    inlines = [YouthEmployerSummerVoucherInline]
     list_display = [
         "id",
         "summer_voucher_serial_number",
@@ -562,7 +641,16 @@ class YouthSummerVoucherAdmin(
         return False
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related("youth_application")
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("youth_application")
+            .prefetch_related(
+                "employer_summer_vouchers",
+                "employer_summer_vouchers__application",
+                "employer_summer_vouchers__application__company",
+            )
+        )
 
     def target_group_display(self, obj):
         return obj.get_target_group_display()
@@ -627,7 +715,84 @@ class YouthSummerVoucherAdmin(
             )
 
 
+class EmployerSummerVoucherInline(admin.TabularInline):
+    """
+    Django Admin Inline View for Employer Summer Vouchers.
+
+    Display employer summer vouchers in the EmployerApplication admin view.
+    Shows related youth summer voucher and employee details in a tabular format
+    with links to the respective admin pages.
+
+    Features:
+        - Read-only fields to prevent direct modifications
+        - Links to youth summer voucher and employer summer voucher admin
+        - Shows key employee information
+        - No add, change, or delete permissions
+    """
+
+    model = EmployerSummerVoucher
+    verbose_name = _("employer summer voucher")
+    verbose_name_plural = _("employer summer vouchers")
+    extra = 0
+    show_change_link = True
+    can_delete = False
+
+    fields = [
+        "employer_summer_voucher_link",
+        "youth_summer_voucher_link",
+        "employee_name",
+        "employee_ssn_display",
+        "employee_school",
+    ]
+    readonly_fields = fields
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("youth_summer_voucher__youth_application")
+        )
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def employer_summer_voucher_link(self, obj):
+        if not obj.pk or obj._state.adding:
+            return ""
+        url = reverse(
+            "admin:applications_employersummervoucher_change",
+            args=[obj.pk],
+        )
+        return mark_safe(f'<a href="{url}">{obj.pk}</a>')
+
+    employer_summer_voucher_link.short_description = _("employer summer voucher")
+
+    def youth_summer_voucher_link(self, obj):
+        if obj._state.adding or not obj.youth_summer_voucher:
+            return ""
+        url = reverse(
+            "admin:applications_youthsummervoucher_change",
+            args=[obj.youth_summer_voucher.pk],
+        )
+        serial = obj.youth_summer_voucher.user_showable_serial_number
+        return mark_safe(f'<a href="{url}">{serial}</a>')
+
+    youth_summer_voucher_link.short_description = _("youth summer voucher")
+
+    def employee_ssn_display(self, obj):
+        return mask_social_security_number(obj.employee_ssn)
+
+    employee_ssn_display.short_description = _("employee social security number")
+
+
 class EmployerApplicationAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
+    inlines = [EmployerSummerVoucherInline]
     list_display = [
         "id",
         "company__name",
@@ -739,8 +904,12 @@ class EmployerApplicationAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin
         return (
             super()
             .get_queryset(request)
-            .select_related("company")
-            .select_related("user")
+            .select_related("company", "user")
+            .prefetch_related(
+                "summer_vouchers",
+                "summer_vouchers__youth_summer_voucher",
+                "summer_vouchers__youth_summer_voucher__youth_application",
+            )
         )
 
 

--- a/backend/kesaseteli/applications/tests/test_employer_application_admin.py
+++ b/backend/kesaseteli/applications/tests/test_employer_application_admin.py
@@ -1,0 +1,69 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from applications.admin import (
+    EmployerApplicationAdmin,
+    EmployerSummerVoucherInline,
+)
+from applications.models import EmployerApplication, EmployerSummerVoucher
+from common.tests.factories import EmployerSummerVoucherFactory
+
+
+@pytest.fixture
+def employer_application_admin():
+    return EmployerApplicationAdmin(EmployerApplication, AdminSite())
+
+
+@pytest.mark.django_db
+def test_employer_summer_voucher_inline_defined(employer_application_admin):
+    # Check that EmployerSummerVoucherInline is registered in inlines
+    assert EmployerSummerVoucherInline in employer_application_admin.inlines
+
+
+@pytest.mark.django_db
+def test_employer_summer_voucher_inline_permissions():
+    inline = EmployerSummerVoucherInline(EmployerSummerVoucher, AdminSite())
+
+    User = get_user_model()  # noqa: N806
+
+    # Normal user request
+    request = RequestFactory().get("/")
+    request.user = User(is_superuser=False)
+    assert not inline.has_add_permission(request)
+    assert not inline.has_change_permission(request)
+    assert not inline.has_delete_permission(request)
+
+    # Superuser request
+    request_su = RequestFactory().get("/")
+    request_su.user = User(is_superuser=True)
+    assert not inline.has_delete_permission(request_su)
+
+
+@pytest.mark.django_db
+def test_employer_summer_voucher_inline_links():
+    inline = EmployerSummerVoucherInline(EmployerSummerVoucher, AdminSite())
+
+    # Create a test voucher with related youth voucher
+    voucher = EmployerSummerVoucherFactory()
+
+    # Test link for employer summer voucher
+    emp_link = inline.employer_summer_voucher_link(voucher)
+    assert f"/{voucher.pk}/change/" in emp_link
+    assert str(voucher.pk) in emp_link
+
+    # Test link for youth summer voucher
+    youth_link = inline.youth_summer_voucher_link(voucher)
+    assert f"/{voucher.youth_summer_voucher.pk}/change/" in youth_link
+    assert voucher.youth_summer_voucher.user_showable_serial_number in youth_link
+
+
+@pytest.mark.django_db
+def test_employer_summer_voucher_inline_links_none_cases():
+    inline = EmployerSummerVoucherInline(EmployerSummerVoucher, AdminSite())
+
+    # Unsaved voucher
+    unsaved_voucher = EmployerSummerVoucher()
+    assert inline.employer_summer_voucher_link(unsaved_voucher) == ""
+    assert inline.youth_summer_voucher_link(unsaved_voucher) == ""

--- a/backend/kesaseteli/applications/tests/test_youth_summer_voucher_admin.py
+++ b/backend/kesaseteli/applications/tests/test_youth_summer_voucher_admin.py
@@ -7,9 +7,12 @@ from django.core import mail
 from django.test import RequestFactory
 from django.urls import reverse
 
-from applications.admin import YouthSummerVoucherAdmin
+from applications.admin import YouthEmployerSummerVoucherInline, YouthSummerVoucherAdmin
 from applications.models import YouthSummerVoucher
-from common.tests.factories import YouthSummerVoucherFactory
+from common.tests.factories import (
+    EmployerSummerVoucherFactory,
+    YouthSummerVoucherFactory,
+)
 
 
 @pytest.fixture
@@ -169,3 +172,37 @@ def test_has_add_permission(youth_summer_voucher_admin):
 def test_has_change_permission(youth_summer_voucher_admin):
     request = RequestFactory().get("/")
     assert youth_summer_voucher_admin.has_change_permission(request) is False
+
+
+@pytest.mark.django_db
+def test_youth_employer_summer_voucher_inline_defined(youth_summer_voucher_admin):
+    assert YouthEmployerSummerVoucherInline in youth_summer_voucher_admin.inlines
+
+
+@pytest.mark.django_db
+def test_youth_employer_summer_voucher_inline_permissions():
+    inline = YouthEmployerSummerVoucherInline(YouthSummerVoucher, AdminSite())
+    request = RequestFactory().get("/")
+    assert not inline.has_add_permission(request)
+    assert not inline.has_change_permission(request)
+    assert not inline.has_delete_permission(request)
+
+
+@pytest.mark.django_db
+def test_youth_employer_summer_voucher_inline_links():
+    inline = YouthEmployerSummerVoucherInline(YouthSummerVoucher, AdminSite())
+
+    # Create a test employer summer voucher
+    voucher = EmployerSummerVoucherFactory()
+
+    # Test link for employer summer voucher
+    emp_link = inline.employer_summer_voucher_link(voucher)
+    assert f"/{voucher.pk}/change/" in emp_link
+
+    # Test link for employer application
+    app_link = inline.employer_application_link(voucher)
+    assert f"/{voucher.application.pk}/change/" in app_link
+
+    # Test company name display
+    comp_name = inline.company_name(voucher)
+    assert comp_name == voucher.application.company.name


### PR DESCRIPTION
YJDH-884.

Simplify administration and improve usability of the admin site. Because YouthSummerVoucher heavily relies on YouthApplication and EmployerSummerVoucher, and EmployerSummerVoucher heavily relies on EmployerApplication and YouthSummerVoucher, showing these relations directly inside the admin inline views makes it significantly easier to track and inspect associated entities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only inline admin views showing employer↔youth summer voucher relationships, linked application and company info, admin links to related records, and masked employee SSN.
  * Admin list/detail views now pre-load related voucher and application data for smoother inline rendering.

* **Tests**
  * Added tests for inline registration, read-only permissions, admin link generation, and unsaved/empty-object cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->