### PR TITLE
chore(ks,shared): ignore S6770 JSX PascalCase rules in Sonar

### DIFF
--- a/frontend/kesaseteli/employer/sonar-project.properties
+++ b/frontend/kesaseteli/employer/sonar-project.properties
@@ -17,3 +17,9 @@ sonar.test.inclusions= \
   src/**/*.test.ts, \
   src/**/*.test.jsx, \
   src/**/*.test.tsx
+
+sonar.issue.ignore.multicriteria=s6770ts,s6770js
+sonar.issue.ignore.multicriteria.s6770ts.ruleKey=typescript:S6770
+sonar.issue.ignore.multicriteria.s6770ts.resourceKey=**/*
+sonar.issue.ignore.multicriteria.s6770js.ruleKey=javascript:S6770
+sonar.issue.ignore.multicriteria.s6770js.resourceKey=**/*

--- a/frontend/kesaseteli/handler/sonar-project.properties
+++ b/frontend/kesaseteli/handler/sonar-project.properties
@@ -17,3 +17,9 @@ sonar.test.inclusions= \
   src/**/*.test.ts, \
   src/**/*.test.jsx, \
   src/**/*.test.tsx
+
+sonar.issue.ignore.multicriteria=s6770ts,s6770js
+sonar.issue.ignore.multicriteria.s6770ts.ruleKey=typescript:S6770
+sonar.issue.ignore.multicriteria.s6770ts.resourceKey=**/*
+sonar.issue.ignore.multicriteria.s6770js.ruleKey=javascript:S6770
+sonar.issue.ignore.multicriteria.s6770js.resourceKey=**/*

--- a/frontend/kesaseteli/shared/sonar-project.properties
+++ b/frontend/kesaseteli/shared/sonar-project.properties
@@ -17,3 +17,9 @@ sonar.test.inclusions= \
   src/**/*.test.ts, \
   src/**/*.test.jsx, \
   src/**/*.test.tsx
+
+sonar.issue.ignore.multicriteria=s6770ts,s6770js
+sonar.issue.ignore.multicriteria.s6770ts.ruleKey=typescript:S6770
+sonar.issue.ignore.multicriteria.s6770ts.resourceKey=**/*
+sonar.issue.ignore.multicriteria.s6770js.ruleKey=javascript:S6770
+sonar.issue.ignore.multicriteria.s6770js.resourceKey=**/*

--- a/frontend/kesaseteli/youth/sonar-project.properties
+++ b/frontend/kesaseteli/youth/sonar-project.properties
@@ -17,3 +17,9 @@ sonar.test.inclusions= \
   src/**/*.test.ts, \
   src/**/*.test.jsx, \
   src/**/*.test.tsx
+
+sonar.issue.ignore.multicriteria=s6770ts,s6770js
+sonar.issue.ignore.multicriteria.s6770ts.ruleKey=typescript:S6770
+sonar.issue.ignore.multicriteria.s6770ts.resourceKey=**/*
+sonar.issue.ignore.multicriteria.s6770js.ruleKey=javascript:S6770
+sonar.issue.ignore.multicriteria.s6770js.resourceKey=**/*


### PR DESCRIPTION
YJDH-920.

Ignore Sonar rule S6770 (JSX components should use Pascal case) in the SonarCloud configurations for kesaseteli projects. This allows styled- components to use the repo-wide naming convention where names begin with a dollar sign ($) without triggering SonarCloud analysis errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality analysis settings across frontend modules to exclude specific TypeScript and JavaScript findings.
  * Reduced irrelevant static-analysis alerts without changing application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->