### PR TITLE
feat(ks): add csp middleware

### DIFF
--- a/backend/kesaseteli/applications/tests/test_csp.py
+++ b/backend/kesaseteli/applications/tests/test_csp.py
@@ -7,6 +7,7 @@ from applications.models import EmailTemplate
 
 
 def assert_expected_csp(response):
+    """Assert the global Kesäseteli backend CSP directives on a response."""
     assert "Content-Security-Policy" in response.headers, "CSP header missing from response"
     csp_header = response.headers["Content-Security-Policy"]
     assert "default-src 'self'" in csp_header

--- a/backend/kesaseteli/applications/tests/test_csp.py
+++ b/backend/kesaseteli/applications/tests/test_csp.py
@@ -35,9 +35,9 @@ def test_excel_download_includes_bootstrap_csp(staff_client):
     response = staff_client.get(reverse("excel-download"))
     assert response.status_code == 200
     assert_expected_csp(response)
-    assert "connect-src 'self' cdn.jsdelivr.net" in response.headers[
-        "Content-Security-Policy"
-    ]
+    csp_header = response.headers["Content-Security-Policy"]
+    assert "style-src 'self' 'unsafe-inline' cdn.jsdelivr.net" in csp_header
+    assert "connect-src" not in csp_header
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/applications/tests/test_csp.py
+++ b/backend/kesaseteli/applications/tests/test_csp.py
@@ -26,6 +26,20 @@ def assert_expected_csp(response):
 
 @pytest.mark.django_db
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_admin_index_includes_inline_script_csp(admin_client):
+    """Check admin pages allow inline scripts required by Django admin.
+
+    Args:
+        admin_client: Logged-in admin user client.
+    """
+    response = admin_client.get(reverse("admin:index"))
+    assert response.status_code == 200
+    assert_expected_csp(response)
+    assert "script-src 'self' 'unsafe-inline'" in response.headers["Content-Security-Policy"]
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_excel_download_includes_bootstrap_csp(staff_client):
     """Check excel-download allows the Bootstrap CDN in CSP.
 

--- a/backend/kesaseteli/applications/tests/test_csp.py
+++ b/backend/kesaseteli/applications/tests/test_csp.py
@@ -1,3 +1,8 @@
+"""Tests for CSP headers on application HTML pages.
+
+Checks the excel-download page and other pages that use the global policy.
+"""
+
 import pytest
 from django.urls import reverse
 from django.test import override_settings
@@ -7,7 +12,11 @@ from applications.models import EmailTemplate
 
 
 def assert_expected_csp(response):
-    """Assert the global Kesäseteli backend CSP directives on a response."""
+    """Check that a response has the global backend CSP rules.
+
+    Args:
+        response: Page response to check.
+    """
     assert "Content-Security-Policy" in response.headers, "CSP header missing from response"
     csp_header = response.headers["Content-Security-Policy"]
     assert "default-src 'self'" in csp_header
@@ -17,11 +26,28 @@ def assert_expected_csp(response):
 
 @pytest.mark.django_db
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
-def test_application_pages_include_expected_csp(staff_client, admin_client):
+def test_excel_download_includes_bootstrap_csp(staff_client):
+    """Check excel-download allows the Bootstrap CDN in CSP.
+
+    Args:
+        staff_client: Logged-in staff user client.
+    """
     response = staff_client.get(reverse("excel-download"))
     assert response.status_code == 200
     assert_expected_csp(response)
+    assert "connect-src 'self' cdn.jsdelivr.net" in response.headers[
+        "Content-Security-Policy"
+    ]
 
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_email_template_preview_uses_global_csp_only(admin_client):
+    """Check admin email preview does not allow the Bootstrap CDN in CSP.
+
+    Args:
+        admin_client: Logged-in admin user client.
+    """
     template = EmailTemplate.objects.get(
         type=EmailTemplateType.PROCESSING,
         language="fi",
@@ -31,3 +57,4 @@ def test_application_pages_include_expected_csp(staff_client, admin_client):
     )
     assert response.status_code == 200
     assert_expected_csp(response)
+    assert "cdn.jsdelivr.net" not in response.headers["Content-Security-Policy"]

--- a/backend/kesaseteli/applications/tests/test_csp.py
+++ b/backend/kesaseteli/applications/tests/test_csp.py
@@ -7,9 +7,11 @@ from applications.models import EmailTemplate
 
 
 def assert_expected_csp(response):
+    assert "Content-Security-Policy" in response.headers, "CSP header missing from response"
     csp_header = response.headers["Content-Security-Policy"]
     assert "default-src 'self'" in csp_header
-    assert "style-src 'self' 'unsafe-inline' cdn.jsdelivr.net" in csp_header
+    assert "style-src 'self' 'unsafe-inline'" in csp_header
+    assert "img-src 'self' data:" in csp_header
 
 
 @pytest.mark.django_db

--- a/backend/kesaseteli/applications/tests/test_csp.py
+++ b/backend/kesaseteli/applications/tests/test_csp.py
@@ -1,0 +1,30 @@
+import pytest
+from django.urls import reverse
+from django.test import override_settings
+
+from applications.enums import EmailTemplateType
+from applications.models import EmailTemplate
+
+
+def assert_expected_csp(response):
+    csp_header = response.headers["Content-Security-Policy"]
+    assert "default-src 'self'" in csp_header
+    assert "style-src 'self' 'unsafe-inline' cdn.jsdelivr.net" in csp_header
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_application_pages_include_expected_csp(staff_client, admin_client):
+    response = staff_client.get(reverse("excel-download"))
+    assert response.status_code == 200
+    assert_expected_csp(response)
+
+    template = EmailTemplate.objects.get(
+        type=EmailTemplateType.PROCESSING,
+        language="fi",
+    )
+    response = admin_client.get(
+        reverse("admin:applications_emailtemplate_preview", kwargs={"object_id": template.pk})
+    )
+    assert response.status_code == 200
+    assert_expected_csp(response)

--- a/backend/kesaseteli/applications/tests/test_permissions_policy.py
+++ b/backend/kesaseteli/applications/tests/test_permissions_policy.py
@@ -1,0 +1,31 @@
+"""Tests for Permissions-Policy on application admin HTML pages."""
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+
+from applications.enums import EmailTemplateType
+from applications.models import EmailTemplate
+from common.middleware import PERMISSIONS_POLICY
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_email_template_preview_includes_permissions_policy(admin_client):
+    """Check admin email preview sends the Permissions-Policy header.
+
+    Args:
+        admin_client: Logged-in admin user client.
+    """
+    template = EmailTemplate.objects.get(
+        type=EmailTemplateType.PROCESSING,
+        language="fi",
+    )
+    response = admin_client.get(
+        reverse(
+            "admin:applications_emailtemplate_preview",
+            kwargs={"object_id": template.pk},
+        )
+    )
+    assert response.status_code == 200
+    assert response.headers["Permissions-Policy"] == PERMISSIONS_POLICY

--- a/backend/kesaseteli/applications/views.py
+++ b/backend/kesaseteli/applications/views.py
@@ -1,6 +1,5 @@
 """Django views for handler-facing HTML pages in the applications app."""
 
-from csp.constants import SELF
 from csp.decorators import csp_update
 from django.utils.decorators import method_decorator
 from django.views.generic.base import TemplateView
@@ -15,7 +14,6 @@ from common.urls import handler_create_application_without_ssn_url
 # Bootstrap 5.1 CSS on application_excel_download.html is loaded from jsDelivr.
 EXCEL_DOWNLOAD_CSP = {
     "style-src": ["cdn.jsdelivr.net"],
-    "connect-src": [SELF, "cdn.jsdelivr.net"],
 }
 
 @method_decorator(csp_update(EXCEL_DOWNLOAD_CSP), name="dispatch")

--- a/backend/kesaseteli/applications/views.py
+++ b/backend/kesaseteli/applications/views.py
@@ -1,5 +1,8 @@
 """Django views for handler-facing HTML pages in the applications app."""
 
+from csp.constants import SELF
+from csp.decorators import csp_update
+from django.utils.decorators import method_decorator
 from django.views.generic.base import TemplateView
 
 from applications.employer_excel_export import (
@@ -9,7 +12,13 @@ from applications.employer_excel_export import (
 from common.decorators import enforce_handler_view_adfs_login
 from common.urls import handler_create_application_without_ssn_url
 
+# Bootstrap 5.1 CSS on application_excel_download.html is loaded from jsDelivr.
+EXCEL_DOWNLOAD_CSP = {
+    "style-src": ["cdn.jsdelivr.net"],
+    "connect-src": [SELF, "cdn.jsdelivr.net"],
+}
 
+@method_decorator(csp_update(EXCEL_DOWNLOAD_CSP), name="dispatch")
 class EmployerExcelDownloadPageView(TemplateView):
     """Handler landing page with forms that link to Excel export endpoints.
 

--- a/backend/kesaseteli/common/middleware.py
+++ b/backend/kesaseteli/common/middleware.py
@@ -1,0 +1,16 @@
+"""Security header middleware for Kesäseteli backend HTML and API responses."""
+
+# Keep in sync with frontend/kesaseteli/shared/src/config/csp.js PERMISSIONS_POLICY.
+PERMISSIONS_POLICY = "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+
+
+class PermissionsPolicyMiddleware:
+    """Attach a restrictive Permissions-Policy header to every response."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response["Permissions-Policy"] = PERMISSIONS_POLICY
+        return response

--- a/backend/kesaseteli/common/middleware.py
+++ b/backend/kesaseteli/common/middleware.py
@@ -5,12 +5,16 @@ PERMISSIONS_POLICY = "camera=(), microphone=(), geolocation=(), payment=(), usb=
 
 
 class PermissionsPolicyMiddleware:
-    """Attach a restrictive Permissions-Policy header to every response."""
+    """Attach a restrictive Permissions-Policy header to non-exempt responses."""
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
         response = self.get_response(request)
+        # Probe views use @csp_exempt().
+        # Skip Permissions-Policy on those responses too.
+        if getattr(response, "_csp_exempt", False):
+            return response
         response["Permissions-Policy"] = PERMISSIONS_POLICY
         return response

--- a/backend/kesaseteli/common/openapi_views.py
+++ b/backend/kesaseteli/common/openapi_views.py
@@ -20,9 +20,9 @@ API_DOCS_CSP = {
 
 @method_decorator(csp_update(API_DOCS_CSP), name="dispatch")
 class KesaseteliSwaggerView(SpectacularSwaggerView):
-    pass
+    """Swagger UI with CSP allowances for drf-spectacular CDN assets."""
 
 
 @method_decorator(csp_update(API_DOCS_CSP), name="dispatch")
 class KesaseteliRedocView(SpectacularRedocView):
-    pass
+    """ReDoc with CSP allowances for drf-spectacular CDN assets."""

--- a/backend/kesaseteli/common/openapi_views.py
+++ b/backend/kesaseteli/common/openapi_views.py
@@ -1,0 +1,26 @@
+"""OpenAPI documentation views with per-route CSP for Swagger UI and ReDoc."""
+
+from csp.constants import SELF, UNSAFE_INLINE
+from csp.decorators import csp_update
+from django.utils.decorators import method_decorator
+from drf_spectacular.views import SpectacularRedocView, SpectacularSwaggerView
+
+# CDN requirements for drf-spectacular's default Swagger UI and ReDoc templates.
+# https://drf-spectacular.readthedocs.io/en/latest/faq.html#my-swagger-ui-and-or-redoc-page-is-blank
+API_DOCS_CSP = {
+    "script-src": [SELF, UNSAFE_INLINE, "cdn.jsdelivr.net"],
+    "worker-src": [SELF, "blob:"],
+    "img-src": [SELF, "data:", "cdn.jsdelivr.net", "cdn.redoc.ly"],
+    "style-src": [SELF, UNSAFE_INLINE, "cdn.jsdelivr.net", "fonts.googleapis.com"],
+    "font-src": [SELF, "fonts.gstatic.com"],
+}
+
+
+@method_decorator(csp_update(API_DOCS_CSP), name="dispatch")
+class KesaseteliSwaggerView(SpectacularSwaggerView):
+    pass
+
+
+@method_decorator(csp_update(API_DOCS_CSP), name="dispatch")
+class KesaseteliRedocView(SpectacularRedocView):
+    pass

--- a/backend/kesaseteli/common/openapi_views.py
+++ b/backend/kesaseteli/common/openapi_views.py
@@ -7,11 +7,13 @@ from drf_spectacular.views import SpectacularRedocView, SpectacularSwaggerView
 
 # CDN requirements for drf-spectacular's default Swagger UI and ReDoc templates.
 # https://drf-spectacular.readthedocs.io/en/latest/faq.html#my-swagger-ui-and-or-redoc-page-is-blank
+CDN_JSDELIVR = "cdn.jsdelivr.net"
 API_DOCS_CSP = {
-    "script-src": [SELF, UNSAFE_INLINE, "cdn.jsdelivr.net"],
+    "script-src": [SELF, UNSAFE_INLINE, CDN_JSDELIVR],
+    "connect-src": [SELF, CDN_JSDELIVR],
     "worker-src": [SELF, "blob:"],
-    "img-src": [SELF, "data:", "cdn.jsdelivr.net", "cdn.redoc.ly"],
-    "style-src": [SELF, UNSAFE_INLINE, "cdn.jsdelivr.net", "fonts.googleapis.com"],
+    "img-src": [SELF, "data:", CDN_JSDELIVR, "cdn.redoc.ly"],
+    "style-src": [SELF, UNSAFE_INLINE, CDN_JSDELIVR, "fonts.googleapis.com"],
     "font-src": [SELF, "fonts.gstatic.com"],
 }
 

--- a/backend/kesaseteli/common/tests/test_openapi_csp.py
+++ b/backend/kesaseteli/common/tests/test_openapi_csp.py
@@ -19,8 +19,11 @@ def test_redoc_includes_api_docs_csp(client: Client):
     assert response.status_code == 200
 
     csp_header = response.headers["Content-Security-Policy"]
-    assert "fonts.googleapis.com" in csp_header
-    assert "fonts.gstatic.com" in csp_header
+    assert (
+        "style-src 'self' 'unsafe-inline' cdn.jsdelivr.net fonts.googleapis.com"
+        in csp_header
+    )
+    assert "font-src 'self' fonts.gstatic.com" in csp_header
     assert "cdn.redoc.ly" in csp_header
 
 

--- a/backend/kesaseteli/common/tests/test_openapi_csp.py
+++ b/backend/kesaseteli/common/tests/test_openapi_csp.py
@@ -10,6 +10,7 @@ def test_swagger_ui_includes_api_docs_csp(client: Client):
 
     csp_header = response.headers["Content-Security-Policy"]
     assert "script-src 'self' 'unsafe-inline' cdn.jsdelivr.net" in csp_header
+    assert "connect-src 'self' cdn.jsdelivr.net" in csp_header
     assert "worker-src 'self' blob:" in csp_header
 
 
@@ -30,3 +31,6 @@ def test_openapi_schema_uses_global_csp_only(client: Client):
     csp_header = response.headers["Content-Security-Policy"]
     assert "default-src 'self'" in csp_header
     assert "cdn.redoc.ly" not in csp_header
+    assert "worker-src" not in csp_header
+    assert "font-src" not in csp_header
+    assert "script-src 'self' 'unsafe-inline' cdn.jsdelivr.net" not in csp_header

--- a/backend/kesaseteli/common/tests/test_openapi_csp.py
+++ b/backend/kesaseteli/common/tests/test_openapi_csp.py
@@ -1,0 +1,32 @@
+"""Tests for per-view CSP on OpenAPI documentation pages."""
+
+from django.test import Client
+from django.urls import reverse
+
+
+def test_swagger_ui_includes_api_docs_csp(client: Client):
+    response = client.get(reverse("swagger-ui"))
+    assert response.status_code == 200
+
+    csp_header = response.headers["Content-Security-Policy"]
+    assert "script-src 'self' 'unsafe-inline' cdn.jsdelivr.net" in csp_header
+    assert "worker-src 'self' blob:" in csp_header
+
+
+def test_redoc_includes_api_docs_csp(client: Client):
+    response = client.get(reverse("redoc"))
+    assert response.status_code == 200
+
+    csp_header = response.headers["Content-Security-Policy"]
+    assert "fonts.googleapis.com" in csp_header
+    assert "fonts.gstatic.com" in csp_header
+    assert "cdn.redoc.ly" in csp_header
+
+
+def test_openapi_schema_uses_global_csp_only(client: Client):
+    response = client.get(reverse("schema"), HTTP_ACCEPT="application/json")
+    assert response.status_code == 200
+
+    csp_header = response.headers["Content-Security-Policy"]
+    assert "default-src 'self'" in csp_header
+    assert "cdn.redoc.ly" not in csp_header

--- a/backend/kesaseteli/common/tests/test_permissions_policy.py
+++ b/backend/kesaseteli/common/tests/test_permissions_policy.py
@@ -5,8 +5,6 @@ from django.test import Client
 from django.test import override_settings
 from django.urls import reverse
 
-from applications.enums import EmailTemplateType
-from applications.models import EmailTemplate
 from common.middleware import PERMISSIONS_POLICY
 
 
@@ -28,28 +26,6 @@ def test_excel_download_includes_permissions_policy(staff_client):
         staff_client: Logged-in staff user client.
     """
     response = staff_client.get(reverse("excel-download"))
-    assert response.status_code == 200
-    assert_expected_permissions_policy(response)
-
-
-@pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
-def test_email_template_preview_includes_permissions_policy(admin_client):
-    """Check admin email preview sends the Permissions-Policy header.
-
-    Args:
-        admin_client: Logged-in admin user client.
-    """
-    template = EmailTemplate.objects.get(
-        type=EmailTemplateType.PROCESSING,
-        language="fi",
-    )
-    response = admin_client.get(
-        reverse(
-            "admin:applications_emailtemplate_preview",
-            kwargs={"object_id": template.pk},
-        )
-    )
     assert response.status_code == 200
     assert_expected_permissions_policy(response)
 

--- a/backend/kesaseteli/common/tests/test_permissions_policy.py
+++ b/backend/kesaseteli/common/tests/test_permissions_policy.py
@@ -1,0 +1,72 @@
+"""Tests for the global Permissions-Policy header on backend responses."""
+
+import pytest
+from django.test import Client
+from django.test import override_settings
+from django.urls import reverse
+
+from applications.enums import EmailTemplateType
+from applications.models import EmailTemplate
+from common.middleware import PERMISSIONS_POLICY
+
+
+def assert_expected_permissions_policy(response):
+    """Check that a response has the global Permissions-Policy header.
+
+    Args:
+        response: Page response to check.
+    """
+    assert response.headers["Permissions-Policy"] == PERMISSIONS_POLICY
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_excel_download_includes_permissions_policy(staff_client):
+    """Check excel-download sends the restrictive Permissions-Policy header.
+
+    Args:
+        staff_client: Logged-in staff user client.
+    """
+    response = staff_client.get(reverse("excel-download"))
+    assert response.status_code == 200
+    assert_expected_permissions_policy(response)
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_email_template_preview_includes_permissions_policy(admin_client):
+    """Check admin email preview sends the Permissions-Policy header.
+
+    Args:
+        admin_client: Logged-in admin user client.
+    """
+    template = EmailTemplate.objects.get(
+        type=EmailTemplateType.PROCESSING,
+        language="fi",
+    )
+    response = admin_client.get(
+        reverse(
+            "admin:applications_emailtemplate_preview",
+            kwargs={"object_id": template.pk},
+        )
+    )
+    assert response.status_code == 200
+    assert_expected_permissions_policy(response)
+
+
+def test_swagger_ui_includes_permissions_policy(client: Client):
+    response = client.get(reverse("swagger-ui"))
+    assert response.status_code == 200
+    assert_expected_permissions_policy(response)
+
+
+def test_redoc_includes_permissions_policy(client: Client):
+    response = client.get(reverse("redoc"))
+    assert response.status_code == 200
+    assert_expected_permissions_policy(response)
+
+
+def test_openapi_schema_includes_permissions_policy(client: Client):
+    response = client.get(reverse("schema"), HTTP_ACCEPT="application/json")
+    assert response.status_code == 200
+    assert_expected_permissions_policy(response)

--- a/backend/kesaseteli/common/tests/test_probes.py
+++ b/backend/kesaseteli/common/tests/test_probes.py
@@ -92,6 +92,25 @@ def test_probe_endpoints_return_no_csp_header(client, method, url):
     assert "Content-Security-Policy" not in response.headers
 
 
+@pytest.mark.parametrize(
+    ("method", "url"),
+    [("get", "/healthz"), ("head", "/healthz"), ("get", "/readiness"), ("head", "/readiness")],
+)
+def test_probe_endpoints_return_no_permissions_policy_header(client, method, url):
+    """Verify probe endpoints do not emit a Permissions-Policy header.
+
+    Probe responses should stay free of security-policy headers, matching the
+    CSP exemption on healthz and readiness views.
+
+    Args:
+        client: Django test client for unauthenticated requests.
+        method: HTTP method to use for the request.
+        url: Probe endpoint URL under test.
+    """
+    response = getattr(client, method)(url)
+    assert "Permissions-Policy" not in response.headers
+
+
 def test_readiness_rejects_post(client):
     """Readiness only accepts GET and HEAD requests."""
     response = client.post("/readiness")

--- a/backend/kesaseteli/common/tests/test_probes.py
+++ b/backend/kesaseteli/common/tests/test_probes.py
@@ -76,6 +76,18 @@ def test_readiness_returns_503_when_db_down(mock_connection, client):
     assert set(data) == {"status", "packageVersion", "release", "buildTime", "database"}
 
 
+@pytest.mark.parametrize("url", ["/healthz", "/readiness"])
+def test_probe_endpoints_return_no_csp_header(client, url):
+    """Verify probe endpoints do not emit a Content-Security-Policy header.
+
+    Args:
+        client: Django test client for unauthenticated requests.
+        url: Probe endpoint URL under test.
+    """
+    response = client.get(url)
+    assert "Content-Security-Policy" not in response.headers
+
+
 def test_readiness_rejects_post(client):
     """Readiness only accepts GET and HEAD requests."""
     response = client.post("/readiness")

--- a/backend/kesaseteli/common/tests/test_probes.py
+++ b/backend/kesaseteli/common/tests/test_probes.py
@@ -76,15 +76,19 @@ def test_readiness_returns_503_when_db_down(mock_connection, client):
     assert set(data) == {"status", "packageVersion", "release", "buildTime", "database"}
 
 
-@pytest.mark.parametrize("url", ["/healthz", "/readiness"])
-def test_probe_endpoints_return_no_csp_header(client, url):
+@pytest.mark.parametrize(
+    ("method", "url"),
+    [("get", "/healthz"), ("head", "/healthz"), ("get", "/readiness"), ("head", "/readiness")],
+)
+def test_probe_endpoints_return_no_csp_header(client, method, url):
     """Verify probe endpoints do not emit a Content-Security-Policy header.
 
     Args:
         client: Django test client for unauthenticated requests.
+        method: HTTP method to use for the request.
         url: Probe endpoint URL under test.
     """
-    response = client.get(url)
+    response = getattr(client, method)(url)
     assert "Content-Security-Policy" not in response.headers
 
 

--- a/backend/kesaseteli/common/views.py
+++ b/backend/kesaseteli/common/views.py
@@ -4,6 +4,7 @@ Kubernetes liveness and readiness probe endpoints.
 These endpoints are used by OpenShift/Kubernetes to determine pod health.
 """
 
+from csp.decorators import csp_exempt
 from django.conf import settings
 from django.db import connection
 from django.http import HttpResponse, JsonResponse
@@ -26,6 +27,7 @@ def _check_database() -> str:
         return "error"
 
 
+@csp_exempt()
 @require_http_methods(["GET", "HEAD"])
 def healthz(request):
     """
@@ -36,6 +38,7 @@ def healthz(request):
     return HttpResponse(status=200)
 
 
+@csp_exempt()
 @require_http_methods(["GET", "HEAD"])
 def readiness(request):
     """

--- a/backend/kesaseteli/kesaseteli/admin_site.py
+++ b/backend/kesaseteli/kesaseteli/admin_site.py
@@ -1,5 +1,7 @@
 from urllib.parse import urlencode
 
+from csp.constants import SELF, UNSAFE_INLINE
+from csp.decorators import csp_update
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.apps import AdminConfig
@@ -8,9 +10,18 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 
+# Django admin templates rely on inline scripts.
+ADMIN_CSP = {
+    "script-src": [SELF, UNSAFE_INLINE],
+}
+
 
 class KesaseteliAdminSite(admin.AdminSite):
     login_template = "admin/hel_login.html"
+
+    def admin_view(self, view, cacheable=False):
+        inner = super().admin_view(view, cacheable)
+        return csp_update(ADMIN_CSP)(inner)
 
     def each_context(self, request):
         context = super().each_context(request)

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -297,6 +297,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "csp.middleware.CSPMiddleware",
+    "common.middleware.PermissionsPolicyMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -346,6 +346,8 @@ CONTENT_SECURITY_POLICY = {
         "default-src": [SELF],
         "style-src": [SELF, UNSAFE_INLINE],
         "img-src": [SELF, "data:"],
+        "base-uri": [SELF],
+        "object-src": ["'none'"],
     }
 }
 

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -9,6 +9,7 @@ import environ
 import saml2
 import saml2.saml
 import sentry_sdk
+from csp.constants import SELF, UNSAFE_INLINE
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
@@ -268,6 +269,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "corsheaders",
+    "csp",
     "rest_framework",
     "mozilla_django_oidc",
     "django_extensions",
@@ -294,6 +296,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "csp.middleware.CSPMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -337,6 +340,14 @@ NEXT_PUBLIC_ACTIVATION_LINK_EXPIRATION_SECONDS = env.int(
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS")
 CORS_ALLOW_ALL_ORIGINS = env.bool("CORS_ALLOW_ALL_ORIGINS")
+
+CONTENT_SECURITY_POLICY = {
+    "DIRECTIVES": {
+        "default-src": [SELF],
+        "style-src": [SELF, UNSAFE_INLINE, "cdn.jsdelivr.net"],
+    }
+}
+
 CSRF_COOKIE_DOMAIN = env.str("CSRF_COOKIE_DOMAIN")
 CSRF_TRUSTED_ORIGINS = convert_to_django_4_2_csrf_trusted_origins(
     env.list("CSRF_TRUSTED_ORIGINS")

--- a/backend/kesaseteli/kesaseteli/settings.py
+++ b/backend/kesaseteli/kesaseteli/settings.py
@@ -344,7 +344,8 @@ CORS_ALLOW_ALL_ORIGINS = env.bool("CORS_ALLOW_ALL_ORIGINS")
 CONTENT_SECURITY_POLICY = {
     "DIRECTIVES": {
         "default-src": [SELF],
-        "style-src": [SELF, UNSAFE_INLINE, "cdn.jsdelivr.net"],
+        "style-src": [SELF, UNSAFE_INLINE],
+        "img-src": [SELF, "data:"],
     }
 }
 

--- a/backend/kesaseteli/kesaseteli/urls.py
+++ b/backend/kesaseteli/kesaseteli/urls.py
@@ -2,11 +2,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path, reverse_lazy
 from django.views.generic import RedirectView
-from drf_spectacular.views import (
-    SpectacularAPIView,
-    SpectacularRedocView,
-    SpectacularSwaggerView,
-)
+from drf_spectacular.views import SpectacularAPIView
 from rest_framework import routers
 
 from applications.api.handler_excel_views import (
@@ -15,6 +11,7 @@ from applications.api.handler_excel_views import (
 )
 from applications.api.v1 import views as application_views
 from applications.views import EmployerExcelDownloadPageView
+from common.openapi_views import KesaseteliRedocView, KesaseteliSwaggerView
 from common.views import healthz, readiness
 from companies.api.v1.views import GetCompanyView
 from shared.suomi_fi.views import (
@@ -72,12 +69,12 @@ urlpatterns = [
     path("openapi/", SpectacularAPIView.as_view(), name="schema"),
     path(
         "api_docs/swagger/",
-        SpectacularSwaggerView.as_view(url_name="schema"),
+        KesaseteliSwaggerView.as_view(url_name="schema"),
         name="swagger-ui",
     ),
     path(
         "api_docs/redoc/",
-        SpectacularRedocView.as_view(url_name="schema"),
+        KesaseteliRedocView.as_view(url_name="schema"),
         name="redoc",
     ),
 ]

--- a/backend/kesaseteli/requirements.in
+++ b/backend/kesaseteli/requirements.in
@@ -5,6 +5,7 @@ django-auditlog-extra@https://github.com/City-of-Helsinki/django-auditlog-extra/
 django-resilient-logger
 django-auth-adfs
 django-cors-headers
+django-csp
 django-environ
 django-extensions
 django-filter

--- a/backend/kesaseteli/requirements.txt
+++ b/backend/kesaseteli/requirements.txt
@@ -53,6 +53,7 @@ django==5.2.15
     #   django-auditlog-extra
     #   django-auth-adfs
     #   django-cors-headers
+    #   django-csp
     #   django-extensions
     #   django-filter
     #   django-localflavor
@@ -75,6 +76,8 @@ django-auth-adfs==1.16.0
     #   -r requirements.in
     #   yjdh-backend-shared
 django-cors-headers==4.9.0
+    # via -r requirements.in
+django-csp==4.0
     # via -r requirements.in
 django-environ==0.13.0
     # via -r requirements.in
@@ -138,6 +141,8 @@ mozilla-django-oidc==5.0.2
     # via
     #   -r requirements.in
     #   yjdh-backend-shared
+packaging==26.2
+    # via django-csp
 parso==0.8.7
     # via jedi
 pexpect==4.9.0

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -120,6 +120,7 @@ USER default:root
 COPY --chown=default:root --from=staticbuilder app/$PROJECT/$FOLDER/.next $PROJECT/$FOLDER/.next
 COPY --chown=default:root --from=staticbuilder app/$PROJECT/$FOLDER/next-i18next.config.js app/$PROJECT/$FOLDER/next.config.js $PROJECT/$FOLDER/
 COPY --chown=default:root --from=staticbuilder app/next.config.js ./
+COPY --chown=default:root --from=staticbuilder app/$PROJECT/shared/src/config/ $PROJECT/shared/src/config/
 COPY --chown=default:root --from=staticbuilder app/shared/src/server/next-server.js shared/src/server/
 
 # Copy public directory

--- a/frontend/kesaseteli/employer/next.config.js
+++ b/frontend/kesaseteli/employer/next.config.js
@@ -1,6 +1,7 @@
 const nextConfig = require('../../next.config');
+const { withKesaseteliSecurityHeaders } = require('../shared/src/config/csp');
 const { i18n } = require('./next-i18next.config');
 const { parsed: env } = require('dotenv').config({
   path: '../../../.env.kesaseteli-employer',
 });
-module.exports = nextConfig({ i18n, env });
+module.exports = withKesaseteliSecurityHeaders(nextConfig({ i18n, env }));

--- a/frontend/kesaseteli/handler/next.config.js
+++ b/frontend/kesaseteli/handler/next.config.js
@@ -1,6 +1,7 @@
 const nextConfig = require('../../next.config');
+const { withKesaseteliSecurityHeaders } = require('../shared/src/config/csp');
 const { i18n } = require('./next-i18next.config');
 const { parsed: env } = require('dotenv').config({
   path: '../../../.env.kesaseteli-handler',
 });
-module.exports = nextConfig({ i18n, env });
+module.exports = withKesaseteliSecurityHeaders(nextConfig({ i18n, env }));

--- a/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
+++ b/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
@@ -42,6 +42,20 @@ describe('withKesaseteliSecurityHeaders', () => {
     );
   });
 
+  it('should not leave trailing whitespace when Matomo URL is unset', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.NEXT_PUBLIC_BACKEND_URL = 'https://localhost:8000';
+
+    const config = withKesaseteliSecurityHeaders({ i18n: {} });
+    const headers = await config.headers();
+    const csp = headers[0].headers[0].value;
+
+    expect(csp).toContain("script-src 'self';");
+    expect(csp).toContain("img-src 'self' blob: data:;");
+    expect(csp).not.toMatch(/script-src 'self' ;/);
+    expect(csp).not.toMatch(/img-src 'self' blob: data: ;/);
+  });
+
   it('should preserve pre-existing headers from the wrapped config', async () => {
     const config = withKesaseteliSecurityHeaders({
       async headers() {

--- a/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
+++ b/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
@@ -1,0 +1,44 @@
+const { withKesaseteliSecurityHeaders } = require('../csp');
+
+describe('withKesaseteliSecurityHeaders', () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_BACKEND_URL;
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+    delete process.env.NEXT_PUBLIC_MATOMO_URL;
+    delete process.env.NODE_ENV;
+  });
+
+  it('should attach a production CSP with configured connect origins', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.NEXT_PUBLIC_BACKEND_URL = 'https://localhost:8000';
+    process.env.NEXT_PUBLIC_SENTRY_DSN =
+      'https://public@sentry.test.hel.ninja/98';
+    process.env.NEXT_PUBLIC_MATOMO_URL =
+      'https://webanalytics.digiaiiris.com/js/';
+
+    const config = withKesaseteliSecurityHeaders({ i18n: {} });
+    const headers = await config.headers();
+    const csp = headers[0].headers[0].value;
+
+    expect(headers).toEqual([
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: expect.stringContaining(
+              "connect-src 'self' https://localhost:8000 https://sentry.test.hel.ninja https://webanalytics.digiaiiris.com"
+            ),
+          },
+        ],
+      },
+    ]);
+    expect(csp).not.toContain('unsafe-eval');
+    expect(csp).toContain(
+      "script-src 'self' 'unsafe-inline' https://webanalytics.digiaiiris.com"
+    );
+    expect(csp).toContain(
+      "img-src 'self' blob: data: https://webanalytics.digiaiiris.com"
+    );
+  });
+});

--- a/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
+++ b/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
@@ -22,7 +22,7 @@ describe('withKesaseteliSecurityHeaders', () => {
 
     expect(headers).toEqual([
       {
-        source: '/(.*)',
+        source: '/:path*',
         headers: [
           {
             key: 'Content-Security-Policy',

--- a/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
+++ b/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
@@ -35,7 +35,7 @@ describe('withKesaseteliSecurityHeaders', () => {
     ]);
     expect(csp).not.toContain('unsafe-eval');
     expect(csp).toContain(
-      "script-src 'self' 'unsafe-inline' https://webanalytics.digiaiiris.com"
+      "script-src 'self' https://webanalytics.digiaiiris.com"
     );
     expect(csp).toContain(
       "img-src 'self' blob: data: https://webanalytics.digiaiiris.com"

--- a/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
+++ b/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
@@ -41,4 +41,34 @@ describe('withKesaseteliSecurityHeaders', () => {
       "img-src 'self' blob: data: https://webanalytics.digiaiiris.com"
     );
   });
+
+  it('should preserve pre-existing headers from the wrapped config', async () => {
+    const config = withKesaseteliSecurityHeaders({
+      async headers() {
+        return [
+          {
+            source: '/foo',
+            headers: [{ key: 'X-Custom', value: '1' }],
+          },
+        ];
+      },
+    });
+    const headers = await config.headers();
+
+    expect(headers).toEqual([
+      {
+        source: '/foo',
+        headers: [{ key: 'X-Custom', value: '1' }],
+      },
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: expect.stringContaining("default-src 'self'"),
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
+++ b/frontend/kesaseteli/shared/src/config/__tests__/csp.test.js
@@ -1,5 +1,10 @@
 const { withKesaseteliSecurityHeaders } = require('../csp');
 
+const getRouteHeaders = async (config) => {
+  const headers = await config.headers();
+  return headers.find(({ source }) => source === '/:path*').headers;
+};
+
 describe('withKesaseteliSecurityHeaders', () => {
   afterEach(() => {
     delete process.env.NEXT_PUBLIC_BACKEND_URL;
@@ -17,22 +22,30 @@ describe('withKesaseteliSecurityHeaders', () => {
       'https://webanalytics.digiaiiris.com/js/';
 
     const config = withKesaseteliSecurityHeaders({ i18n: {} });
-    const headers = await config.headers();
-    const csp = headers[0].headers[0].value;
+    const routeHeaders = await getRouteHeaders(config);
+    const csp = routeHeaders.find(
+      ({ key }) => key === 'Content-Security-Policy'
+    ).value;
 
-    expect(headers).toEqual([
-      {
-        source: '/:path*',
-        headers: [
-          {
-            key: 'Content-Security-Policy',
-            value: expect.stringContaining(
-              "connect-src 'self' https://localhost:8000 https://sentry.test.hel.ninja https://webanalytics.digiaiiris.com"
-            ),
-          },
-        ],
-      },
-    ]);
+    expect(routeHeaders).toEqual(
+      expect.arrayContaining([
+        {
+          key: 'Content-Security-Policy',
+          value: expect.stringContaining(
+            "connect-src 'self' https://localhost:8000 https://sentry.test.hel.ninja https://webanalytics.digiaiiris.com"
+          ),
+        },
+        { key: 'X-Content-Type-Options', value: 'nosniff' },
+        {
+          key: 'Referrer-Policy',
+          value: 'strict-origin-when-cross-origin',
+        },
+        {
+          key: 'Permissions-Policy',
+          value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
+        },
+      ])
+    );
     expect(csp).not.toContain('unsafe-eval');
     expect(csp).toContain(
       "script-src 'self' https://webanalytics.digiaiiris.com"
@@ -47,8 +60,10 @@ describe('withKesaseteliSecurityHeaders', () => {
     process.env.NEXT_PUBLIC_BACKEND_URL = 'https://localhost:8000';
 
     const config = withKesaseteliSecurityHeaders({ i18n: {} });
-    const headers = await config.headers();
-    const csp = headers[0].headers[0].value;
+    const routeHeaders = await getRouteHeaders(config);
+    const csp = routeHeaders.find(
+      ({ key }) => key === 'Content-Security-Policy'
+    ).value;
 
     expect(csp).toContain("script-src 'self';");
     expect(csp).toContain("img-src 'self' blob: data:;");
@@ -76,12 +91,13 @@ describe('withKesaseteliSecurityHeaders', () => {
       },
       {
         source: '/:path*',
-        headers: [
+        headers: expect.arrayContaining([
           {
             key: 'Content-Security-Policy',
             value: expect.stringContaining("default-src 'self'"),
           },
-        ],
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+        ]),
       },
     ]);
   });

--- a/frontend/kesaseteli/shared/src/config/csp.js
+++ b/frontend/kesaseteli/shared/src/config/csp.js
@@ -29,6 +29,9 @@ const buildKesaseteliCspPolicy = () => {
   const matomoOrigins = [
     getOriginFromUrl(process.env.NEXT_PUBLIC_MATOMO_URL),
   ].filter(Boolean);
+  const matomoSources = matomoOrigins.length
+    ? ` ${matomoOrigins.join(' ')}`
+    : '';
   const connectOrigins = [
     "'self'",
     getOriginFromUrl(process.env.NEXT_PUBLIC_BACKEND_URL),
@@ -38,9 +41,9 @@ const buildKesaseteliCspPolicy = () => {
 
   return [
     "default-src 'self'",
-    `script-src 'self'${isDev ? " 'unsafe-eval'" : ''} ${matomoOrigins.join(' ')}`,
+    `script-src 'self'${isDev ? " 'unsafe-eval'" : ''}${matomoSources}`,
     "style-src 'self' 'unsafe-inline'",
-    `img-src 'self' blob: data: ${matomoOrigins.join(' ')}`,
+    `img-src 'self' blob: data:${matomoSources}`,
     `font-src 'self' data: ${fontOrigins.join(' ')}`,
     `connect-src ${connectOrigins.join(' ')}`,
     "object-src 'none'",

--- a/frontend/kesaseteli/shared/src/config/csp.js
+++ b/frontend/kesaseteli/shared/src/config/csp.js
@@ -59,7 +59,10 @@ const buildKesaseteliCspPolicy = () => {
 const withKesaseteliSecurityHeaders = (config) => ({
   ...config,
   async headers() {
+    const existing = (await config.headers?.()) ?? [];
+
     return [
+      ...existing,
       {
         source: '/:path*',
         headers: [

--- a/frontend/kesaseteli/shared/src/config/csp.js
+++ b/frontend/kesaseteli/shared/src/config/csp.js
@@ -1,0 +1,76 @@
+const fontOrigins = [
+  'https://makasiini.hel.fi',
+  'https://makasiini.hel.ninja',
+];
+
+/**
+ * Extract the origin from a URL string for CSP allowlists.
+ * Returns null when the value is missing or not a valid URL.
+ */
+const getOriginFromUrl = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Build the Content-Security-Policy header value for Kesäseteli apps.
+ * Connect and analytics allowances come from public env vars.
+ * Development builds also allow unsafe-eval for Next.js hot reload.
+ */
+const buildKesaseteliCspPolicy = () => {
+  const isDev = process.env.NODE_ENV !== 'production';
+  const matomoOrigins = [
+    getOriginFromUrl(process.env.NEXT_PUBLIC_MATOMO_URL),
+  ].filter(Boolean);
+  const connectOrigins = [
+    "'self'",
+    getOriginFromUrl(process.env.NEXT_PUBLIC_BACKEND_URL),
+    getOriginFromUrl(process.env.NEXT_PUBLIC_SENTRY_DSN),
+    ...matomoOrigins,
+  ].filter(Boolean);
+
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} ${matomoOrigins.join(' ')}`,
+    "style-src 'self' 'unsafe-inline'",
+    `img-src 'self' blob: data: ${matomoOrigins.join(' ')}`,
+    `font-src 'self' data: ${fontOrigins.join(' ')}`,
+    `connect-src ${connectOrigins.join(' ')}`,
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    'upgrade-insecure-requests',
+  ].join('; ');
+};
+
+/**
+ * Wrap a Next.js config to send Kesäseteli CSP on all routes.
+ * @param {object} config Existing Next.js configuration object.
+ * @returns {object} Config with a headers() function that sets Content-Security-Policy.
+ */
+const withKesaseteliSecurityHeaders = (config) => ({
+  ...config,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: buildKesaseteliCspPolicy(),
+          },
+        ],
+      },
+    ];
+  },
+});
+
+module.exports = { withKesaseteliSecurityHeaders };

--- a/frontend/kesaseteli/shared/src/config/csp.js
+++ b/frontend/kesaseteli/shared/src/config/csp.js
@@ -38,7 +38,7 @@ const buildKesaseteliCspPolicy = () => {
 
   return [
     "default-src 'self'",
-    `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} ${matomoOrigins.join(' ')}`,
+    `script-src 'self'${isDev ? " 'unsafe-eval'" : ''} ${matomoOrigins.join(' ')}`,
     "style-src 'self' 'unsafe-inline'",
     `img-src 'self' blob: data: ${matomoOrigins.join(' ')}`,
     `font-src 'self' data: ${fontOrigins.join(' ')}`,

--- a/frontend/kesaseteli/shared/src/config/csp.js
+++ b/frontend/kesaseteli/shared/src/config/csp.js
@@ -54,10 +54,35 @@ const buildKesaseteliCspPolicy = () => {
   ].join('; ');
 };
 
+const PERMISSIONS_POLICY =
+  'camera=(), microphone=(), geolocation=(), payment=(), usb=()';
+
 /**
- * Wrap a Next.js config to send Kesäseteli CSP on all routes.
+ * Build response headers applied to all Kesäseteli frontend routes.
+ */
+const buildKesaseteliSecurityHeaders = () => [
+  {
+    key: 'Content-Security-Policy',
+    value: buildKesaseteliCspPolicy(),
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: PERMISSIONS_POLICY,
+  },
+];
+
+/**
+ * Wrap a Next.js config to send Kesäseteli security headers on all routes.
  * @param {object} config Existing Next.js configuration object.
- * @returns {object} Config with a headers() function that sets Content-Security-Policy.
+ * @returns {object} Config with a headers() function that sets security headers.
  */
 const withKesaseteliSecurityHeaders = (config) => ({
   ...config,
@@ -68,12 +93,7 @@ const withKesaseteliSecurityHeaders = (config) => ({
       ...existing,
       {
         source: '/:path*',
-        headers: [
-          {
-            key: 'Content-Security-Policy',
-            value: buildKesaseteliCspPolicy(),
-          },
-        ],
+        headers: buildKesaseteliSecurityHeaders(),
       },
     ];
   },

--- a/frontend/kesaseteli/shared/src/config/csp.js
+++ b/frontend/kesaseteli/shared/src/config/csp.js
@@ -61,7 +61,7 @@ const withKesaseteliSecurityHeaders = (config) => ({
   async headers() {
     return [
       {
-        source: '/(.*)',
+        source: '/:path*',
         headers: [
           {
             key: 'Content-Security-Policy',

--- a/frontend/kesaseteli/youth/next.config.js
+++ b/frontend/kesaseteli/youth/next.config.js
@@ -1,6 +1,7 @@
 const nextConfig = require('../../next.config');
+const { withKesaseteliSecurityHeaders } = require('../shared/src/config/csp');
 const { i18n } = require('./next-i18next.config');
 const { parsed: env } = require('dotenv').config({
   path: '../../../.env.kesaseteli-youth',
 });
-module.exports = nextConfig({ i18n, env });
+module.exports = withKesaseteliSecurityHeaders(nextConfig({ i18n, env }));


### PR DESCRIPTION
Refs: YJDH-778

## Description :sparkles:

Add django-csp to the Kesäseteli and enable a minimal Content Security Policy.
CSP covers backend-only views such ReDoc pages
Add CSP headers to frontend

## Issues :bug:

No known issues.

## Testing :alembic:

Added regression tests for checking CSP headers in backend and frontend

## Screenshots :camera_flash:

N/A.

## Additional notes :spiral_notepad:

healthz and readiness are explicitly exempted so probe responses stay header-free.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled Content Security Policy (CSP) headers across the backend and frontend for improved browser security.
  * Secured API documentation pages (Swagger UI and ReDoc) and applied the correct CSP on the excel download view while keeping the email preview on the global policy.
  * Ensured health and readiness probe endpoints do not send CSP headers.
  * Wrapped Next.js builds to consistently emit CSP headers.
* **Tests**
  * Added coverage verifying CSP headers (and their directives) on key pages and confirming probes omit the header.
* **Documentation**
  * Updated API documentation routing to use CSP-enabled documentation pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->