### PR TITLE
feat(ks): add target group calculation and exclude 2026 columns

### DIFF
--- a/backend/kesaseteli/applications/api/handler_excel_views.py
+++ b/backend/kesaseteli/applications/api/handler_excel_views.py
@@ -112,6 +112,10 @@ class YouthApplicationExcelExportViewSet(ModelViewSet):
                     ("status", str(_("Hakemuksen tila"))),
                     ("application_year", str(_("Hakuvuosi"))),
                     ("summer_voucher_serial_number", str(_("Kesäsetelinro"))),
+                    (
+                        "target_group",
+                        str(_("Erikoistapaus (esim yhdeksäsluokkalainen)")),
+                    ),
                     ("birth_year", str(_("Syntymävuosi"))),
                     ("birthdate", str(_("Syntymäpvm"))),
                     ("first_name", str(_("Etunimi"))),
@@ -129,6 +133,10 @@ class YouthApplicationExcelExportViewSet(ModelViewSet):
                     ("confirmation_date", str(_("Vahvistettu"))),
                     ("additional_info_providing_date", str(_("Lisätiedot annettu"))),
                     ("handling_date", str(_("Käsitelty"))),
+                    (
+                        "target_group_calculation_status",
+                        str(_("Erikoistapauksen laskentatila")),
+                    ),
                 ]
             )
 

--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -23,6 +23,7 @@ from applications.enums import (
     get_supported_languages,
     YouthApplicationStatus,
 )
+from applications.exporters.excel_exporter import resolve_target_group_and_status
 from applications.models import (
     Attachment,
     EmployerApplication,
@@ -1188,6 +1189,8 @@ class YouthApplicationExcelExportSerializer(serializers.ModelSerializer):
     additional_info_user_reasons = serializers.SerializerMethodField()
     summer_voucher_serial_number = serializers.SerializerMethodField()
     is_unlisted_school = serializers.SerializerMethodField()
+    target_group = serializers.SerializerMethodField()
+    target_group_calculation_status = serializers.SerializerMethodField()
 
     @staticmethod
     def to_isoformat_localdate(value: datetime) -> str:
@@ -1232,6 +1235,14 @@ class YouthApplicationExcelExportSerializer(serializers.ModelSerializer):
     def get_additional_info_user_reasons(self, obj: YouthApplication) -> str:
         return ", ".join(sorted(obj.additional_info_user_reasons))
 
+    def get_target_group(self, obj: YouthApplication) -> str:
+        val, _ = resolve_target_group_and_status(obj)
+        return val
+
+    def get_target_group_calculation_status(self, obj: YouthApplication) -> str:
+        _, status_val = resolve_target_group_and_status(obj)
+        return status_val
+
     def get_is_unlisted_school(self, obj: YouthApplication) -> str:
         with translation.override("fi"):
             return str(_("Kyllä") if obj.is_unlisted_school else _("Ei"))
@@ -1266,6 +1277,8 @@ class YouthApplicationExcelExportSerializer(serializers.ModelSerializer):
             "school",
             "status",
             "summer_voucher_serial_number",
+            "target_group",
+            "target_group_calculation_status",
             "vtj_home_municipality",
             "vtj_last_name",
         ]

--- a/backend/kesaseteli/applications/employer_excel_export.py
+++ b/backend/kesaseteli/applications/employer_excel_export.py
@@ -175,7 +175,11 @@ class EmployerExcelExportService:
             base_queryset = base_queryset.filter(pk__in=filter_pks)
         return (
             base_queryset.select_related(
-                "application", "application__company", "application__user"
+                "application",
+                "application__company",
+                "application__user",
+                "youth_summer_voucher",
+                "youth_summer_voucher__youth_application",
             )
             .prefetch_related("attachments")
             .order_by("application__submitted_at", "created_at", "pk")

--- a/backend/kesaseteli/applications/exporters/excel_exporter.py
+++ b/backend/kesaseteli/applications/exporters/excel_exporter.py
@@ -4,14 +4,15 @@ from typing import Iterable, List, Literal, NamedTuple
 from django.db.models import QuerySet
 from django.http import HttpRequest
 from django.shortcuts import reverse
-from django.utils import timezone
+from django.utils import timezone, translation
 from django.utils.translation import gettext_lazy as _
 from xlsxwriter import Workbook
 from xlsxwriter.worksheet import Worksheet
 
-from applications.enums import ExcelColumns
+from applications.enums import AdditionalInfoUserReason, ExcelColumns
 from applications.models import EmployerSummerVoucher
-from common.utils import getattr_nested
+from applications.target_groups import get_target_group_class_by_age
+from common.utils import get_age, getattr_nested
 
 ExcelFieldType = Literal["int", "str"]
 
@@ -41,6 +42,45 @@ INVOICER_NAME_FIELD_TITLE = _("Laskuttajan nimi")
 INVOICER_PHONE_NUMBER_FIELD_TITLE = _("Laskuttajan Puhelin")
 VOUCHER_NUMBER_FIELD_TITLE = _("Setelin numero")
 
+
+def resolve_target_group_and_status(youth_application) -> tuple[str, str]:
+    """Resolve the target group display name and calculation status.
+
+    Returns:
+        Tuple of (target_group_display_name, calculation_status).
+        - target_group_display_name: Finnish display name or "" if unresolvable.
+        - calculation_status: One of "annettu", "laskettu", "selvittämätön".
+    """
+    with translation.override("fi"):
+        if not youth_application:
+            return "", str(_("selvittämätön"))
+
+        target_group = youth_application.target_group
+        if target_group:
+            return youth_application.get_target_group_display(), str(_("annettu"))
+
+        reasons = youth_application.additional_info_user_reasons or []
+        if AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE.value in reasons:
+            return "", str(_("selvittämätön"))
+
+        birthdate = youth_application.birthdate
+        if birthdate:
+            created_year = (
+                youth_application.created_at.year
+                if youth_application.created_at
+                else timezone.now().year
+            )
+            age = get_age(birthdate, created_year)
+            cls = get_target_group_class_by_age(age)
+            if cls:
+                return str(cls().name), str(_("laskettu"))
+
+        return "", str(_("selvittämätön"))
+
+
+# These fields are omitted when exporting the "Reporting" Excel sheet.
+# The reporting export should focus on application/voucher content and omit
+# handler-specific or detailed company fields.
 REMOVABLE_REPORTING_FIELD_TITLES = [
     _("Y-tunnus"),
     _("Yhdyshenkilö"),
@@ -66,6 +106,9 @@ REMOVABLE_REPORTING_FIELD_TITLES = [
 ]
 
 
+# The 6 new 2026 fields and the calculation status field are excluded from
+# the Talpa Excel export to ensure the robot processing sheet format matches
+# previous years exactly.
 REMOVABLE_TALPA_FIELD_TITLES = [
     _("Henkilötunnus"),
     _("Koulu"),
@@ -92,6 +135,13 @@ REMOVABLE_TALPA_FIELD_TITLES = [
     HIRED_WITHOUT_VOUCHER_ASSESSMENT_FIELD_TITLE,
     _("Työnantajan kokemus"),
     _("Muuta"),
+    _("VTJ-tietojen luovutuskielto (ts. turvakielto)"),
+    _("Maksunsaajan nimi"),
+    _("Maksunsaajan osoite"),
+    _("Pankin SWIFT / BIC koodi"),
+    _("Pankin nimi"),
+    _("Pankin käyntiosoite"),
+    _("Erikoistapauksen laskentatila"),
 ]
 
 
@@ -287,6 +337,13 @@ FIELDS = [
     ExcelField(_("Tarkastaja sukunimi"), "", [], 30, "#F7DAE3"),
     ExcelField(_("Hyväksyjä etunimi"), "", [], 30, "#F7DAE3"),
     ExcelField(_("Hyväksyjä sukunimi"), "", [], 30, "#F7DAE3"),
+    ExcelField(
+        _("Erikoistapauksen laskentatila"),
+        "%s",
+        ["target_group_calculation_status"],
+        30,
+        "white",
+    ),
 ]
 
 
@@ -382,6 +439,21 @@ def handle_special_cases(
         summer_voucher, "application", None
     ):
         value = value if summer_voucher.application.is_separate_invoicer else ""
+    elif attr_str == "target_group":
+        if not value:
+            youth_app = (
+                summer_voucher.youth_summer_voucher.youth_application
+                if getattr(summer_voucher, "youth_summer_voucher", None)
+                else None
+            )
+            value = resolve_target_group_and_status(youth_app)[0]
+    elif attr_str == "target_group_calculation_status":
+        youth_app = (
+            summer_voucher.youth_summer_voucher.youth_application
+            if getattr(summer_voucher, "youth_summer_voucher", None)
+            else None
+        )
+        value = resolve_target_group_and_status(youth_app)[1]
     return value
 
 

--- a/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/en/LC_MESSAGES/django.po
@@ -1016,3 +1016,15 @@ msgstr "Request for additional information"
 
 msgid "Käsitelty"
 msgstr ""
+
+msgid "Erikoistapauksen laskentatila"
+msgstr "Special case calculation status"
+
+msgid "annettu"
+msgstr "given"
+
+msgid "laskettu"
+msgstr "calculated"
+
+msgid "selvittämätön"
+msgstr "unresolved"

--- a/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/fi/LC_MESSAGES/django.po
@@ -1013,3 +1013,15 @@ msgstr ""
 
 msgid "Käsitelty"
 msgstr ""
+
+msgid "Erikoistapauksen laskentatila"
+msgstr "Erikoistapauksen laskentatila"
+
+msgid "annettu"
+msgstr "annettu"
+
+msgid "laskettu"
+msgstr "laskettu"
+
+msgid "selvittämätön"
+msgstr "selvittämätön"

--- a/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
+++ b/backend/kesaseteli/applications/locale/sv/LC_MESSAGES/django.po
@@ -1016,3 +1016,15 @@ msgstr "Begäran om ytterligare information"
 
 msgid "Käsitelty"
 msgstr ""
+
+msgid "Erikoistapauksen laskentatila"
+msgstr "Specialfalls beräkningsstatus"
+
+msgid "annettu"
+msgstr "given"
+
+msgid "laskettu"
+msgstr "beräknad"
+
+msgid "selvittämätön"
+msgstr "oavgjord"

--- a/backend/kesaseteli/applications/tests/test_excel_export.py
+++ b/backend/kesaseteli/applications/tests/test_excel_export.py
@@ -14,6 +14,7 @@ from django.shortcuts import reverse
 from django.test import override_settings
 from django.utils import translation
 from django.utils.timezone import localdate
+from django.utils.translation import gettext_lazy as _
 from freezegun import freeze_time
 from rest_framework import status
 
@@ -23,6 +24,7 @@ from applications.employer_excel_export import (
     get_excel_download_error_message,
 )
 from applications.enums import (
+    AdditionalInfoUserReason,
     EmployerApplicationStatus,
     ExcelColumns,
     VtjTestCase,
@@ -566,6 +568,20 @@ def test_youth_excel_download_content(staff_client):  # noqa: C901
                     assert app.handled_at is None
                 else:
                     assert date.fromisoformat(output_value) == localdate(app.handled_at)
+            elif source_field == "target_group":
+                from applications.exporters.excel_exporter import (
+                    resolve_target_group_and_status,
+                )
+
+                expected_val, _ = resolve_target_group_and_status(app)
+                assert output_value == expected_val
+            elif source_field == "target_group_calculation_status":
+                from applications.exporters.excel_exporter import (
+                    resolve_target_group_and_status,
+                )
+
+                _, expected_status = resolve_target_group_and_status(app)
+                assert output_value == expected_status
             else:
                 assert output_value == getattr(app, source_field), source_field
 
@@ -742,3 +758,179 @@ def test_youth_excel_download_unauthenticated_redirects_with_mock_flag(client):
     response = client.get(youth_excel_download_url())
     assert response.status_code == status.HTTP_302_FOUND
     assert response.url.startswith(reverse("django_auth_adfs:login"))
+
+
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_employer_excel_target_group_calculated_when_missing(staff_client):
+    """When youth application has no target_group, Excel should calculate it from age."""
+    voucher = EmployerSummerVoucherFactory(
+        youth_summer_voucher__youth_application__social_security_number="",
+        youth_summer_voucher__youth_application__non_vtj_birthdate=date(
+            date.today().year - 16, 7, 1
+        ),
+    )
+    youth_app = voucher.youth_summer_voucher.youth_application
+    youth_app.target_group = ""
+    youth_app.save(update_fields=["target_group"])
+
+    response = staff_client.get(
+        employer_excel_export_url("annual", ExcelColumns.REPORTING.value)
+    )
+    workbook = openpyxl.load_workbook(filename=BytesIO(response.getvalue()))
+    rows = list(workbook.active.rows)
+    header = [c.value for c in rows[0]]
+    data = [c.value for c in rows[1]]
+
+    with translation.override("fi"):
+        special_case_title = str(SPECIAL_CASE_FIELD_TITLE)
+    idx = header.index(special_case_title)
+    # Should have calculated a target group from the youth's age
+    assert data[idx] != "" and data[idx] is not None
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_employer_excel_target_group_unresolved_with_underage_or_overage(staff_client):
+    """When youth has underage_or_overage and no target_group, Excel should leave it empty."""
+    voucher = EmployerSummerVoucherFactory(
+        youth_summer_voucher__youth_application__social_security_number="",
+        youth_summer_voucher__youth_application__non_vtj_birthdate=date(
+            date.today().year - 16, 7, 1
+        ),
+    )
+    youth_app = voucher.youth_summer_voucher.youth_application
+    youth_app.target_group = ""
+    youth_app.additional_info_user_reasons = [
+        AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE.value
+    ]
+    youth_app.save(update_fields=["target_group", "additional_info_user_reasons"])
+
+    response = staff_client.get(
+        employer_excel_export_url("annual", ExcelColumns.REPORTING.value)
+    )
+    workbook = openpyxl.load_workbook(filename=BytesIO(response.getvalue()))
+    rows = list(workbook.active.rows)
+    header = [c.value for c in rows[0]]
+    data = [c.value for c in rows[1]]
+
+    with translation.override("fi"):
+        special_case_title = str(SPECIAL_CASE_FIELD_TITLE)
+    idx = header.index(special_case_title)
+    assert data[idx] in ("", None)
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+@pytest.mark.parametrize(
+    "target_group,additional_reasons,expected_status",
+    [
+        ("primary_target_group", [], "annettu"),
+        ("", [], "laskettu"),
+        ("", [AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE.value], "selvittämätön"),
+    ],
+)
+def test_employer_excel_calculation_status_values(
+    staff_client, target_group, additional_reasons, expected_status
+):
+    """Calculation status field shows correct value based on target group state."""
+    voucher = EmployerSummerVoucherFactory(
+        youth_summer_voucher__youth_application__social_security_number="",
+        youth_summer_voucher__youth_application__non_vtj_birthdate=date(
+            date.today().year - 16, 7, 1
+        ),
+    )
+    youth_app = voucher.youth_summer_voucher.youth_application
+    youth_app.target_group = target_group
+    youth_app.additional_info_user_reasons = additional_reasons
+    youth_app.save(update_fields=["target_group", "additional_info_user_reasons"])
+
+    response = staff_client.get(
+        employer_excel_export_url("annual", ExcelColumns.REPORTING.value)
+    )
+    workbook = openpyxl.load_workbook(filename=BytesIO(response.getvalue()))
+    rows = list(workbook.active.rows)
+    header = [c.value for c in rows[0]]
+    data = [c.value for c in rows[1]]
+
+    with translation.override("fi"):
+        status_title = str(_("Erikoistapauksen laskentatila"))
+    idx = header.index(status_title)
+    assert data[idx] == expected_status
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
+def test_talpa_excel_excludes_2026_and_status_fields(staff_client):
+    """All 2026 fields AND the new status field must be absent from Talpa Excel."""
+    EmployerSummerVoucherFactory(
+        application=EmployerApplicationFactory(
+            status=EmployerApplicationStatus.SUBMITTED
+        )
+    )
+
+    response = staff_client.get(
+        employer_excel_export_url("annual", ExcelColumns.TALPA.value)
+    )
+    workbook = openpyxl.load_workbook(filename=BytesIO(response.getvalue()))
+    header = [c.value for c in next(workbook.active.rows)]
+
+    excluded = [
+        "VTJ-tietojen luovutuskielto (ts. turvakielto)",
+        "Maksunsaajan nimi",
+        "Maksunsaajan osoite",
+        "Pankin SWIFT / BIC koodi",
+        "Pankin nimi",
+        "Pankin käyntiosoite",
+        "Erikoistapauksen laskentatila",
+    ]
+    for title in excluded:
+        assert title not in header, f"{title} should not be in Talpa Excel"
+
+
+@pytest.mark.django_db
+def test_resolve_target_group_and_status_always_finnish():
+    from applications.exporters.excel_exporter import resolve_target_group_and_status
+
+    # 1. No youth application
+    with translation.override("en"):
+        _, status1 = resolve_target_group_and_status(None)
+        assert status1 == "selvittämätön"
+
+    with translation.override("sv"):
+        _, status2 = resolve_target_group_and_status(None)
+        assert status2 == "selvittämätön"
+
+    # 2. Youth application with target group
+    app = YouthApplicationFactory(target_group="primary_target_group")
+    with translation.override("en"):
+        display, status = resolve_target_group_and_status(app)
+        assert display == "9. luokkalainen"
+        assert status == "annettu"
+
+    with translation.override("sv"):
+        display, status = resolve_target_group_and_status(app)
+        assert display == "9. luokkalainen"
+        assert status == "annettu"
+
+    # 3. Youth application with underage/overage reason
+    app_err = YouthApplicationFactory(
+        target_group="",
+        additional_info_user_reasons=[
+            AdditionalInfoUserReason.UNDERAGE_OR_OVERAGE.value
+        ],
+    )
+    with translation.override("en"):
+        display, status = resolve_target_group_and_status(app_err)
+        assert display == ""
+        assert status == "selvittämätön"
+
+    # 4. Youth application where target group class is resolved by age (e.g. age 15)
+    app_calculated = YouthApplicationFactory(
+        target_group="",
+        social_security_number="",
+        non_vtj_birthdate=date(date.today().year - 15, 7, 1),
+    )
+    with translation.override("en"):
+        display, status = resolve_target_group_and_status(app_calculated)
+        assert display == "8. luokkalainen"
+        assert status == "laskettu"


### PR DESCRIPTION
YJDH-909.

Calculate missing target group from youth age in exports. Temporarily exclude all newly added 2026 columns and the calculation status column from Talpa Excel exports to avoid breaking robot processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Excel column showing the special-case calculation status alongside the existing target-group value.
  * Expanded Excel exports to display this information in multiple languages.

* **Bug Fixes**
  * Improved target-group values in exported youth application spreadsheets when the field is missing or affected by age-related special cases.
  * Updated Talpa export output to omit the new status field where appropriate.

* **Tests**
  * Added coverage for the new export column and special-case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->