### PR TITLE
fix(benefit): show all pdf terms on summary page

### DIFF
--- a/frontend/benefit/applicant/public/locales/en/common.json
+++ b/frontend/benefit/applicant/public/locales/en/common.json
@@ -848,6 +848,10 @@
     "next": "Next page",
     "page": "Page",
     "terms": "Terms.PDF",
+    "terms1": "Open the Helsinki benefit for employer conditions as a pdf file",
+    "terms2": "Open the preconditions of the Helsinki benefit from 1 May 2026 as a pdf file",
+    "terms3": "Open the ethical partnership principles for cooperation with organizations and grant activities as a pdf file",
+    "terms4": "Open the City of Helsinki's general guidelines for grants as a pdf file",
     "openInExternalDomainAriaLabel": "Opens a different website"
   },
   "tooltip": {

--- a/frontend/benefit/applicant/public/locales/fi/common.json
+++ b/frontend/benefit/applicant/public/locales/fi/common.json
@@ -848,6 +848,10 @@
     "next": "Seuraava sivu",
     "page": "Sivu",
     "terms": "Ehdot.PDF",
+    "terms1": "Avaa Helsinki-lisän myöntämisen ehdot pdf-tiedostona",
+    "terms2": "Avaa Helsinki-lisän myöntämisen ja maksamisen reunaehdot 1.5.2026 pdf-tiedostona",
+    "terms3": "Avaa järjestöyhteistyön ja avustustoiminnan eettiset kumppanuusperiaatteet pdf-tiedostona",
+    "terms4": "Avaa Helsingin kaupungin avustusten yleisohjeet pdf-tiedostona",
     "openInExternalDomainAriaLabel": "Avautuu uudella verkkosivulla"
   },
   "tooltip": {

--- a/frontend/benefit/applicant/public/locales/sv/common.json
+++ b/frontend/benefit/applicant/public/locales/sv/common.json
@@ -848,6 +848,10 @@
     "next": "Nästa sida",
     "page": "Sida",
     "terms": "Villkor.PDF",
+    "terms1": "Öppna villkor för beviljande av Helsingforstillägget som pdf-fil",
+    "terms2": "Öppna de allmänna villkoren för beviljande och utbetalning av Helsingforstillägg från och med 1 maj 2026 som pdf-fil",
+    "terms3": "Öppna etiska partnerskaps principer för samarbete med organisationer och bidragsverksamhet som pdf-fil",
+    "terms4": "Öppna Helsingfors stads allmänna anvisningar för bidrag pdf-fil",
     "openInExternalDomainAriaLabel": "Öppnas på en annan webbplats"
   },
   "tooltip": {

--- a/frontend/benefit/applicant/src/components/applications/forms/application/consentViewer/ConsentViewer.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/consentViewer/ConsentViewer.tsx
@@ -13,11 +13,27 @@ const ConsentViewer: React.FC<DynamicFormStepComponentProps> = ({ data }) => {
   const { textLocale, cbPrefix, t } = useConsentViewer();
   const theme = useTheme();
 
+  const termsPdfLinks = React.useMemo(
+    () =>
+      [
+        { termsKey: 'terms1', urlKey: `termsPdf${textLocale}` },
+        { termsKey: 'terms2', urlKey: `termsPdf2${textLocale}` },
+        { termsKey: 'terms3', urlKey: `termsPdf3${textLocale}` },
+        { termsKey: 'terms4', urlKey: `termsPdf4${textLocale}` },
+      ]
+        .map(({ termsKey, urlKey }) => ({
+          termsKey,
+          url: data?.applicantTermsApproval?.terms?.[urlKey as TermsProp] ?? '',
+        }))
+        .filter(({ url }) => url.length > 0),
+    [data?.applicantTermsApproval?.terms, textLocale]
+  );
+
   if (!data) return null;
   return (
     <>
-      {data && (
-        <$GridCell $colSpan={12}>
+      {termsPdfLinks.map(({ url, termsKey }) => (
+        <$GridCell $colSpan={12} key={termsKey}>
           <OpenInNewTabLink
             style={{ color: theme.colors.black }}
             external
@@ -26,16 +42,12 @@ const ConsentViewer: React.FC<DynamicFormStepComponentProps> = ({ data }) => {
             )}
             size={LinkSize.Medium}
             openInNewTab
-            href={
-              data.applicantTermsApproval?.terms?.[
-                `termsPdf${textLocale}` as TermsProp
-              ] ?? ''
-            }
+            href={url}
           >
-            {t('common:pdfViewer.terms')}
+            {t(`common:pdfViewer.${termsKey}`)}
           </OpenInNewTabLink>
         </$GridCell>
-      )}
+      ))}
       {data?.applicantTermsApproval?.terms?.applicantConsents?.map(
         (consent, i) => (
           <$GridCell $colSpan={12} key={consent.id}>

--- a/frontend/benefit/applicant/src/components/applications/forms/application/consentViewer/__tests__/ConsentViewer.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/consentViewer/__tests__/ConsentViewer.test.tsx
@@ -28,6 +28,9 @@ const baseApplication = createMockApplication({
       effectiveFrom: '2026-01-01',
       termsType: ATTACHMENT_TYPES.EMPLOYEE_CONSENT,
       termsPdfFi: 'https://example.com/terms-fi.pdf',
+      termsPdf2Fi: 'https://example.com/terms-2-fi.pdf',
+      termsPdf3Fi: 'https://example.com/terms-3-fi.pdf',
+      termsPdf4Fi: 'https://example.com/terms-4-fi.pdf',
       applicantConsents: [
         createMockApplicantConsent({
           id: 'consent-1',
@@ -47,6 +50,9 @@ const renderConsentViewer = (
 ): ReturnType<typeof renderComponent> =>
   renderComponent(<ConsentViewer data={data as Application} />);
 
+const escapeRegExp = (value: string):string =>
+  value.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+
 describe('ConsentViewer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -64,17 +70,78 @@ describe('ConsentViewer', () => {
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
 
-  it('renders terms pdf link with translated label and href', () => {
+  it('renders all available PDF links with translated labels and correct hrefs', () => {
     renderConsentViewer(baseApplication);
 
-    const termsLink = screen.getByRole('link', {
-      name: /ehdot\.pdf.*avautuu uudessa välilehdessä.*avautuu uudella verkkosivulla/i,
+    const expectedLinks = [
+      {
+        name: 'Avaa Helsinki-lisän myöntämisen ehdot pdf-tiedostona',
+        href: 'https://example.com/terms-fi.pdf',
+      },
+      {
+        name: 'Avaa Helsinki-lisän myöntämisen ja maksamisen reunaehdot 1.5.2026 pdf-tiedostona',
+        href: 'https://example.com/terms-2-fi.pdf',
+      },
+      {
+        name: 'Avaa järjestöyhteistyön ja avustustoiminnan eettiset kumppanuusperiaatteet pdf-tiedostona',
+        href: 'https://example.com/terms-3-fi.pdf',
+      },
+      {
+        name: 'Avaa Helsingin kaupungin avustusten yleisohjeet pdf-tiedostona',
+        href: 'https://example.com/terms-4-fi.pdf',
+      },
+    ];
+
+    expectedLinks.forEach(({ name, href }) => {
+      const link = screen.getByRole('link', {
+        name: new RegExp(escapeRegExp(name)),
+      });
+
+      expect(link).toHaveAttribute('href', href);
     });
-    expect(termsLink).toBeInTheDocument();
-    expect(termsLink).toHaveAttribute(
+  });
+
+  it('does not render PDF links without href values', () => {
+    renderConsentViewer(
+      createMockApplication({
+        applicantTermsApproval: {
+          ...baseApplication.applicantTermsApproval,
+          terms: {
+            ...baseApplication.applicantTermsApproval?.terms,
+            termsPdfFi: 'https://example.com/terms-fi.pdf',
+            termsPdf2Fi: '',
+            termsPdf3Fi: undefined,
+            termsPdf4Fi: '',
+          },
+        },
+      } as Partial<Application>)
+    );
+
+    const renderedLink = screen.getByRole('link', {
+      name: /avaa helsinki-lisän myöntämisen ehdot pdf-tiedostona/i,
+    });
+
+    expect(renderedLink).toBeInTheDocument();
+    expect(renderedLink).toHaveAttribute(
       'href',
       'https://example.com/terms-fi.pdf'
     );
+
+    expect(
+      screen.queryByRole('link', {
+        name: /avaa helsinki-lisän myöntämisen ja maksamisen reunaehdot/i,
+      })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: /avaa järjestöyhteistyön ja avustustoiminnan eettiset kumppanuusperiaatteet/i,
+      })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: /avaa helsingin kaupungin avustusten yleisohjeet/i,
+      })
+    ).not.toBeInTheDocument();
   });
 
   it('renders one disabled checked checkbox for each applicant consent', () => {


### PR DESCRIPTION
## Description :sparkles:

Summary page showed only one pdf terms document.
Fixed to show all the terms documents with a map
loop.

## Context

[HL-1838](https://helsinkisolutionoffice.atlassian.net/browse/HL-1838)

## Testing :alembic:

Visual testing.


[HL-1838]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the consent view to support multiple terms PDF links (up to four) instead of a single document.
  * Added new localized labels for these additional PDF links in English, Finnish, and Swedish.
* **Bug Fixes**
  * Improved behavior for missing PDF URLs by only showing links for available documents.
* **Tests**
  * Expanded test coverage to verify all available links render with correct text and URLs, and that empty links are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->