### PR TITLE
fix(ks): skip redundant logout logs for already logged out users

### DIFF
--- a/backend/kesaseteli/applications/tests/test_applications_auth_logging.py
+++ b/backend/kesaseteli/applications/tests/test_applications_auth_logging.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.test import override_settings, RequestFactory
 from requests.exceptions import ConnectionError as RequestsConnectionError
@@ -148,3 +149,20 @@ def test_fetch_vtj_json_raises_service_unavailable_on_value_error():
     application = YouthApplicationFactory()
     with pytest.raises(VTJServiceUnavailableError):
         VTJService.fetch_vtj_json(application, end_user="test-handler-uuid")
+
+
+@override_settings(ENABLE_AUTH_LOGGING=True)
+@pytest.mark.parametrize("user", [None, AnonymousUser()])
+def test_on_user_logged_out_does_not_log_if_anonymous_or_none(user):
+    """Anonymous or None user logout does not trigger a LOGOUT log entry."""
+    request = RequestFactory().get("/")
+    user_logged_out.send(
+        sender=user.__class__ if user else None, request=request, user=user
+    )
+
+    assert (
+        ResilientLogEntry.objects.filter(
+            context__operation=AuthEventType.LOGOUT
+        ).count()
+        == 0
+    )

--- a/backend/kesaseteli/kesaseteli/auth_logging.py
+++ b/backend/kesaseteli/kesaseteli/auth_logging.py
@@ -194,7 +194,13 @@ def log_logout_event(request, user):
         request: The current Django ``HttpRequest``.
         user: The Django ``User`` instance that is logging out.
     """
-    user_id = str(user.pk) if user else "unknown"
+    # Django sends the `user_logged_out` signal unconditionally on every logout request.
+    # If the user is already logged out (or the session is anonymous), Django passes
+    # `user=None`. We skip logging in this case to avoid redundant/empty log entries.
+    if user is None or not user.is_authenticated:
+        return
+
+    user_id = str(user.pk)
     ResilientLogSource.create_structured(
         level=logging.INFO,
         message=AuthEventMessage.LOGOUT,


### PR DESCRIPTION
YJDH-902.

Django sends the `user_logged_out` signal unconditionally on every logout request, even when the user session is already logged out or anonymous (passing `user=None` to the signal). This leads to writing redundant compliance log entries with unknown actors. Skip logging if the user is None or not authenticated.