### PR TITLE
fix(benefit): fix terms handling

### DIFF
--- a/backend/benefit/applications/api/v1/serializers/application.py
+++ b/backend/benefit/applications/api/v1/serializers/application.py
@@ -1279,10 +1279,7 @@ class BaseApplicationSerializer(DynamicFieldsModelSerializer):
             data = self.context["request"].data
             action = data["action"] if "action" in data else None
 
-            # Ignore applicant's terms if app origin is from handler
-            if instance.application_origin == ApplicationOrigin.HANDLER or action in [
-                ApplicationActions.HANDLER_ALLOW_APPLICATION_EDIT
-            ]:
+            if action in [ApplicationActions.HANDLER_ALLOW_APPLICATION_EDIT]:
                 return
 
             if not approve_terms:

--- a/backend/benefit/terms/models.py
+++ b/backend/benefit/terms/models.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.forms import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+from applications.enums import ApplicationOrigin
 from applications.models import Application
 from companies.api.v1.serializers import CompanySerializer
 from companies.models import Company
@@ -257,8 +258,13 @@ class ApplicantTermsApproval(AbstractTermsApproval):
         except ObjectDoesNotExist:
             return True
         else:
+            terms_type = (
+                TermsType.HANDLER_TERMS
+                if application.application_origin == ApplicationOrigin.HANDLER
+                else TermsType.APPLICANT_TERMS
+            )
             return (
-                Terms.objects.get_terms_in_effect(TermsType.APPLICANT_TERMS)
+                Terms.objects.get_terms_in_effect(terms_type)
                 != application.applicant_terms_approval.terms
             )
 

--- a/frontend/benefit/handler/src/components/applicationForm/review/companySection/__tests__/CompanySection.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/review/companySection/__tests__/CompanySection.test.tsx
@@ -4,6 +4,10 @@ import { render, RenderResult, screen } from '@testing-library/react';
 import { ORGANIZATION_TYPES } from 'benefit-shared/constants';
 import React from 'react';
 
+import {
+  Application,
+  ApplicationFields,
+} from '../../../../../types/application';
 import CompanySection from '../CompanySection';
 
 jest.mock('next-i18next', () => ({
@@ -208,13 +212,10 @@ const baseData = {
 const renderSubject = (dataOverrides = {}): RenderResult =>
   render(
     <CompanySection
-      data={{
-        ...baseData,
-        ...dataOverrides,
-      }}
+      data={{ ...baseData, ...dataOverrides } as unknown as Application}
       translationsBase={translationsBase}
       dispatchStep={jest.fn()}
-      fields={fields}
+      fields={fields as unknown as ApplicationFields}
     />
   );
 

--- a/frontend/benefit/handler/src/components/applicationForm/review/employeeSection/__tests__/EmployeeSection.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/review/employeeSection/__tests__/EmployeeSection.test.tsx
@@ -4,6 +4,10 @@ import { render, RenderResult, screen } from '@testing-library/react';
 import { ORGANIZATION_TYPES } from 'benefit-shared/constants';
 import React from 'react';
 
+import {
+  Application,
+  ApplicationFields,
+} from '../../../../../types/application';
 import EmployeeSection from '../EmployeeSection';
 
 jest.mock('next-i18next', () => ({
@@ -113,13 +117,10 @@ const baseData = {
 const renderSubject = (dataOverrides = {}): RenderResult =>
   render(
     <EmployeeSection
-      data={{
-        ...baseData,
-        ...dataOverrides,
-      }}
+      data={{ ...baseData, ...dataOverrides } as unknown as Application}
       translationsBase={translationsBase}
       dispatchStep={jest.fn()}
-      fields={fields}
+      fields={fields as unknown as ApplicationFields}
     />
   );
 

--- a/frontend/benefit/handler/src/components/applicationForm/review/employmentSection/__tests__/EmploymentSection.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/review/employmentSection/__tests__/EmploymentSection.test.tsx
@@ -3,6 +3,10 @@ import '@testing-library/jest-dom';
 import { render, RenderResult, screen } from '@testing-library/react';
 import React from 'react';
 
+import {
+  Application,
+  ApplicationFields,
+} from '../../../../../types/application';
 import EmploymentSection from '../EmploymentSection';
 
 jest.mock('next-i18next', () => ({
@@ -140,13 +144,10 @@ const baseData = {
 const renderSubject = (dataOverrides = {}): RenderResult =>
   render(
     <EmploymentSection
-      data={{
-        ...baseData,
-        ...dataOverrides,
-      }}
+      data={{ ...baseData, ...dataOverrides } as unknown as Application}
       translationsBase={translationsBase}
       dispatchStep={jest.fn()}
-      fields={fields}
+      fields={fields as unknown as ApplicationFields}
     />
   );
 
@@ -297,10 +298,10 @@ describe('review EmploymentSection', () => {
   it('uses empty section names for edit buttons when fields are missing', () => {
     render(
       <EmploymentSection
-        data={baseData}
+        data={baseData as unknown as Application}
         translationsBase={translationsBase}
         dispatchStep={jest.fn()}
-        fields={{}}
+        fields={{} as unknown as ApplicationFields}
       />
     );
 

--- a/frontend/benefit/handler/src/components/applicationReview/consentView/ConsentView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/consentView/ConsentView.tsx
@@ -42,7 +42,10 @@ const ConsentView: React.FC<ApplicationReviewViewProps> = ({ data }) => {
           />
         </$GridCell>
       ) : (
-        data?.applicantTermsInEffect?.applicantConsents.map((consent, i) => (
+        (
+          data?.applicantTermsApproval?.terms?.applicantConsents ??
+          data?.applicantTermsInEffect?.applicantConsents
+        )?.map((consent, i) => (
           <$GridCell $colSpan={12} id="termsSection" key={consent.id}>
             <$Checkbox
               style={{ marginBottom: theme.spacing.xs }}


### PR DESCRIPTION
## Description :sparkles:
Fixes to terms handling.
Application should show the term that were approved when the application was send.
Couple of bugs were found. 
- terms_approval_needed always return TermsType.HANDLER_TERMS
- _update_applicant_terms_approval did not save approved terms for paper applications
- ConsentView.tsx: showed current consents instead of the saved approval record

In addition new terms has been updated to old records instead of creating new one with Django Admin.
This needs to be manually fixed in database.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how applicant terms approval is evaluated for different application types, improving consistency when editing applications.
  * Fixed consent information in the review screen so the most relevant consent list is shown when available.
  * Updated review form checks to better handle application data in the company, employee, and employment sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->