### PR TITLE
feat(ks,handler): persist active tab state in application lists

### DIFF
--- a/frontend/kesaseteli/handler/src/components/applicationList/EmployerApplicationList.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/EmployerApplicationList.tsx
@@ -187,14 +187,14 @@ export default function EmployerApplicationList(): JSX.Element {
   return (
     <Tabs initiallyActiveTab={activeTab}>
       <$TabList>
-        <Tab index={0} onClick={() => setActiveTab(0)}>
+        <Tab onClick={() => setActiveTab(0)}>
           {t('common:applicationList.tabs.pending')} ({pendingCount})
         </Tab>
-        <Tab index={1} onClick={() => setActiveTab(1)}>
+        <Tab onClick={() => setActiveTab(1)}>
           {t('common:applicationList.tabs.processed')} ({processedCount})
         </Tab>
       </$TabList>
-      <TabPanel index={0}>
+      <TabPanel>
         <ApplicationListTable.FilterSection
           ariaLabelledBy="employer-pending-filters-heading"
           title={t('common:applicationList.filterTitle')}
@@ -217,7 +217,7 @@ export default function EmployerApplicationList(): JSX.Element {
           defaultSortColumnKey="-submitted_at"
         />
       </TabPanel>
-      <TabPanel index={1}>
+      <TabPanel>
         <ApplicationListTable.FilterSection
           ariaLabelledBy="employer-processed-filters-heading"
           title={t('common:applicationList.filterTitle')}

--- a/frontend/kesaseteli/handler/src/components/applicationList/EmployerApplicationList.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/EmployerApplicationList.tsx
@@ -5,7 +5,9 @@ import { UseQueryResult } from 'react-query/types/react/types';
 import useLocale from 'shared/hooks/useLocale';
 import styled from 'styled-components';
 
+import { SESSION_STORAGE_KEYS } from '../../constants/session-storage-keys';
 import useEmployerApplicationsListQuery from '../../hooks/backend/useEmployerApplicationsListQuery';
+import useSessionStorageState from '../../hooks/useSessionStorageState';
 import {
   ApplicationStatus,
   EmployerApplication,
@@ -155,7 +157,10 @@ const useEmployerApplications = (
 export default function EmployerApplicationList(): JSX.Element {
   const { t } = useTranslation();
 
-  const [activeTab, setActiveTab] = useState(0);
+  const [activeTab, setActiveTab] = useSessionStorageState(
+    SESSION_STORAGE_KEYS.EMPLOYER_APPLICATIONS_ACTIVE_TAB,
+    0
+  );
 
   // Pending Tab States & Query
   const {
@@ -180,12 +185,12 @@ export default function EmployerApplicationList(): JSX.Element {
   const columns = useEmployerApplicationListColumns();
 
   return (
-    <Tabs index={activeTab} onChange={setActiveTab}>
+    <Tabs initiallyActiveTab={activeTab}>
       <$TabList>
-        <Tab index={0}>
+        <Tab index={0} onClick={() => setActiveTab(0)}>
           {t('common:applicationList.tabs.pending')} ({pendingCount})
         </Tab>
-        <Tab index={1}>
+        <Tab index={1} onClick={() => setActiveTab(1)}>
           {t('common:applicationList.tabs.processed')} ({processedCount})
         </Tab>
       </$TabList>

--- a/frontend/kesaseteli/handler/src/components/applicationList/YouthApplicationList.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/YouthApplicationList.tsx
@@ -194,14 +194,14 @@ export default function YouthApplicationList(): JSX.Element {
   return (
     <Tabs initiallyActiveTab={activeTab}>
       <$TabList>
-        <Tab index={0} onClick={() => setActiveTab(0)}>
+        <Tab onClick={() => setActiveTab(0)}>
           {t('common:applicationList.tabs.pending')} ({pendingCount})
         </Tab>
-        <Tab index={1} onClick={() => setActiveTab(1)}>
+        <Tab onClick={() => setActiveTab(1)}>
           {t('common:applicationList.tabs.processed')} ({processedCount})
         </Tab>
       </$TabList>
-      <TabPanel index={0}>
+      <TabPanel>
         <ApplicationListTable.FilterSection
           ariaLabelledBy="youth-pending-filters-heading"
           title={t('common:applicationList.filterTitle')}
@@ -223,7 +223,7 @@ export default function YouthApplicationList(): JSX.Element {
           isLoading={pendingQuery.isLoading}
         />
       </TabPanel>
-      <TabPanel index={1}>
+      <TabPanel>
         <ApplicationListTable.FilterSection
           ariaLabelledBy="youth-processed-filters-heading"
           title={t('common:applicationList.filterTitle')}

--- a/frontend/kesaseteli/handler/src/components/applicationList/YouthApplicationList.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/YouthApplicationList.tsx
@@ -5,7 +5,9 @@ import { UseQueryResult } from 'react-query/types/react/types';
 import useLocale from 'shared/hooks/useLocale';
 import styled from 'styled-components';
 
+import { SESSION_STORAGE_KEYS } from '../../constants/session-storage-keys';
 import useYouthApplicationsListQuery from '../../hooks/backend/useYouthApplicationsListQuery';
+import useSessionStorageState from '../../hooks/useSessionStorageState';
 import {
   ApplicationStatus,
   PaginatedResponse,
@@ -164,7 +166,10 @@ const useYouthApplications = (
 export default function YouthApplicationList(): JSX.Element {
   const { t } = useTranslation();
 
-  const [activeTab, setActiveTab] = useState(0);
+  const [activeTab, setActiveTab] = useSessionStorageState(
+    SESSION_STORAGE_KEYS.YOUTH_APPLICATIONS_ACTIVE_TAB,
+    0
+  );
 
   const {
     page: pendingPage,
@@ -187,12 +192,12 @@ export default function YouthApplicationList(): JSX.Element {
   const columns = useYouthApplicationListColumns();
 
   return (
-    <Tabs index={activeTab} onChange={setActiveTab}>
+    <Tabs initiallyActiveTab={activeTab}>
       <$TabList>
-        <Tab index={0}>
+        <Tab index={0} onClick={() => setActiveTab(0)}>
           {t('common:applicationList.tabs.pending')} ({pendingCount})
         </Tab>
-        <Tab index={1}>
+        <Tab index={1} onClick={() => setActiveTab(1)}>
           {t('common:applicationList.tabs.processed')} ({processedCount})
         </Tab>
       </$TabList>

--- a/frontend/kesaseteli/handler/src/components/applicationList/__tests__/EmployerApplicationList.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/__tests__/EmployerApplicationList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable scanjs-rules/property_sessionStorage, scanjs-rules/identifier_sessionStorage */
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
@@ -30,6 +31,7 @@ const mockProcessedApps = [
 
 describe('EmployerApplicationList', () => {
   beforeEach(() => {
+    window.sessionStorage.clear();
     mockUseQuery.mockImplementation((params) => {
       if (
         params?.status?.includes('accepted') ||
@@ -174,3 +176,6 @@ describe('EmployerApplicationList', () => {
     );
   });
 });
+
+/* eslint-enable scanjs-rules/property_sessionStorage, scanjs-rules/identifier_sessionStorage */
+

--- a/frontend/kesaseteli/handler/src/components/applicationList/__tests__/YouthApplicationList.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/__tests__/YouthApplicationList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable scanjs-rules/property_sessionStorage, scanjs-rules/identifier_sessionStorage */
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import renderComponent from 'kesaseteli-shared/__tests__/utils/components/render-component';
@@ -32,6 +33,7 @@ const mockProcessedApps = [
 
 describe('YouthApplicationList', () => {
   beforeEach(() => {
+    window.sessionStorage.clear();
     mockUseQuery.mockImplementation((params) => {
       if (
         params?.status?.includes('accepted') ||
@@ -177,3 +179,5 @@ describe('YouthApplicationList', () => {
     );
   });
 });
+
+/* eslint-enable scanjs-rules/property_sessionStorage, scanjs-rules/identifier_sessionStorage */

--- a/frontend/kesaseteli/handler/src/constants/session-storage-keys.ts
+++ b/frontend/kesaseteli/handler/src/constants/session-storage-keys.ts
@@ -1,0 +1,13 @@
+/**
+ * Session storage keys used within the handler application.
+ */
+export const SESSION_STORAGE_KEYS = {
+  /**
+   * The active tab index (Pending vs. Processed) for the employer applications list.
+   */
+  EMPLOYER_APPLICATIONS_ACTIVE_TAB: 'employer-applications-active-tab',
+  /**
+   * The active tab index (Pending vs. Processed) for the youth applications list.
+   */
+  YOUTH_APPLICATIONS_ACTIVE_TAB: 'youth-applications-active-tab',
+} as const;

--- a/frontend/kesaseteli/handler/src/hooks/__tests__/useSessionStorageState.test.ts
+++ b/frontend/kesaseteli/handler/src/hooks/__tests__/useSessionStorageState.test.ts
@@ -1,0 +1,35 @@
+/* eslint-disable scanjs-rules/property_sessionStorage, scanjs-rules/identifier_sessionStorage */
+import { act,renderHook } from '@testing-library/react-hooks';
+
+import useSessionStorageState from '../useSessionStorageState';
+
+describe('useSessionStorageState', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('returns initial value when no saved value exists', () => {
+    const { result } = renderHook(() => useSessionStorageState('test-key', 0));
+    expect(result.current[0]).toBe(0);
+  });
+
+  it('updates storage and state on setter call', () => {
+    const { result } = renderHook(() => useSessionStorageState('test-key', 0));
+
+    act(() => {
+      result.current[1](1);
+    });
+
+    expect(result.current[0]).toBe(1);
+    expect(window.sessionStorage.getItem('test-key')).toBe('1');
+  });
+
+  it('loads saved value on mount', () => {
+    window.sessionStorage.setItem('test-key', '2');
+    const { result } = renderHook(() => useSessionStorageState('test-key', 0));
+
+    expect(result.current[0]).toBe(2);
+  });
+});
+
+/* eslint-enable scanjs-rules/property_sessionStorage, scanjs-rules/identifier_sessionStorage */

--- a/frontend/kesaseteli/handler/src/hooks/useSessionStorageState.ts
+++ b/frontend/kesaseteli/handler/src/hooks/useSessionStorageState.ts
@@ -1,0 +1,30 @@
+import { Dispatch, SetStateAction,useEffect, useState } from 'react';
+import {
+  getSessionStorageItem,
+  setSessionStorageItem,
+} from 'shared/utils/localstorage.utils';
+
+export default function useSessionStorageState<T>(
+  key: string,
+  initialValue: T
+): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => {
+    const saved = getSessionStorageItem(key);
+    if (saved !== '') {
+      try {
+        return JSON.parse(saved) as T;
+      } catch {
+        return saved as unknown as T;
+      }
+    }
+    return initialValue;
+  });
+
+  useEffect(() => {
+    const stringValue =
+      typeof state === 'string' ? state : JSON.stringify(state);
+    setSessionStorageItem(key, stringValue);
+  }, [key, state]);
+
+  return [state, setState];
+}


### PR DESCRIPTION
YJDH-916.

Create a custom React hook useSessionStorageState that manages state and synchronizes it with sessionStorage to preserve the user's active tab index (Pending vs. Processed) in both the Employer and Youth application list tables.

This ensures that when a handler navigates to a detail view and back, they are returned to their active tab queue instead of the default tab.
