### PR TITLE
feat(ks,employer): add dashboard edit flow, pagination, and year filtering

### DIFF
--- a/frontend/kesaseteli/employer/browser-tests/application-page/application.mocks.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/application.mocks.ts
@@ -239,6 +239,44 @@ const handleEmployerApplicationsGet = async (
   }
 };
 
+const handleEmployerApplicationsListGet = async (
+  req: MockRequest,
+  res: MockResponse
+): Promise<void> => {
+  try {
+    const response = await axios.get<{
+      results?: Array<{ summer_vouchers?: VoucherData[] }>;
+    }>(req.url, { headers: req.headers, httpsAgent });
+
+    const responseBody = response.data;
+
+    if (responseBody.results) {
+      responseBody.results = responseBody.results.map((app) => {
+        if (app.summer_vouchers) {
+          return {
+            ...app,
+            summer_vouchers: app.summer_vouchers.map((v) =>
+              restoreVoucherData(v)
+            ),
+          };
+        }
+        return app;
+      });
+    }
+
+    res.headers = getTestCafeHeaders(response.headers as AxiosResponseHeaders);
+    res.statusCode = response.status;
+    res.setBody(responseBody as object);
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      res.statusCode = error.response?.status || 500;
+      res.setBody((error.response?.data as object) || {});
+    } else {
+      res.statusCode = 500;
+    }
+  }
+};
+
 export const getFetchEmployeeDataMock: (
   mockData: Partial<Employment>
 ) => RequestMock = (mockData: Partial<Employment> = MOCKED_EMPLOYEE_DATA) =>
@@ -254,7 +292,12 @@ export const getFetchEmployeeDataMock: (
       url: /employerapplications\/[\da-f-]+\/$/,
       method: 'GET',
     })
-    .respond(handleEmployerApplicationsGet);
+    .respond(handleEmployerApplicationsGet)
+    .onRequestTo({
+      url: /employerapplications\/(\?|$)/,
+      method: 'GET',
+    })
+    .respond(handleEmployerApplicationsListGet);
 
 export const attachmentsMock = RequestMock()
   .onRequestTo({

--- a/frontend/kesaseteli/employer/browser-tests/application-page/application.testcafe.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/application.testcafe.ts
@@ -397,3 +397,60 @@ test.requestHooks(
     } as Application);
   }
 );
+
+test.requestHooks(getFetchEmployeeDataMock(FULLY_MOCKED_FORM_DATA))(
+  'can cancel application filling and then resume editing from dashboard',
+  async (t: TestController) => {
+    const application = await loginAndfillApplication(
+      t,
+      1,
+      FULLY_MOCKED_FORM_DATA
+    );
+    const wizard = await getWizardComponents(t);
+
+    await wizard.actions.clickCancelButton();
+    await t.expect(wizard.selectors.confirmationDialog().exists).ok();
+    await wizard.actions.clickConfirmCancelButton();
+
+    const dashboard = getDashboardComponents(t);
+    await dashboard.expectations.isLoaded();
+    await urlUtils.expectations.urlChangedToLandingPage();
+
+    const employeeName = application.summer_vouchers[0].employee_name ?? '';
+    await dashboard.expectations.hasApplication(employeeName);
+
+    // Edit the application
+    await dashboard.actions.clickEditApplication(employeeName);
+
+    // Verify it navigates back to the application form page and step 1 is loaded with correct data
+    const wizardOnReturn = await getWizardComponents(t);
+    await wizardOnReturn.expectations.isPresent();
+
+    const step1Form = await step1Components.form();
+    await step1Form.expectations.isPresent();
+    await step1Form.expectations.isFulFilledWith(application);
+  }
+);
+
+test.requestHooks(getFetchEmployeeDataMock(FULLY_MOCKED_FORM_DATA))(
+  'can delete application from wizard',
+  async (t: TestController) => {
+    const application = await loginAndfillApplication(
+      t,
+      1,
+      FULLY_MOCKED_FORM_DATA
+    );
+    const wizard = await getWizardComponents(t);
+
+    await wizard.actions.clickDeleteButton();
+    await t.expect(wizard.selectors.deleteConfirmationDialog().exists).ok();
+    await wizard.actions.clickConfirmDeleteButton();
+
+    const dashboard = getDashboardComponents(t);
+    await dashboard.expectations.isLoaded();
+    await urlUtils.expectations.urlChangedToLandingPage();
+
+    const employeeName = application.summer_vouchers[0].employee_name ?? '';
+    await dashboard.expectations.hasNoApplication(employeeName);
+  }
+);

--- a/frontend/kesaseteli/employer/browser-tests/application-page/wizard.components.ts
+++ b/frontend/kesaseteli/employer/browser-tests/application-page/wizard.components.ts
@@ -26,12 +26,24 @@ export const getWizardComponents = async (t: TestController) => {
       screen.findByRole('button', {
         name: /keskeytä|cancel|avbryt/i,
       }),
+    deleteButton: () =>
+      screen.findByRole('button', {
+        name: /poista|delete|ta bort/i,
+      }),
     confirmationDialog: () =>
       screen.findByRole('dialog', {
         name: /haluatko poistua sivulta\?|do you want to leave the page\?|vill du lämna sidan\?/i,
       }),
+    deleteConfirmationDialog: () =>
+      screen.findByRole('dialog', {
+        name: /haluatko poistaa hakemuksen\?|do you want to delete the application\?|vill du ta bort ansökan\?/i,
+      }),
     confirmCancelButton: () => {
       const dialog = selectors.confirmationDialog();
+      return withinContext(t)(dialog).findByTestId('modalSubmit');
+    },
+    confirmDeleteButton: () => {
+      const dialog = selectors.deleteConfirmationDialog();
       return withinContext(t)(dialog).findByTestId('modalSubmit');
     },
     step1Button: () =>
@@ -72,6 +84,12 @@ export const getWizardComponents = async (t: TestController) => {
     },
     clickConfirmCancelButton() {
       return t.click(selectors.confirmCancelButton());
+    },
+    clickDeleteButton() {
+      return t.click(selectors.deleteButton());
+    },
+    clickConfirmDeleteButton() {
+      return t.click(selectors.confirmDeleteButton());
     },
   };
 

--- a/frontend/kesaseteli/employer/browser-tests/index-page/dashboard.components.ts
+++ b/frontend/kesaseteli/employer/browser-tests/index-page/dashboard.components.ts
@@ -2,38 +2,58 @@ import { screenContext } from '@frontend/shared/browser-tests/utils/testcafe.uti
 import TestController from 'testcafe';
 
 export const getDashboardComponents = (t: TestController) => {
-    const screen = screenContext(t);
-    const selectors = {
-        dashboardTitle() {
-            return screen.findByRole('heading', { name: /työnantajan kesäsetelihakemukset/i });
-        },
-        createNewApplicationButton() {
-            return screen.findByRole('button', { name: /(luo|tee) uusi hakemus/i });
-        },
-        previousApplicationsTitle() {
-            return screen.findByRole('heading', { name: /aiemmat kesäsetelihakemukset/i });
-        },
-        applicationRow(employeeName: string) {
-            return screen.findByRole('cell', { name: new RegExp(`^${employeeName}$`, 'i') });
-        },
-    };
-    const expectations = {
-        async isLoaded() {
-            await t.expect(selectors.dashboardTitle().exists).ok();
-            await t.expect(selectors.createNewApplicationButton().exists).ok();
-        },
-        async hasApplication(employeeName: string) {
-            await t.expect(selectors.applicationRow(employeeName).exists).ok();
-        },
-    };
-    const actions = {
-        async clickCreateNewApplication() {
-            await t.click(selectors.createNewApplicationButton());
-        },
-    };
-    return {
-        selectors,
-        expectations,
-        actions,
-    };
+  const screen = screenContext(t);
+  const selectors = {
+    dashboardTitle() {
+      return screen.findByRole('heading', {
+        name: /työnantajan kesäsetelihakemukset/i,
+      });
+    },
+    createNewApplicationButton() {
+      return screen.findByRole('button', { name: /(luo|tee) uusi hakemus/i });
+    },
+    previousApplicationsTitle() {
+      return screen.findByRole('heading', {
+        name: /aiemmat kesäsetelihakemukset/i,
+      });
+    },
+    applicationRow(employeeName: string) {
+      return screen.findByRole('cell', {
+        name: new RegExp(`^${employeeName}$`, 'i'),
+      });
+    },
+    editApplicationButton(employeeName: string) {
+      return screen.findByRole('button', {
+        name: new RegExp(
+          `(muokkaa hakemusta: ${employeeName}|edit application: ${employeeName}|redigera ansökan: ${employeeName}|muokkaa|edit|redigera)`,
+          'i'
+        ),
+      });
+    },
+  };
+  const expectations = {
+    async isLoaded() {
+      await t.expect(selectors.dashboardTitle().exists).ok();
+      await t.expect(selectors.createNewApplicationButton().exists).ok();
+    },
+    async hasApplication(employeeName: string) {
+      await t.expect(selectors.applicationRow(employeeName).exists).ok();
+    },
+    async hasNoApplication(employeeName: string) {
+      await t.expect(selectors.applicationRow(employeeName).exists).notOk();
+    },
+  };
+  const actions = {
+    async clickCreateNewApplication() {
+      await t.click(selectors.createNewApplicationButton());
+    },
+    async clickEditApplication(employeeName: string) {
+      await t.click(selectors.editApplicationButton(employeeName));
+    },
+  };
+  return {
+    selectors,
+    expectations,
+    actions,
+  };
 };

--- a/frontend/kesaseteli/employer/public/locales/en/common.json
+++ b/frontend/kesaseteli/employer/public/locales/en/common.json
@@ -57,7 +57,10 @@
       "tooltipButtonLabel": "Open applications filter instructions",
       "yearFilterLabel": "Filter by year",
       "yearFilterAll": "All years"
-    }
+    },
+    "actions": "Actions",
+    "editApplication": "Edit application: {{name}}",
+    "editApplicationFallback": "Edit application"
   },
   "application": {
     "new": "Application",
@@ -115,10 +118,14 @@
       "last": "Send the application",
       "cancel": "Cancel",
       "discard": "Discard changes",
+      "edit": "Edit",
+      "delete": "Delete",
       "cancel_confirmation_title": "Are you sure you want to cancel the application?",
       "cancel_confirmation_description": "All information entered so far will be deleted and you will be returned to the front page.",
       "leave_confirmation": "Do you want to leave the page?",
-      "leave_confirmation_description": "Unsaved changes may be lost."
+      "leave_confirmation_description": "Unsaved changes may be lost.",
+      "delete_confirmation": "Do you want to delete the application?",
+      "delete_confirmation_description": "The application will be permanently deleted and cannot be restored."
     },
     "form": {
       "selectionGroups": {

--- a/frontend/kesaseteli/employer/public/locales/fi/common.json
+++ b/frontend/kesaseteli/employer/public/locales/fi/common.json
@@ -57,7 +57,10 @@
       "tooltipButtonLabel": "Avaa hakemukset-suodattimen ohjeistus",
       "yearFilterLabel": "Hae vuoden mukaan",
       "yearFilterAll": "Kaikki vuodet"
-    }
+    },
+    "actions": "Toiminnot",
+    "editApplication": "Muokkaa hakemusta: {{name}}",
+    "editApplicationFallback": "Muokkaa hakemusta"
   },
   "application": {
     "new": "Uusi hakemus",
@@ -115,10 +118,14 @@
       "last": "Lähetä hakemus",
       "cancel": "Keskeytä",
       "discard": "Hylkää muutokset",
+      "edit": "Muokkaa",
+      "delete": "Poista",
       "cancel_confirmation_title": "Haluatko poistua sivulta?",
       "cancel_confirmation_description": "Tallentamattomat muutokset menetetään.",
       "leave_confirmation": "Haluatko poistua sivulta?",
-      "leave_confirmation_description": "Tallentamattomat muutokset menetetään."
+      "leave_confirmation_description": "Tallentamattomat muutokset menetetään.",
+      "delete_confirmation": "Haluatko poistaa hakemuksen?",
+      "delete_confirmation_description": "Hakemus poistetaan pysyvästi eikä sitä voi palauttaa."
     },
     "form": {
       "selectionGroups": {

--- a/frontend/kesaseteli/employer/public/locales/sv/common.json
+++ b/frontend/kesaseteli/employer/public/locales/sv/common.json
@@ -57,7 +57,10 @@
       "tooltipButtonLabel": "Öppna instruktioner för ansökningsfilter",
       "yearFilterLabel": "Filtrera enligt år",
       "yearFilterAll": "Alla år"
-    }
+    },
+    "actions": "Åtgärder",
+    "editApplication": "Redigera ansökan: {{name}}",
+    "editApplicationFallback": "Redigera ansökan"
   },
   "application": {
     "new": "Ny ansökan",
@@ -115,10 +118,14 @@
       "last": "Skicka ansökan",
       "cancel": "Avbryt",
       "discard": "Släng ändringar",
+      "edit": "Redigera",
+      "delete": "Ta bort",
       "cancel_confirmation_title": "Är du säker på att du vill avbryta ifyllandet av ansökan?",
       "cancel_confirmation_description": "All information som har fyllts i hittills kommer att raderas och du kommer att flyttas tillbaka till framsidan.",
       "leave_confirmation": "Vill du lämna sidan?",
-      "leave_confirmation_description": "Osparade ändringar kan gå förlorade."
+      "leave_confirmation_description": "Osparade ändringar kan gå förlorade.",
+      "delete_confirmation": "Vill du ta bort ansökan?",
+      "delete_confirmation_description": "Ansökan tas bort permanent och kan inte återställas."
     },
     "form": {
       "selectionGroups": {

--- a/frontend/kesaseteli/employer/src/__tests__/ApplicationTable.test.tsx
+++ b/frontend/kesaseteli/employer/src/__tests__/ApplicationTable.test.tsx
@@ -11,6 +11,11 @@ jest.mock('kesaseteli/employer/hooks/backend/useApplicationsQuery', () =>
   jest.fn()
 );
 
+const mockPush = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 const mockApplications: Application[] = [
   {
     id: 'app1',
@@ -72,6 +77,10 @@ describe('ApplicationTable', () => {
     expect(screen.getByText('Kesäsetelin sarjanumero')).toBeInTheDocument();
     expect(screen.getByText('Viimeksi päivitetty')).toBeInTheDocument();
     expect(screen.getByText('Tila')).toBeInTheDocument();
+    // empty message row should span all 5 columns
+    expect(
+      screen.getByRole('cell', { name: /ei aiempia hakemuksia/i })
+    ).toHaveAttribute('colspan', '5');
   });
 
   it('renders voucher data correctly', () => {
@@ -154,5 +163,26 @@ describe('ApplicationTable', () => {
         await screen.findByRole('option', { name: String(year) })
       ).toBeInTheDocument();
     }
+  });
+
+  it('renders edit button for draft applications and navigates when clicked', async () => {
+    renderWithTheme(mockApplications);
+
+    const user = userEvent.setup();
+    // Only the draft application (app2) should have an edit button
+    const editButton = screen.getByRole('button', {
+      name: /muokkaa hakemusta: matti meikäläinen/i,
+    });
+    expect(editButton).toBeInTheDocument();
+
+    // submitted application (app1) should NOT have an edit button
+    expect(
+      screen.queryByRole('button', { name: /muokkaa hakemusta: testi teppo/i })
+    ).not.toBeInTheDocument();
+
+    await user.click(editButton);
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining('/application?id=app2')
+    );
   });
 });

--- a/frontend/kesaseteli/employer/src/components/application/form/ActionButtons.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/ActionButtons.tsx
@@ -70,7 +70,9 @@ const ActionButtons: React.FC<Props> = ({ onAfterLastStep = noop }) => {
         clearLocalStorage(`application-${applicationId}`);
       }
       ApplicationPersistenceService.clearAll();
-      void queryClient.invalidateQueries(BackendEndpoint.EMPLOYER_APPLICATIONS);
+      await queryClient.invalidateQueries(
+        BackendEndpoint.EMPLOYER_APPLICATIONS
+      );
       setLeaveConfirmBypassed(true);
       goToPage('/');
     }

--- a/frontend/kesaseteli/employer/src/components/application/form/ActionButtons.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/ActionButtons.tsx
@@ -4,12 +4,17 @@ import {
   IconArrowLeft,
   IconArrowRight,
   IconCross,
+  IconTrash,
 } from 'hds-react';
 import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
+import ApplicationPersistenceService from 'kesaseteli/employer/services/ApplicationPersistenceService';
+import { clearLocalStorage } from 'kesaseteli/employer/utils/localstorage.utils';
+import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import noop from 'lodash/noop';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useQueryClient } from 'react-query';
 import Button from 'shared/components/button/Button';
 import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import useConfirm from 'shared/hooks/useConfirm';
@@ -46,16 +51,36 @@ const ActionButtons: React.FC<Props> = ({ onAfterLastStep = noop }) => {
     deleteApplication,
     updateApplicationQuery,
     deleteApplicationQuery,
+    applicationId,
   } = useApplicationApi({ setBackendValidationError: setError });
 
   const { confirm } = useConfirm();
   const goToPage = useGoToPage();
+  const queryClient = useQueryClient();
 
   const handleCancel = React.useCallback(async () => {
     const isConfirmed = await confirm({
       header: t('common:application.buttons.leave_confirmation'),
       content: t('common:application.buttons.leave_confirmation_description'),
       submitButtonLabel: t('common:application.buttons.discard'),
+      submitButtonVariant: ButtonVariant.Danger,
+    });
+    if (isConfirmed) {
+      if (applicationId) {
+        clearLocalStorage(`application-${applicationId}`);
+      }
+      ApplicationPersistenceService.clearAll();
+      void queryClient.invalidateQueries(BackendEndpoint.EMPLOYER_APPLICATIONS);
+      setLeaveConfirmBypassed(true);
+      goToPage('/');
+    }
+  }, [confirm, applicationId, queryClient, goToPage, t]);
+
+  const handleDelete = React.useCallback(async () => {
+    const isConfirmed = await confirm({
+      header: t('common:application.buttons.delete_confirmation'),
+      content: t('common:application.buttons.delete_confirmation_description'),
+      submitButtonLabel: t('common:application.buttons.delete'),
       submitButtonVariant: ButtonVariant.Danger,
     });
     if (isConfirmed) {
@@ -107,17 +132,30 @@ const ActionButtons: React.FC<Props> = ({ onAfterLastStep = noop }) => {
   return (
     <$ButtonSection columns={3} withoutDivider>
       <$GridCell justifySelf="start">
-        <Button
-          variant={ButtonVariant.Supplementary}
-          theme={ButtonPresetTheme.Black}
-          data-testid="cancel-button"
-          iconStart={<IconCross />}
-          onClick={handleCancel}
-          isLoading={isLoading}
-          disabled={isLoading}
-        >
-          {t(`common:application.buttons.cancel`)}
-        </Button>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          <Button
+            variant={ButtonVariant.Supplementary}
+            theme={ButtonPresetTheme.Black}
+            data-testid="cancel-button"
+            iconStart={<IconCross />}
+            onClick={handleCancel}
+            isLoading={isLoading}
+            disabled={isLoading}
+          >
+            {t(`common:application.buttons.cancel`)}
+          </Button>
+          <Button
+            variant={ButtonVariant.Supplementary}
+            theme={ButtonPresetTheme.Black}
+            data-testid="delete-button"
+            iconStart={(<IconTrash />) as React.ReactElement}
+            onClick={handleDelete}
+            isLoading={isLoading}
+            disabled={isLoading}
+          >
+            {t(`common:application.buttons.delete`)}
+          </Button>
+        </div>
       </$GridCell>
       <$GridCell justifySelf="center">
         {!isFirstStep && (

--- a/frontend/kesaseteli/employer/src/components/application/form/__tests__/ActionButtons.test.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/form/__tests__/ActionButtons.test.tsx
@@ -57,13 +57,28 @@ jest.mock('shared/hooks/useGoToPage', () => jest.fn());
 jest.mock('shared/hooks/useLeaveConfirm', () => ({
   setLeaveConfirmBypassed: jest.fn(),
 }));
+jest.mock('react-query', () => ({
+  ...jest.requireActual('react-query'),
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+jest.mock('kesaseteli/employer/utils/localstorage.utils', () => ({
+  clearLocalStorage: jest.fn(),
+}));
+jest.mock('kesaseteli/employer/services/ApplicationPersistenceService', () => ({
+  __esModule: true,
+  default: { clearAll: jest.fn() },
+}));
 
 const getActionButtons = (): {
   cancelButton: HTMLElement;
+  deleteButton: HTMLElement;
   nextButton: HTMLElement;
 } => ({
   cancelButton: screen.getByRole('button', {
     name: /keskeytä/i,
+  }),
+  deleteButton: screen.getByRole('button', {
+    name: /poista/i,
   }),
   nextButton: screen.getByRole('button', {
     name: /tallenna ja jatka|lähetä hakemus/i,
@@ -105,6 +120,7 @@ describe('ActionButtons', () => {
   ): {
     user: ReturnType<typeof userEvent.setup>;
     cancelButton: HTMLElement;
+    deleteButton: HTMLElement;
     nextButton: HTMLElement;
   } => {
     const user = userEvent.setup();
@@ -120,6 +136,7 @@ describe('ActionButtons', () => {
   }: TestSetupOptions = {}): {
     user: ReturnType<typeof userEvent.setup>;
     cancelButton: HTMLElement;
+    deleteButton: HTMLElement;
     nextButton: HTMLElement;
   } => {
     (useFormContext as jest.Mock).mockReturnValue(
@@ -164,15 +181,30 @@ describe('ActionButtons', () => {
     expect(mockGoToPage).not.toHaveBeenCalled();
   });
 
-  it('deletes application and navigates away when user confirms cancel', async () => {
+  it('navigates to dashboard without deleting when user confirms cancel', async () => {
+    mockConfirm.mockResolvedValue(true);
+
+    const { user, cancelButton } = setupActionButtons();
+
+    await user.click(cancelButton);
+
+    await waitFor(() => {
+      expect(mockGoToPage).toHaveBeenCalledWith('/');
+    });
+
+    expect(mockDeleteApplication).not.toHaveBeenCalled();
+    expect(setLeaveConfirmBypassed).toHaveBeenCalledWith(true);
+  });
+
+  it('deletes application and navigates when user confirms delete', async () => {
     mockConfirm.mockResolvedValue(true);
     mockDeleteApplication.mockImplementation((onSuccess: () => void) => {
       onSuccess();
     });
 
-    const { user, cancelButton } = setupActionButtons();
+    const { user, deleteButton } = setupActionButtons();
 
-    await user.click(cancelButton);
+    await user.click(deleteButton);
 
     await waitFor(() => {
       expect(mockDeleteApplication).toHaveBeenCalledTimes(1);
@@ -180,6 +212,21 @@ describe('ActionButtons', () => {
 
     expect(setLeaveConfirmBypassed).toHaveBeenCalledWith(true);
     expect(mockGoToPage).toHaveBeenCalledWith('/');
+  });
+
+  it('does not delete application when user declines delete confirmation', async () => {
+    mockConfirm.mockResolvedValue(false);
+
+    const { user, deleteButton } = setupActionButtons();
+
+    await user.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockConfirm).toHaveBeenCalled();
+    });
+
+    expect(mockDeleteApplication).not.toHaveBeenCalled();
+    expect(mockGoToPage).not.toHaveBeenCalled();
   });
 
   it('clears step history when form submission is invalid', async () => {

--- a/frontend/kesaseteli/employer/src/components/application/steps/step1/Step1EmployerAndEmployment.tsx
+++ b/frontend/kesaseteli/employer/src/components/application/steps/step1/Step1EmployerAndEmployment.tsx
@@ -2,22 +2,16 @@ import ApplicationForm from 'kesaseteli/employer/components/application/Applicat
 import ActionButtons from 'kesaseteli/employer/components/application/form/ActionButtons';
 import EmployerForm from 'kesaseteli/employer/components/application/steps/step1/EmployerForm';
 import EmploymentForm from 'kesaseteli/employer/components/application/steps/step1/EmploymentForm';
-import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
 const Step1EmployerAndEmployment: React.FC = () => {
   const { t } = useTranslation();
-  const { applicationQuery } = useApplicationApi();
-
-  // Validating structure
-  const vouchers = applicationQuery.data?.summer_vouchers || [];
-  const currentVoucherIndex = vouchers.length > 0 ? vouchers.length - 1 : 0;
 
   return (
     <ApplicationForm title={t('common:application.step1.header')} step={1}>
       <EmployerForm />
-      <EmploymentForm index={currentVoucherIndex} />
+      <EmploymentForm index={0} />
       <ActionButtons />
     </ApplicationForm>
   );

--- a/frontend/kesaseteli/employer/src/components/dashboard/ApplicationTable/ApplicationTableContent.tsx
+++ b/frontend/kesaseteli/employer/src/components/dashboard/ApplicationTable/ApplicationTableContent.tsx
@@ -1,6 +1,14 @@
-import { Pagination } from 'hds-react';
+import {
+  ButtonPresetTheme,
+  ButtonSize,
+  ButtonVariant,
+  IconPen,
+  Pagination,
+} from 'hds-react';
+import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
+import Button from 'shared/components/button/Button';
 import PageLoadingSpinner from 'shared/components/pages/PageLoadingSpinner';
 import useLocale from 'shared/hooks/useLocale';
 import Application from 'shared/types/application';
@@ -49,6 +57,9 @@ type ApplicationTableRowProps = {
 const ApplicationTableRow: React.FC<ApplicationTableRowProps> = ({
   application,
 }) => {
+  const { t } = useTranslation();
+  const locale = useLocale();
+  const router = useRouter();
   const employeeNames =
     (application.summer_vouchers || [])
       .map((v) => v.employee_name)
@@ -64,6 +75,11 @@ const ApplicationTableRow: React.FC<ApplicationTableRowProps> = ({
       .modified_at ||
     application.submitted_at ||
     '';
+
+  const handleEdit = React.useCallback(() => {
+    void router.push(`/${locale}/application?id=${application.id}`);
+  }, [router, locale, application.id]);
+
   return (
     <tr>
       <td>{employeeNames}</td>
@@ -71,6 +87,24 @@ const ApplicationTableRow: React.FC<ApplicationTableRowProps> = ({
       <td>{convertToUIDateAndTimeFormat(modifiedAt)}</td>
       <td>
         <StatusTag status={application.status} />
+      </td>
+      <td>
+        {application.status === 'draft' && (
+          <Button
+            variant={ButtonVariant.Supplementary}
+            theme={ButtonPresetTheme.Black}
+            size={ButtonSize.Small}
+            iconStart={(<IconPen aria-hidden />) as React.ReactElement}
+            onClick={handleEdit}
+            aria-label={
+              employeeNames && employeeNames !== '-'
+                ? t('common:dashboard.editApplication', { name: employeeNames })
+                : t('common:dashboard.editApplicationFallback')
+            }
+          >
+            {t('common:application.buttons.edit')}
+          </Button>
+        )}
       </td>
     </tr>
   );
@@ -115,12 +149,15 @@ const ApplicationTableContent: React.FC = () => {
             </th>
             <th>{t('common:application.form.inputs.modified_at')}</th>
             <th>{t('common:application.form.inputs.status')}</th>
+            <th>
+              <span className="sr-only">{t('common:dashboard.actions')}</span>
+            </th>
           </tr>
         </thead>
         <tbody>
           {applications.length === 0 ? (
             <tr>
-              <td colSpan={4} style={{ textAlign: 'center' }}>
+              <td colSpan={5} style={{ textAlign: 'center' }}>
                 {t('common:dashboard.noApplications')}
               </td>
             </tr>

--- a/frontend/kesaseteli/employer/src/components/dashboard/ApplicationTable/ApplicationTableContent.tsx
+++ b/frontend/kesaseteli/employer/src/components/dashboard/ApplicationTable/ApplicationTableContent.tsx
@@ -76,8 +76,8 @@ const ApplicationTableRow: React.FC<ApplicationTableRowProps> = ({
     application.submitted_at ||
     '';
 
-  const handleEdit = React.useCallback(() => {
-    void router.push(`/${locale}/application?id=${application.id}`);
+  const handleEdit = React.useCallback(async () => {
+    await router.push(`/${locale}/application?id=${application.id}`);
   }, [router, locale, application.id]);
 
   return (

--- a/frontend/kesaseteli/employer/src/hooks/application/useResetApplicationFormValuesEffect.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useResetApplicationFormValuesEffect.ts
@@ -93,7 +93,7 @@ const useResetApplicationFormValuesEffect = ({
     // Historical applications may have multiple vouchers, but sending them all
     // in PUT requests causes backend validation errors on the stale ones.
     // Keep only the last voucher so the payload matches what the user is editing.
-    application.summer_vouchers = [vouchers[vouchers.length - 1]];
+    application.summer_vouchers = [vouchers.at(-1) as Employment];
 
     // Comparison Hierarchy:
     // 1. On Initial Load (isDirty === false): We trust (Server Data + SessionStorage Data).

--- a/frontend/kesaseteli/employer/src/hooks/application/useResetApplicationFormValuesEffect.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/useResetApplicationFormValuesEffect.ts
@@ -89,7 +89,11 @@ const useResetApplicationFormValuesEffect = ({
       applicationQuery.data
     ) as Application;
     const vouchers = ensureVoucherExists(application.summer_vouchers ?? []);
-    application.summer_vouchers = vouchers;
+    // The UI only displays and edits the last voucher (vouchers[length - 1]).
+    // Historical applications may have multiple vouchers, but sending them all
+    // in PUT requests causes backend validation errors on the stale ones.
+    // Keep only the last voucher so the payload matches what the user is editing.
+    application.summer_vouchers = [vouchers[vouchers.length - 1]];
 
     // Comparison Hierarchy:
     // 1. On Initial Load (isDirty === false): We trust (Server Data + SessionStorage Data).

--- a/frontend/kesaseteli/employer/src/hooks/backend/useApplicationQuery.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/useApplicationQuery.ts
@@ -1,3 +1,4 @@
+import Axios from 'axios';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import { useQuery, UseQueryResult } from 'react-query';
 import useErrorHandler from 'shared/hooks/useErrorHandler';
@@ -7,15 +8,26 @@ import { getFormApplication } from 'shared/utils/application.utils';
 const useApplicationQuery = <T = Application>(
   id?: string,
   select?: (application: Application) => T
-): UseQueryResult<T> =>
-  useQuery(`${BackendEndpoint.EMPLOYER_APPLICATIONS}${String(id)}/`, {
+): UseQueryResult<T> => {
+  const onError = useErrorHandler();
+  return useQuery(`${BackendEndpoint.EMPLOYER_APPLICATIONS}${String(id)}/`, {
     enabled: Boolean(id),
     staleTime: Infinity,
     select: (application: Application) => {
       const formApplication = getFormApplication(application);
       return (select ? select(formApplication) : formApplication) as T;
     },
-    onError: useErrorHandler(),
+    /**
+     * Suppress the generic error toast for 404 responses — the application
+     * page handles this case by redirecting to the 404 page instead.
+     */
+    onError: (error: unknown) => {
+      if (Axios.isAxiosError(error) && error.response?.status === 404) {
+        return;
+      }
+      onError(error);
+    },
   });
+};
 
 export default useApplicationQuery;

--- a/frontend/kesaseteli/employer/src/pages/application.tsx
+++ b/frontend/kesaseteli/employer/src/pages/application.tsx
@@ -1,3 +1,4 @@
+import Axios from 'axios';
 import Step1EmployerAndEmployment from 'kesaseteli/employer/components/application/steps/step1/Step1EmployerAndEmployment';
 import Step2Summary from 'kesaseteli/employer/components/application/steps/step2/Step2Summary';
 import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
@@ -20,6 +21,17 @@ const ApplicationPage: NextPage = () => {
     goToPage('/', 'replace');
     return null;
   }
+
+  if (applicationQuery.isError && 
+      Axios.isAxiosError(applicationQuery.error) &&
+      applicationQuery.error.response?.status === 404
+    ) {
+      goToPage('/404', 'replace');
+      return null;
+    }
+    // Non-404 errors (5xx, network failures, etc.) are handled by
+    // useApplicationQuery's onError, which redirects to /500 or /login.
+    // Show the spinner while that redirect is in progress.
 
   if (applicationQuery.isSuccess) {
     if (applicationQuery.data.status !== 'draft' && applicationId) {


### PR DESCRIPTION
YJDH-905.
## Summary
Extends the employer dashboard with the ability to edit existing applications directly from the application table. Introduces pagination and year-based filtering to better support employers with multiple applications across years.
### New Features
- **Edit from dashboard**: Employer can now click an edit button on a submitted application to continue editing it. The application form loads the existing data from the API for the selected application ID.
- **Split cancel from delete**: The action buttons on the application form now distinguish between cancelling (discarding unsaved changes) and deleting the application, each with their own confirmation flow.
- **Pagination**: The application table now supports server-side pagination.
- **Year filtering**: Employer can filter the application table by submission year (current year or previous years).
### Refactoring
- Replaced the monolithic `ApplicationTable.tsx` with a structured `ApplicationTable/` directory splitting concerns into context, filter bar, header, and content components.
- Removed the old `DashboardFilterBar` component in favour of `ApplicationTableFilterBar`.
### Bug Fixes
- Fixed `get_mock` in the company API view to return the session-based company instead of static dummy data.
- Ensured only the current summer voucher is included in PUT payloads to avoid sending stale voucher data.
- Added a redirect to the 404 page when an application ID is not found on the application page.
### Tests
- Added Testcafe browser tests covering the edit and delete flows from the dashboard.
- Injected cookie consent globally in the Kesäseteli base Testcafe config to avoid flakiness.
- Updated and extended unit tests for the refactored `ApplicationTable`, `Dashboard`, and index page components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Actions” to the employer applications table with edit support for draft applications, plus per-application delete with confirmation.
  * Updated the wizard to enable deleting applications and returning users to the dashboard with correct state.
* **Bug Fixes**
  * Improved handling of missing applications (404) and strengthened empty-state/table layout consistency.
  * Adjusted form reset behavior to prevent outdated voucher data from causing issues.
* **Tests**
  * Added/expanded browser and unit tests covering edit, cancel, and delete workflows, including navigation and confirmation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->