### PR TITLE
fix(benefit): translations and error messages

### DIFF
--- a/frontend/benefit/handler/public/locales/en/common.json
+++ b/frontend/benefit/handler/public/locales/en/common.json
@@ -1882,6 +1882,9 @@
       "companyContactPersonEmail": {
         "label": "Yhteyshenkilön sähköposti"
       },
+      "companyNumberOfEmployees": {
+        "label": "Työntekijöiden määrä ennen työllistettyä"
+      },
       "deMinimisAid": {
         "label": "De minimis -tuet"
       },

--- a/frontend/benefit/handler/public/locales/fi/common.json
+++ b/frontend/benefit/handler/public/locales/fi/common.json
@@ -1882,6 +1882,9 @@
       "companyContactPersonEmail": {
         "label": "Yhteyshenkilön sähköposti"
       },
+      "companyNumberOfEmployees": {
+        "label": "Työntekijöiden määrä ennen työllistettyä"
+      },
       "deMinimisAid": {
         "label": "De minimis -tuet"
       },

--- a/frontend/benefit/handler/public/locales/sv/common.json
+++ b/frontend/benefit/handler/public/locales/sv/common.json
@@ -1882,6 +1882,9 @@
       "companyContactPersonEmail": {
         "label": "Yhteyshenkilön sähköposti"
       },
+      "companyNumberOfEmployees": {
+        "label": "Työntekijöiden määrä ennen työllistettyä"
+      },
       "deMinimisAid": {
         "label": "De minimis -tuet"
       },

--- a/frontend/benefit/handler/src/components/applicationForm/__tests__/useApplicationForm.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/__tests__/useApplicationForm.test.tsx
@@ -1,0 +1,278 @@
+import { act, renderHook } from '@testing-library/react';
+import { APPLICATION_FIELD_KEYS } from 'benefit/handler/constants';
+import DeMinimisContext from 'benefit/handler/context/DeMinimisContext';
+import { useApplicationFormContext } from 'benefit/handler/hooks/useApplicationFormContext';
+import useApplicationQueryWithState from 'benefit/handler/hooks/useApplicationQueryWithState';
+import useFormActions from 'benefit/handler/hooks/useFormActions';
+import { useSteps } from 'benefit/handler/hooks/useSteps';
+import useUserQuery from 'benefit/handler/hooks/useUserQuery';
+import { APPLICATION_ORIGINS } from 'benefit-shared/constants';
+import { useFormik } from 'formik';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+import { focusAndScroll } from 'shared/utils/dom.utils';
+
+import { useApplicationForm } from '../useApplicationForm';
+import {
+  getApplication,
+  getDates,
+  getFields,
+  getSubsidyOptions,
+  handleErrorFieldKeys,
+  requiredAttachments,
+} from '../utils/applicationForm';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: jest.fn(),
+}));
+
+jest.mock('formik', () => ({
+  useFormik: jest.fn(),
+}));
+
+jest.mock('benefit/handler/hooks/useApplicationFormContext', () => ({
+  useApplicationFormContext: jest.fn(),
+}));
+
+jest.mock('benefit/handler/hooks/useApplicationQueryWithState', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('benefit/handler/hooks/useFormActions', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('benefit/handler/hooks/useSteps', () => ({
+  useSteps: jest.fn(),
+}));
+
+jest.mock('benefit/handler/hooks/useUserQuery', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('shared/utils/dom.utils', () => ({
+  focusAndScroll: jest.fn(),
+}));
+
+jest.mock('../utils/validation', () => ({
+  getValidationSchema: jest.fn(() => ({})),
+}));
+
+jest.mock('../utils/applicationForm', () => ({
+  errorToast: jest.fn(),
+  getApplication: jest.fn(),
+  getDates: jest.fn(),
+  getFields: jest.fn(),
+  getSubsidyOptions: jest.fn(),
+  handleErrorFieldKeys: jest.fn(),
+  requiredAttachments: jest.fn(),
+}));
+
+const onSave = jest.fn();
+const onQuietSave = jest.fn();
+const onSubmit = jest.fn();
+const onNext = jest.fn();
+const onDelete = jest.fn();
+const dispatchStep = jest.fn();
+const validateForm = jest.fn();
+const setTouched = jest.fn();
+const submitForm = jest.fn();
+const setFieldValue = jest.fn();
+
+const application = {
+  id: 'application-id',
+  applicationOrigin: APPLICATION_ORIGINS.HANDLER,
+  company: {
+    organizationType: 'company',
+  },
+  attachments: [],
+  applicantTermsInEffect: {
+    applicantConsents: [],
+  },
+  deMinimisAidSet: [],
+};
+
+const formikMock = {
+  values: {
+    ...application,
+    deMinimisAid: false,
+  },
+  validateForm,
+  setTouched,
+  submitForm,
+  setFieldValue,
+};
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <DeMinimisContext.Provider
+    value={{
+      deMinimisAids: [],
+      setDeMinimisAids: jest.fn(),
+      unfinishedDeMinimisAidRow: false,
+    }}
+  >
+    {children}
+  </DeMinimisContext.Provider>
+);
+
+describe('useApplicationForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useRouter as jest.Mock).mockReturnValue({
+      query: {},
+      push: jest.fn(),
+    });
+
+    (useTranslation as jest.Mock).mockReturnValue({
+      t: (key: string) => key,
+    });
+
+    (useApplicationFormContext as jest.Mock).mockReturnValue({
+      isFormActionNew: true,
+      isFormActionEdit: false,
+    });
+
+    (useSteps as jest.Mock).mockReturnValue({
+      stepState: {
+        activeStepIndex: 1,
+        steps: [],
+      },
+      dispatchStep,
+      activeStep: 1,
+    });
+
+    (useFormActions as jest.Mock).mockReturnValue({
+      onSave,
+      onQuietSave,
+      onSubmit,
+      onNext,
+      onDelete,
+    });
+
+    (useApplicationQueryWithState as jest.Mock).mockReturnValue({
+      status: 'idle',
+      data: undefined,
+      error: undefined,
+    });
+
+    (useUserQuery as jest.Mock).mockReturnValue({
+      data: {
+        id: 'user-id',
+      },
+    });
+
+    (getApplication as jest.Mock).mockReturnValue(application);
+
+    (getFields as jest.Mock).mockReturnValue({
+      endDate: {
+        name: APPLICATION_FIELD_KEYS.END_DATE,
+      },
+    });
+
+    (getDates as jest.Mock).mockReturnValue({
+      minEndDate: new Date('2024-01-01'),
+      minEndDateFormatted: '1.1.2024',
+      maxEndDate: undefined,
+      isEndDateEligible: true,
+    });
+
+    (getSubsidyOptions as jest.Mock).mockReturnValue([]);
+
+    (requiredAttachments as jest.Mock).mockReturnValue(true);
+
+    (handleErrorFieldKeys as jest.Mock).mockImplementation(
+      (fieldKey) => fieldKey
+    );
+
+    (useFormik as jest.Mock).mockReturnValue(formikMock);
+  });
+
+  it('marks invalid top-level and nested fields as touched when validation fails', async () => {
+    validateForm.mockResolvedValue({
+      [APPLICATION_FIELD_KEYS.PURCHASED_SERVICE]: 'required',
+      employee: {
+        firstName: 'required',
+      },
+    });
+
+    const { result } = renderHook(() => useApplicationForm(), { wrapper });
+
+    let isValid = true;
+
+    await act(async () => {
+      isValid = await result.current.handleValidation();
+    });
+
+    expect(isValid).toBe(false);
+    expect(setTouched).toHaveBeenCalledWith(
+      {
+        [APPLICATION_FIELD_KEYS.PURCHASED_SERVICE]: true,
+        employee: {
+          firstName: true,
+        },
+      },
+      true
+    );
+    expect(focusAndScroll).toHaveBeenCalledWith(
+      APPLICATION_FIELD_KEYS.PURCHASED_SERVICE
+    );
+  });
+
+  it('does not mark fields as touched when validation has no errors', async () => {
+    validateForm.mockResolvedValue({});
+
+    const { result } = renderHook(() => useApplicationForm(), { wrapper });
+
+    let isValid = false;
+
+    await act(async () => {
+      isValid = await result.current.handleValidation();
+    });
+
+    expect(isValid).toBe(true);
+    expect(setTouched).not.toHaveBeenCalled();
+    expect(focusAndScroll).not.toHaveBeenCalled();
+  });
+
+  it('marks invalid fields as touched and does not submit when saving invalid form', async () => {
+    validateForm.mockResolvedValue({
+      [APPLICATION_FIELD_KEYS.CO_OPERATION_NEGOTIATIONS]: 'required',
+    });
+
+    const { result } = renderHook(() => useApplicationForm(), { wrapper });
+
+    await act(() => result.current.handleSave() as unknown as Promise<void>);
+
+    expect(setTouched).toHaveBeenCalledWith(
+      {
+        [APPLICATION_FIELD_KEYS.CO_OPERATION_NEGOTIATIONS]: true,
+      },
+      true
+    );
+    expect(focusAndScroll).toHaveBeenCalledWith(
+      APPLICATION_FIELD_KEYS.CO_OPERATION_NEGOTIATIONS
+    );
+    expect(submitForm).not.toHaveBeenCalled();
+  });
+
+  it('submits the form when saving valid form', async () => {
+    validateForm.mockResolvedValue({});
+
+    const { result } = renderHook(() => useApplicationForm(), { wrapper });
+
+    await act(() => result.current.handleSave() as unknown as Promise<void>);
+
+    expect(setTouched).not.toHaveBeenCalled();
+    expect(focusAndScroll).not.toHaveBeenCalled();
+    expect(submitForm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/companySection/CompanySection.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/companySection/CompanySection.tsx
@@ -394,8 +394,10 @@ const CompanySection: React.FC<Props> = ({
             id={`${fields.purchasedService.name}`}
             label={fields.purchasedService.label}
             direction="vertical"
-            required
+            invalid={!!getErrorMessage(fields.purchasedService.name)}
             errorText={getErrorMessage(fields.purchasedService.name)}
+            aria-invalid={!!getErrorMessage(fields.purchasedService.name)}
+            required
           >
             <$RadioButton
               id={`${fields.purchasedService.name}False`}
@@ -585,6 +587,8 @@ const CompanySection: React.FC<Props> = ({
             direction="vertical"
             required
             errorText={getErrorMessage(fields.coOperationNegotiations.name)}
+            invalid={!!getErrorMessage(fields.coOperationNegotiations.name)}
+            aria-invalid={!!getErrorMessage(fields.coOperationNegotiations.name)}
           >
             <$RadioButton
               id={`${fields.coOperationNegotiations.name}False`}

--- a/frontend/benefit/handler/src/components/applicationForm/useApplicationForm.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/useApplicationForm.ts
@@ -25,7 +25,7 @@ import {
   ApplicationData,
   DeMinimisAid,
 } from 'benefit-shared/types/application';
-import { FormikErrors, FormikProps, useFormik } from 'formik';
+import { FormikErrors, FormikProps, FormikTouched, useFormik } from 'formik';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 import { NextRouter, useRouter } from 'next/router';
@@ -59,10 +59,10 @@ type ExtendedComponentProps = {
   application: Application;
   formik: FormikProps<Partial<Application>>;
   fields: ApplicationFields;
-  handleSave: () => void;
-  handleSaveDraft: () => void;
+  handleSave: () => Promise<void>;
+  handleSaveDraft: () => Promise<void>;
   handleDelete: () => void;
-  handleSubmit: () => void;
+  handleSubmit: () => Promise<void>;
   handleQuietSave: () => Promise<ApplicationData | void>;
   handleValidation: () => Promise<boolean>;
   showDeminimisSection: boolean;
@@ -82,6 +82,26 @@ type ExtendedComponentProps = {
   initialApplication: Application | null;
   user: User | undefined;
 };
+
+const getTouchedFromErrors = <TValues,>(
+  errors: FormikErrors<TValues>
+): FormikTouched<TValues> =>
+  Object.keys(errors).reduce((touched, key) => {
+    const error = errors[key as keyof FormikErrors<TValues>];
+
+    return {
+      ...touched,
+      [key]: Array.isArray(error)
+        ? error.map((item) =>
+          item && typeof item === 'object'
+            ? getTouchedFromErrors(item as FormikErrors<unknown>)
+            : true
+        )
+        : error && typeof error === 'object'
+          ? getTouchedFromErrors(error as FormikErrors<unknown>)
+          : true,
+    };
+  }, {} as FormikTouched<TValues>);
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export const useApplicationForm = (): ExtendedComponentProps => {
@@ -299,18 +319,24 @@ export const useApplicationForm = (): ExtendedComponentProps => {
       return;
     }
 
+    if (Object.keys(errors).length > 0) {
+      await formik.setTouched(getTouchedFromErrors(errors), true);
+    }
+
     if (!errorActions(errors)) {
       await formik.submitForm();
     }
   };
 
-  const handleValidation = (): Promise<boolean> =>
-    formik.validateForm().then((errors) => {
-      if (!errorActions(errors)) {
-        return true;
-      }
-      return false;
-    });
+  const handleValidation = async (): Promise<boolean> => {
+    const errors = await formik.validateForm();
+
+    if (Object.keys(errors).length > 0) {
+      await formik.setTouched(getTouchedFromErrors(errors), true);
+    }
+
+    return !errorActions(errors);
+  };
 
   const handleSubmit = async (): Promise<void> => {
     await onSubmit(values, id ?? undefined);


### PR DESCRIPTION
## Description :sparkles:

Translations were missing from one field.
Missing oolean fields did not give error message if on submit.

## Issues :bug:

[HL-1824](https://helsinkisolutionoffice.atlassian.net/browse/HL-1824)
[HL-1840](https://helsinkisolutionoffice.atlassian.net/browse/HL-1840)

## Testing :alembic:

Jest tests


[HL-1824]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-1840]: https://helsinkisolutionoffice.atlassian.net/browse/HL-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/updated employee-count labels for Finnish and Swedish benefit change forms.

* **Bug Fixes**
  * Improved validation behavior so invalid fields are marked more reliably, including proper accessibility states.
  * Enhanced Form validation flow to mark fields as touched and focus the first invalid field before saving/submitting.

* **Tests**
  * Added coverage for validation and save behaviors in the application form hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->