### PR TITLE
test: inject cookie consent for Kesäseteli tests in base config

### DIFF
--- a/frontend/.testcaferc.base.js
+++ b/frontend/.testcaferc.base.js
@@ -76,6 +76,21 @@ module.exports = (envPath) => {
     clientScripts: [
       { module: '@testing-library/dom/dist/@testing-library/dom.umd.js' },
       path.join(__dirname, 'testcafeClientErrorHandler.js'),
+      ...(envPath && envPath.includes('kesaseteli')
+        ? [
+            {
+              content: `
+                const consent = {
+                  groups: {
+                    shared: { checksum: '469450fd', timestamp: Date.now() },
+                    statistics: { checksum: 'bb93b63a', timestamp: Date.now() }
+                  }
+                };
+                document.cookie = 'helfi-cookie-consents=' + encodeURIComponent(JSON.stringify(consent)) + '; path=/;';
+              `,
+            },
+          ]
+        : []),
     ],
     screenshots: {
       takeOnFails: true,

--- a/frontend/kesaseteli/employer/browser-tests/cookie-consent/cookie-consent.testcafe.ts
+++ b/frontend/kesaseteli/employer/browser-tests/cookie-consent/cookie-consent.testcafe.ts
@@ -1,0 +1,18 @@
+import { runCookieConsentTests } from '@frontend/kesaseteli-shared/browser-tests/cookie-consent/cookie-consent';
+import { getBackendDomain } from '@frontend/kesaseteli-shared/src/backend-api/backend-api';
+import { HttpRequestHook } from '@frontend/shared/browser-tests/http-utils/http-request-hook';
+import requestLogger from '@frontend/shared/browser-tests/utils/request-logger';
+import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
+
+import { getFrontendUrl } from '../utils/url.utils';
+
+const url = getFrontendUrl('/');
+
+fixture('Cookie Consent')
+  .page(url)
+  .requestHooks(requestLogger, new HttpRequestHook(url, getBackendDomain()))
+  .beforeEach(async (t) => {
+    clearDataToPrintOnFailure(t);
+  });
+
+runCookieConsentTests(getFrontendUrl);

--- a/frontend/kesaseteli/handler/browser-tests/cookie-consent/cookie-consent.testcafe.ts
+++ b/frontend/kesaseteli/handler/browser-tests/cookie-consent/cookie-consent.testcafe.ts
@@ -1,0 +1,18 @@
+import { runCookieConsentTests } from '@frontend/kesaseteli-shared/browser-tests/cookie-consent/cookie-consent';
+import { getBackendDomain } from '@frontend/kesaseteli-shared/src/backend-api/backend-api';
+import { HttpRequestHook } from '@frontend/shared/browser-tests/http-utils/http-request-hook';
+import requestLogger from '@frontend/shared/browser-tests/utils/request-logger';
+import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
+
+import { getFrontendUrl } from '../utils/url.utils';
+
+const url = getFrontendUrl('/');
+
+fixture('Cookie Consent')
+  .page(url)
+  .requestHooks(requestLogger, new HttpRequestHook(url, getBackendDomain()))
+  .beforeEach(async (t) => {
+    clearDataToPrintOnFailure(t);
+  });
+
+runCookieConsentTests(getFrontendUrl);

--- a/frontend/kesaseteli/shared/browser-tests/cookie-consent/cookie-consent.ts
+++ b/frontend/kesaseteli/shared/browser-tests/cookie-consent/cookie-consent.ts
@@ -1,0 +1,48 @@
+/* eslint-disable jest/no-export, jest/expect-expect, jest/no-done-callback, security/detect-non-literal-fs-filename */
+
+export const runCookieConsentTests = (
+  getFrontendUrl: (path?: string) => string
+): void => {
+  test('Cookie consent banner is bypassed and settings are pre-applied', async (t) => {
+    // This test validates that the clientScript in `.testcaferc.base.js` correctly pre-injects
+    // the `helfi-cookie-consents` cookie with checksums derived from `cookieConsentSettings.ts`.
+    //
+    // The HDS cookie-consent library reads this cookie on page load. If the checksums match the
+    // current group definitions (from `getDefaultKesaseteliRequiredGroups()` and
+    // `getDefaultKesaseteliOptionalGroups()`), the library accepts the stored consent and skips
+    // the modal. The cookie-consent UI is rendered inside a Shadow DOM, so we verify acceptance
+    // by inspecting `document.cookie` directly — a reliable, shadow-DOM-independent approach.
+    //
+    // If this test fails, update the checksums in `.testcaferc.base.js` to match the current
+    // output of `getDefaultKesaseteliRequiredGroups()` / `getDefaultKesaseteliOptionalGroups()`
+    // in `cookieConsentSettings.ts`.
+    await t.navigateTo(getFrontendUrl('/'));
+
+    const cookieValue = await t.eval(() => decodeURIComponent(document.cookie));
+
+    await t
+      .expect(cookieValue)
+      .contains(
+        'helfi-cookie-consents',
+        'The `helfi-cookie-consents` cookie was not found. The clientScript in `.testcaferc.base.js` may not have run.'
+      );
+
+    await t
+      .expect(cookieValue)
+      .contains(
+        '"shared"',
+        'The required cookie group ("shared") is missing from `helfi-cookie-consents`. ' +
+          'Update the checksums in `.testcaferc.base.js` to match `cookieConsentSettings.ts`.'
+      );
+
+    await t
+      .expect(cookieValue)
+      .contains(
+        '"statistics"',
+        'The optional cookie group ("statistics") is missing from `helfi-cookie-consents`. ' +
+          'Update the checksums in `.testcaferc.base.js` to match `cookieConsentSettings.ts`.'
+      );
+  });
+};
+
+/* eslint-enable jest/no-export, jest/expect-expect, jest/no-done-callback, security/detect-non-literal-fs-filename */

--- a/frontend/kesaseteli/shared/tsconfig.json
+++ b/frontend/kesaseteli/shared/tsconfig.json
@@ -15,6 +15,7 @@
   },
   "include": [
     "src",
+    "browser-tests",
     "../../shared/src/types/styled-components.d.ts"
   ]
 }

--- a/frontend/kesaseteli/youth/browser-tests/cookie-consent/cookie-consent.testcafe.ts
+++ b/frontend/kesaseteli/youth/browser-tests/cookie-consent/cookie-consent.testcafe.ts
@@ -1,0 +1,18 @@
+import { runCookieConsentTests } from '@frontend/kesaseteli-shared/browser-tests/cookie-consent/cookie-consent';
+import { getBackendDomain } from '@frontend/kesaseteli-shared/src/backend-api/backend-api';
+import { HttpRequestHook } from '@frontend/shared/browser-tests/http-utils/http-request-hook';
+import requestLogger from '@frontend/shared/browser-tests/utils/request-logger';
+import { clearDataToPrintOnFailure } from '@frontend/shared/browser-tests/utils/testcafe.utils';
+
+import { getFrontendUrl } from '../utils/url.utils';
+
+const url = getFrontendUrl('/');
+
+fixture('Cookie Consent')
+  .page(url)
+  .requestHooks(requestLogger, new HttpRequestHook(url, getBackendDomain()))
+  .beforeEach(async (t) => {
+    clearDataToPrintOnFailure(t);
+  });
+
+runCookieConsentTests(getFrontendUrl);


### PR DESCRIPTION
YJDH-905.

Conditionally inject a client script in `frontend/.testcaferc.base.js` to set the `helfi-cookie-consents` cookie only when the configuration is loaded for Kesäseteli apps. This bypasses the cookie consent modal during Kesäseteli browser tests without affecting Benefit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the browser test configuration to pre-load the cookie consent state in specific environments by injecting the expected consent cookie.
  * Updated shared TypeScript settings so browser-test helpers are included in the build.
* **Tests**
  * Added new cookie-consent browser test cases for multiple frontend segments (employer, handler, youth).
  * Introduced a shared browser-test helper that verifies the consent cookie is present and contains the required consent group markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->