### PR TITLE
feat(ks): add summer voucher attachments to Django admin

### DIFF
--- a/backend/kesaseteli/applications/admin.py
+++ b/backend/kesaseteli/applications/admin.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from itertools import chain
 
 from auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
@@ -7,17 +8,24 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin import helpers
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import (
+    FileResponse,
+    Http404,
+    HttpResponse,
+    HttpResponseForbidden,
+    HttpResponseRedirect,
+)
 from django.shortcuts import render
 from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.formats import date_format
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
 from applications.admin_forms import SchoolImportForm
 from applications.models import (
+    Attachment,
     EmailTemplate,
     EmployerApplication,
     EmployerSummerVoucher,
@@ -26,7 +34,11 @@ from applications.models import (
     YouthApplication,
     YouthSummerVoucher,
 )
-from applications.services import EmailTemplateService, SchoolService
+from applications.services import (
+    AuditAccessLogService,
+    EmailTemplateService,
+    SchoolService,
+)
 from applications.target_groups import get_target_group_choices
 from common.utils import mask_social_security_number
 
@@ -88,6 +100,53 @@ class TargetGroupFilter(admin.SimpleListFilter):
         if value:
             return queryset.filter(target_group__contains=[value])
         return queryset
+
+
+class ReadOnlyAdminMixin:
+    """Mixin that disables add, change, and delete permissions."""
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+class SuperuserDeleteAdminMixin:
+    """Mixin that disables add/change; only superusers can delete."""
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+
+class AttachmentDownloadLinkMixin:
+    """Mixin that provides a download_link method for Attachment objects."""
+
+    def download_link(self, obj):
+        if not obj.pk or not obj.attachment_file:
+            return ""
+        url = reverse("admin:applications_attachment_download", args=[obj.pk])
+        filename = getattr(obj.attachment_file, "name", "")
+        if filename:
+            filename = os.path.basename(filename)
+        else:
+            filename = _("Download")
+        return format_html(
+            '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>',
+            url,
+            filename,
+        )
+
+    download_link.short_description = _("download link")
 
 
 class SummerVoucherConfigurationAdmin(
@@ -517,7 +576,7 @@ class YouthApplicationAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
         return False
 
 
-class YouthEmployerSummerVoucherInline(admin.TabularInline):
+class YouthEmployerSummerVoucherInline(ReadOnlyAdminMixin, admin.TabularInline):
     """
     Django Admin Inline View for Employer Summer Vouchers
 
@@ -556,15 +615,6 @@ class YouthEmployerSummerVoucherInline(admin.TabularInline):
             .select_related("application", "application__company")
         )
 
-    def has_add_permission(self, request, obj=None):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
     def employer_summer_voucher_link(self, obj):
         if not obj.pk or obj._state.adding:
             return ""
@@ -572,7 +622,7 @@ class YouthEmployerSummerVoucherInline(admin.TabularInline):
             "admin:applications_employersummervoucher_change",
             args=[obj.pk],
         )
-        return mark_safe(f'<a href="{url}">{obj.pk}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.pk)
 
     employer_summer_voucher_link.short_description = _("employer summer voucher")
 
@@ -583,7 +633,7 @@ class YouthEmployerSummerVoucherInline(admin.TabularInline):
             "admin:applications_employerapplication_change",
             args=[obj.application.pk],
         )
-        return mark_safe(f'<a href="{url}">{obj.application.pk}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.application.pk)
 
     employer_application_link.short_description = _("employer application")
 
@@ -674,7 +724,7 @@ class YouthSummerVoucherAdmin(
             args=[obj.youth_application.id],
         )
         link_text = obj.youth_application.name or obj.youth_application.email
-        return mark_safe(f'<a href="{url}">{link_text}</a>')
+        return format_html('<a href="{}">{}</a>', url, link_text)
 
     youth_application_link.short_description = _("youth application")
 
@@ -715,7 +765,7 @@ class YouthSummerVoucherAdmin(
             )
 
 
-class EmployerSummerVoucherInline(admin.TabularInline):
+class EmployerSummerVoucherInline(ReadOnlyAdminMixin, admin.TabularInline):
     """
     Django Admin Inline View for Employer Summer Vouchers.
 
@@ -753,15 +803,6 @@ class EmployerSummerVoucherInline(admin.TabularInline):
             .select_related("youth_summer_voucher__youth_application")
         )
 
-    def has_add_permission(self, request, obj=None):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
     def employer_summer_voucher_link(self, obj):
         if not obj.pk or obj._state.adding:
             return ""
@@ -769,7 +810,7 @@ class EmployerSummerVoucherInline(admin.TabularInline):
             "admin:applications_employersummervoucher_change",
             args=[obj.pk],
         )
-        return mark_safe(f'<a href="{url}">{obj.pk}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.pk)
 
     employer_summer_voucher_link.short_description = _("employer summer voucher")
 
@@ -781,7 +822,7 @@ class EmployerSummerVoucherInline(admin.TabularInline):
             args=[obj.youth_summer_voucher.pk],
         )
         serial = obj.youth_summer_voucher.user_showable_serial_number
-        return mark_safe(f'<a href="{url}">{serial}</a>')
+        return format_html('<a href="{}">{}</a>', url, serial)
 
     youth_summer_voucher_link.short_description = _("youth summer voucher")
 
@@ -913,9 +954,182 @@ class EmployerApplicationAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin
         )
 
 
+class AttachmentInline(
+    SuperuserDeleteAdminMixin, AttachmentDownloadLinkMixin, admin.TabularInline
+):
+    model = Attachment
+    verbose_name = _("attachment")
+    verbose_name_plural = _("attachments")
+    extra = 0
+    # Delete from inline needs a save to whole form, which is not desired.
+    # Instead, delete should happen from attachemtn admin view with delete permission.
+    # Use "attachment_admin_link" to link to attachment admin change page.
+    can_delete = False
+
+    fields = [
+        "attachment_admin_link",
+        "attachment_type",
+        "content_type",
+        "download_link",
+        "created_at",
+    ]
+    readonly_fields = fields
+
+    def attachment_admin_link(self, obj):
+        if not obj.pk:
+            return ""
+        url = reverse("admin:applications_attachment_change", args=[obj.pk])
+        return format_html('<a href="{}">{}</a>', url, obj.pk)
+
+    attachment_admin_link.short_description = _("attachment")
+
+
+class AttachmentAdmin(
+    AuditlogAdminViewAccessLogMixin,
+    SuperuserDeleteAdminMixin,
+    AttachmentDownloadLinkMixin,
+    admin.ModelAdmin,
+):
+    list_display = [
+        "id",
+        "summer_voucher_link",
+        "employer_application_link",
+        "company_name",
+        "attachment_type",
+        "content_type",
+        "download_link",
+        "created_at",
+    ]
+    list_filter = ["attachment_type", "created_at", "content_type"]
+    search_fields = [
+        "id",
+        "summer_voucher__id",
+        "summer_voucher__youth_summer_voucher__summer_voucher_serial_number",
+        "summer_voucher__application__company__name",
+        "summer_voucher__application__company__business_id",
+    ]
+    readonly_fields = [
+        "summer_voucher",
+        "attachment_type",
+        "content_type",
+        "attachment_file",
+        "created_at",
+    ]
+    date_hierarchy = "created_at"
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related(
+                "summer_voucher",
+                "summer_voucher__application",
+                "summer_voucher__application__company",
+                "summer_voucher__youth_summer_voucher",
+            )
+        )
+
+    def summer_voucher_link(self, obj):
+        if not obj.summer_voucher:
+            return ""
+        url = reverse(
+            "admin:applications_employersummervoucher_change",
+            args=[obj.summer_voucher.pk],
+        )
+        return format_html('<a href="{}">{}</a>', url, obj.summer_voucher.pk)
+
+    summer_voucher_link.short_description = _("employer summer voucher")
+
+    def employer_application_link(self, obj):
+        if not obj.summer_voucher or not obj.summer_voucher.application:
+            return ""
+        app = obj.summer_voucher.application
+        url = reverse(
+            "admin:applications_employerapplication_change",
+            args=[app.pk],
+        )
+        return format_html('<a href="{}">{}</a>', url, app.pk)
+
+    employer_application_link.short_description = _("employer application")
+
+    def company_name(self, obj):
+        if (
+            not obj.summer_voucher
+            or not obj.summer_voucher.application
+            or not obj.summer_voucher.application.company
+        ):
+            return ""
+        return obj.summer_voucher.application.company.name
+
+    company_name.short_description = _("company")
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "<uuid:pk>/download/",
+                self.admin_site.admin_view(self.download_view),
+                name="applications_attachment_download",
+            ),
+        ]
+        return custom_urls + urls
+
+    def download_view(self, request, pk):
+        try:
+            attachment = Attachment.objects.get(pk=pk)
+        except Attachment.DoesNotExist:
+            raise Http404(_("Attachment not found"))
+
+        if not self.has_view_permission(request, attachment):
+            return HttpResponseForbidden(
+                _("You do not have permission to download this file")
+            )
+
+        if not attachment.attachment_file:
+            raise Http404(_("Attachment file not found"))
+
+        try:
+            file_handle = attachment.attachment_file.open("rb")
+        except OSError as exc:
+            raise Http404(_("Attachment file not found")) from exc
+
+        # Defensive fallback: if os.path.basename returns a falsy value (e.g.,
+        # directory/empty path), we fall back to a translated "attachment" to ensure
+        # FileResponse has a valid filename string. Explicit str() coercion is used
+        # because gettext_lazy (_) returns a proxy object that can cause
+        # TypeError/serialization issues when formatted into response headers.
+        filename = os.path.basename(attachment.attachment_file.name) or str(
+            _("attachment")
+        )
+        try:
+            response = FileResponse(
+                file_handle,
+                as_attachment=True,
+                filename=filename,
+                content_type=attachment.content_type,
+            )
+            response["X-Content-Type-Options"] = "nosniff"
+        except OSError as exc:
+            file_handle.close()
+            raise Http404(_("Attachment file not found")) from exc
+
+        AuditAccessLogService.create_access_log_entry_with_related_object_and_additional_data(
+            accessed_instance=attachment,
+            actor=request.user,
+            actor_email=request.user.email,
+            additional_data={
+                "method": "AttachmentAdmin.download_view",
+                "request_path": request.path,
+            },
+        )
+
+        return response
+
+
 class EmployerSummerVoucherAdmin(
     AuditlogAdminViewAccessLogMixin, SerialNumberDecodingSearchMixin, admin.ModelAdmin
 ):
+    inlines = [AttachmentInline]
     list_display = [
         "id",
         "youth_summer_voucher_id",
@@ -1029,6 +1243,7 @@ class EmployerSummerVoucherAdmin(
             .select_related("application")
             .select_related("application__company")
             .select_related("youth_summer_voucher")
+            .prefetch_related("attachments")
         )
 
     def has_migrated_obsolete_serial_number(self, obj):
@@ -1061,3 +1276,4 @@ if apps.is_installed("django.contrib.admin"):
     admin.site.register(YouthSummerVoucher, YouthSummerVoucherAdmin)
     admin.site.register(EmployerApplication, EmployerApplicationAdmin)
     admin.site.register(EmployerSummerVoucher, EmployerSummerVoucherAdmin)
+    admin.site.register(Attachment, AttachmentAdmin)

--- a/backend/kesaseteli/applications/tests/test_admin_attachments.py
+++ b/backend/kesaseteli/applications/tests/test_admin_attachments.py
@@ -1,0 +1,272 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from applications.models import Attachment
+from common.tests.factories import AttachmentFactory, EmployerSummerVoucherFactory
+from shared.common.tests.factories import (
+    StaffSuperuserFactory,
+    StaffUserFactory,
+    UserFactory,
+)
+
+
+@pytest.mark.django_db
+def test_attachment_inline_rendered(admin_client):
+    # Create an employer summer voucher and an attachment for it
+    voucher = EmployerSummerVoucherFactory()
+    attachment = AttachmentFactory(summer_voucher=voucher)
+
+    # Resolve URL for EmployerSummerVoucher change page
+    url = reverse(
+        "admin:applications_employersummervoucher_change",
+        args=[voucher.pk],
+    )
+
+    response = admin_client.get(url)
+    assert response.status_code == 200
+
+    content = response.content.decode("utf-8")
+    assert attachment.get_attachment_type_display() in content
+    assert attachment.content_type in content
+
+    # The download link should be visible in the inline
+    download_url = reverse(
+        "admin:applications_attachment_download", args=[attachment.pk]
+    )
+    assert download_url in content
+
+    # The change page link to the attachment admin should be visible in the inline
+    change_url = reverse("admin:applications_attachment_change", args=[attachment.pk])
+    assert change_url in content
+
+
+@pytest.mark.django_db
+def test_attachment_admin_changelist_rendered(admin_client):
+    # Create attachment
+    voucher = EmployerSummerVoucherFactory()
+    attachment = AttachmentFactory(summer_voucher=voucher)
+
+    # Resolve URL for Attachment changelist view
+    url = reverse("admin:applications_attachment_changelist")
+
+    response = admin_client.get(url)
+    assert response.status_code == 200
+
+    content = response.content.decode("utf-8")
+    # Verify the download link and properties are listed in changelist
+    download_url = reverse(
+        "admin:applications_attachment_download", args=[attachment.pk]
+    )
+    assert download_url in content
+    assert attachment.get_attachment_type_display() in content
+
+
+@pytest.mark.django_db
+def test_download_attachment_as_staff_without_permission_denied(client):
+    # Create attachment with mock file content
+    voucher = EmployerSummerVoucherFactory()
+    dummy_file = SimpleUploadedFile(
+        "test_contract.pdf", b"pdf content", content_type="application/pdf"
+    )
+    attachment = AttachmentFactory(
+        summer_voucher=voucher,
+        attachment_file=dummy_file,
+        content_type="application/pdf",
+    )
+
+    # Create a normal staff user (not superuser, lacks view_attachment permission)
+    staff_user = StaffUserFactory()
+    client.force_login(staff_user)
+
+    url = reverse("admin:applications_attachment_download", args=[attachment.pk])
+    response = client.get(url)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_download_attachment_as_staff_with_permission_allowed(client):
+    # Create attachment with mock file content
+    voucher = EmployerSummerVoucherFactory()
+    dummy_file = SimpleUploadedFile(
+        "test_contract.pdf", b"pdf content", content_type="application/pdf"
+    )
+    attachment = AttachmentFactory(
+        summer_voucher=voucher,
+        attachment_file=dummy_file,
+        content_type="application/pdf",
+    )
+
+    # Create a normal staff user
+    staff_user = StaffUserFactory()
+
+    # Grant view_attachment permission
+    from django.contrib.auth.models import Permission
+    from django.contrib.contenttypes.models import ContentType
+
+    content_type = ContentType.objects.get_for_model(Attachment)
+    permission = Permission.objects.get(
+        codename="view_attachment", content_type=content_type
+    )
+    staff_user.user_permissions.add(permission)
+
+    client.force_login(staff_user)
+
+    url = reverse("admin:applications_attachment_download", args=[attachment.pk])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert response.getvalue() == b"pdf content"
+    assert response.headers["Content-Type"] == "application/pdf"
+    assert "attachment; filename=" in response.headers["Content-Disposition"]
+
+
+@pytest.mark.django_db
+def test_download_attachment_as_superuser_allowed(client):
+    # Create attachment with mock file content
+    voucher = EmployerSummerVoucherFactory()
+    dummy_file = SimpleUploadedFile(
+        "test_contract.pdf", b"pdf content", content_type="application/pdf"
+    )
+    attachment = AttachmentFactory(
+        summer_voucher=voucher,
+        attachment_file=dummy_file,
+        content_type="application/pdf",
+    )
+
+    # Superuser has all permissions implicitly
+    superuser = StaffSuperuserFactory()
+    client.force_login(superuser)
+
+    url = reverse("admin:applications_attachment_download", args=[attachment.pk])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert response.getvalue() == b"pdf content"
+    assert response.headers["Content-Type"] == "application/pdf"
+    assert "attachment; filename=" in response.headers["Content-Disposition"]
+
+
+@pytest.mark.django_db
+def test_download_attachment_unauthenticated_denied(client):
+    voucher = EmployerSummerVoucherFactory()
+    attachment = AttachmentFactory(summer_voucher=voucher)
+    url = reverse("admin:applications_attachment_download", args=[attachment.pk])
+
+    # Try as unauthenticated user
+    response = client.get(url)
+    # self.admin_site.admin_view redirects unauthenticated users to admin login page
+    assert response.status_code == 302
+    assert "login" in response.url
+
+
+@pytest.mark.django_db
+def test_download_attachment_non_staff_denied(client):
+    voucher = EmployerSummerVoucherFactory()
+    attachment = AttachmentFactory(summer_voucher=voucher)
+    url = reverse("admin:applications_attachment_download", args=[attachment.pk])
+
+    # Try as a regular authenticated non-staff user
+    regular_user = UserFactory()
+    client.force_login(regular_user)
+
+    response = client.get(url)
+    # self.admin_site.admin_view redirects non-staff users
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_delete_attachment_permissions(client):
+    voucher = EmployerSummerVoucherFactory()
+    attachment = AttachmentFactory(summer_voucher=voucher)
+
+    # 1. Staff user (non-superuser) should NOT have delete permission
+    staff_user = StaffUserFactory()
+    client.force_login(staff_user)
+
+    delete_url = reverse("admin:applications_attachment_delete", args=[attachment.pk])
+    response = client.get(delete_url)
+    # Non-superusers should be redirected or denied access
+    assert response.status_code in [302, 403]
+
+    # 2. Superuser should have delete permission (should load delete confirmation page)
+    superuser = StaffSuperuserFactory()
+    client.force_login(superuser)
+
+    response = client.get(delete_url, HTTP_ACCEPT_LANGUAGE="en")
+    assert response.status_code == 200
+    assert "Delete" in response.content.decode("utf-8")
+
+
+@pytest.mark.django_db
+def test_add_change_attachment_permissions(client):
+    # Create users
+    staff_user = StaffUserFactory()
+    superuser = StaffSuperuserFactory()
+
+    # Resolve URLs
+    add_url = reverse("admin:applications_attachment_add")
+
+    # Staff user should not be able to load the add page
+    client.force_login(staff_user)
+    response = client.get(add_url)
+    assert response.status_code in [302, 403]
+
+    # Superuser should not be able to load the add page either since has_add_permission is False
+    client.force_login(superuser)
+    response = client.get(add_url)
+    assert response.status_code in [302, 403]
+
+
+@pytest.mark.django_db
+def test_download_attachment_writes_audit_log(client):
+    from auditlog.models import LogEntry
+    from django.contrib.contenttypes.models import ContentType
+
+    # Create attachment with mock file content
+    voucher = EmployerSummerVoucherFactory()
+    dummy_file = SimpleUploadedFile(
+        "test_contract.pdf", b"pdf content", content_type="application/pdf"
+    )
+    attachment = AttachmentFactory(
+        summer_voucher=voucher,
+        attachment_file=dummy_file,
+        content_type="application/pdf",
+    )
+
+    # Create a normal staff user
+    staff_user = StaffUserFactory()
+
+    # Grant view_attachment permission
+    from django.contrib.auth.models import Permission
+
+    content_type = ContentType.objects.get_for_model(Attachment)
+    permission = Permission.objects.get(
+        codename="view_attachment", content_type=content_type
+    )
+    staff_user.user_permissions.add(permission)
+
+    client.force_login(staff_user)
+
+    url = reverse("admin:applications_attachment_download", args=[attachment.pk])
+
+    old_audit_log_entry_count = LogEntry.objects.count()
+    response = client.get(url)
+    assert response.status_code == 200
+
+    assert LogEntry.objects.count() == old_audit_log_entry_count + 1
+    audit_event = LogEntry.objects.filter(
+        action=LogEntry.Action.ACCESS,
+        content_type=content_type,
+        object_pk=str(attachment.pk),
+    ).first()
+
+    assert audit_event is not None
+    assert audit_event.actor_id == staff_user.pk
+    assert audit_event.actor_email == staff_user.email
+    assert audit_event.additional_data == {
+        "is_sent": False,
+        "method": "AttachmentAdmin.download_view",
+        "request_path": url,
+    }


### PR DESCRIPTION
YJDH-899.

Allow staff members with view permissions to list, inspect, and securely download employer summer voucher attachments. A standalone AttachmentAdmin view and an AttachmentInline component are registered, enforcing superuser-only delete permissions and read-only attributes, with query prefetching/select_related optimization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attachment inline support in the admin, showing attachment details and a download link while keeping inline editing disabled.
  * Introduced an attachment admin download page with secure, permission-based access and file streaming.
  * Added audit logging when attachments are downloaded/viewed.

* **Bug Fixes**
  * Strengthened read-only enforcement for attachment-related admin views.
  * Improved admin link rendering for voucher inlines to use safe HTML formatting.

* **Tests**
  * Added coverage for attachment admin UI rendering, download authorization behavior, delete/add restrictions, and audit-log creation on download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->