### PR TITLE
feat(ks,handler): redesign youth application view layout and alerts

### DIFF
--- a/frontend/kesaseteli/handler/public/locales/fi/common.json
+++ b/frontend/kesaseteli/handler/public/locales/fi/common.json
@@ -103,7 +103,10 @@
     "status": "Tila",
     "employerApplicationTitle": "Työnantajan tiedot",
     "employerCompanySectionTitle": "Yrityksen tiedot",
+    "employerApplicationTitleLinked": "Liitetty työnantajahakemus",
     "employerApplicationsTitle": "Liitetyt työnantajahakemukset",
+    "employerApplicationDescription": "Seuraava työnantajahakemus on liitetty tähän nuoren hakemukseen.",
+    "employerApplicationsDescription": "Seuraavat työnantajahakemukset on liitetty tähän nuoren hakemukseen.",
     "employerApplicationLinkText": "Avaa työnantajan {{companyName}} hakemus ({{date}})",
     "multipleVouchersNotification": "Tähän hakemukseen on poikkeuksellisesti liitetty useita kesäseteleitä. Tämä poikkeaa nykyisestä käytännöstä ja johtuu aiemmista tietomalli- ja käyttöliittymäratkaisuista.",
     "company": "Yritys",
@@ -171,10 +174,19 @@
       "submitted": "Lähetetty",
       "additional_information_requested": "Lisätietoja pyydetty",
       "additional_information_provided": "Lisätietoja toimitettu",
+      "awaiting_manual_processing": "Odottaa käsittelyä",
       "accepted": "Hyväksytty",
       "rejected": "Hylätty",
       "draft": "Luonnos",
       "deleted_by_customer": "Poistettu"
+    },
+    "statusTooltip": {
+      "submitted": "Nuori on täyttänyt hakemuksen, mutta ei ole vielä aktivoinut sitä sähköpostiinsa tulleesta vahvistuslinkistä.",
+      "awaiting_manual_processing": "Hakemus odottaa käsittelijän tarkistusta ja päätöstä (hyväksymistä tai hylkäämistä).",
+      "additional_information_requested": "Hakemukseen on pyydetty lisätietoja. Odotetaan nuoren vastausta.",
+      "additional_information_provided": "Hakija on toimittanut pyydetyt lisätiedot. Hakemus odottaa käsittelijän tarkistusta.",
+      "accepted": "Hakemus on hyväksytty ja kesäseteli on lähetetty sähköpostitse.",
+      "rejected": "Hakemus on hylätty."
     },
     "vtjInfo": {
       "title": "Tiedot väestötietojärjestelmästä",
@@ -186,6 +198,7 @@
       "dataRestricted": "Hakijalla on turvakielto VTJ:ssä. Kaikkia tietoja ei ole saatavilla."
     },
     "vtjException": {
+      "alertTitle": "Ongelma VTJ-tiedoissa",
       "notFound": "Väestötietojärjestelmästä ei löytynyt tietoja henkilötunnuksella: {{ social_security_number }}!",
       "missingSsn": "Henkilötunnus puuttuu!",
       "differentLastName": "Sukunimi poikkeaa hakemukselle syötetystä sukunimestä ({{ last_name }})",

--- a/frontend/kesaseteli/handler/src/__tests__/utils/components/get-index-page-api.ts
+++ b/frontend/kesaseteli/handler/src/__tests__/utils/components/get-index-page-api.ts
@@ -7,6 +7,7 @@ import getHandlerTranslationsApi from 'kesaseteli/handler/__tests__/utils/i18n/g
 import CompleteOperation from 'kesaseteli/handler/types/complete-operation';
 import VtjExceptionType from 'kesaseteli/handler/types/vtj-exception-type';
 import ActivatedYouthApplication from 'kesaseteli-shared/types/activated-youth-application';
+import type YouthApplicationStatusType from 'kesaseteli-shared/types/youth-application-status-type';
 import {
   waitForBackendRequestsToComplete,
   waitForLoadingCompleted,
@@ -179,15 +180,17 @@ const getIndexPageApi = async (
       ).toBeDisabled();
     },
     statusNotificationIsPresent: async (
-      status: keyof typeof translations.handlerApplication.notification
-    ): Promise<HTMLElement> =>
-      screen.findByRole(
-        'heading',
-        {
-          name: translations.handlerApplication.notification[status],
-        },
-        { timeout: 20_000 }
-      ),
+      status: YouthApplicationStatusType
+    ): Promise<HTMLElement> => {
+      const statusText =
+        translations.handlerApplication.applicationStatus[
+          status as keyof typeof translations.handlerApplication.applicationStatus
+        ] ??
+        translations.handlerApplication.notification[
+          status as keyof typeof translations.handlerApplication.notification
+        ];
+      return screen.findByText(statusText, {}, { timeout: 20_000 });
+    },
     showsConfirmDialog: async (type: CompleteOperation['type']) => {
       const dialog = await screen.findByRole('dialog');
       return within(dialog).findByText(translations.dialog[type].content);

--- a/frontend/kesaseteli/handler/src/components/form/HandlerForm.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/HandlerForm.tsx
@@ -1,4 +1,10 @@
-import { NotificationType } from 'hds-react';
+import {
+  IconAlertCircle,
+  IconCheckCircle,
+  IconClock,
+  StatusLabel,
+  Tooltip,
+} from 'hds-react';
 import ActionButtons from 'kesaseteli/handler/components/form/ActionButtons';
 import Field, {
   $DescriptionList,
@@ -6,11 +12,9 @@ import Field, {
 import LinkedEmployerApplications from 'kesaseteli/handler/components/form/LinkedEmployerApplications';
 import VtjInfo from 'kesaseteli/handler/components/form/VtjInfo';
 import isHandlerNewBetaUiEnabled from 'kesaseteli/handler/flags/is-handler-new-beta-ui-enabled';
-import {
-  YOUTH_APPLICATION_STATUS_COMPLETED,
-  YOUTH_APPLICATION_STATUS_WAITING_FOR_HANDLER_ACTION,
-  YOUTH_APPLICATION_STATUS_WAITING_FOR_YOUTH_ACTION,
-} from 'kesaseteli-shared/constants/youth-application-status';
+import { ApplicationStatus } from 'kesaseteli/handler/types/application';
+import { getVtjException } from 'kesaseteli/handler/utils/map-vtj-data';
+import { YOUTH_APPLICATION_STATUS_WAITING_FOR_HANDLER_ACTION } from 'kesaseteli-shared/constants/youth-application-status';
 import isVtjDisabled from 'kesaseteli-shared/flags/is-vtj-disabled';
 import useSummerVoucherConfigurationQuery from 'kesaseteli-shared/hooks/useSummerVoucherConfigurationQuery';
 import ActivatedYouthApplication from 'kesaseteli-shared/types/activated-youth-application';
@@ -35,16 +39,6 @@ const includesStatus = (
   arr: ReadonlyArray<YouthApplicationStatusType>,
   val: YouthApplicationStatusType
 ): boolean => arr.includes(val);
-
-const getNotificationType = (
-  status: YouthApplicationStatusType,
-  waitingForUserAction: boolean
-): NotificationType | undefined => {
-  if (waitingForUserAction) return 'error';
-  if (status === 'accepted') return 'success';
-  if (status === 'rejected') return 'alert';
-  return undefined;
-};
 
 type TargetGroupParams = {
   receiptConfirmedAt?: string;
@@ -73,6 +67,39 @@ const getTargetGroupName = ({
   );
 };
 
+const getStatusLabelProps = (
+  status: YouthApplicationStatusType
+): {
+  type: 'success' | 'error' | 'alert' | 'info';
+  icon: React.ReactNode;
+} => {
+  switch (status) {
+    case ApplicationStatus.ACCEPTED:
+      return {
+        type: 'success' as const,
+        icon: <IconCheckCircle aria-hidden />,
+      };
+
+    case ApplicationStatus.REJECTED:
+      return { type: 'error' as const, icon: <IconAlertCircle aria-hidden /> };
+
+    case ApplicationStatus.AWAITING_MANUAL_PROCESSING:
+    case ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED:
+      return { type: 'alert' as const, icon: <IconClock aria-hidden /> };
+
+    case ApplicationStatus.SUBMITTED:
+    case ApplicationStatus.ADDITIONAL_INFORMATION_REQUESTED:
+    default:
+      return { type: 'info' as const, icon: <IconAlertCircle aria-hidden /> };
+  }
+};
+
+const $StatusValueWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${(props) => props.theme.spacing.xs2};
+`;
+
 const $PanelGrid = styled.div`
   display: flex;
   gap: 2rem;
@@ -84,18 +111,22 @@ const $PanelGrid = styled.div`
   }
 `;
 
-const $StatusNotification = styled($Notification)`
-  margin-bottom: ${(props) => props.theme.spacing.m};
-`;
-
 const $Column = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${(props) => props.theme.spacing.m};
 `;
 
+const $VtjBlockerNotification = styled($Notification)`
+  margin-bottom: ${(props) => props.theme.spacing.m};
+`;
+
 const $ActionButtonsWrapper = styled.div`
   margin-top: ${(props) => props.theme.spacing.m};
+`;
+
+const $DescriptionField = styled(Field)`
+  margin-bottom: ${(props) => props.theme.spacing.s};
 `;
 
 const AdditionalInfoSection: React.FC<{
@@ -117,10 +148,9 @@ const AdditionalInfoSection: React.FC<{
         value={convertToUIDateAndTimeFormat(providedAt)}
       />
       <Field type="additional_info_user_reasons" value={reasons} />
-      <Field
+      <$DescriptionField
         type="additional_info_description"
         value={description}
-        style={{ marginBottom: '1rem' }}
       />
     </$DescriptionList>
   </>
@@ -128,11 +158,9 @@ const AdditionalInfoSection: React.FC<{
 
 type FormLayoutProps = {
   application: ActivatedYouthApplication;
-  t: (key: string) => string;
+  t: (key: string, options?: Record<string, string | number>) => string;
   waitingForHandlerAction: boolean;
-  isCompleted: boolean;
   additionalInfoProvided: boolean;
-  notificationType: NotificationType | undefined;
   targetGroupName: string;
   schoolValue: string;
   additionalInfoReasons: string;
@@ -144,9 +172,7 @@ const FormLayout: React.FC<FormLayoutProps> = ({
   application,
   t,
   waitingForHandlerAction,
-  isCompleted,
   additionalInfoProvided,
-  notificationType,
   targetGroupName,
   schoolValue,
   additionalInfoReasons,
@@ -169,22 +195,45 @@ const FormLayout: React.FC<FormLayoutProps> = ({
     employer_applications,
   } = application;
 
+  const vtjException = showVtj ? getVtjException(application) : undefined;
+  const statusProps = getStatusLabelProps(status);
+
   return (
     <$GridCell $colSpan={2}>
-      {!waitingForHandlerAction && (
-        <$StatusNotification
-          data-testid={`status-notification-${status}`}
-          label={t(`common:handlerApplication.notification.${status}`)}
-          type={notificationType}
+      {vtjException && (
+        <$VtjBlockerNotification
+          data-testid={`vtj-exception-${vtjException}`}
+          label={t('common:handlerApplication.vtjException.alertTitle')}
+          type="error"
         >
-          {isCompleted && email && <a href={`mailto:${email}`}>{email}</a>}
-        </$StatusNotification>
+          {t(`common:handlerApplication.vtjException.${vtjException}`, {
+            social_security_number,
+          })}
+        </$VtjBlockerNotification>
       )}
 
       <$PanelGrid>
         <$Column>
           <FormSection columns={1} withoutDivider>
             <$DescriptionList aria-label={t('common:handlerApplication.title')}>
+              <Field
+                type="status"
+                value={
+                  <$StatusValueWrapper>
+                    <StatusLabel
+                      type={statusProps.type}
+                      iconStart={statusProps.icon}
+                    >
+                      {t(
+                        `common:handlerApplication.applicationStatus.${status}`
+                      )}
+                    </StatusLabel>
+                    <Tooltip>
+                      {t(`common:handlerApplication.statusTooltip.${status}`)}
+                    </Tooltip>
+                  </$StatusValueWrapper>
+                }
+              />
               {receipt_confirmed_at && (
                 <Field
                   id="receipt_confirmed_at"
@@ -216,7 +265,12 @@ const FormLayout: React.FC<FormLayoutProps> = ({
               <Field type="postcode" value={postcode} />
               <Field type="school" value={schoolValue} />
               <Field type="phone_number" value={phone_number} />
-              <Field type="email" value={email} />
+              <Field
+                type="email"
+                value={
+                  email ? <a href={`mailto:${email}`}>{email}</a> : undefined
+                }
+              />
               <Field type="target_group" value={targetGroupName} />
             </$DescriptionList>
 
@@ -266,21 +320,13 @@ const HandlerForm: React.FC<Props> = ({ application }) => {
     employer_applications,
   } = application;
 
-  const waitingForUserAction = includesStatus(
-    YOUTH_APPLICATION_STATUS_WAITING_FOR_YOUTH_ACTION,
-    status
-  );
   const waitingForHandlerAction = includesStatus(
     YOUTH_APPLICATION_STATUS_WAITING_FOR_HANDLER_ACTION,
     status
   );
-  const isCompleted = includesStatus(
-    YOUTH_APPLICATION_STATUS_COMPLETED,
-    status
-  );
-  const additionalInfoProvided = status === 'additional_information_provided';
+  const additionalInfoProvided =
+    status === ApplicationStatus.ADDITIONAL_INFORMATION_PROVIDED;
 
-  const notificationType = getNotificationType(status, waitingForUserAction);
   const showVtj = !isVtjDisabled();
   const showEmployerApps =
     isHandlerNewBetaUiEnabled() && (employer_applications?.length ?? 0) > 0;
@@ -304,9 +350,7 @@ const HandlerForm: React.FC<Props> = ({ application }) => {
       application={application}
       t={t}
       waitingForHandlerAction={waitingForHandlerAction}
-      isCompleted={isCompleted}
       additionalInfoProvided={additionalInfoProvided}
-      notificationType={notificationType}
       targetGroupName={targetGroupName}
       schoolValue={schoolValue}
       additionalInfoReasons={additionalInfoReasons}

--- a/frontend/kesaseteli/handler/src/components/form/LinkedEmployerApplications.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/LinkedEmployerApplications.tsx
@@ -4,7 +4,7 @@ import ActivatedYouthApplication from 'kesaseteli-shared/types/activated-youth-a
 import NextLink from 'next/link';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import { $Notification } from 'shared/components/notification/Notification.sc';
+import FormSectionHeading from 'shared/components/forms/section/FormSectionHeading';
 import { convertToUIDateFormat } from 'shared/utils/date.utils';
 import styled from 'styled-components';
 
@@ -12,11 +12,26 @@ type Props = {
   employerApplications?: ActivatedYouthApplication['employer_applications'];
 };
 
+const $EmployerCard = styled.div`
+  background-color: var(--color-bus-light);
+  border: 1px solid ${(props) => props.theme.colors.black10};
+  padding: ${(props) => props.theme.spacing.m};
+  display: grid;
+  grid-template-columns: 1fr;
+  align-content: start;
+`;
+
 const $EmployerApplicationsList = styled.ul`
   display: flex;
   flex-direction: column;
   gap: ${(props) => props.theme.spacing.xs};
-  margin-top: ${(props) => props.theme.spacing.s};
+`;
+
+const $DescriptionText = styled.p`
+  margin-top: 0;
+  margin-bottom: ${(props) => props.theme.spacing.m};
+  font-size: ${(props) => props.theme.fontSize.body.m};
+  color: ${(props) => props.theme.colors.black80};
 `;
 
 const LinkedEmployerApplications: React.FC<Props> = ({
@@ -28,12 +43,26 @@ const LinkedEmployerApplications: React.FC<Props> = ({
     return null;
   }
 
+  // NOTE: For historical reasons, ther emight be some (rare) cases where there
+  // could be more than 1 employer applicaiton linked to this youth application.
+
+  const isPlural = employerApplications.length > 1;
+  const titleKey = isPlural
+    ? 'common:handlerApplication.employerApplicationsTitle'
+    : 'common:handlerApplication.employerApplicationTitleLinked';
+  const descriptionKey = isPlural
+    ? 'common:handlerApplication.employerApplicationsDescription'
+    : 'common:handlerApplication.employerApplicationDescription';
+
   return (
-    <$Notification
-      label={t('common:handlerApplication.employerApplicationsTitle')}
-      type="info"
-    >
-      <$EmployerApplicationsList>
+    <$EmployerCard>
+      <FormSectionHeading
+        id="employer-applications-heading"
+        header={t(titleKey)}
+        as="h4"
+      />
+      <$DescriptionText>{t(descriptionKey)}</$DescriptionText>
+      <$EmployerApplicationsList aria-labelledby="employer-applications-heading">
         {employerApplications.map((empApp) => (
           <li key={empApp.id}>
             <NextLink
@@ -51,7 +80,7 @@ const LinkedEmployerApplications: React.FC<Props> = ({
           </li>
         ))}
       </$EmployerApplicationsList>
-    </$Notification>
+    </$EmployerCard>
   );
 };
 

--- a/frontend/kesaseteli/handler/src/components/form/VtjErrorNotification.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/VtjErrorNotification.tsx
@@ -21,7 +21,7 @@ const VtjErrorNotification: React.FC<Props> = ({
   return (
     <$VtjException
       data-testid={`vtj-exception-${reason}`}
-      label=" "
+      label={t('common:handlerApplication.vtjException.alertTitle')}
       type={type}
       size={size}
     >

--- a/frontend/kesaseteli/handler/src/components/form/VtjInfo.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/VtjInfo.tsx
@@ -1,55 +1,52 @@
-import { NotificationSize } from 'hds-react';
 import Field, {
   $DescriptionList,
 } from 'kesaseteli/handler/components/form/Field';
 import VtjErrorMessage from 'kesaseteli/handler/components/form/VtjErrorMessage';
-import VtjErrorNotification from 'kesaseteli/handler/components/form/VtjErrorNotification';
 import VtjRawDataAccordion from 'kesaseteli/handler/components/form/VtjRawData';
-import { mapVtjData } from 'kesaseteli/handler/utils/map-vtj-data';
+import {
+  getVtjException,
+  mapVtjData,
+} from 'kesaseteli/handler/utils/map-vtj-data';
 import ActivatedYouthApplication from 'kesaseteli-shared/types/activated-youth-application';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import FormSection from 'shared/components/forms/section/FormSection';
+import FormSectionHeading from 'shared/components/forms/section/FormSectionHeading';
 import { $Notification } from 'shared/components/notification/Notification.sc';
-import { DefaultTheme } from 'styled-components';
+import styled from 'styled-components';
 
 type Props = {
   application: ActivatedYouthApplication;
 };
 
+const $RestrictedNotification = styled($Notification)`
+  margin-bottom: ${(props) => props.theme.spacing.m};
+`;
+
+const $VtjCard = styled.div`
+  background-color: var(--color-fog-light);
+  border: 1px solid ${(props) => props.theme.colors.black10};
+  padding: ${(props) => props.theme.spacing.m};
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: ${(props) => props.theme.spacing.m};
+  align-content: start;
+`;
+
 const VtjInfo: React.FC<Props> = ({ application }) => {
   const { t } = useTranslation();
   const {
     encrypted_handler_vtj_json: vtjData,
-    social_security_number,
     last_name,
     postcode,
     is_vtj_data_restricted,
   } = application;
 
-  if (!social_security_number) {
-    return (
-      <VtjErrorNotification
-        reason="missingSsn"
-        type="error"
-        size={NotificationSize.Large}
-      />
-    );
-  }
-
-  if (!vtjData || !('Henkilo' in vtjData)) {
-    return (
-      <VtjErrorNotification
-        reason="notFound"
-        type="error"
-        size={NotificationSize.Large}
-        params={{ social_security_number }}
-      />
-    );
+  const vtjException = getVtjException(application);
+  if (vtjException) {
+    return null;
   }
 
   const {
-    notFound,
     providedAt,
     fullName,
     differentLastName,
@@ -60,79 +57,56 @@ const VtjInfo: React.FC<Props> = ({ application }) => {
     differentPostCode,
     age,
     notInTargetAgeGroup,
-    isDead,
   } = mapVtjData(application);
 
   return (
     <span data-testid="vtj-info">
       {is_vtj_data_restricted && (
-        <$Notification
+        <$RestrictedNotification
           label={t('common:handlerApplication.vtjInfo.dataRestricted')}
           type="info"
-          css={`
-            margin-bottom: ${({ theme }: { theme: DefaultTheme }) =>
-              theme.spacing.m};
-          `}
         />
       )}
-      {!notFound && (
-        <$Notification
-          label={t(`common:handlerApplication.vtjInfo.title`)}
-          type="info"
-        >
-          <FormSection columns={1} withoutDivider>
-            <$DescriptionList
-              aria-label={t('common:handlerApplication.vtjInfo.title')}
-            >
-              <Field
-                id="vtjInfo.providedAt"
-                type="vtjInfo.providedAt"
-                value={providedAt}
+      <$VtjCard>
+        <FormSectionHeading
+          id="vtj-info-heading"
+          header={t('common:handlerApplication.vtjInfo.title')}
+          as="h4"
+        />
+        <$DescriptionList aria-labelledby="vtj-info-heading">
+          <Field
+            id="vtjInfo.providedAt"
+            type="vtjInfo.providedAt"
+            value={providedAt}
+          />
+          <Field type="vtjInfo.name" value={fullName}>
+            {differentLastName && (
+              <VtjErrorMessage
+                reason="differentLastName"
+                params={{ last_name }}
               />
-              <Field type="vtjInfo.name" value={fullName}>
-                {differentLastName && (
-                  <VtjErrorMessage
-                    reason="differentLastName"
-                    params={{ last_name }}
-                  />
-                )}
-              </Field>
-              <Field type="vtjInfo.ssn" value={socialSecurityNumber}>
-                {notInTargetAgeGroup && (
-                  <VtjErrorMessage
-                    reason="notInTargetAgeGroup"
-                    params={{ age }}
-                  />
-                )}
-              </Field>
-              <Field type="vtjInfo.address" value={fullAddress}>
-                {addressNotFound && (
-                  <VtjErrorMessage reason="addressNotFound" />
-                )}
-                {!addressNotFound && differentPostCode && (
-                  <VtjErrorMessage
-                    reason="differentPostCode"
-                    params={{ postcode }}
-                  />
-                )}
-                {!addressNotFound && outsideHelsinki && (
-                  <VtjErrorMessage reason="outsideHelsinki" />
-                )}
-              </Field>
-            </$DescriptionList>
-            <VtjRawDataAccordion data={vtjData} />
-          </FormSection>
-        </$Notification>
-      )}
-      {notFound && (
-        <VtjErrorNotification
-          reason="notFound"
-          type="error"
-          size={NotificationSize.Large}
-          params={{ social_security_number }}
-        />
-      )}
-      {isDead && <VtjErrorNotification reason="isDead" type="error" />}
+            )}
+          </Field>
+          <Field type="vtjInfo.ssn" value={socialSecurityNumber}>
+            {notInTargetAgeGroup && (
+              <VtjErrorMessage reason="notInTargetAgeGroup" params={{ age }} />
+            )}
+          </Field>
+          <Field type="vtjInfo.address" value={fullAddress}>
+            {addressNotFound && <VtjErrorMessage reason="addressNotFound" />}
+            {!addressNotFound && differentPostCode && (
+              <VtjErrorMessage
+                reason="differentPostCode"
+                params={{ postcode }}
+              />
+            )}
+            {!addressNotFound && outsideHelsinki && (
+              <VtjErrorMessage reason="outsideHelsinki" />
+            )}
+          </Field>
+        </$DescriptionList>
+        <VtjRawDataAccordion data={vtjData} />
+      </$VtjCard>
     </span>
   );
 };

--- a/frontend/kesaseteli/handler/src/components/form/__tests__/LinkedEmployerApplications.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/__tests__/LinkedEmployerApplications.test.tsx
@@ -25,16 +25,45 @@ describe('LinkedEmployerApplications', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders employer application links when data is present', () => {
+  it('renders a single employer application link with singular title and description', () => {
     renderComponent(
       <LinkedEmployerApplications employerApplications={mockApplications} />
     );
     expect(
-      screen.getByText(fi.handlerApplication.employerApplicationsTitle)
+      screen.getByText(fi.handlerApplication.employerApplicationTitleLinked)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(fi.handlerApplication.employerApplicationDescription)
     ).toBeInTheDocument();
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', '/employer-applications/emp-1');
     expect(link).toHaveTextContent('Test Oy');
     expect(link).toHaveTextContent('10.5.2024');
+  });
+
+  it('renders multiple employer application links with plural title and description', () => {
+    const multipleMocks = [
+      ...mockApplications,
+      {
+        id: 'emp-2',
+        company_name: 'Example Oy',
+        company_business_id: '7654321-0',
+        summer_voucher_serial_number: '54321',
+        submitted_at: '2024-06-15',
+      },
+    ];
+    renderComponent(
+      <LinkedEmployerApplications employerApplications={multipleMocks} />
+    );
+    expect(
+      screen.getByText(fi.handlerApplication.employerApplicationsTitle)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(fi.handlerApplication.employerApplicationsDescription)
+    ).toBeInTheDocument();
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', '/employer-applications/emp-1');
+    expect(links[1]).toHaveAttribute('href', '/employer-applications/emp-2');
   });
 });

--- a/frontend/kesaseteli/handler/src/constants/vtj-exception.ts
+++ b/frontend/kesaseteli/handler/src/constants/vtj-exception.ts
@@ -1,0 +1,19 @@
+/**
+ * Enum-style constant for all known VTJ exception codes.
+ * Values must stay in sync with VTJ_EXCEPTIONS in vtj-exceptions.ts
+ * and with handlerApplication.vtjException translation keys.
+ */
+const VtjException = {
+  NOT_FOUND: 'notFound',
+  MISSING_SSN: 'missingSsn',
+  DIFFERENT_LAST_NAME: 'differentLastName',
+  NOT_IN_TARGET_AGE_GROUP: 'notInTargetAgeGroup',
+  ADDRESS_NOT_FOUND: 'addressNotFound',
+  DIFFERENT_POST_CODE: 'differentPostCode',
+  OUTSIDE_HELSINKI: 'outsideHelsinki',
+  IS_DEAD: 'isDead',
+} as const;
+
+export type VtjExceptionValue = typeof VtjException[keyof typeof VtjException];
+
+export default VtjException;

--- a/frontend/kesaseteli/handler/src/types/application.ts
+++ b/frontend/kesaseteli/handler/src/types/application.ts
@@ -2,6 +2,7 @@ export type ApplicationListType = 'youth' | 'employer';
 
 export enum ApplicationStatus {
   SUBMITTED = 'submitted',
+  AWAITING_MANUAL_PROCESSING = 'awaiting_manual_processing',
   ADDITIONAL_INFORMATION_REQUESTED = 'additional_information_requested',
   ADDITIONAL_INFORMATION_PROVIDED = 'additional_information_provided',
   HANDLING = 'handling',

--- a/frontend/kesaseteli/handler/src/utils/__tests__/map-vtj-data.test.ts
+++ b/frontend/kesaseteli/handler/src/utils/__tests__/map-vtj-data.test.ts
@@ -1,0 +1,71 @@
+import VtjException from 'kesaseteli/handler/constants/vtj-exception';
+import { getVtjException } from 'kesaseteli/handler/utils/map-vtj-data';
+import { fakeActivatedYouthApplication } from 'kesaseteli-shared/__tests__/utils/fake-objects';
+
+describe('getVtjException', () => {
+  it('returns undefined if application has valid VTJ data', () => {
+    const application = fakeActivatedYouthApplication({
+      social_security_number: '010101-123A',
+      encrypted_handler_vtj_json: {
+        Henkilo: {
+          Henkilotunnus: {
+            '@voimassaolokoodi': '1',
+          },
+        },
+      },
+    });
+
+    expect(getVtjException(application)).toBeUndefined();
+  });
+
+  it('returns MISSING_SSN if social_security_number is missing', () => {
+    const application = fakeActivatedYouthApplication({});
+    application.social_security_number = '';
+
+    expect(getVtjException(application)).toBe(VtjException.MISSING_SSN);
+  });
+
+  it('returns NOT_FOUND if encrypted_handler_vtj_json is missing or invalid', () => {
+    const application = fakeActivatedYouthApplication({
+      social_security_number: '010101-123A',
+    });
+    (
+      application as unknown as { encrypted_handler_vtj_json: unknown }
+    ).encrypted_handler_vtj_json = undefined;
+
+    expect(getVtjException(application)).toBe(VtjException.NOT_FOUND);
+  });
+
+  it('returns NOT_FOUND if voimassaolokoodi is not 1', () => {
+    const application = fakeActivatedYouthApplication({
+      social_security_number: '010101-123A',
+      encrypted_handler_vtj_json: {
+        Henkilo: {
+          Henkilotunnus: {
+            '@voimassaolokoodi': '0',
+          },
+        },
+      },
+    });
+
+    expect(getVtjException(application)).toBe(VtjException.NOT_FOUND);
+  });
+
+  it('returns IS_DEAD if Kuollut is 1', () => {
+    const application = fakeActivatedYouthApplication({
+      social_security_number: '010101-123A',
+      encrypted_handler_vtj_json: {
+        Henkilo: {
+          Henkilotunnus: {
+            '@voimassaolokoodi': '1',
+          },
+          Kuolintiedot: {
+            Kuollut: '1',
+          },
+        },
+      },
+    });
+
+    expect(getVtjException(application)).toBe(VtjException.IS_DEAD);
+  });
+});

--- a/frontend/kesaseteli/handler/src/utils/map-vtj-data.ts
+++ b/frontend/kesaseteli/handler/src/utils/map-vtj-data.ts
@@ -1,4 +1,7 @@
 import { FinnishSSN } from 'finnish-ssn';
+import VtjException, {
+  VtjExceptionValue,
+} from 'kesaseteli/handler/constants/vtj-exception';
 import { TARGET_GROUP_AGES } from 'kesaseteli-shared/constants/target-group-ages';
 import ActivatedYouthApplication from 'kesaseteli-shared/types/activated-youth-application';
 import VtjAddress from 'kesaseteli-shared/types/vtj-address';
@@ -101,4 +104,38 @@ export const mapVtjData = (application: ActivatedYouthApplication): VtjInfo => {
     notInTargetAgeGroup,
     isDead,
   };
+};
+
+/**
+ * Determines whether a youth application has a global blocker-level VTJ exception
+ * that prevents normal rendering of VTJ details. Covers:
+ * - Missing SSN (no lookup possible)
+ * - VTJ record not found or invalid (lookup returned no usable Henkilo node)
+ * - Person is deceased
+ *
+ * Field-level warnings (name mismatch, postcode mismatch, etc.) are NOT covered
+ * here — they are rendered inline inside VtjInfo.
+ *
+ * @param application The activated youth application object.
+ * @returns The matching VtjExceptionValue, or undefined if no blocker is found.
+ */
+export const getVtjException = (
+  application: ActivatedYouthApplication
+): VtjExceptionValue | undefined => {
+  const { encrypted_handler_vtj_json: vtjData, social_security_number } =
+    application;
+
+  if (!social_security_number) {
+    return VtjException.MISSING_SSN;
+  }
+  if (!vtjData || !('Henkilo' in vtjData)) {
+    return VtjException.NOT_FOUND;
+  }
+  if (vtjData.Henkilo?.Henkilotunnus?.['@voimassaolokoodi'] !== '1') {
+    return VtjException.NOT_FOUND;
+  }
+  if (vtjData.Henkilo?.Kuolintiedot?.Kuollut === '1') {
+    return VtjException.IS_DEAD;
+  }
+  return undefined;
 };

--- a/frontend/kesaseteli/shared/browser-tests/page-models/HandlerForm.ts
+++ b/frontend/kesaseteli/shared/browser-tests/page-models/HandlerForm.ts
@@ -58,21 +58,21 @@ export default class HandlerForm<
     }
   );
 
-  private notYetActivated = this.component.findByRole('heading', {
-    name: /nuori ei ole vielä aktivoinut hakemusta/i,
-  });
+  private notYetActivated = this.component
+    .findByTestId('handlerApplication-status')
+    .withText(/lähetetty/i);
 
-  private additionalInfoRequested = this.component.findByRole('heading', {
-    name: /nuori ei ole vielä täyttänyt lisätietohakemusta/i,
-  });
+  private additionalInfoRequested = this.component
+    .findByTestId('handlerApplication-status')
+    .withText(/lisätietoja pyydetty/i);
 
-  private isAccepted = this.component.findByRole('heading', {
-    name: /hyväksytty/i,
-  });
+  private isAccepted = this.component
+    .findByTestId('handlerApplication-status')
+    .withText(/hyväksytty/i);
 
-  private isRejected = this.component.findByRole('heading', {
-    name: /hylätty/i,
-  });
+  private isRejected = this.component
+    .findByTestId('handlerApplication-status')
+    .withText(/hylätty/i);
 
   public applicantIsNotInTargetGroup(age: number) {
     return this.expect(

--- a/frontend/kesaseteli/youth/browser-tests/page-models/YouthForm.ts
+++ b/frontend/kesaseteli/youth/browser-tests/page-models/YouthForm.ts
@@ -113,9 +113,8 @@ class YouthForm extends YouthPageComponent {
   public selectTargetGroup(ssn?: string): TestControllerPromise {
     const age = getAgeFromSsn(ssn);
     const index = age === 17 ? 1 : 0;
-    return this.clickSelectRadioButton(
-      this.component.findAllByRole('radio').nth(index)
-    );
+    const radioInput = this.component.findAllByRole('radio').nth(index);
+    return this.clickSelectRadioButton(radioInput.parent().find('label'));
   }
 
   public clickSendButton(): TestControllerPromise {


### PR DESCRIPTION
YJDH-945.

Redesign the youth application details page to improve the visual hierarchy and structural presentation.

- Redesign the youth application details page in the handler UI using a 2-column CSS grid and flatten components to remove nested forms.
- Replace top status notifications with a permanent "Tila" field under details, styled with HDS StatusLabel and Tooltip.
- Relocate global blocker-level VTJ warnings to the top of the form layout to span full-width.
- Display singular heading "Liitetty työnantajahakemus" when only one employer application is linked, and add matching description text.
- Clean up inactive alerts, update component tests, and add unit tests for the getVtjException utility.


From these screenshots can be seen that there are now less notification boxes, since status is now indicated with a label-pill (with tooltip), the VTJ-info is jsut a color box as is linking to employer application (that is only shown when beta-UI -feature flag is enabled). This gives more focus to actual notifications like error messaging.
<img width="494" height="944" alt="image" src="https://github.com/user-attachments/assets/52f5ac95-bb88-4ea1-a2d7-e75719c3457d" />
<img width="1197" height="1190" alt="image" src="https://github.com/user-attachments/assets/3da9f7c6-4429-46a0-8468-b80f5c3d75f2" />
<img width="1480" height="1165" alt="image" src="https://github.com/user-attachments/assets/a47bbc26-45bd-443b-b65a-97871c5b0ac9" />
<img width="1468" height="1183" alt="image" src="https://github.com/user-attachments/assets/5bc9c2c7-bfb9-48e4-a9fe-4ddffc895bcd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more granular application status labels and expanded tooltips, including manual processing.
  * Improved linked employer applications display with distinct singular/plural headings, descriptions, and a card layout.
  * Added a dedicated alert title for VTJ exception notices.
* **Bug Fixes**
  * Updated VTJ handling to render a blocking exception card when key eligibility data is missing/invalid or the person is marked deceased, and simplified when VTJ details are shown.
  * Refined status and email presentation for more consistent inline behavior.
* **Tests**
  * Improved component and browser test coverage and selectors for the updated UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->