### PR TITLE
fix(ks): restrict handler permissions to authenticated users

### DIFF
--- a/backend/kesaseteli/applications/tests/test_excel_export.py
+++ b/backend/kesaseteli/applications/tests/test_excel_export.py
@@ -730,3 +730,15 @@ def test_youth_excel_download_with_missing_birthdate(staff_client):
     # Test that birth_year and birthdate use their respective fallback values:
     assert row_by_field["birth_year"] == -1
     assert row_by_field["birthdate"] == "N/A"
+
+
+@pytest.mark.django_db
+@override_settings(NEXT_PUBLIC_MOCK_FLAG=True)
+def test_youth_excel_download_unauthenticated_redirects_with_mock_flag(client):
+    """
+    Test that when mock flag is on, a GET request on youth-excel-download
+    by a plain unauthenticated client redirects to the ADFS login page.
+    """
+    response = client.get(youth_excel_download_url())
+    assert response.status_code == status.HTTP_302_FOUND
+    assert response.url.startswith(reverse("django_auth_adfs:login"))

--- a/backend/kesaseteli/applications/tests/test_youth_applications_api.py
+++ b/backend/kesaseteli/applications/tests/test_youth_applications_api.py
@@ -12,7 +12,6 @@ import factory.random
 import pytest
 from auditlog.models import LogEntry
 from dateutil.relativedelta import relativedelta
-from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.template import Context, Template
@@ -41,7 +40,6 @@ from applications.tests.data.mock_vtj import (
     mock_vtj_person_id_query_found_content,
     mock_vtj_person_id_query_not_found_content,
 )
-from common.permissions import HandlerPermission
 from common.tests.conftest import (
     api_client,
 )
@@ -387,7 +385,7 @@ def test_youth_applications_not_allowed_methods(
         (False, staff_client, 302, RedirectTo.handler_process),
         (False, superuser_client, 302, RedirectTo.handler_process),
         # With mock flag
-        (True, unauth_api_client, 302, RedirectTo.handler_process),
+        (True, unauth_api_client, 302, RedirectTo.adfs_login),
         (True, api_client, 302, RedirectTo.handler_process),
         (True, staff_client, 302, RedirectTo.handler_process),
         (True, superuser_client, 302, RedirectTo.handler_process),
@@ -426,7 +424,7 @@ def test_youth_applications_process_valid_pk(
         (False, staff_client, 200, None),
         (False, superuser_client, 200, None),
         # With mock flag
-        (True, unauth_api_client, 200, None),
+        (True, unauth_api_client, 302, RedirectTo.adfs_login),
         (True, api_client, 200, None),
         (True, staff_client, 200, None),
         (True, superuser_client, 200, None),
@@ -464,7 +462,7 @@ def test_youth_applications_detail_valid_pk(
         (False, staff_client, 404, None),
         (False, superuser_client, 404, None),
         # With mock flag
-        (True, unauth_api_client, 404, None),
+        (True, unauth_api_client, 302, RedirectTo.adfs_login),
         (True, api_client, 404, None),
         (True, staff_client, 404, None),
         (True, superuser_client, 404, None),
@@ -1821,7 +1819,7 @@ def test_youth_summer_voucher_email_plaintext_content(api_client, language):
 )
 @pytest.mark.parametrize("language", get_supported_languages())
 def test_youth_applications_accept_acceptable_with_invalid_smtp_server(
-    api_client, language
+    api_client, user, language
 ):
     # Use an email address which uses a reserved domain name (See RFC 2606)
     # so even if it'd be sent to an SMTP server it wouldn't go anywhere
@@ -1830,7 +1828,7 @@ def test_youth_applications_accept_acceptable_with_invalid_smtp_server(
     )
     assert not acceptable_youth_application.is_accepted
     assert acceptable_youth_application.can_accept_manually(
-        handler=AnonymousUser(),
+        handler=user,
         encrypted_handler_vtj_json=json.dumps(
             get_test_handling_data()["encrypted_handler_vtj_json"]
         ),
@@ -2190,7 +2188,7 @@ def test_youth_application_post_success(
         (False, staff_client, 200, None),
         (False, superuser_client, 200, None),
         # With mock flag
-        (True, unauth_api_client, 200, None),
+        (True, unauth_api_client, 302, RedirectTo.adfs_login),
         (True, api_client, 200, None),
         (True, staff_client, 200, None),
         (True, superuser_client, 200, None),
@@ -2255,17 +2253,11 @@ def test_youth_applications_accept_acceptable(
         ]
         handler = response.wsgi_request.user
         assert handler is not None
-        if handler == AnonymousUser():
-            assert HandlerPermission.allow_empty_handler()
-            assert handler.pk is None
-            assert acceptable_youth_application.handler is None
-            assert youth_voucher_audit_event.actor_id is None
-            assert youth_app_audit_event.actor_id is None
-        else:
-            assert handler.pk is not None
-            assert acceptable_youth_application.handler == handler
-            assert youth_voucher_audit_event.actor_id == handler.pk
-            assert youth_app_audit_event.actor_id == handler.pk
+        assert handler.is_authenticated
+        assert handler.pk is not None
+        assert acceptable_youth_application.handler == handler
+        assert youth_voucher_audit_event.actor_id == handler.pk
+        assert youth_app_audit_event.actor_id == handler.pk
     else:
         assert acceptable_youth_application.status == old_status
         assert acceptable_youth_application.modified_at == old_modified_at
@@ -2332,7 +2324,7 @@ def test_youth_applications_accept_acceptable__vtj_disabled(
         (False, staff_client, 400, None),
         (False, superuser_client, 400, None),
         # With mock flag
-        (True, unauth_api_client, 400, None),
+        (True, unauth_api_client, 302, RedirectTo.adfs_login),
         (True, api_client, 400, None),
         (True, staff_client, 400, None),
         (True, superuser_client, 400, None),
@@ -2386,7 +2378,7 @@ def test_youth_applications_handle_handled(
         (False, staff_client, 200, None),
         (False, superuser_client, 200, None),
         # With mock flag
-        (True, unauth_api_client, 200, None),
+        (True, unauth_api_client, 302, RedirectTo.adfs_login),
         (True, api_client, 200, None),
         (True, staff_client, 200, None),
         (True, superuser_client, 200, None),
@@ -2438,15 +2430,10 @@ def test_youth_applications_reject_rejectable(
         ]
         handler = response.wsgi_request.user
         assert handler is not None
-        if handler == AnonymousUser():
-            assert HandlerPermission.allow_empty_handler()
-            assert handler.pk is None
-            assert rejectable_youth_application.handler is None
-            assert audit_event.actor_id is None
-        else:
-            assert handler.pk is not None
-            assert rejectable_youth_application.handler == handler
-            assert audit_event.actor_id == handler.pk
+        assert handler.is_authenticated
+        assert handler.pk is not None
+        assert rejectable_youth_application.handler == handler
+        assert audit_event.actor_id == handler.pk
     else:
         assert rejectable_youth_application.status == old_status
         assert rejectable_youth_application.modified_at == old_modified_at

--- a/backend/kesaseteli/common/permissions.py
+++ b/backend/kesaseteli/common/permissions.py
@@ -1,7 +1,11 @@
+import logging
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import Q
 from rest_framework.permissions import BasePermission
+
+LOGGER = logging.getLogger(__name__)
 
 
 class DenyAll(BasePermission):
@@ -51,19 +55,37 @@ class HandlerPermission(BasePermission):
         Does the user have permission to act as a handler for youth
         applications / youth summer vouchers?
 
-        :return: True if NEXT_PUBLIC_MOCK_FLAG setting is set, or user is an
-            active staff or superuser user, otherwise False.
+        :return: True if NEXT_PUBLIC_MOCK_FLAG setting is set and user is
+            authenticated, or user is an active staff or superuser user,
+            otherwise False.
         """
+        if not (user and user.is_authenticated):
+            LOGGER.debug("User is not authenticated")
+            return False
+
         if settings.NEXT_PUBLIC_MOCK_FLAG:
+            # Under mock flag (local dev / testing), any authenticated user is allowed
+            # to act as a handler. This simplifies local development and satisfies
+            # test cases parametrized with non-staff authenticated clients (api_client).
+            LOGGER.info(
+                "Returning True from HandlerPermission.has_user_permission ("
+                "NEXT_PUBLIC_MOCK_FLAG is True)"
+            )
             return True
 
-        return bool(user and user.is_active and (user.is_staff or user.is_superuser))
+        has_permission = bool(user.is_active and (user.is_staff or user.is_superuser))
+        LOGGER.debug(
+            f"User has permission: {has_permission} (is_active={user.is_active}, "
+            f"is_staff={user.is_staff}, is_superuser={user.is_superuser})"
+        )
+        return has_permission
 
     def has_permission(self, request, view):
         """
         Does the request's user have permission to the given view?
 
-        :return: True if NEXT_PUBLIC_MOCK_FLAG setting is set, or request has
-            an active staff or superuser user, otherwise False.
+        :return: True if NEXT_PUBLIC_MOCK_FLAG setting is set and request has
+            an authenticated user, or request has an active staff or superuser
+            user, otherwise False.
         """
         return HandlerPermission.has_user_permission(request.user)

--- a/backend/kesaseteli/common/tests/test_permissions.py
+++ b/backend/kesaseteli/common/tests/test_permissions.py
@@ -75,7 +75,7 @@ def test_handler_permission_has_user_permission_without_mock_flag(
 @pytest.mark.parametrize(
     "test_user,expected_result",
     [
-        (test_user, True)
+        (test_user, bool(test_user and test_user.is_authenticated))
         for test_user, _ in _get_test_user_and_expected_handler_permission_tuples()
     ],
 )

--- a/frontend/kesaseteli/youth/browser-tests/handler-application.testcafe.ts
+++ b/frontend/kesaseteli/youth/browser-tests/handler-application.testcafe.ts
@@ -4,6 +4,7 @@ import {
   fakeAdditionalInfoApplication,
   fakeYouthApplication,
 } from '@frontend/kesaseteli-shared/src/__tests__/utils/fake-objects';
+import { ADDITIONAL_INFO_REASON_TYPE } from '@frontend/kesaseteli-shared/src/constants/additional-info-reason-type';
 import requestLogger, {
   filterLoggedRequests,
 } from '@frontend/shared/browser-tests/utils/request-logger';
@@ -108,7 +109,12 @@ if (!isRealIntegrationsEnabled()) {
     } = getYouthTranslationsApi();
     await handlerFormPage.applicationFieldHasValue(
       'additional_info_user_reasons',
-      activatedApplication.additional_info_user_reasons
+      [...(activatedApplication.additional_info_user_reasons ?? [])]
+        .sort(
+          (leftReason, rightReason) =>
+            ADDITIONAL_INFO_REASON_TYPE.indexOf(leftReason) -
+            ADDITIONAL_INFO_REASON_TYPE.indexOf(rightReason)
+        )
         ?.map((reason) => fi.additionalInfo.reasons[reason])
         .join('. ') ?? ''
     );

--- a/frontend/kesaseteli/youth/browser-tests/page-models/AdditionalInfoPage.tsx
+++ b/frontend/kesaseteli/youth/browser-tests/page-models/AdditionalInfoPage.tsx
@@ -1,7 +1,7 @@
 import AdditionalInfoApplication from '@frontend/kesaseteli-shared/src/types/additional-info-application';
 import AdditionalInfoReasonType from '@frontend/kesaseteli-shared/src/types/additional-info-reason-type';
 import { Language } from '@frontend/shared/src/i18n/i18n';
-import { t } from 'testcafe';
+import { Selector, t } from 'testcafe';
 
 import YouthTranslations from '../../src/__tests__/utils/i18n/youth-translations';
 import YouthPageComponent from './YouthPageComponent';
@@ -24,8 +24,8 @@ class AdditionalInfoPage extends YouthPageComponent {
     name: this.translations.additionalInfo.title,
   });
 
-  private reasonOption(reason: Reason): SelectorPromise {
-    return this.withinForm.findByRole('option', {
+  private reasonOption(reason: Reason): Selector {
+    return this.screen.findByRole('option', {
       name: this.regexp(this.translations.additionalInfo.reasons[reason]),
     });
   }
@@ -58,14 +58,14 @@ class AdditionalInfoPage extends YouthPageComponent {
   public async clickAndSelectReasonsFromDropdown(
     reasons: AdditionalInfoReasonType[]
   ): Promise<void> {
-    await this.htmlElementClick('#additional_info_user_reasons-toggle-button');
+    await t.click(Selector('#additional_info_user_reasons-main-button'));
     /* eslint-disable no-await-in-loop */
     // eslint-disable-next-line no-restricted-syntax
     for (const reason of reasons) {
       await t.click(this.reasonOption(reason));
     }
     /* eslint-enable no-await-in-loop */
-    await this.htmlElementClick('#additional_info_user_reasons-toggle-button');
+    await t.click(Selector('#additional_info_user_reasons-main-button'));
   }
 
   public async typeAdditionalInfoDescription(text: string): Promise<void> {

--- a/frontend/kesaseteli/youth/browser-tests/page-models/YouthForm.ts
+++ b/frontend/kesaseteli/youth/browser-tests/page-models/YouthForm.ts
@@ -15,6 +15,23 @@ type CheckboxName = keyof Pick<
   'is_unlisted_school' | 'termsAndConditions'
 >;
 
+const getAgeFromSsn = (ssn?: string): number => {
+  if (!ssn || ssn.length < 7) {
+    return 16;
+  }
+  let year = parseInt(ssn.slice(4, 6), 10);
+  const separator = ssn.charAt(6).toUpperCase();
+  if (separator === '+') {
+    year += 1800;
+  } else if (['A', 'B', 'C', 'D', 'E', 'F'].includes(separator)) {
+    year += 2000;
+  } else {
+    year += 1900;
+  }
+  const currentYear = new Date().getFullYear();
+  return currentYear - year;
+};
+
 class YouthForm extends YouthPageComponent {
   public constructor(lang?: Language) {
     super({ datatestId: 'youth-form', lang });
@@ -93,9 +110,11 @@ class YouthForm extends YouthPageComponent {
     return t.click(this.checkbox(name));
   }
 
-  public selectTargetGroup(): TestControllerPromise {
+  public selectTargetGroup(ssn?: string): TestControllerPromise {
+    const age = getAgeFromSsn(ssn);
+    const index = age === 17 ? 1 : 0;
     return this.clickSelectRadioButton(
-      this.component.findAllByRole('radio').nth(0)
+      this.component.findAllByRole('radio').nth(index)
     );
   }
 
@@ -126,7 +145,7 @@ class YouthForm extends YouthPageComponent {
     }
     await this.typeInput('phone_number', application.phone_number);
     await this.typeInput('email', application.email);
-    await this.selectTargetGroup();
+    await this.selectTargetGroup(application.social_security_number);
     await this.toggleCheckbox('termsAndConditions');
     return this.clickSendButton();
   }


### PR DESCRIPTION
YJDH-910.

Ensure that HandlerPermission is not granted to AnonymousUser even when NEXT_PUBLIC_MOCK_FLAG is True. This prevents unauthenticated users from accessing sensitive views like Excel downloads and makes audit logging robust by ensuring an authenticated actor is always present.

Add detailed comments in HandlerPermission explaining why the mock flag bypass check is kept for authenticated users (to support api_client in parametrized tests and local development).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In mock mode, unauthenticated requests across the youth application flow now consistently redirect to the login page instead of returning mixed success/error responses.
  * Permission checks now only grant access in mock mode to authenticated users, improving consistency and preventing unintended handling.
  * Updated youth application action/acceptance behavior so unauthorized clients are redirected prior to viewing or processing requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->