### PR TITLE
Filter by status on pending applications listing

### DIFF
--- a/frontend/kesaseteli/handler/src/components/applicationList/ApplicationListTable.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/ApplicationListTable.tsx
@@ -55,7 +55,7 @@ type ApplicationListTableProps<T extends BaseApplication = BaseApplication> = {
   defaultSortColumnKey?: OrderingField<T>;
 };
 
-type TableState<T extends BaseApplication = BaseApplication> = {
+export type TableState<T extends BaseApplication = BaseApplication> = {
   page: number;
   setPage: (page: number) => void;
   ordering: OrderingField<T>;

--- a/frontend/kesaseteli/handler/src/components/applicationList/EmployerApplicationList.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/EmployerApplicationList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'next-i18next';
 import React, { useEffect, useState } from 'react';
 import { UseQueryResult } from 'react-query/types/react/types';
 import useLocale from 'shared/hooks/useLocale';
+import styled from 'styled-components';
 
 import useEmployerApplicationsListQuery from '../../hooks/backend/useEmployerApplicationsListQuery';
 import {
@@ -16,7 +17,7 @@ import ApplicationListTable, {
   TableState,
   useApplicationTableQuery,
 } from './ApplicationListTable';
-import styled from 'styled-components';
+import StatusFilter from './searchFilters/StatusFilter';
 
 const $TabList = styled(TabList)`
   margin-bottom: 1rem;
@@ -130,14 +131,24 @@ type UsePendingEmployerApplicationsResultType =
  */
 const usePendingEmployerApplications =
   (): UsePendingEmployerApplicationsResultType => {
+    const [selectedPendingStatuses, setSelectedPendingStatuses] = useState<
+      ApplicationStatus[]
+    >(DEFAULT_PENDING_STATUSES);
+
     const tableQuery = useApplicationTableQuery<EmployerApplication>(
       useEmployerApplicationsListQuery,
-      DEFAULT_PENDING_STATUSES
+      selectedPendingStatuses
     );
+
+    const { setPage } = tableQuery;
+
+    useEffect(() => {
+      setPage(0);
+    }, [selectedPendingStatuses, setPage]);
 
     return {
       ...tableQuery,
-      setSelectedStatuses: () => {},
+      setSelectedStatuses: setSelectedPendingStatuses,
     };
   };
 
@@ -151,6 +162,7 @@ export default function EmployerApplicationList(): JSX.Element {
     page: pendingPage,
     setPage: setPendingPage,
     setOrdering: setPendingOrdering,
+    setSelectedStatuses: setSelectedPendingStatuses,
     query: pendingQuery,
     count: pendingCount,
   } = usePendingEmployerApplications();
@@ -180,6 +192,12 @@ export default function EmployerApplicationList(): JSX.Element {
         </Tab>
       </$TabList>
       <TabPanel index={0}>
+        <StatusFilter
+          id="employer-application-pending-status-filter"
+          statuses={EMPLOYER_PENDING_STATUSES}
+          defaultSelectedStatuses={DEFAULT_PENDING_STATUSES}
+          onChange={setSelectedPendingStatuses}
+        />
         <ApplicationListTable<EmployerApplication>
           columns={columns}
           data={pendingQuery.data?.results ?? []}

--- a/frontend/kesaseteli/handler/src/components/applicationList/EmployerApplicationList.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/EmployerApplicationList.tsx
@@ -1,22 +1,39 @@
 import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
 import { useTranslation } from 'next-i18next';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { UseQueryResult } from 'react-query/types/react/types';
 import useLocale from 'shared/hooks/useLocale';
 
 import useEmployerApplicationsListQuery from '../../hooks/backend/useEmployerApplicationsListQuery';
 import {
   ApplicationStatus,
   EmployerApplication,
+  PaginatedResponse,
 } from '../../types/application';
 import ActionCell from './ActionCell';
 import ApplicationListTable, {
   HdsHeader,
+  TableState,
   useApplicationTableQuery,
 } from './ApplicationListTable';
+import styled from 'styled-components';
+
+const $TabList = styled(TabList)`
+  margin-bottom: 1rem;
+`;
 
 const EMPLOYER_PENDING_STATUSES = [
   ApplicationStatus.SUBMITTED,
   ApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED,
+  ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED,
+];
+
+/**
+ * The initial and default statuses selected for the pending employer applications list query.
+ * Also used as default/fallback statuses when no specific filters are checked by the user.
+ */
+const DEFAULT_PENDING_STATUSES = [
+  ApplicationStatus.SUBMITTED,
   ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED,
 ];
 
@@ -94,6 +111,36 @@ export const useEmployerApplicationListColumns =
     ];
   };
 
+/** Result type for the hook managing pending employer applications */
+type UsePendingEmployerApplicationsResultType =
+  TableState<EmployerApplication> & {
+    /** The React Query result containing paginated application data */
+    query: UseQueryResult<PaginatedResponse<EmployerApplication>>;
+    /** Total count of applications matching the query */
+    count: number;
+    /** Function to update the selected status filters */
+    setSelectedStatuses: React.Dispatch<
+      React.SetStateAction<ApplicationStatus[]>
+    >;
+  };
+
+/**
+ * Hook to manage the state and data query for pending employer applications.
+ * Handles default and user-selected status filters.
+ */
+const usePendingEmployerApplications =
+  (): UsePendingEmployerApplicationsResultType => {
+    const tableQuery = useApplicationTableQuery<EmployerApplication>(
+      useEmployerApplicationsListQuery,
+      DEFAULT_PENDING_STATUSES
+    );
+
+    return {
+      ...tableQuery,
+      setSelectedStatuses: () => {},
+    };
+  };
+
 export default function EmployerApplicationList(): JSX.Element {
   const { t } = useTranslation();
 
@@ -106,10 +153,7 @@ export default function EmployerApplicationList(): JSX.Element {
     setOrdering: setPendingOrdering,
     query: pendingQuery,
     count: pendingCount,
-  } = useApplicationTableQuery<EmployerApplication>(
-    useEmployerApplicationsListQuery,
-    EMPLOYER_PENDING_STATUSES
-  );
+  } = usePendingEmployerApplications();
 
   // Processed Tab States & Query
   const {
@@ -127,14 +171,14 @@ export default function EmployerApplicationList(): JSX.Element {
 
   return (
     <Tabs index={activeTab} onChange={setActiveTab}>
-      <TabList style={{ marginBottom: '1rem' }}>
+      <$TabList>
         <Tab index={0}>
           {t('common:applicationList.tabs.pending')} ({pendingCount})
         </Tab>
         <Tab index={1}>
           {t('common:applicationList.tabs.processed')} ({processedCount})
         </Tab>
-      </TabList>
+      </$TabList>
       <TabPanel index={0}>
         <ApplicationListTable<EmployerApplication>
           columns={columns}

--- a/frontend/kesaseteli/handler/src/components/applicationList/YouthApplicationList.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/YouthApplicationList.tsx
@@ -17,6 +17,8 @@ import ApplicationListTable, {
   TableState,
   useApplicationTableQuery,
 } from './ApplicationListTable';
+import StatusFilter from './searchFilters/StatusFilter';
+
 const $TabList = styled(TabList)`
   margin-bottom: 1rem;
 `;
@@ -137,14 +139,26 @@ type UsePendingYouthApplicationsResultType = TableState<YouthApplication> & {
 
 const usePendingYouthApplications =
   (): UsePendingYouthApplicationsResultType => {
+    // selected status filter options
+    const [selectedPendingStatuses, setSelectedPendingStatuses] = useState<
+      ApplicationStatus[]
+    >(DEFAULT_PENDING_STATUSES);
+
     const tableQuery = useApplicationTableQuery<YouthApplication>(
       useYouthApplicationsListQuery,
-      DEFAULT_PENDING_STATUSES
+      selectedPendingStatuses
     );
+
+    const { setPage } = tableQuery;
+
+    // Reset page when statuses change to avoid showing stale data
+    useEffect(() => {
+      setPage(0);
+    }, [selectedPendingStatuses, setPage]);
 
     return {
       ...tableQuery,
-      setSelectedStatuses: () => {},
+      setSelectedStatuses: setSelectedPendingStatuses,
     };
   };
 
@@ -157,6 +171,7 @@ export default function YouthApplicationList(): JSX.Element {
     page: pendingPage,
     setPage: setPendingPage,
     setOrdering: setPendingOrdering,
+    setSelectedStatuses: setSelectedPendingStatuses,
     query: pendingQuery,
     count: pendingCount,
   } = usePendingYouthApplications();
@@ -185,6 +200,12 @@ export default function YouthApplicationList(): JSX.Element {
         </Tab>
       </$TabList>
       <TabPanel index={0}>
+        <StatusFilter
+          id="youth-application-pending-status-filter"
+          statuses={YOUTH_PENDING_STATUSES}
+          defaultSelectedStatuses={DEFAULT_PENDING_STATUSES}
+          onChange={setSelectedPendingStatuses}
+        />
         <ApplicationListTable
           columns={columns}
           data={pendingQuery.data?.results ?? []}

--- a/frontend/kesaseteli/handler/src/components/applicationList/YouthApplicationList.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/YouthApplicationList.tsx
@@ -1,22 +1,48 @@
 import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
 import { useTranslation } from 'next-i18next';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { UseQueryResult } from 'react-query/types/react/types';
 import useLocale from 'shared/hooks/useLocale';
+import styled from 'styled-components';
 
 import useYouthApplicationsListQuery from '../../hooks/backend/useYouthApplicationsListQuery';
-import { ApplicationStatus, YouthApplication } from '../../types/application';
+import {
+  ApplicationStatus,
+  PaginatedResponse,
+  YouthApplication,
+} from '../../types/application';
 import ActionCell from './ActionCell';
 import ApplicationListTable, {
   HdsHeader,
-  PAGE_SIZE,
+  TableState,
+  useApplicationTableQuery,
 } from './ApplicationListTable';
+const $TabList = styled(TabList)`
+  margin-bottom: 1rem;
+`;
 
+/**
+ * All possible statuses that fall under the "pending" category for youth applications.
+ * Used to define the available options in the pending status search filter component.
+ */
 const YOUTH_PENDING_STATUSES = [
   ApplicationStatus.SUBMITTED,
   ApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED,
   ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED,
 ];
 
+/**
+ * The initial and default statuses selected for the pending youth applications list query.
+ * Also used as default/fallback statuses when no specific filters are checked by the user.
+ */
+const DEFAULT_PENDING_STATUSES = [
+  ApplicationStatus.SUBMITTED,
+  ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED,
+];
+
+/**
+ * All statuses considered "processed" for youth applications
+ */
 const PROCESSED_STATUSES = [
   ApplicationStatus.ACCEPTED,
   ApplicationStatus.REJECTED,
@@ -71,9 +97,9 @@ export const useYouthApplicationListColumns =
         transform: (row) =>
           row.age && row.birth_year
             ? t('common:applicationList.ageFormat', {
-              age: row.age,
-              birthYear: row.birth_year,
-            })
+                age: row.age,
+                birthYear: row.birth_year,
+              })
             : '-',
       },
       {
@@ -97,46 +123,67 @@ export const useYouthApplicationListColumns =
     ];
   };
 
+/** Result type for the hook managing pending youth applications */
+type UsePendingYouthApplicationsResultType = TableState<YouthApplication> & {
+  /** The React Query result containing paginated application data */
+  query: UseQueryResult<PaginatedResponse<YouthApplication>>;
+  /** Total count of applications matching the query */
+  count: number;
+  /** Function to update the selected status filters */
+  setSelectedStatuses: React.Dispatch<
+    React.SetStateAction<ApplicationStatus[]>
+  >;
+};
+
+const usePendingYouthApplications =
+  (): UsePendingYouthApplicationsResultType => {
+    const tableQuery = useApplicationTableQuery<YouthApplication>(
+      useYouthApplicationsListQuery,
+      DEFAULT_PENDING_STATUSES
+    );
+
+    return {
+      ...tableQuery,
+      setSelectedStatuses: () => {},
+    };
+  };
+
 export default function YouthApplicationList(): JSX.Element {
   const { t } = useTranslation();
 
   const [activeTab, setActiveTab] = useState(0);
 
-  // Pending Tab States & Query
-  const [pendingPage, setPendingPage] = useState(0);
-  const [pendingOrdering, setPendingOrdering] = useState('-created_at');
-  const pendingQuery = useYouthApplicationsListQuery({
-    status: YOUTH_PENDING_STATUSES,
-    limit: PAGE_SIZE,
-    offset: pendingPage * PAGE_SIZE,
-    ordering: pendingOrdering,
-  });
+  const {
+    page: pendingPage,
+    setPage: setPendingPage,
+    setOrdering: setPendingOrdering,
+    query: pendingQuery,
+    count: pendingCount,
+  } = usePendingYouthApplications();
 
-  // Processed Tab States & Query
-  const [processedPage, setProcessedPage] = useState(0);
-  const [processedOrdering, setProcessedOrdering] = useState('-created_at');
-  const processedQuery = useYouthApplicationsListQuery({
-    status: PROCESSED_STATUSES,
-    limit: PAGE_SIZE,
-    offset: processedPage * PAGE_SIZE,
-    ordering: processedOrdering,
-  });
-
-  const pendingCount = pendingQuery.data?.count ?? 0;
-  const processedCount = processedQuery.data?.count ?? 0;
+  const {
+    page: processedPage,
+    setPage: setProcessedPage,
+    setOrdering: setProcessedOrdering,
+    query: processedQuery,
+    count: processedCount,
+  } = useApplicationTableQuery<YouthApplication>(
+    useYouthApplicationsListQuery,
+    PROCESSED_STATUSES
+  );
 
   const columns = useYouthApplicationListColumns();
 
   return (
     <Tabs index={activeTab} onChange={setActiveTab}>
-      <TabList style={{ marginBottom: '1rem' }}>
+      <$TabList>
         <Tab index={0}>
           {t('common:applicationList.tabs.pending')} ({pendingCount})
         </Tab>
         <Tab index={1}>
           {t('common:applicationList.tabs.processed')} ({processedCount})
         </Tab>
-      </TabList>
+      </$TabList>
       <TabPanel index={0}>
         <ApplicationListTable
           columns={columns}

--- a/frontend/kesaseteli/handler/src/components/applicationList/__tests__/EmployerApplicationList.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/__tests__/EmployerApplicationList.test.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import fi from '../../../../public/locales/fi/common.json';
 import useEmployerApplicationsListQuery from '../../../hooks/backend/useEmployerApplicationsListQuery';
 import EmployerApplicationList from '../EmployerApplicationList';
+import { ApplicationStatus } from '../../../types/application';
 
 jest.mock('../../../hooks/backend/useEmployerApplicationsListQuery');
 const mockUseQuery = useEmployerApplicationsListQuery as jest.Mock;
@@ -70,5 +71,17 @@ describe('EmployerApplicationList', () => {
     // Verify processed tab content is displayed
     expect(screen.getByText('Company Processed Oy')).toBeInTheDocument();
     expect(screen.queryByText('Company Pending Oy')).not.toBeInTheDocument();
+  });
+
+  it('calls useEmployerApplicationsListQuery with default pending statuses initially', () => {
+    renderComponent(<EmployerApplicationList />);
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: [
+          ApplicationStatus.SUBMITTED,
+          ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED,
+        ],
+      })
+    );
   });
 });

--- a/frontend/kesaseteli/handler/src/components/applicationList/__tests__/EmployerApplicationList.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/__tests__/EmployerApplicationList.test.tsx
@@ -1,12 +1,12 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
 import React from 'react';
 
 import fi from '../../../../public/locales/fi/common.json';
 import useEmployerApplicationsListQuery from '../../../hooks/backend/useEmployerApplicationsListQuery';
-import EmployerApplicationList from '../EmployerApplicationList';
 import { ApplicationStatus } from '../../../types/application';
+import EmployerApplicationList from '../EmployerApplicationList';
 
 jest.mock('../../../hooks/backend/useEmployerApplicationsListQuery');
 const mockUseQuery = useEmployerApplicationsListQuery as jest.Mock;
@@ -81,6 +81,56 @@ describe('EmployerApplicationList', () => {
           ApplicationStatus.SUBMITTED,
           ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED,
         ],
+      })
+    );
+  });
+
+  it('calls useEmployerApplicationsListQuery with updated statuses when filters change', async () => {
+    renderComponent(<EmployerApplicationList />);
+
+    const combobox = screen.getByRole('combobox', { name: /tila/i });
+    await userEvent.click(combobox);
+
+    // Select "Lisätietoja pyydetty" to check it
+    await userEvent.click(
+      screen.getByText(
+        fi.applicationList.status.additional_information_requested
+      )
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: [
+          ApplicationStatus.SUBMITTED,
+          ApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED,
+          ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED,
+        ],
+      })
+    );
+  });
+
+  it('calls useEmployerApplicationsListQuery with empty status list when all filters are deselected', async () => {
+    renderComponent(<EmployerApplicationList />);
+
+    const combobox = screen.getByRole('combobox', { name: /tila/i });
+    await userEvent.click(combobox);
+
+    const listbox = screen.getByRole('listbox');
+
+    // Deselect "Avoin"
+    await userEvent.click(
+      within(listbox).getByText(fi.applicationList.status.submitted)
+    );
+    // Deselect "Lisätiedot toimitettu"
+    await userEvent.click(
+      within(listbox).getByText(
+        fi.applicationList.status.additional_information_provided
+      )
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: [],
       })
     );
   });

--- a/frontend/kesaseteli/handler/src/components/applicationList/__tests__/YouthApplicationList.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/__tests__/YouthApplicationList.test.tsx
@@ -1,12 +1,12 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
 import React from 'react';
 
 import fi from '../../../../public/locales/fi/common.json';
 import useYouthApplicationsListQuery from '../../../hooks/backend/useYouthApplicationsListQuery';
-import YouthApplicationList from '../YouthApplicationList';
 import { ApplicationStatus } from '../../../types/application';
+import YouthApplicationList from '../YouthApplicationList';
 
 jest.mock('../../../hooks/backend/useYouthApplicationsListQuery');
 const mockUseQuery = useYouthApplicationsListQuery as jest.Mock;
@@ -84,6 +84,56 @@ describe('YouthApplicationList', () => {
           ApplicationStatus.SUBMITTED,
           ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED,
         ],
+      })
+    );
+  });
+
+  it('calls useYouthApplicationsListQuery with updated statuses when filters change', async () => {
+    renderComponent(<YouthApplicationList />);
+
+    const combobox = screen.getByRole('combobox', { name: /tila/i });
+    await userEvent.click(combobox);
+
+    // Select "Lisätietoja pyydetty" to check it
+    await userEvent.click(
+      screen.getByText(
+        fi.applicationList.status.additional_information_requested
+      )
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: [
+          ApplicationStatus.SUBMITTED,
+          ApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED,
+          ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED,
+        ],
+      })
+    );
+  });
+
+  it('calls useYouthApplicationsListQuery with empty status list when all filters are deselected', async () => {
+    renderComponent(<YouthApplicationList />);
+
+    const combobox = screen.getByRole('combobox', { name: /tila/i });
+    await userEvent.click(combobox);
+
+    const listbox = screen.getByRole('listbox');
+
+    // Deselect "Avoin"
+    await userEvent.click(
+      within(listbox).getByText(fi.applicationList.status.submitted)
+    );
+    // Deselect "Lisätiedot toimitettu"
+    await userEvent.click(
+      within(listbox).getByText(
+        fi.applicationList.status.additional_information_provided
+      )
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: [],
       })
     );
   });

--- a/frontend/kesaseteli/handler/src/components/applicationList/__tests__/YouthApplicationList.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/__tests__/YouthApplicationList.test.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import fi from '../../../../public/locales/fi/common.json';
 import useYouthApplicationsListQuery from '../../../hooks/backend/useYouthApplicationsListQuery';
 import YouthApplicationList from '../YouthApplicationList';
+import { ApplicationStatus } from '../../../types/application';
 
 jest.mock('../../../hooks/backend/useYouthApplicationsListQuery');
 const mockUseQuery = useYouthApplicationsListQuery as jest.Mock;
@@ -73,5 +74,17 @@ describe('YouthApplicationList', () => {
     expect(screen.getByText('222222-2222')).toBeInTheDocument();
     expect(screen.getByText('Maija Meikäläinen')).toBeInTheDocument();
     expect(screen.queryByText('111111-1111')).not.toBeInTheDocument();
+  });
+
+  it('calls useYouthApplicationsListQuery with default pending statuses initially', () => {
+    renderComponent(<YouthApplicationList />);
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: [
+          ApplicationStatus.SUBMITTED,
+          ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED,
+        ],
+      })
+    );
   });
 });

--- a/frontend/kesaseteli/handler/src/components/applicationList/searchFilters/StatusFilter.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/searchFilters/StatusFilter.tsx
@@ -1,0 +1,96 @@
+import { Select } from 'hds-react';
+import { useTranslation } from 'next-i18next';
+import React, { useEffect, useMemo, useState } from 'react';
+import { OptionType } from 'shared/types/common';
+import styled from 'styled-components';
+
+import { ApplicationStatus } from '../../../types/application';
+
+const $Wrapper = styled.div`
+  margin-bottom: 1rem;
+`;
+
+type StatusFilterProps = {
+  id: string;
+  statuses: ApplicationStatus[];
+  defaultSelectedStatuses?: ApplicationStatus[];
+  onChange: (statuses: ApplicationStatus[]) => void;
+};
+
+type UseStatusFilterProps = {
+  defaultSelectedStatuses?: ApplicationStatus[];
+  statuses: ApplicationStatus[];
+};
+
+export const useStatusFilter = ({
+  defaultSelectedStatuses,
+  statuses,
+}: UseStatusFilterProps): {
+  selectedStatuses: ApplicationStatus[];
+  setSelectedStatuses: React.Dispatch<
+    React.SetStateAction<ApplicationStatus[]>
+  >;
+} => {
+  const [selectedStatuses, setSelectedStatuses] = useState<ApplicationStatus[]>(
+    defaultSelectedStatuses ?? statuses
+  );
+
+  useEffect(() => {
+    if (defaultSelectedStatuses) {
+      setSelectedStatuses(defaultSelectedStatuses);
+    }
+  }, [defaultSelectedStatuses]);
+
+  return { selectedStatuses, setSelectedStatuses };
+};
+
+const StatusFilter = ({
+  id,
+  statuses,
+  defaultSelectedStatuses,
+  onChange,
+}: StatusFilterProps): JSX.Element => {
+  const { t } = useTranslation();
+  const { selectedStatuses, setSelectedStatuses } = useStatusFilter({
+    defaultSelectedStatuses,
+    statuses,
+  });
+
+  const options = useMemo<OptionType<ApplicationStatus>[]>(
+    () =>
+      statuses.map((status) => ({
+        label: t(`common:applicationList.status.${status}`),
+        value: status,
+      })),
+    [statuses, t]
+  );
+
+  const selectedOptions = useMemo(
+    () => options.filter((option) => selectedStatuses.includes(option.value)),
+    [options, selectedStatuses]
+  );
+
+  return (
+    <$Wrapper>
+      <Select
+        id={id}
+        multiSelect
+        texts={{
+          label: t('common:applicationList.columns.status'),
+        }}
+        options={options}
+        value={selectedOptions}
+        invalid={selectedStatuses.length === 0}
+        onChange={(nextSelectedOptions: OptionType<ApplicationStatus>[]) => {
+          const nextStatuses = nextSelectedOptions.map(
+            (option) => option.value
+          );
+          setSelectedStatuses(nextStatuses);
+          onChange(nextStatuses);
+        }}
+      />
+    </$Wrapper>
+  );
+};
+
+export default StatusFilter;

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useEmployerApplicationsListQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useEmployerApplicationsListQuery.test.tsx
@@ -82,4 +82,29 @@ describe('useEmployerApplicationsListQuery', () => {
     await waitFor(() => result.current.isError);
     expect(mockErrorHandler).toHaveBeenCalled();
   });
+
+  it('does not include status parameter when status list is empty', async () => {
+    nock(API_BASE_TEST_URL)
+      .get(BackendEndpoint.EMPLOYER_APPLICATIONS)
+      .query(
+        (queryObj) =>
+          !('status' in queryObj) &&
+          queryObj.limit === '20' &&
+          queryObj.offset === '0'
+      )
+      .reply(200, mockListResponse);
+
+    const { result, waitFor } = renderHook(
+      () =>
+        useEmployerApplicationsListQuery({
+          status: [],
+          limit: 20,
+          offset: 0,
+        }),
+      { wrapper }
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data).toEqual(mockListResponse);
+    expect(nock.isDone()).toBe(true);
+  });
 });

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useYouthApplicationsListQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useYouthApplicationsListQuery.test.tsx
@@ -107,4 +107,29 @@ describe('useYouthApplicationsListQuery', () => {
     await waitFor(() => result.current.isError);
     expect(mockErrorHandler).toHaveBeenCalled();
   });
+
+  it('does not include status parameter when status list is empty', async () => {
+    nock(API_BASE_TEST_URL)
+      .get(BackendEndpoint.YOUTH_APPLICATIONS)
+      .query(
+        (queryObj) =>
+          !('status' in queryObj) &&
+          queryObj.limit === '20' &&
+          queryObj.offset === '0'
+      )
+      .reply(200, mockListResponse);
+
+    const { result, waitFor } = renderHook(
+      () =>
+        useYouthApplicationsListQuery({
+          status: [],
+          limit: 20,
+          offset: 0,
+        }),
+      { wrapper }
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data).toEqual(mockListResponse);
+    expect(nock.isDone()).toBe(true);
+  });
 });

--- a/frontend/kesaseteli/handler/src/hooks/backend/useEmployerApplicationsListQuery.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/useEmployerApplicationsListQuery.ts
@@ -31,7 +31,7 @@ const useEmployerApplicationsListQuery = <
   const handleError = useErrorHandler();
 
   const searchParams = new URLSearchParams();
-  if (params.status) {
+  if (params.status && params.status.length > 0) {
     params.status.forEach((s) => searchParams.append('status', s));
   }
   searchParams.append('limit', String(params.limit));

--- a/frontend/kesaseteli/handler/src/hooks/backend/useYouthApplicationsListQuery.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/useYouthApplicationsListQuery.ts
@@ -1,14 +1,10 @@
 import {
-  BaseApplication,
   PaginatedResponse,
+  YouthApplication,
 } from 'kesaseteli/handler/types/application';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
-import {
-  QueryKey,
-  useQuery,
-  UseQueryOptions,
-  UseQueryResult,
-} from 'react-query';
+import { QueryKey, useQuery, UseQueryOptions } from 'react-query';
+import { UseQueryResult } from 'react-query/types/react/types';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 import useErrorHandler from 'shared/hooks/useErrorHandler';
 
@@ -22,8 +18,8 @@ export type YouthApplicationsQueryParams = {
 
 const useYouthApplicationsListQuery = (
   params: YouthApplicationsQueryParams,
-  options?: UseQueryOptions<PaginatedResponse<BaseApplication>>
-): UseQueryResult<PaginatedResponse<BaseApplication>> => {
+  options?: UseQueryOptions<PaginatedResponse<YouthApplication>>
+): UseQueryResult<PaginatedResponse<YouthApplication>> => {
   const { axios, handleResponse } = useBackendAPI();
   const handleError = useErrorHandler();
 
@@ -41,9 +37,11 @@ const useYouthApplicationsListQuery = (
     [BackendEndpoint.YOUTH_APPLICATIONS, params] as QueryKey,
     () =>
       handleResponse(
-        axios.get<PaginatedResponse<BaseApplication>>(
+        axios.get<PaginatedResponse<YouthApplication>>(
           BackendEndpoint.YOUTH_APPLICATIONS,
-          { params: searchParams }
+          {
+            params: searchParams,
+          }
         )
       ),
     {

--- a/frontend/kesaseteli/handler/src/hooks/backend/useYouthApplicationsListQuery.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/useYouthApplicationsListQuery.ts
@@ -24,7 +24,7 @@ const useYouthApplicationsListQuery = (
   const handleError = useErrorHandler();
 
   const searchParams = new URLSearchParams();
-  if (params.status) {
+  if (params.status && params.status.length > 0) {
     params.status.forEach((s) => searchParams.append('status', s));
   }
   searchParams.append('limit', String(params.limit));


### PR DESCRIPTION
YJDH-916.

Introduce status filter dropdown components to the pending tabs of both YouthApplicationList and EmployerApplicationList. Include supporting unit tests and align selected default pending status options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status-based filtering for pending application lists, with the filter remembered while browsing.
  * Improved the application list experience by resetting results to the first page when filter selections change.
* **Bug Fixes**
  * Updated application list queries and result handling for more accurate pending and processed views.
* **Tests**
  * Expanded coverage for filter behavior and query parameters in the application list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->