### PR TITLE
YJDH-810 | Update all backends to django-resilient-logger v2.3.0

### DIFF
--- a/backend/benefit/requirements.txt
+++ b/backend/benefit/requirements.txt
@@ -104,7 +104,7 @@ django-logger-extra==1.1.2
     # via -r requirements.in
 django-phonenumber-field==8.3.0
     # via -r requirements.in
-django-resilient-logger==1.2.0
+django-resilient-logger==2.3.0
     # via -r requirements.in
 django-searchable-encrypted-fields==0.2.1
     # via -r requirements.in

--- a/backend/kesaseteli/kesaseteli/log_targets.py
+++ b/backend/kesaseteli/kesaseteli/log_targets.py
@@ -1,7 +1,9 @@
 import logging
 
-from resilient_logger.sources.django_audit_log_source import DjangoAuditLogSource
-from resilient_logger.sources.resilient_log_source import ResilientLogSource
+from resilient_logger.sources.django_audit_log_source_entry import (
+    DjangoAuditLogSourceEntry,
+)
+from resilient_logger.sources.resilient_log_source_entry import ResilientLogSourceEntry
 from resilient_logger.targets.elasticsearch_log_target import ElasticsearchLogTarget
 
 logger = logging.getLogger(__name__)
@@ -38,9 +40,9 @@ class RoutedElasticsearchLogTarget(ElasticsearchLogTarget):
             bool: True if the log entry was submitted successfully, False otherwise.
         """
         # Dynamically switch the index based on the source class type
-        if isinstance(entry, ResilientLogSource):
+        if isinstance(entry, ResilientLogSourceEntry):
             self._index = self._resilient_index
-        elif isinstance(entry, DjangoAuditLogSource):
+        elif isinstance(entry, DjangoAuditLogSourceEntry):
             self._index = self._auditlog_index
         else:
             logger.warning(

--- a/backend/kesaseteli/kesaseteli/tests/test_routed_log_target.py
+++ b/backend/kesaseteli/kesaseteli/tests/test_routed_log_target.py
@@ -1,7 +1,9 @@
 from unittest import mock
 
-from resilient_logger.sources.django_audit_log_source import DjangoAuditLogSource
-from resilient_logger.sources.resilient_log_source import ResilientLogSource
+from resilient_logger.sources.django_audit_log_source_entry import (
+    DjangoAuditLogSourceEntry,
+)
+from resilient_logger.sources.resilient_log_source_entry import ResilientLogSourceEntry
 
 from kesaseteli.log_targets import RoutedElasticsearchLogTarget
 
@@ -19,8 +21,8 @@ def test_routed_elasticsearch_log_target_routes_correctly(mock_es):
     mock_client = mock_es.return_value
     mock_client.index.return_value = {"result": "created"}
 
-    # 1. ResilientLogSource -> resilient-index-name
-    resilient_entry = mock.Mock(spec=ResilientLogSource)
+    # 1. ResilientLogSourceEntry -> resilient-index-name
+    resilient_entry = mock.Mock(spec=ResilientLogSourceEntry)
     resilient_entry.get_document.return_value = {"audit_event": {"message": "auth log"}}
 
     success = target.submit(resilient_entry)
@@ -32,8 +34,8 @@ def test_routed_elasticsearch_log_target_routes_correctly(mock_es):
         op_type="create",
     )
 
-    # 2. DjangoAuditLogSource -> auditlog-index-name
-    audit_entry = mock.Mock(spec=DjangoAuditLogSource)
+    # 2. DjangoAuditLogSourceEntry -> auditlog-index-name
+    audit_entry = mock.Mock(spec=DjangoAuditLogSourceEntry)
     audit_entry.get_document.return_value = {"audit_event": {"message": "audit log"}}
 
     success = target.submit(audit_entry)

--- a/backend/kesaseteli/requirements.txt
+++ b/backend/kesaseteli/requirements.txt
@@ -85,7 +85,7 @@ drf-spectacular==0.29.0
     # via -r requirements.in
 django-localflavor==5.0
     # via -r requirements.in
-django-resilient-logger==2.1.0
+django-resilient-logger==2.3.0
     # via -r requirements.in
 django-searchable-encrypted-fields==0.2.1
     # via -r requirements.in

--- a/backend/shared/shared/audit_log/audit_logging.py
+++ b/backend/shared/shared/audit_log/audit_logging.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ImproperlyConfigured
 import logging
 from datetime import datetime, timezone
 from typing import Callable, Optional, Union
@@ -6,16 +5,13 @@ from typing import Callable, Optional, Union
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
 from django.db.models.base import ModelBase
-
-try:
-    from resilient_logger.sources.resilient_log_source import (
-        ResilientLogSource,
-        StructuredResilientLogEntryData,
-    )
-except ImportError:
-    pass
+from resilient_logger.sources.resilient_log_source import (
+    ResilientLogSource,
+    StructuredResilientLogEntryData,
+)
 
 from shared.audit_log.enums import Operation, Role, Status
 from shared.audit_log.mappings import DJANGO_BACKEND_MAPPING

--- a/backend/shared/shared/audit_log/tests/test_resilient_audit_logging.py
+++ b/backend/shared/shared/audit_log/tests/test_resilient_audit_logging.py
@@ -2,28 +2,17 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
+from resilient_logger.models import ResilientLogEntry
+from resilient_logger.sources.resilient_log_source_entry import ResilientLogSourceEntry
 
 from shared.audit_log import audit_logging
 from shared.audit_log.enums import Operation, Status
 
-try:
-    from resilient_logger.models import ResilientLogEntry
-    from resilient_logger.sources import ResilientLogSource
-
-    LOGGER_IMPORTED = True
-except ImportError:
-    LOGGER_IMPORTED = False
-
-resilient_logger_configured = pytest.mark.skipif(
-    not LOGGER_IMPORTED, reason="Resilient logger not available"
-)
-
 
 @pytest.fixture(autouse=True)
 def set_resilient_settings(settings):
-    if LOGGER_IMPORTED:
-        settings.RESILIENT_LOGGER["origin"] = "yjdh-test"
-        settings.RESILIENT_LOGGER["environment"] = "unittesting"
+    settings.RESILIENT_LOGGER["origin"] = "yjdh-test"
+    settings.RESILIENT_LOGGER["environment"] = "unittesting"
 
 
 FIXED_TIMESTAMP = "2020-06-01T00:00:00.000Z"
@@ -51,7 +40,6 @@ _common_fields = {
 }
 
 
-@resilient_logger_configured
 @pytest.mark.freeze_time(FIXED_TIMESTAMP)
 @pytest.mark.django_db
 @pytest.mark.parametrize("operation", list(Operation))
@@ -59,7 +47,7 @@ def test_log_owner_operation(user, operation):
     audit_logging.log(user, "", operation, user, ip_address="192.168.1.1")
 
     log_entry = ResilientLogEntry.objects.first()
-    document = ResilientLogSource(log_entry).get_document()
+    document = ResilientLogSourceEntry(log_entry).get_document()
 
     assert document == {
         **_common_fields,
@@ -80,7 +68,6 @@ def test_log_owner_operation(user, operation):
     }
 
 
-@resilient_logger_configured
 @pytest.mark.freeze_time(FIXED_TIMESTAMP)
 @pytest.mark.django_db
 def test_log_anonymous_role(user):
@@ -89,7 +76,7 @@ def test_log_anonymous_role(user):
     )
 
     log_entry = ResilientLogEntry.objects.first()
-    document = ResilientLogSource(log_entry).get_document()
+    document = ResilientLogSourceEntry(log_entry).get_document()
 
     assert document == {
         **_common_fields,
@@ -109,14 +96,13 @@ def test_log_anonymous_role(user):
     }
 
 
-@resilient_logger_configured
 @pytest.mark.freeze_time(FIXED_TIMESTAMP)
 @pytest.mark.django_db
 def test_log_user_role(user, other_user):
     audit_logging.log(user, "", Operation.READ, other_user, ip_address="192.168.1.1")
 
     log_entry = ResilientLogEntry.objects.first()
-    document = ResilientLogSource(log_entry).get_document()
+    document = ResilientLogSourceEntry(log_entry).get_document()
 
     assert document == {
         **_common_fields,
@@ -133,7 +119,6 @@ def test_log_user_role(user, other_user):
     }
 
 
-@resilient_logger_configured
 @pytest.mark.freeze_time(FIXED_TIMESTAMP)
 @pytest.mark.django_db
 @pytest.mark.parametrize("operation", list(Operation))
@@ -141,7 +126,7 @@ def test_log_system_operation(user, operation):
     audit_logging.log(None, "", operation, user, ip_address="192.168.1.1")
 
     log_entry = ResilientLogEntry.objects.first()
-    document = ResilientLogSource(log_entry).get_document()
+    document = ResilientLogSourceEntry(log_entry).get_document()
 
     assert document == {
         **_common_fields,
@@ -162,7 +147,6 @@ def test_log_system_operation(user, operation):
     }
 
 
-@resilient_logger_configured
 @pytest.mark.freeze_time(FIXED_TIMESTAMP)
 @pytest.mark.django_db
 @pytest.mark.parametrize("status", list(Status))
@@ -170,7 +154,7 @@ def test_log_status(user, status):
     audit_logging.log(user, "", Operation.READ, user, status, ip_address="192.168.1.1")
 
     log_entry = ResilientLogEntry.objects.first()
-    document = ResilientLogSource(log_entry).get_document()
+    document = ResilientLogSourceEntry(log_entry).get_document()
 
     assert document == {
         **_common_fields,
@@ -191,18 +175,16 @@ def test_log_status(user, status):
     }
 
 
-@resilient_logger_configured
 @pytest.mark.freeze_time(FIXED_TIMESTAMP)
 @pytest.mark.django_db
 def test_log_origin(user):
     audit_logging.log(user, "", Operation.READ, user, ip_address="192.168.1.1")
 
     log_entry = ResilientLogEntry.objects.first()
-    document = ResilientLogSource(log_entry).get_document()
+    document = ResilientLogSourceEntry(log_entry).get_document()
     assert document["audit_event"]["origin"] == "yjdh-test"
 
 
-@resilient_logger_configured
 @pytest.mark.django_db
 def test_log_current_timestamp(user):
     tolerance = timedelta(seconds=1)
@@ -211,7 +193,7 @@ def test_log_current_timestamp(user):
     date_after_logging = datetime.now(tz=timezone.utc) + tolerance
 
     log_entry = ResilientLogEntry.objects.first()
-    document = ResilientLogSource(log_entry).get_document()
+    document = ResilientLogSourceEntry(log_entry).get_document()
 
     logged_date_from_date_time = datetime.strptime(
         document["audit_event"]["date_time"], "%Y-%m-%dT%H:%M:%S.%f%z"
@@ -219,7 +201,6 @@ def test_log_current_timestamp(user):
     assert date_before_logging <= logged_date_from_date_time <= date_after_logging
 
 
-@resilient_logger_configured
 @pytest.mark.django_db
 def test_log_additional_information(user):
     audit_logging.log(
@@ -231,12 +212,11 @@ def test_log_additional_information(user):
     )
 
     log_entry = ResilientLogEntry.objects.first()
-    document = ResilientLogSource(log_entry).get_document()
+    document = ResilientLogSourceEntry(log_entry).get_document()
 
     assert document["audit_event"]["extra"]["additional_information"] == "test"
 
 
-@resilient_logger_configured
 @pytest.mark.freeze_time(FIXED_TIMESTAMP)
 @pytest.mark.django_db
 def test_log_user_with_backend(user):
@@ -249,7 +229,7 @@ def test_log_user_with_backend(user):
     )
 
     log_entry = ResilientLogEntry.objects.first()
-    document = ResilientLogSource(log_entry).get_document()
+    document = ResilientLogSourceEntry(log_entry).get_document()
 
     assert document == {
         **_common_fields,


### PR DESCRIPTION
## Description :sparkles:

### Update all backends to django-resilient-logger v2.3.0

Update relevant tests to work with django-resilient-logger v2.3.0, see related PR:
- "feat: split log source into repository and entrypoint"
  - https://github.com/City-of-Helsinki/django-resilient-logger/pull/43

Make django-resilient-logger mandatory in shared backend tests, as now all backends (kesaseteli and benefit) both use it, to reduce unnecessary code complexity and add bit of clarity.

## Related

[YJDH-810](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-810)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-810]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `django-resilient-logger` dependency across backend modules (versions 1.2.0 and 2.1.0 → 2.3.0)
  * Refined logging infrastructure configuration handling

* **Tests**
  * Updated test suite to reflect logging system changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->