### PR TITLE
YJDH-810 | Kesäseteli backend: Update dependencies to latest

### DIFF
--- a/backend/kesaseteli/requirements-dev.txt
+++ b/backend/kesaseteli/requirements-dev.txt
@@ -20,13 +20,13 @@ click==8.4.1
     # via pip-tools
 coverage[toml]==7.14.1
     # via pytest-cov
-distlib==0.4.2
+distlib==0.4.3
     # via virtualenv
 et-xmlfile==2.0.0
     # via openpyxl
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.29.1
+filelock==3.29.4
     # via
     #   python-discovery
     #   virtualenv
@@ -77,7 +77,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==9.0.3
+pytest==9.1.0
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -96,10 +96,12 @@ python-dateutil==2.9.0.post0
     # via
     #   -c requirements.txt
     #   freezegun
-python-discovery==1.4.0
+python-discovery==1.4.2
     # via virtualenv
 pyyaml==6.0.3
-    # via pre-commit
+    # via
+    #   -c requirements.txt
+    #   pre-commit
 requests==2.34.2
     # via
     #   -c requirements.txt
@@ -115,7 +117,7 @@ urllib3==2.7.0
     # via
     #   -c requirements.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.5.0
     # via pre-commit
 werkzeug==3.1.8
     # via -r requirements-dev.in

--- a/backend/kesaseteli/requirements.in
+++ b/backend/kesaseteli/requirements.in
@@ -1,5 +1,5 @@
 -e file:../shared
-base32-lib@https://github.com/inveniosoftware/base32-lib/archive/254311bba7aaa7e5b9e0e364adfdb7c057e252d2.zip
+base32-lib@https://github.com/inveniosoftware/base32-lib/archive/bf1b3b188660eecb127031f6d5db1c877b6ab127.zip
 django-auditlog
 django-auditlog-extra@https://github.com/City-of-Helsinki/django-auditlog-extra/archive/64476c69a68023f78e423be466ac16723b1c8b92.zip
 django-resilient-logger

--- a/backend/kesaseteli/requirements.txt
+++ b/backend/kesaseteli/requirements.txt
@@ -12,13 +12,17 @@ asgiref==3.11.1
     #   django-cors-headers
 asttokens==3.0.1
     # via stack-data
+attrs==26.1.0
+    # via
+    #   jsonschema
+    #   referencing
 azure-core==1.41.0
     # via
     #   azure-storage-blob
     #   django-storages
 azure-storage-blob==12.30.0
     # via django-storages
-base32-lib @ https://github.com/inveniosoftware/base32-lib/archive/254311bba7aaa7e5b9e0e364adfdb7c057e252d2.zip
+base32-lib @ https://github.com/inveniosoftware/base32-lib/archive/bf1b3b188660eecb127031f6d5db1c877b6ab127.zip
     # via -r requirements.in
 certifi==2026.5.20
     # via
@@ -42,8 +46,6 @@ defusedxml==0.7.1
     # via
     #   djangosaml2
     #   pysaml2
-attrs==25.4.0
-    # via jsonschema
 django==5.2.15
     # via
     #   -r requirements.in
@@ -59,6 +61,7 @@ django==5.2.15
     #   django-storages
     #   djangorestframework
     #   djangosaml2
+    #   drf-spectacular
     #   mozilla-django-oidc
     #   yjdh-backend-shared
 django-auditlog==3.4.1
@@ -81,8 +84,6 @@ django-extensions==4.1
     #   yjdh-backend-shared
 django-filter==25.2
     # via -r requirements.in
-drf-spectacular==0.29.0
-    # via -r requirements.in
 django-localflavor==5.0
     # via -r requirements.in
 django-resilient-logger==2.3.0
@@ -92,27 +93,31 @@ django-searchable-encrypted-fields==0.2.1
 django-storages[azure]==1.14.6
     # via -r requirements.in
 djangorestframework==3.17.1
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   drf-spectacular
 djangosaml2==1.12.0
     # via yjdh-backend-shared
+drf-spectacular==0.29.0
+    # via -r requirements.in
 elastic-transport==8.17.1
     # via elasticsearch8
 elasticsearch8==8.19.3
     # via django-resilient-logger
-inflection==0.5.1
-    # via drf-spectacular
 elementpath==4.8.0
     # via xmlschema
 executing==2.2.1
     # via stack-data
 factory-boy==3.3.3
     # via -r requirements.in
-faker==40.21.0
+faker==40.23.0
     # via factory-boy
 filetype==1.2.0
     # via -r requirements.in
 idna==3.18
     # via requests
+inflection==0.5.1
+    # via drf-spectacular
 ipython==9.14.1
     # via -r requirements.in
 ipython-pygments-lexers==1.1.1
@@ -123,7 +128,7 @@ jedi==0.20.0
     # via ipython
 jsonpath-ng==1.8.0
     # via -r requirements.in
-jsonschema==4.25.1
+jsonschema==4.26.0
     # via drf-spectacular
 jsonschema-specifications==2025.9.1
     # via jsonschema
@@ -155,8 +160,6 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==3.0
     # via cffi
-pyyaml==6.0.3
-    # via drf-spectacular
 pycryptodome==3.23.0
     # via django-searchable-encrypted-fields
 pygments==2.20.0
@@ -180,6 +183,8 @@ python-stdnum==2.2
     # via
     #   -r requirements.in
     #   django-localflavor
+pyyaml==6.0.3
+    # via drf-spectacular
 referencing==0.37.0
     # via
     #   jsonschema
@@ -191,6 +196,10 @@ requests==2.34.2
     #   django-auth-adfs
     #   mozilla-django-oidc
     #   pysaml2
+rpds-py==2026.5.1
+    # via
+    #   jsonschema
+    #   referencing
 sentry-sdk==2.62.0
     # via -r requirements.in
 six==1.17.0
@@ -208,14 +217,7 @@ typing-extensions==4.15.0
     #   azure-core
     #   azure-storage-blob
     #   elasticsearch8
-    #   drf-spectacular
-    #   jsonschema
-    #   referencing
-    #   urllib3
     #   psycopg
-rpds-py==0.29.0
-    # via
-    #   jsonschema
     #   referencing
 uritemplate==4.2.0
     # via drf-spectacular


### PR DESCRIPTION
## Description :sparkles:

### Kesäseteli backend: Update dependencies to latest

Used the README.md instructions with pip-compile in Kesäseteli backend Docker container to upgrade the dependencies to latest and manually upgraded hardcoded commit hash based dependencies to latest commit hashes available.

Looked at the changes made to base32-lib between the old and new commit hash and it looks safe, see
https://github.com/inveniosoftware/base32-lib/compare/254311bba7aaa7e5b9e0e364adfdb7c057e252d2...bf1b3b188660eecb127031f6d5db1c877b6ab127

Django stays at 5.2 as it is the latest LTS version.

## Related

[YJDH-810](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-810)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-810]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated development dependencies including pytest, virtualenv, distlib, filelock, and python-discovery to newer versions.
- Updated production dependencies including attrs, jsonschema, faker, and rpds-py to newer versions.
- Updated base32-lib dependency source reference to a new archive revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->