### PR TITLE
fix: make company TOL code endpoint use drf

### DIFF
--- a/backend/benefit/companies/api/v1/serializers.py
+++ b/backend/benefit/companies/api/v1/serializers.py
@@ -38,12 +38,14 @@ class CompanySearchSerializer(serializers.Serializer):
     business_id = serializers.CharField(max_length=20)
 
 
-class UpdateCompanyIndustryCodeSerializer(serializers.Serializer):
-    industry_code = serializers.CharField(max_length=10)
-    industry = serializers.CharField(max_length=255, allow_blank=True, default="")
-
-    def update(self, instance, validated_data):
-        instance.industry_code = validated_data["industry_code"]
-        instance.industry = validated_data["industry"]
-        instance.save(update_fields=["industry_code", "industry"])
-        return instance
+class UpdateCompanyIndustryCodeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Company
+        fields = [
+            "industry",
+            "industry_code",
+        ]
+        extra_kwargs = {
+            "industry": {"required": True},
+            "industry_code": {"required": True, "allow_blank": False},
+        }

--- a/backend/benefit/companies/api/v1/views.py
+++ b/backend/benefit/companies/api/v1/views.py
@@ -8,6 +8,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from requests.exceptions import HTTPError
 from rest_framework import status
+from rest_framework.generics import UpdateAPIView
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
@@ -124,23 +125,21 @@ class GetUsersOrganizationView(APIView):
         return Response(company_data)
 
 
-class UpdateCompanyIndustryCodeView(APIView):
+class UpdateCompanyIndustryCodeView(UpdateAPIView):
     """Handler-only endpoint to set the industry (TOL) code on a company."""
 
     permission_classes = [BFIsHandler]
+    queryset = Company.objects.all()
+    serializer_class = UpdateCompanyIndustryCodeSerializer
 
     @transaction.atomic
-    def patch(self, request: HttpRequest, id: str) -> Response:
-        try:
-            company = Company.objects.get(pk=id)
-        except (Company.DoesNotExist, ValueError):
-            return Response(status=status.HTTP_404_NOT_FOUND)
+    def put(self, request, *args, **kwargs):
+        return self.update(request, *args, **kwargs)
 
-        serializer = UpdateCompanyIndustryCodeSerializer(company, data=request.data)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-        serializer.save()
-        return Response(CompanySerializer(company).data)
+    @transaction.atomic
+    def patch(self, request, *args, **kwargs):
+        # Don't allow partial updates
+        return self.update(request, *args, **kwargs)
 
 
 class SearchOrganisationsView(APIView):

--- a/backend/benefit/helsinkibenefit/urls.py
+++ b/backend/benefit/helsinkibenefit/urls.py
@@ -166,7 +166,7 @@ urlpatterns = [
     path("v1/company/", GetUsersOrganizationView.as_view()),
     path("v1/company/search/<str:name>/", SearchOrganisationsView.as_view()),
     path("v1/company/get/<str:business_id>/", GetOrganisationByIdView.as_view()),
-    path("v1/company/<str:id>/industry_code/", UpdateCompanyIndustryCodeView.as_view()),
+    path("v1/company/<str:pk>/industry_code/", UpdateCompanyIndustryCodeView.as_view()),
     path("v1/users/me/", CurrentUserView.as_view(), name="users-me"),
     path("v1/users/options/", UserOptionsView.as_view()),
     path(


### PR DESCRIPTION
Use functionality included in DRF.

Refs: HL-1801


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated company industry code API endpoint to use standard REST patterns with improved request handling and validation.
  * URL parameter changed from `id` to `pk` for endpoint consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->