### PR TITLE
feat(ks,handler): implement application status transition activity logs on timeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,8 @@ dmypy.json
 .gemini/**
 .*antigravity*
 .ag_cache/
+.claude
+.continue
 
 node_modules
 

--- a/backend/kesaseteli/applications/README.md
+++ b/backend/kesaseteli/applications/README.md
@@ -18,6 +18,10 @@
     - [API Endpoint](#api-endpoint)
   - [Youth Summer Vouchers](#youth-summer-vouchers)
     - [Resend Summer Voucher](#resend-summer-voucher)
+  - [Timeline Activity Log](#timeline-activity-log)
+    - [Architecture Decision Story](#architecture-decision-story)
+    - [Secure and Configurable Log Parsing](#secure-and-configurable-log-parsing)
+    - [Unified Timeline Schema](#unified-timeline-schema)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -154,3 +158,43 @@ In cases where a youth needs their voucher email resent (e.g., accidental deleti
 
 The system will attempt to resend the voucher email to the youth's email address and report the number of successful and failed attempts.
 
+
+## Timeline Activity Log
+
+This section describes the design and implementation of the Phase 3 activity log for Youth and Employer applications.
+
+### Architecture Decision Story
+
+When designing the timeline activity log, we explored three main approaches:
+
+1. **Custom Model + Django Signals:** Add a new `ActivityLogEntry` model using `ContentType` to link generic actions. While clean, Signals do not have access to the HTTP request object. Capturing the user (`author`) would require adding middleware to store the current user in thread-local context (e.g. `django-crum`). This adds extra complexity and maintenance overhead.
+2. **Explicit Logging in ViewSets:** Log the changes explicitly inside API views and serializers. While highly transparent, this misses any changes made via Django Admin, command-line management commands, or automated background processes.
+3. **Reusing django-auditlog (Selected):** `django-auditlog` is already set up and configured in the project. It tracks status changes automatically on all registered models, resolves the request user through its built-in middleware, and stores changes as a structured JSON/dict payload (`changes`). By reusing this existing database, we avoid duplication of database tables, avoid extra signals, and leverage tested middleware.
+
+### Secure and Configurable Log Parsing
+
+Because audit logs can contain highly sensitive information (such as personal data, encrypted VTJ results, etc.), we explicitly filter which models and fields are exposed on the public or handler-facing timeline.
+
+The allowlist lives in `TimelineService.ALLOWED_TIMELINE_FIELDS` in `applications/services.py`:
+
+```python
+ALLOWED_TIMELINE_FIELDS: dict[str, dict[str, ActionType]] = {
+    "youthapplication": {
+        "status": ActionType.APPLICATION_STATUS_CHANGE,
+    },
+    "employerapplication": {
+        "status": ActionType.APPLICATION_STATUS_CHANGE,
+    },
+}
+```
+
+Only models and fields matching this exact registry are surfaced. Any other keys inside `LogEntry.changes` are ignored and completely stripped before returning data to the client.
+
+### Unified Timeline Schema
+
+The `/timeline/` API endpoints merge notes and auditlog activities into a single chronologically sorted array. To distinguish them, each item has an `item_type` field:
+
+- `note`: Generated from handler internal/external notes.
+- `activity`: Generated from auditlog entries (e.g. status changes).
+
+Optional filtering is supported via the `item_types` query parameter (e.g. `/timeline/?item_types=note`). When omitted, all types are returned.

--- a/backend/kesaseteli/applications/api/v1/serializers.py
+++ b/backend/kesaseteli/applications/api/v1/serializers.py
@@ -17,10 +17,12 @@ from rest_framework.exceptions import APIException
 
 from applications.api.v1.validators import validate_additional_info_user_reasons
 from applications.enums import (
+    ActionType,
     AdditionalInfoUserReason,
     AttachmentType,
     EmployerApplicationStatus,
     get_supported_languages,
+    TimelineItemType,
     YouthApplicationStatus,
 )
 from applications.exporters.excel_exporter import resolve_target_group_and_status
@@ -47,6 +49,25 @@ from companies.services import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+VALID_TIMELINE_ITEM_TYPES = {choice[0] for choice in TimelineItemType.choices}
+
+
+def validate_timeline_item_types(requested_types: set) -> set:
+    """
+    Validate requested item_types against the documented enum.
+    Returns the validated set (empty means all types).
+    Raises ValidationError for unsupported values.
+    """
+    if not requested_types:
+        return requested_types
+    invalid = requested_types - VALID_TIMELINE_ITEM_TYPES
+    if invalid:
+        raise serializers.ValidationError(
+            f"Unsupported item_types: {', '.join(sorted(invalid))}. "
+            f"Valid values: {', '.join(sorted(VALID_TIMELINE_ITEM_TYPES))}"
+        )
+    return requested_types
 
 
 class EmployerApplicationStatusValidator:
@@ -1447,3 +1468,20 @@ class YouthApplicationExcelExportSerializer(serializers.ModelSerializer):
             "vtj_home_municipality",
             "vtj_last_name",
         ]
+
+
+class ActivityLogItemSerializer(serializers.Serializer):
+    """
+    Serializer for a single parsed timeline activity item (ActivityLogItem DTO).
+    Represents actions like status changes recorded by the application's audit log.
+    """
+
+    item_type = serializers.SerializerMethodField()
+    action_type = serializers.ChoiceField(choices=ActionType.choices)
+    old_value = serializers.CharField(allow_blank=True)
+    new_value = serializers.CharField(allow_blank=True)
+    author_name = serializers.CharField(allow_blank=True)
+    created_at = serializers.DateTimeField()
+
+    def get_item_type(self, obj) -> str:
+        return TimelineItemType.ACTIVITY

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -50,6 +50,7 @@ from applications.api.v1.serializers import (
     SchoolSerializer,
     SummerVoucherConfigurationSerializer,
     TargetGroupSerializer,
+    validate_timeline_item_types,
     YouthApplicationAdditionalInfoSerializer,
     YouthApplicationFetchEmployeeDataInputSerializer,
     YouthApplicationFetchEmployeeDataOutputSerializer,
@@ -72,7 +73,7 @@ from applications.models import (
     YouthApplication,
     YouthSummerVoucher,
 )
-from applications.services import AuditAccessLogService, VTJService
+from applications.services import AuditAccessLogService, TimelineService, VTJService
 from applications.target_groups import (
     AbstractTargetGroup,
     get_target_group_data,
@@ -80,8 +81,6 @@ from applications.target_groups import (
 from common.decorators import enforce_handler_view_adfs_login
 from common.fuzzy_matching import is_last_name_fuzzy_match_in_full_name
 from common.permissions import HandlerPermission
-from handler_notes.api.v1.serializers import NoteSerializer
-from handler_notes.models import Note
 from shared.vtj.vtj_client import VTJClient
 
 LOGGER = logging.getLogger(__name__)
@@ -267,9 +266,13 @@ class YouthApplicationViewSet(ModelViewSet):
         the timeline.
         """
         application = self.get_object()
-        qs = Note.objects.for_application_timeline(application)
-        serializer = NoteSerializer(qs, many=True)
-        return Response(serializer.data)
+        requested_types = validate_timeline_item_types(
+            set(request.query_params.getlist("item_types"))
+        )
+        combined_data = TimelineService.get_application_timeline_data(
+            application, requested_types
+        )
+        return Response(combined_data)
 
     def get_serializer_class(self):
         """
@@ -1079,9 +1082,13 @@ class EmployerApplicationViewSet(ModelViewSet):
         of its child models (like Attachments).
         """
         application = self.get_object()
-        qs = Note.objects.for_application_timeline(application)
-        serializer = NoteSerializer(qs, many=True)
-        return Response(serializer.data)
+        requested_types = validate_timeline_item_types(
+            set(request.query_params.getlist("item_types"))
+        )
+        combined_data = TimelineService.get_application_timeline_data(
+            application, requested_types
+        )
+        return Response(combined_data)
 
     def create(self, request: Request, *args, **kwargs) -> Response:
         """

--- a/backend/kesaseteli/applications/api/v1/views.py
+++ b/backend/kesaseteli/applications/api/v1/views.py
@@ -22,6 +22,7 @@ from drf_spectacular.utils import (
     extend_schema_view,
     OpenApiParameter,
     OpenApiResponse,
+    PolymorphicProxySerializer,
 )
 from rest_framework import status
 from rest_framework.decorators import action
@@ -42,6 +43,7 @@ from applications.api.v1.permissions import (
     get_user_company,
 )
 from applications.api.v1.serializers import (
+    ActivityLogItemSerializer,
     AttachmentSerializer,
     EmployerApplicationSerializer,
     EmployerSummerVoucherAttachmentUploadInputSerializer,
@@ -81,6 +83,7 @@ from applications.target_groups import (
 from common.decorators import enforce_handler_view_adfs_login
 from common.fuzzy_matching import is_last_name_fuzzy_match_in_full_name
 from common.permissions import HandlerPermission
+from handler_notes.api.v1.serializers import NoteSerializer
 from shared.vtj.vtj_client import VTJClient
 
 LOGGER = logging.getLogger(__name__)
@@ -224,6 +227,38 @@ class YouthApplicationFilter(filters.FilterSet):
     update=extend_schema(exclude=True),
     partial_update=extend_schema(exclude=True),
     destroy=extend_schema(exclude=True),
+    timeline=extend_schema(
+        description=(
+            "Returns a unified chronological timeline for the application. "
+            "Aggregates notes linked to the application AND notes linked to any "
+            "of its child models (like Attachments)."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name="item_types",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                many=True,
+                explode=True,
+                description=(
+                    "Filter timeline items by type. If omitted, all types are returned."
+                ),
+                enum=["note", "activity"],
+            ),
+        ],
+        responses={
+            200: PolymorphicProxySerializer(
+                component_name="TimelineItem",
+                serializers={
+                    "note": NoteSerializer,
+                    "activity": ActivityLogItemSerializer,
+                },
+                resource_type_field_name="item_type",
+                many=True,
+            ),
+        },
+    ),
 )
 class YouthApplicationViewSet(ModelViewSet):
     """
@@ -255,7 +290,7 @@ class YouthApplicationViewSet(ModelViewSet):
         )
 
     @enforce_handler_view_adfs_login
-    @action(detail=True, methods=["get"])
+    @action(detail=True, methods=["get"], pagination_class=None, filter_backends=[])
     def timeline(self, request, pk=None):
         """
         Returns a unified chronological timeline for the application.
@@ -1020,6 +1055,38 @@ class EmployerApplicationFilter(filters.FilterSet):
         description="Delete an employer summer voucher application.",
         responses=OpenApiResponse(description="Application deleted."),
     ),
+    timeline=extend_schema(
+        description=(
+            "Returns a unified chronological timeline for the application. "
+            "Aggregates notes linked to the application AND notes linked to any "
+            "of its child models (like Attachments)."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name="item_types",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                many=True,
+                explode=True,
+                description=(
+                    "Filter timeline items by type. If omitted, all types are returned."
+                ),
+                enum=["note", "activity"],
+            ),
+        ],
+        responses={
+            200: PolymorphicProxySerializer(
+                component_name="TimelineItem",
+                serializers={
+                    "note": NoteSerializer,
+                    "activity": ActivityLogItemSerializer,
+                },
+                resource_type_field_name="item_type",
+                many=True,
+            ),
+        },
+    ),
 )
 class EmployerApplicationViewSet(ModelViewSet):
     queryset = EmployerApplication.objects.all()
@@ -1074,7 +1141,7 @@ class EmployerApplicationViewSet(ModelViewSet):
         return queryset.none()
 
     @enforce_handler_view_adfs_login
-    @action(detail=True, methods=["get"])
+    @action(detail=True, methods=["get"], pagination_class=None, filter_backends=[])
     def timeline(self, request, pk=None):
         """
         Returns a unified chronological timeline for the application.

--- a/backend/kesaseteli/applications/enums.py
+++ b/backend/kesaseteli/applications/enums.py
@@ -251,3 +251,24 @@ class EmailTemplateType(models.TextChoices):
     )
     PROCESSING = "processing", _("Processing")
     YOUTH_SUMMER_VOUCHER = "youth_summer_voucher", _("Youth summer voucher")
+
+
+class TimelineItemType(models.TextChoices):
+    """
+    Specifies the type of an item displayed on the application timeline.
+    """
+
+    NOTE = "note", _("Note")
+    ACTIVITY = "activity", _("Activity")
+
+
+class ActionType(models.TextChoices):
+    """
+    Identifies the specific action performed on a tracked model instance.
+    Used to categorize audit log activities on the timeline.
+    """
+
+    APPLICATION_STATUS_CHANGE = (
+        "application_status_change",
+        _("Application status change"),
+    )

--- a/backend/kesaseteli/applications/services.py
+++ b/backend/kesaseteli/applications/services.py
@@ -1,12 +1,15 @@
 import json
 import logging
-from typing import Optional, TYPE_CHECKING
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
 
 import jsonpath_ng
 import sentry_sdk
 from auditlog.models import LogEntry
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.template import Context, Template
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import get_template
@@ -16,13 +19,16 @@ from requests.exceptions import RequestException
 import applications.target_groups
 from applications.api.v1.exceptions import VTJServiceUnavailableError
 from applications.enums import (
+    ActionType,
     APPLICATION_LANGUAGE_CHOICES,
     EmailTemplateType,
+    TimelineItemType,
     VtjTestCase,
 )
 from applications.mock_context_service import MockContextService
 from applications.models import (
     EmailTemplate,
+    EmployerApplication,
     School,
     SummerVoucherConfiguration,
     YouthApplication,
@@ -34,10 +40,6 @@ from applications.tests.data.mock_vtj import (
 )
 from common.utils import are_same_texts, html_to_text, send_mail_with_error_logging
 from shared.vtj.vtj_client import VTJClient
-
-if TYPE_CHECKING:
-    from django.contrib.contenttypes.models import ContentType
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -495,3 +497,122 @@ class VTJService:
             return []
         matches = jsonpath_ng.parse(expression).find(vtj_json_dict)
         return [match.value for match in matches]
+
+
+@dataclass(frozen=True)
+class ActivityLogItem:
+    """
+    Data transfer object (DTO) representing a single parsed timeline activity.
+
+    This dataclass maps a secure and filtered subset of fields from a django-auditlog
+    `LogEntry` instance. It decouples the raw model (which contains complete,
+    potentially sensitive `changes` dicts and internal FK relationships) from the API
+    serialization layer, allowing activity events to be easily sorted and combined with
+    notes before delivery.
+
+    Attributes:
+        action_type (str): The mapped ActionType enum value
+            (e.g. 'application_status_change').
+        old_value (str): The previous value of the tracked field (coerced to a string).
+        new_value (str): The updated value of the tracked field (coerced to a string).
+        author_name (str): The full name of the user who performed the action,
+            or an empty string.
+        created_at (datetime): The timestamp when the change was recorded.
+    """
+
+    action_type: str
+    old_value: str
+    new_value: str
+    author_name: str
+    created_at: datetime
+
+
+class TimelineService:
+    """
+    Service for aggregating and formatting the application timeline,
+    combining audit log activities and handler notes.
+    """
+
+    ALLOWED_TIMELINE_FIELDS = {
+        YouthApplication._meta.model_name: {
+            "status": ActionType.APPLICATION_STATUS_CHANGE,
+        },
+        EmployerApplication._meta.model_name: {
+            "status": ActionType.APPLICATION_STATUS_CHANGE,
+        },
+    }
+
+    @classmethod
+    def get_activity_logs_for_application(cls, application) -> list[ActivityLogItem]:
+        """
+        Securely fetch and parse audit log entries for an application.
+        Only fields declared in ALLOWED_TIMELINE_FIELDS are surfaced.
+        """
+        model_name = application._meta.model_name
+        allowed_fields = cls.ALLOWED_TIMELINE_FIELDS.get(model_name)
+        if not allowed_fields:
+            return []
+
+        ct = ContentType.objects.get_for_model(application)
+        log_entries = (
+            LogEntry.objects.filter(content_type=ct, object_pk=str(application.pk))
+            .select_related("actor")
+            .order_by("timestamp")
+        )
+
+        items: list[ActivityLogItem] = []
+        for entry in log_entries:
+            if not isinstance(entry.changes, dict):
+                continue
+
+            for field_name, action_type in allowed_fields.items():
+                change = entry.changes.get(field_name)
+                if not isinstance(change, list) or len(change) != 2:
+                    continue
+
+                old_value, new_value = change
+                if old_value == new_value:
+                    continue
+
+                items.append(
+                    ActivityLogItem(
+                        action_type=action_type.value,
+                        old_value=str(old_value) if old_value is not None else "",
+                        new_value=str(new_value) if new_value is not None else "",
+                        author_name=entry.actor.get_full_name() if entry.actor else "",
+                        created_at=entry.timestamp,
+                    )
+                )
+        return items
+
+    @classmethod
+    def get_application_timeline_data(
+        cls, application, requested_types: set[str]
+    ) -> list[dict]:
+        """
+        Get combined, sorted notes and activity log data for an application timeline.
+        """
+        # Dynamic imports to avoid circular imports.
+        from applications.api.v1.serializers import ActivityLogItemSerializer
+        from handler_notes.api.v1.serializers import NoteSerializer
+        from handler_notes.models import Note
+
+        include_all = not requested_types
+
+        notes_data = []
+        if include_all or TimelineItemType.NOTE.value in requested_types:
+            notes_qs = Note.objects.for_application_timeline(application)
+            notes_data = list(NoteSerializer(notes_qs, many=True).data)
+
+        activity_data = []
+        if include_all or TimelineItemType.ACTIVITY.value in requested_types:
+            activity_items = cls.get_activity_logs_for_application(application)
+            activity_data = list(
+                ActivityLogItemSerializer(activity_items, many=True).data
+            )
+
+        return sorted(
+            notes_data + activity_data,
+            key=lambda x: datetime.fromisoformat(x["created_at"]),
+            reverse=True,
+        )

--- a/backend/kesaseteli/applications/tests/test_timeline_service.py
+++ b/backend/kesaseteli/applications/tests/test_timeline_service.py
@@ -1,0 +1,246 @@
+from unittest.mock import MagicMock
+
+import pytest
+from auditlog.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.test import override_settings
+
+from applications.enums import ActionType, TimelineItemType
+from applications.models import Attachment, EmployerApplication, YouthApplication
+from applications.services import TimelineService
+from common.tests.factories import (
+    EmployerApplicationFactory,
+    YouthApplicationFactory,
+)
+from handler_notes.tests.factories import NoteFactory
+from shared.common.tests.factories import UserFactory
+
+get_activity_logs_for_application = TimelineService.get_activity_logs_for_application
+get_application_timeline_data = TimelineService.get_application_timeline_data
+ALLOWED_TIMELINE_FIELDS = TimelineService.ALLOWED_TIMELINE_FIELDS
+
+
+@pytest.mark.django_db
+@override_settings(AUDITLOG_INCLUDE_ALL_MODELS=True)
+def test_youth_application_status_change_creates_auditlog_entry():
+    """Changing YouthApplication.status via the API creates a LogEntry
+    whose changes dict contains a 'status' key with [old, new] strings.
+    Guards against accidental removal of auditlog tracking for this field."""
+    app = YouthApplicationFactory(status="submitted")
+    old_status = app.status
+
+    # Simulate update
+    app.status = "accepted"
+    app.save()
+
+    ct = ContentType.objects.get_for_model(YouthApplication)
+    log_entry = LogEntry.objects.filter(
+        content_type=ct, object_pk=str(app.pk), action=LogEntry.Action.UPDATE
+    ).last()
+
+    assert log_entry is not None
+    assert "status" in log_entry.changes
+    assert log_entry.changes["status"] == [old_status, "accepted"]
+
+
+@pytest.mark.django_db
+@override_settings(AUDITLOG_INCLUDE_ALL_MODELS=True)
+def test_employer_application_status_change_creates_auditlog_entry():
+    """Same guarantee as above, but for EmployerApplication.status."""
+    app = EmployerApplicationFactory(status="draft")
+    old_status = app.status
+
+    app.status = "submitted"
+    app.save()
+
+    ct = ContentType.objects.get_for_model(EmployerApplication)
+    log_entry = LogEntry.objects.filter(
+        content_type=ct, object_pk=str(app.pk), action=LogEntry.Action.UPDATE
+    ).last()
+
+    assert log_entry is not None
+    assert "status" in log_entry.changes
+    assert log_entry.changes["status"] == [old_status, "submitted"]
+
+
+@pytest.mark.django_db
+def test_service_strips_unallowed_fields():
+    """A LogEntry that records both a status change and a change to a
+    sensitive field (e.g. encrypted_handler_vtj_json) must produce only
+    one ActivityLogItem — the status change. Sensitive fields are silently
+    ignored by the allowlist."""
+    app = YouthApplicationFactory(status="submitted")
+    ct = ContentType.objects.get_for_model(YouthApplication)
+
+    # Manually create a LogEntry to simulate both fields changing
+    actor = UserFactory(first_name="Test", last_name="User")
+    log_entry = LogEntry.objects.create(
+        content_type=ct,
+        object_pk=str(app.pk),
+        action=LogEntry.Action.UPDATE,
+        actor=actor,
+        changes={
+            "status": ["submitted", "accepted"],
+            "encrypted_handler_vtj_json": ["old_secret", "new_secret"],
+        },
+    )
+
+    items = get_activity_logs_for_application(app)
+    assert len(items) == 1
+    item = items[0]
+    assert item.action_type == ActionType.APPLICATION_STATUS_CHANGE.value
+    assert item.old_value == "submitted"
+    assert item.new_value == "accepted"
+    assert item.author_name == "Test User"
+    assert item.created_at == log_entry.timestamp
+
+
+@pytest.mark.django_db
+def test_service_returns_empty_for_unregistered_model():
+    """Passing an Attachment instance (not in ALLOWED_TIMELINE_FIELDS)
+    to get_activity_logs_for_application must return an empty list,
+    ensuring unregistered models never leak audit data."""
+    attachment = MagicMock(spec=Attachment)
+    attachment._meta.model_name = Attachment._meta.model_name
+    assert Attachment._meta.model_name not in ALLOWED_TIMELINE_FIELDS
+
+    items = get_activity_logs_for_application(attachment)
+    assert items == []
+
+
+@pytest.mark.django_db
+def test_service_skips_no_op_changes():
+    """A LogEntry where old_value and new_value are identical (e.g.
+    ['submitted', 'submitted']) must be silently skipped, producing no
+    ActivityLogItem."""
+    app = YouthApplicationFactory(status="submitted")
+    ct = ContentType.objects.get_for_model(YouthApplication)
+
+    LogEntry.objects.create(
+        content_type=ct,
+        object_pk=str(app.pk),
+        action=LogEntry.Action.UPDATE,
+        changes={
+            "status": ["submitted", "submitted"],
+        },
+    )
+
+    items = get_activity_logs_for_application(app)
+    assert len(items) == 0
+
+
+@pytest.mark.django_db
+def test_service_handles_malformed_change():
+    """A LogEntry whose change value is not a 2-element list (e.g. a plain
+    string or a single-element list) must be skipped without raising an
+    exception, keeping the timeline endpoint stable."""
+    app = YouthApplicationFactory(status="submitted")
+    ct = ContentType.objects.get_for_model(YouthApplication)
+
+    LogEntry.objects.create(
+        content_type=ct,
+        object_pk=str(app.pk),
+        action=LogEntry.Action.UPDATE,
+        changes={
+            "status": "not-a-list",
+        },
+    )
+
+    LogEntry.objects.create(
+        content_type=ct,
+        object_pk=str(app.pk),
+        action=LogEntry.Action.UPDATE,
+        changes={
+            "status": ["only-one-item"],
+        },
+    )
+
+    items = get_activity_logs_for_application(app)
+    assert len(items) == 0
+
+
+@pytest.mark.django_db
+def test_service_handles_null_actor():
+    """A LogEntry with actor=None (system-generated or actor deleted) must
+    produce an ActivityLogItem with author_name='' and must not raise."""
+    app = YouthApplicationFactory(status="submitted")
+    ct = ContentType.objects.get_for_model(YouthApplication)
+
+    LogEntry.objects.create(
+        content_type=ct,
+        object_pk=str(app.pk),
+        action=LogEntry.Action.UPDATE,
+        actor=None,
+        changes={
+            "status": ["submitted", "accepted"],
+        },
+    )
+
+    items = get_activity_logs_for_application(app)
+    assert len(items) == 1
+    assert items[0].author_name == ""
+
+
+@pytest.mark.django_db
+def test_service_coerces_null_values():
+    """Verify that a changes list containing None values is coerced to empty
+    strings in the resulting ActivityLogItem, preventing None leaking or crashing."""
+    app = YouthApplicationFactory(status="submitted")
+    ct = ContentType.objects.get_for_model(YouthApplication)
+
+    LogEntry.objects.create(
+        content_type=ct,
+        object_pk=str(app.pk),
+        action=LogEntry.Action.UPDATE,
+        changes={
+            "status": [None, "accepted"],
+        },
+    )
+
+    items = get_activity_logs_for_application(app)
+    assert len(items) == 1
+    assert items[0].old_value == ""
+    assert items[0].new_value == "accepted"
+
+
+@pytest.mark.django_db
+@override_settings(AUDITLOG_INCLUDE_ALL_MODELS=True)
+def test_get_application_timeline_data_combines_filters_and_sorts():
+    """Verify that get_application_timeline_data combines activity log items
+    and notes, respects requested_types filters, and returns them sorted
+    in descending order of created_at."""
+    app = YouthApplicationFactory(status="submitted")
+    NoteFactory(content_object=app, content="First note")
+
+    # Generate status change (Activity)
+    app.status = "accepted"
+    app.save()
+
+    # Generate another note
+    NoteFactory(content_object=app, content="Second note")
+
+    # 1. Test combining all with no filter
+    timeline = get_application_timeline_data(app, requested_types=set())
+    assert len(timeline) == 3
+    # Check sorting order: second note is newest (created after status change), then activity, then first note
+    assert timeline[0]["item_type"] == TimelineItemType.NOTE.value
+    assert timeline[0]["content"] == "Second note"
+    assert timeline[1]["item_type"] == TimelineItemType.ACTIVITY.value
+    assert timeline[1]["old_value"] == "submitted"
+    assert timeline[1]["new_value"] == "accepted"
+    assert timeline[2]["item_type"] == TimelineItemType.NOTE.value
+    assert timeline[2]["content"] == "First note"
+
+    # 2. Test filtering to notes only
+    timeline_notes = get_application_timeline_data(app, requested_types={"note"})
+    assert len(timeline_notes) == 2
+    assert all(
+        item["item_type"] == TimelineItemType.NOTE.value for item in timeline_notes
+    )
+
+    # 3. Test filtering to activities only
+    timeline_activities = get_application_timeline_data(
+        app, requested_types={"activity"}
+    )
+    assert len(timeline_activities) == 1
+    assert timeline_activities[0]["item_type"] == TimelineItemType.ACTIVITY.value

--- a/backend/kesaseteli/handler_notes/api/v1/serializers.py
+++ b/backend/kesaseteli/handler_notes/api/v1/serializers.py
@@ -2,12 +2,14 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+from applications.enums import TimelineItemType
 from handler_notes.enums import NoteType
 from handler_notes.models import Note
 from handler_notes.utils import get_note_target_model
 
 
 class NoteSerializer(serializers.ModelSerializer):
+    item_type = serializers.SerializerMethodField()
     author_username = serializers.SlugRelatedField(
         slug_field="username", read_only=True, source="author"
     )
@@ -19,6 +21,7 @@ class NoteSerializer(serializers.ModelSerializer):
         model = Note
         fields = [
             "id",
+            "item_type",
             "content",
             "author_username",
             "author_name",
@@ -112,6 +115,9 @@ class NoteSerializer(serializers.ModelSerializer):
         if obj.author:
             return obj.author.get_full_name()
         return ""
+
+    def get_item_type(self, obj) -> str:
+        return TimelineItemType.NOTE
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)

--- a/backend/kesaseteli/handler_notes/tests/test_api.py
+++ b/backend/kesaseteli/handler_notes/tests/test_api.py
@@ -1,10 +1,13 @@
 import uuid
 
+import factory as factory_boy
 import pytest
+from django.db.models.signals import post_save
 from django.test import override_settings
 from django.urls import reverse
 from rest_framework import serializers, status
 
+from applications.enums import ActionType, TimelineItemType
 from common.tests.factories import (
     AttachmentFactory,
     EmployerApplicationFactory,
@@ -18,6 +21,7 @@ from shared.common.tests.factories import UserFactory
 
 @pytest.mark.django_db
 def test_create_note_api(staff_client, user):
+    """Test creating a handler note via API succeeds for staff users."""
     app = YouthApplicationFactory()
     url = reverse("v1:handlernotes-list")
 
@@ -40,7 +44,7 @@ def test_create_note_api(staff_client, user):
 
 @pytest.mark.django_db
 def test_youth_application_timeline_api(staff_client):
-    # Tests the timeline @action defined on YouthApplicationViewSet (applications app)
+    """Test fetching the timeline of a youth application returns its notes."""
     app = YouthApplicationFactory()
     NoteFactory(content_object=app, content="Note 1")
     NoteFactory(content_object=app, content="Note 2")
@@ -57,8 +61,12 @@ def test_youth_application_timeline_api(staff_client):
 
 @pytest.mark.django_db
 def test_employer_application_timeline_api(staff_client):
-    # Tests the timeline @action defined on EmployerApplicationViewSet (applications app)
-    app = EmployerApplicationFactory()
+    """Test fetching the timeline of an employer application returns notes."""
+    # Mute signals during factory creation to avoid recording the initial status creation
+    # in the audit log (which is factory setup and not part of the timeline notes we are testing).
+    with factory_boy.django.mute_signals(post_save):
+        app = EmployerApplicationFactory()
+
     NoteFactory(content_object=app, content="Emp Note 1")
     NoteFactory(content_object=app, content="Emp Note 2")
 
@@ -81,6 +89,7 @@ def test_employer_application_timeline_api(staff_client):
 @pytest.mark.django_db
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_note_list_permissions_unauthenticated(api_client):
+    """Test listing notes fails with a 401/403 for unauthenticated requests."""
     url = reverse("v1:handlernotes-list")
     response = api_client.get(url)
     assert response.status_code in [
@@ -92,6 +101,7 @@ def test_note_list_permissions_unauthenticated(api_client):
 @pytest.mark.django_db
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_note_list_permissions_non_handler(api_client, user):
+    """Test listing notes fails with a 403 for authenticated non-handler/non-staff users."""
     url = reverse("v1:handlernotes-list")
     api_client.force_authenticate(user=user)
     response = api_client.get(url)
@@ -101,6 +111,7 @@ def test_note_list_permissions_non_handler(api_client, user):
 @pytest.mark.django_db
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_note_detail_permissions_unauthenticated(api_client):
+    """Test accessing note details fails with a 401/403 for unauthenticated requests."""
     note = NoteFactory()
     url = reverse("v1:handlernotes-detail", kwargs={"pk": note.id})
     response = api_client.get(url)
@@ -113,6 +124,7 @@ def test_note_detail_permissions_unauthenticated(api_client):
 @pytest.mark.django_db
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_note_detail_permissions_non_handler(api_client, user):
+    """Test accessing note details fails with a 403 for authenticated non-staff users."""
     note = NoteFactory()
     url = reverse("v1:handlernotes-detail", kwargs={"pk": note.id})
     api_client.force_authenticate(user=user)
@@ -122,6 +134,7 @@ def test_note_detail_permissions_non_handler(api_client, user):
 
 @pytest.mark.django_db
 def test_attachment_external_note_invalid(staff_client):
+    """Test that external messages cannot be created for attachments."""
     attachment = AttachmentFactory(summer_voucher=EmployerSummerVoucherFactory())
     url = reverse("v1:handlernotes-list")
 
@@ -141,6 +154,7 @@ def test_attachment_external_note_invalid(staff_client):
 @pytest.mark.django_db
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_youth_application_timeline_permissions(api_client, user):
+    """Test that fetching the youth application timeline requires staff authentication."""
     app = YouthApplicationFactory()
     url = reverse("v1:youthapplication-timeline", kwargs={"pk": app.id})
 
@@ -160,6 +174,7 @@ def test_youth_application_timeline_permissions(api_client, user):
 @pytest.mark.django_db
 @override_settings(NEXT_PUBLIC_MOCK_FLAG=False)
 def test_employer_application_timeline_permissions(api_client, user):
+    """Test that fetching the employer application timeline requires staff authentication."""
     app = EmployerApplicationFactory()
     url = reverse("v1:employerapplication-timeline", kwargs={"pk": app.id})
 
@@ -178,6 +193,7 @@ def test_employer_application_timeline_permissions(api_client, user):
 
 @pytest.mark.django_db
 def test_update_note_author(staff_client, user):
+    """Test that the note author can successfully update their own note."""
     note = NoteFactory(author=user, content="Original content")
     url = reverse("v1:handlernotes-detail", kwargs={"pk": note.id})
 
@@ -190,6 +206,7 @@ def test_update_note_author(staff_client, user):
 
 @pytest.mark.django_db
 def test_update_note_non_author(staff_client):
+    """Test that updating another user's note fails with a 403 Forbidden."""
     other_user = UserFactory(is_staff=True)
     note = NoteFactory(author=other_user, content="Original content")
     url = reverse("v1:handlernotes-detail", kwargs={"pk": note.id})
@@ -204,6 +221,7 @@ def test_update_note_non_author(staff_client):
 
 @pytest.mark.django_db
 def test_delete_note_author(staff_client, user):
+    """Test that the note author can successfully delete their own note."""
     note = NoteFactory(author=user)
     url = reverse("v1:handlernotes-detail", kwargs={"pk": note.id})
 
@@ -214,6 +232,7 @@ def test_delete_note_author(staff_client, user):
 
 @pytest.mark.django_db
 def test_delete_note_non_author(staff_client):
+    """Test that deleting another user's note fails with a 403 Forbidden."""
     other_user = UserFactory(is_staff=True)
     note = NoteFactory(author=other_user)
     url = reverse("v1:handlernotes-detail", kwargs={"pk": note.id})
@@ -226,6 +245,7 @@ def test_delete_note_non_author(staff_client):
 
 @pytest.mark.django_db
 def test_note_serializer_fields(staff_client, user):
+    """Test that the serialized note response contains all expected fields."""
     note = NoteFactory(
         author=user,
         content="Serializer test note content",
@@ -238,6 +258,7 @@ def test_note_serializer_fields(staff_client, user):
     # Strict snapshot/structure validation
     assert response.data == {
         "id": str(note.id),
+        "item_type": "note",
         "content": "Serializer test note content",
         "author_username": user.username,
         "author_name": user.get_full_name(),
@@ -252,6 +273,7 @@ def test_note_serializer_fields(staff_client, user):
 
 @pytest.mark.django_db
 def test_create_note_partial_target_type_fails(staff_client):
+    """Test that creating a note with only target_type fails validation."""
     url = reverse("v1:handlernotes-list")
     data = {
         "target_type": "youthapplication",
@@ -264,6 +286,7 @@ def test_create_note_partial_target_type_fails(staff_client):
 
 @pytest.mark.django_db
 def test_create_note_partial_target_id_fails(staff_client):
+    """Test that creating a note with only target_id fails validation."""
     url = reverse("v1:handlernotes-list")
     data = {
         "target_id": uuid.uuid4(),
@@ -276,6 +299,7 @@ def test_create_note_partial_target_id_fails(staff_client):
 
 @pytest.mark.django_db
 def test_note_serializer_no_author(staff_client):
+    """Test that serializing a note with a null author is handled safely."""
     note = NoteFactory(
         author=None,
         content="No author test content",
@@ -290,6 +314,7 @@ def test_note_serializer_no_author(staff_client):
 
 @pytest.mark.django_db
 def test_create_note_no_target_fails(staff_client):
+    """Test that creating a note without any target identifier fails validation."""
     url = reverse("v1:handlernotes-list")
     data = {
         "content": "API test note with no target at all",
@@ -301,6 +326,7 @@ def test_create_note_no_target_fails(staff_client):
 
 @pytest.mark.django_db
 def test_list_notes_no_target_returns_empty(staff_client):
+    """Test that listing notes without target query parameters returns an empty list."""
     NoteFactory()
     url = reverse("v1:handlernotes-list")
     response = staff_client.get(url)
@@ -310,6 +336,7 @@ def test_list_notes_no_target_returns_empty(staff_client):
 
 @pytest.mark.django_db
 def test_list_notes_partial_target_returns_empty(staff_client):
+    """Test that listing notes with incomplete target query parameters returns an empty list."""
     app = YouthApplicationFactory()
     NoteFactory(content_object=app)
     url = reverse("v1:handlernotes-list")
@@ -327,6 +354,7 @@ def test_list_notes_partial_target_returns_empty(staff_client):
 
 @pytest.mark.django_db
 def test_detail_note_works_without_query_params(staff_client, user):
+    """Test that accessing a note's detail view succeeds without target query params."""
     note = NoteFactory(author=user)
     url = reverse("v1:handlernotes-detail", kwargs={"pk": note.id})
     response = staff_client.get(url)
@@ -377,3 +405,147 @@ def test_update_note_with_different_target_fails(staff_client, user):
     response = staff_client.put(url, data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "target_type" in response.data
+
+
+@pytest.mark.django_db
+@override_settings(AUDITLOG_INCLUDE_ALL_MODELS=True)
+@pytest.mark.parametrize(
+    "factory,url_name,initial_status,updated_status,note_content",
+    [
+        (
+            YouthApplicationFactory,
+            "v1:youthapplication-timeline",
+            "submitted",
+            "accepted",
+            "First note",
+        ),
+        (
+            EmployerApplicationFactory,
+            "v1:employerapplication-timeline",
+            "draft",
+            "submitted",
+            "Application note",
+        ),
+    ],
+)
+def test_application_timeline_includes_notes_and_activities(
+    staff_client, factory, url_name, initial_status, updated_status, note_content
+):
+    """The timeline endpoint must return a combined, descending-chronological
+    list containing both item_type='note' entries (from handler notes) and
+    item_type='activity' entries (from status changes)."""
+    # Mute signals during factory creation to avoid recording the initial status creation
+    # in the audit log (which is factory setup and not part of the status update timeline
+    # activity we are testing).
+    with factory_boy.django.mute_signals(post_save):
+        app = factory(status=initial_status)
+
+    NoteFactory(content_object=app, content=note_content)
+
+    # Change status to generate a LogEntry
+    app.status = updated_status
+    app.save()
+
+    url = reverse(url_name, kwargs={"pk": app.id})
+    response = staff_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 2
+
+    # Since descending chronological, let's verify item types and keys
+    activity = response.data[0]
+    note = response.data[1]
+
+    assert activity["item_type"] == TimelineItemType.ACTIVITY.value
+    assert activity["action_type"] == ActionType.APPLICATION_STATUS_CHANGE.value
+    assert activity["old_value"] == initial_status
+    assert activity["new_value"] == updated_status
+
+    assert note["item_type"] == TimelineItemType.NOTE.value
+    assert note["content"] == note_content
+
+
+@pytest.mark.django_db
+@override_settings(AUDITLOG_INCLUDE_ALL_MODELS=True)
+def test_timeline_filtered_to_notes_excludes_activities(staff_client):
+    """When ?item_types=note is passed, the response must contain only
+    item_type='note' entries. No activity entries are present."""
+    app = YouthApplicationFactory(status="submitted")
+    NoteFactory(content_object=app, content="First note")
+    NoteFactory(content_object=app, content="Second note")
+
+    # Generate an activity log entry
+    app.status = "accepted"
+    app.save()
+
+    url = reverse("v1:youthapplication-timeline", kwargs={"pk": app.id})
+    response = staff_client.get(f"{url}?item_types=note")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 2
+    assert all(
+        item["item_type"] == TimelineItemType.NOTE.value for item in response.data
+    )
+    assert {item["content"] for item in response.data} == {"First note", "Second note"}
+
+
+@pytest.mark.django_db
+@override_settings(AUDITLOG_INCLUDE_ALL_MODELS=True)
+def test_timeline_filtered_to_activities_excludes_notes(staff_client):
+    """When ?item_types=activity is passed, the response must contain only
+    item_type='activity' entries. No note entries are present."""
+    app = YouthApplicationFactory(status="submitted")
+    NoteFactory(content_object=app, content="First note")
+
+    # Generate first status change activity
+    app.status = "additional_information_needed"
+    app.save()
+
+    # Generate second status change activity
+    app.status = "accepted"
+    app.save()
+
+    url = reverse("v1:youthapplication-timeline", kwargs={"pk": app.id})
+    response = staff_client.get(f"{url}?item_types=activity")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 2
+    assert all(
+        item["item_type"] == TimelineItemType.ACTIVITY.value for item in response.data
+    )
+
+    old_new_pairs = {(item["old_value"], item["new_value"]) for item in response.data}
+    assert old_new_pairs == {
+        ("submitted", "additional_information_needed"),
+        ("additional_information_needed", "accepted"),
+    }
+
+
+@pytest.mark.django_db
+@override_settings(AUDITLOG_INCLUDE_ALL_MODELS=True)
+def test_timeline_without_filter_returns_all_types(staff_client):
+    """When no item_types query param is provided, both note and activity
+    entries are returned — the default is to include everything."""
+    app = YouthApplicationFactory(status="submitted")
+    NoteFactory(content_object=app, content="First note")
+
+    app.status = "accepted"
+    app.save()
+
+    url = reverse("v1:youthapplication-timeline", kwargs={"pk": app.id})
+    response = staff_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 2
+
+    # Descending chronological order: newest status change activity first, then the note.
+    activity = response.data[0]
+    note_data = response.data[1]
+
+    assert activity["item_type"] == TimelineItemType.ACTIVITY.value
+    assert activity["action_type"] == ActionType.APPLICATION_STATUS_CHANGE.value
+    assert activity["old_value"] == "submitted"
+    assert activity["new_value"] == "accepted"
+
+    assert note_data["item_type"] == TimelineItemType.NOTE.value
+    assert note_data["content"] == "First note"

--- a/frontend/kesaseteli/handler/public/locales/fi/common.json
+++ b/frontend/kesaseteli/handler/public/locales/fi/common.json
@@ -196,7 +196,8 @@
       "accepted": "Hyväksytty",
       "rejected": "Hylätty",
       "draft": "Luonnos",
-      "deleted_by_customer": "Poistettu"
+      "deleted_by_customer": "Poistettu",
+      "None": "Ei asetettu"
     },
     "statusTooltip": {
       "submitted": "Nuori on täyttänyt hakemuksen, mutta ei ole vielä aktivoinut sitä sähköpostiinsa tulleesta vahvistuslinkistä.",
@@ -330,7 +331,8 @@
     "noteTypeLabel": "Huomion tyyppi",
     "noteType": {
       "internal": "Sisäinen huomio",
-      "external_message": "Ulkoinen viesti"
+      "external_message": "Ulkoinen viesti",
+      "activity": "Tilamuutos"
     },
     "noteTypeHelperText": "Huomion tyyppi vaikuttaa vain sen ulkoasuun tässä näkymässä. Ulkoinen viesti ei vielä lähetä viestiä hakijalle.",
     "isImportantLabel": "Merkitse tärkeäksi",
@@ -345,6 +347,7 @@
     "sidebarToggleClose": "Sulje aikajana",
     "emptyState": "Ei vielä tapahtumia aikajanalla.",
     "jumpToNote": "Siirry huomioon →",
+    "statusChange": "Tila muuttunut: <statusValue>{{oldStatus}}</statusValue> → <statusValue>{{newStatus}}</statusValue>",
     "developerNote": {
       "label": "Kehittäjän huomiot",
       "content": "Sivupalkki on testikäytössä. Sivupalkin aikajanan tarkoituksena on näyttää tulevaisuudessa kommenttien lisäksi myös mm. hakemuksen tilamuutokset. Näin ollen se eroaa päänäkymän \"käsittelijän huomiot\" -osiosta, jossa listataan toistaiseksi vain huomioita. Sivupalkista voitaisiin luopua kokonaan ja listata kaikki yllämainitut asiat samassa päänäkymän huomio-osiossa, eli huomio-osio vaihdettaisiin aikajanaksi. Tällöin sivupalkkia ei tarvita ollenkaan."

--- a/frontend/kesaseteli/handler/src/__tests__/utils/backend/fake-notes.ts
+++ b/frontend/kesaseteli/handler/src/__tests__/utils/backend/fake-notes.ts
@@ -1,14 +1,21 @@
-import { HandlerNote, NoteTargetType, NoteType } from '../../../types/note';
+import { NoteTargetType, NoteType } from '../../../types/note';
+import {
+  ActionType,
+  ActivityLogItem,
+  TimelineItemType,
+  TimelineNoteItem,
+} from '../../../types/timeline';
 
 export const fakeNote = (
-  overrides?: Partial<HandlerNote>,
+  overrides?: Partial<TimelineNoteItem>,
   index = 0
-): HandlerNote => {
+): TimelineNoteItem => {
   const id = overrides?.id ?? `note-${index + 1}`;
   const timeOffset = index * 60 * 1000; // each note is 1 minute older than the previous
   const defaultCreated = new Date(Date.now() - timeOffset).toISOString();
 
   return {
+    item_type: TimelineItemType.NOTE,
     id,
     content: `note ${index + 1}`,
     author_username: overrides?.author_username ?? 'user-1',
@@ -25,8 +32,10 @@ export const fakeNote = (
 
 export const fakeNotes = (
   count: number,
-  overrides?: Partial<HandlerNote>[] | ((index: number) => Partial<HandlerNote>)
-): HandlerNote[] =>
+  overrides?:
+    | Partial<TimelineNoteItem>[]
+    | ((index: number) => Partial<TimelineNoteItem>)
+): TimelineNoteItem[] =>
   Array.from({ length: count }, (_, index) => {
     const override =
       typeof overrides === 'function'
@@ -34,3 +43,21 @@ export const fakeNotes = (
         : overrides?.[index] ?? {};
     return fakeNote(override, index);
   });
+
+export const fakeActivityLogItem = (
+  overrides?: Partial<ActivityLogItem>,
+  index = 0
+): ActivityLogItem => {
+  const timeOffset = index * 60 * 1000;
+  const defaultCreated = new Date(Date.now() - timeOffset).toISOString();
+
+  return {
+    item_type: TimelineItemType.ACTIVITY,
+    action_type: ActionType.APPLICATION_STATUS_CHANGE,
+    old_value: 'submitted',
+    new_value: 'additional_information_requested',
+    author_name: 'Author 1',
+    created_at: defaultCreated,
+    ...overrides,
+  };
+};

--- a/frontend/kesaseteli/handler/src/components/notes/NoteCard.sc.ts
+++ b/frontend/kesaseteli/handler/src/components/notes/NoteCard.sc.ts
@@ -1,7 +1,6 @@
 import styled, { DefaultTheme } from 'styled-components';
 
-import { NoteType } from '../../types/note';
-import { NOTE_TYPE_CONFIGS, NoteItemType } from '../timeline/TimelineTheme';
+
 
 export const $NoteCardContainer = styled.div``;
 
@@ -11,16 +10,7 @@ export const $NoteContent = styled.p`
   word-break: break-word;
 `;
 
-export const $NoteTypeBadge = styled.span<{ $type: NoteType }>`
-  display: inline-block;
-  font-size: var(--fontsize-body-xs);
-  padding: 2px 8px;
-  border-radius: 12px;
-  background-color: ${({ $type }) =>
-    NOTE_TYPE_CONFIGS[$type as NoteItemType]?.avatarBackground};
-  color: var(--color-black-90);
-  margin-right: var(--spacing-xs);
-`;
+
 
 export const $NoteActions = styled.div`
   display: flex;

--- a/frontend/kesaseteli/handler/src/components/notes/NotesSection.tsx
+++ b/frontend/kesaseteli/handler/src/components/notes/NotesSection.tsx
@@ -6,9 +6,8 @@ import useCreateNoteMutation from '../../hooks/backend/useCreateNoteMutation';
 import useHandlerNotesQuery from '../../hooks/backend/useHandlerNotesQuery';
 import { CreateNotePayload, NoteTargetType } from '../../types/note';
 import Timeline, { TimelineSize } from '../timeline/Timeline';
-import { getNoteTypeIcon } from '../timeline/TimelineTheme';
+import { getTimelineIcon } from '../timeline/TimelineTheme';
 import NoteCard from './NoteCard';
-import { $NoteTypeBadge } from './NoteCard.sc';
 import NoteForm from './NoteForm';
 import { $NotesContainer } from './NotesSection.sc';
 
@@ -23,10 +22,7 @@ const NotesSection: React.FC<Props> = ({ applicationId, targetType }) => {
 
   const { data: notes = [] } = useHandlerNotesQuery(targetType, applicationId);
 
-  const createMutation = useCreateNoteMutation(
-    targetType,
-    applicationId || ''
-  );
+  const createMutation = useCreateNoteMutation(targetType, applicationId || '');
 
   return (
     <$NotesContainer>
@@ -47,7 +43,7 @@ const NotesSection: React.FC<Props> = ({ applicationId, targetType }) => {
         emptyState={t('common:handlerNotes.noNotes')}
       >
         {notes.map((note) => {
-          const TypeIcon = getNoteTypeIcon(note.note_type);
+          const TypeIcon = getTimelineIcon(note.note_type);
           const formattedDate = new Date(note.created_at).toLocaleString(
             locale
           );
@@ -63,9 +59,9 @@ const NotesSection: React.FC<Props> = ({ applicationId, targetType }) => {
               size={TimelineSize.large}
             >
               <Timeline.Item.Header>
-                <$NoteTypeBadge $type={note.note_type}>
+                <Timeline.Item.Badge $type={note.note_type}>
                   {t(`common:handlerNotes.noteType.${note.note_type}`)}
-                </$NoteTypeBadge>
+                </Timeline.Item.Badge>
                 {t('common:handlerNotes.authorAt', {
                   author: note.author_name,
                   date: formattedDate,

--- a/frontend/kesaseteli/handler/src/components/sidebar/ApplicationTimeline.sc.ts
+++ b/frontend/kesaseteli/handler/src/components/sidebar/ApplicationTimeline.sc.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+
+
+export const $StatusValue = styled.strong`
+  font-weight: 600;
+  color: var(--color-black-90);
+`;
+
+export const $PreWrapParagraph = styled.p`
+  margin: var(--spacing-xs) 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+`;

--- a/frontend/kesaseteli/handler/src/components/sidebar/ApplicationTimeline.tsx
+++ b/frontend/kesaseteli/handler/src/components/sidebar/ApplicationTimeline.tsx
@@ -1,25 +1,19 @@
 import { ApplicationListType } from 'kesaseteli/handler/types/application';
-import { useTranslation } from 'next-i18next';
+import { Trans, useTranslation } from 'next-i18next';
 import React from 'react';
 import useLocale from 'shared/hooks/useLocale';
-import styled from 'styled-components';
 
 import useApplicationTimelineQuery from '../../hooks/backend/useApplicationTimelineQuery';
-import { $NoteContent, $NoteTypeBadge } from '../notes/NoteCard.sc';
+import { ActionType, TimelineItemType } from '../../types/timeline';
 import Timeline, { TimelineSize } from '../timeline/Timeline';
-import { getNoteTypeIcon } from '../timeline/TimelineTheme';
+import { getTimelineIcon } from '../timeline/TimelineTheme';
+import { $PreWrapParagraph, $StatusValue } from './ApplicationTimeline.sc';
 
 export type ApplicationTimelineProps = {
   applicationId: string;
   applicationType: ApplicationListType;
   onToggle: () => void;
 };
-
-const $TimelineItemAuthor = styled.b`
-  display: block;
-  margin-top: var(--spacing-s);
-`;
-
 
 const ApplicationTimeline: React.FC<ApplicationTimelineProps> = ({
   applicationId,
@@ -45,36 +39,68 @@ const ApplicationTimeline: React.FC<ApplicationTimelineProps> = ({
       aria-label={t('common:timeline.title')}
       emptyState={t('common:timeline.emptyState')}
     >
-      {timeline.map((note) => {
-        const TypeIcon = getNoteTypeIcon(note.note_type);
-        const formattedDate = new Date(note.created_at).toLocaleString(locale);
+      {timeline.map((item) => {
+        const isActivity = item.item_type === TimelineItemType.ACTIVITY;
+        const noteType = isActivity ? 'activity' : item.note_type;
+        const TypeIcon = getTimelineIcon(noteType);
+        const formattedDate = new Date(item.created_at).toLocaleString(locale);
+        const key = isActivity
+          ? `activity-${item.created_at}-${item.action_type}`
+          : item.id;
+        const isImportant = isActivity ? false : item.is_important;
 
         return (
           <Timeline.Item
-            key={note.id}
-            type={note.note_type}
-            isImportant={note.is_important}
+            key={key}
+            type={noteType}
+            isImportant={isImportant}
             icon={TypeIcon}
             size={TimelineSize.small}
           >
             <Timeline.Item.Header>
-              <$NoteTypeBadge $type={note.note_type}>
-                {t(`common:handlerNotes.noteType.${note.note_type}`)}
-              </$NoteTypeBadge>
-              <$TimelineItemAuthor>{t('common:handlerNotes.authorAt', {
-                author: note.author_name,
-                date: formattedDate,
-              })}</$TimelineItemAuthor>
+              <Timeline.Item.Badge $type={noteType}>
+                {t(`common:handlerNotes.noteType.${noteType}`)}
+              </Timeline.Item.Badge>
+              <Timeline.Item.Author>
+                {item.author_name
+                  ? t('common:handlerNotes.authorAt', {
+                      author: item.author_name,
+                      date: formattedDate,
+                    })
+                  : formattedDate}
+              </Timeline.Item.Author>
             </Timeline.Item.Header>
             <Timeline.Item.Content>
-              <$NoteContent>{note.content}</$NoteContent>
+              {isActivity &&
+              item.action_type === ActionType.APPLICATION_STATUS_CHANGE ? (
+                <$PreWrapParagraph>
+                  <Trans
+                    i18nKey="common:timeline.statusChange"
+                    values={{
+                      oldStatus: t(
+                        `common:handlerApplication.applicationStatus.${item.old_value}`
+                      ),
+                      newStatus: t(
+                        `common:handlerApplication.applicationStatus.${item.new_value}`
+                      ),
+                    }}
+                    components={{ statusValue: <$StatusValue /> }}
+                  />
+                </$PreWrapParagraph>
+              ) : (
+                <$PreWrapParagraph>
+                  {!isActivity ? item.content : ''}
+                </$PreWrapParagraph>
+              )}
             </Timeline.Item.Content>
-            <Timeline.Item.Link
-              href={`#note-${note.id}`}
-              onClick={handleNoteClick}
-            >
-              {t('common:timeline.jumpToNote')}
-            </Timeline.Item.Link>
+            {!isActivity && (
+              <Timeline.Item.Link
+                href={`#note-${item.id}`}
+                onClick={handleNoteClick}
+              >
+                {t('common:timeline.jumpToNote')}
+              </Timeline.Item.Link>
+            )}
           </Timeline.Item>
         );
       })}

--- a/frontend/kesaseteli/handler/src/components/sidebar/__tests__/ApplicationSidebar.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/sidebar/__tests__/ApplicationSidebar.test.tsx
@@ -5,7 +5,10 @@ import React from 'react';
 import useLocale from 'shared/hooks/useLocale';
 import useMediaQuery from 'shared/hooks/useMediaQuery';
 
-import { fakeNotes } from '../../../__tests__/utils/backend/fake-notes';
+import {
+  fakeActivityLogItem,
+  fakeNotes,
+} from '../../../__tests__/utils/backend/fake-notes';
 import useApplicationTimelineQuery from '../../../hooks/backend/useApplicationTimelineQuery';
 import ApplicationSidebar from '../ApplicationSidebar';
 
@@ -13,11 +16,17 @@ jest.mock('../../../hooks/backend/useApplicationTimelineQuery');
 jest.mock('shared/hooks/useLocale', () => jest.fn());
 jest.mock('shared/hooks/useMediaQuery', () => jest.fn());
 
-const mockTimelineNotes = fakeNotes(1, [
-  {
-    content: 'timeline note 1 content',
-  },
-]);
+const mockTimelineNotes = [
+  ...fakeNotes(1, [
+    {
+      content: 'timeline note 1 content',
+    },
+  ]),
+  fakeActivityLogItem({
+    old_value: 'submitted',
+    new_value: 'additional_information_requested',
+  }),
+];
 
 describe('ApplicationSidebar', () => {
   const mockOnToggle = jest.fn();
@@ -78,5 +87,31 @@ describe('ApplicationSidebar', () => {
     await userEvent.click(link);
 
     expect(mockOnToggle).toHaveBeenCalled();
+  });
+
+  it('renders activity log items correctly', () => {
+    renderComponent(
+      <ApplicationSidebar
+        applicationId="app-1"
+        applicationType="youth"
+        isOpen
+        onToggle={mockOnToggle}
+      />
+    );
+
+    expect(screen.getByText('Tilamuutos')).toBeInTheDocument();
+
+    // Test for the prefix text first
+    expect(screen.getByText(/tila muuttunut:/i)).toBeInTheDocument();
+
+    // The inner content within Trans components should be accessible via regular getByText
+    expect(screen.getByText('Lähetetty')).toBeInTheDocument();
+    expect(screen.getByText('Lisätietoja pyydetty')).toBeInTheDocument();
+
+    // Verify 'Siirry huomioon' is NOT present for the activity item.
+    // There is one note and one activity, so there should only be one 'Siirry huomioon' link.
+    expect(
+      screen.getByRole('link', { name: /siirry huomioon/i })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/kesaseteli/handler/src/components/timeline/TimelineItem.sc.ts
+++ b/frontend/kesaseteli/handler/src/components/timeline/TimelineItem.sc.ts
@@ -4,15 +4,15 @@ import { TIMELINE_AVATAR_SIZE, TIMELINE_COLUMN_WIDTH } from './Timeline.sc';
 import {
   getItemBackgroundColor,
   getItemBorderColor,
-  NOTE_TYPE_CONFIGS,
-  NoteItemType,
+  TIMELINE_ITEM_THEME_CONFIGS,
+  TimelineItemThemeType,
 } from './TimelineTheme';
 
 const getBorderColor = ({
   $type,
   $isImportant,
 }: {
-  $type: NoteItemType;
+  $type: TimelineItemThemeType;
   $isImportant: boolean;
 }): string => getItemBorderColor($type, $isImportant);
 
@@ -20,7 +20,7 @@ const getBackgroundColor = ({
   $type,
   $isImportant,
 }: {
-  $type: NoteItemType;
+  $type: TimelineItemThemeType;
   $isImportant: boolean;
 }): string => getItemBackgroundColor($type, $isImportant);
 
@@ -65,7 +65,7 @@ export const $TimelineItemCard = styled.li<{ $size?: 'small' | 'large' }>`
 `;
 
 export const $TimelineItemAvatar = styled.div<{
-  $type: NoteItemType;
+  $type: TimelineItemThemeType;
   $size?: 'small' | 'large';
 }>`
   position: relative;
@@ -77,10 +77,10 @@ export const $TimelineItemAvatar = styled.div<{
   height: ${({ $size }: { $size?: 'small' | 'large' }) => getAvatarSize($size)};
   border-radius: 50%;
   flex-shrink: 0;
-  background-color: ${({ $type }: { $type: NoteItemType }) =>
-    NOTE_TYPE_CONFIGS[$type]?.avatarBackground};
-  color: ${({ $type }: { $type: NoteItemType }) =>
-    NOTE_TYPE_CONFIGS[$type]?.avatarColor};
+  background-color: ${({ $type }: { $type: TimelineItemThemeType }) =>
+    TIMELINE_ITEM_THEME_CONFIGS[$type]?.avatarBackground};
+  color: ${({ $type }: { $type: TimelineItemThemeType }) =>
+    TIMELINE_ITEM_THEME_CONFIGS[$type]?.avatarColor};
 
   svg {
     width: ${({ $size }: { $size?: 'small' | 'large' }) => getSvgSize($size)};
@@ -122,4 +122,20 @@ export const $TimelineItemLink = styled.a`
   &:hover {
     color: var(--color-coat-of-arms-dark);
   }
+`;
+
+export const $TimelineItemBadge = styled.span<{ $type: TimelineItemThemeType }>`
+  display: inline-block;
+  font-size: var(--fontsize-body-xs);
+  padding: 2px 8px;
+  border-radius: 12px;
+  background-color: ${({ $type }: { $type: TimelineItemThemeType }) =>
+    TIMELINE_ITEM_THEME_CONFIGS[$type]?.avatarBackground};
+  color: var(--color-black-90);
+  margin-right: var(--spacing-xs);
+`;
+
+export const $TimelineItemAuthor = styled.b`
+  display: block;
+  margin-top: var(--spacing-s);
 `;

--- a/frontend/kesaseteli/handler/src/components/timeline/TimelineItem.tsx
+++ b/frontend/kesaseteli/handler/src/components/timeline/TimelineItem.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
 
 import {
+  $TimelineItemAuthor,
   $TimelineItemAvatar,
+  $TimelineItemBadge,
   $TimelineItemBody,
   $TimelineItemCard,
   $TimelineItemContent,
   $TimelineItemHeader,
   $TimelineItemLink,
 } from './TimelineItem.sc';
-import { NoteItemType } from './TimelineTheme';
+import { TimelineItemThemeType } from './TimelineTheme';
 
 export type TimelineCardProps = {
   children: React.ReactNode;
-  type: NoteItemType;
+  type: TimelineItemThemeType;
   isImportant?: boolean;
   size?: 'small' | 'large';
   icon?: React.ComponentType;
@@ -24,6 +26,8 @@ export const TimelineItem: React.FC<TimelineCardProps> & {
   Header: typeof $TimelineItemHeader;
   Content: typeof $TimelineItemContent;
   Link: typeof $TimelineItemLink;
+  Badge: typeof $TimelineItemBadge;
+  Author: typeof $TimelineItemAuthor;
 } = ({
   children,
   type,
@@ -52,3 +56,5 @@ export const TimelineItem: React.FC<TimelineCardProps> & {
 TimelineItem.Header = $TimelineItemHeader;
 TimelineItem.Content = $TimelineItemContent;
 TimelineItem.Link = $TimelineItemLink;
+TimelineItem.Badge = $TimelineItemBadge;
+TimelineItem.Author = $TimelineItemAuthor;

--- a/frontend/kesaseteli/handler/src/components/timeline/TimelineTheme.ts
+++ b/frontend/kesaseteli/handler/src/components/timeline/TimelineTheme.ts
@@ -1,11 +1,11 @@
-import { IconEnvelope, IconPaperclip, IconSpeechbubbleText } from 'hds-react';
+import { IconEnvelope, IconHistory, IconPaperclip, IconSpeechbubbleText } from 'hds-react';
 import React from 'react';
 
 import { NoteType } from '../../types/note';
 
-export type NoteItemType = NoteType | 'attachment';
+export type TimelineItemThemeType = NoteType | 'attachment' | 'activity';
 
-export interface NoteTypeConfig {
+export interface TimelineItemThemeConfig {
   icon: React.ComponentType;
   background: string;
   avatarBackground: string;
@@ -15,7 +15,7 @@ export interface NoteTypeConfig {
 
 const COLOR_WHITE = 'var(--color-white)';
 
-export const NOTE_TYPE_CONFIGS: Record<NoteItemType, NoteTypeConfig> = {
+export const TIMELINE_ITEM_THEME_CONFIGS: Record<TimelineItemThemeType, TimelineItemThemeConfig> = {
   [NoteType.INTERNAL]: {
     icon: IconSpeechbubbleText,
     background: COLOR_WHITE,
@@ -37,27 +37,34 @@ export const NOTE_TYPE_CONFIGS: Record<NoteItemType, NoteTypeConfig> = {
     avatarColor: 'var(--color-black-70)',
     borderColor: 'var(--color-black-20)',
   },
+  activity: {
+    icon: IconHistory,
+    background: COLOR_WHITE,
+    avatarBackground: 'var(--color-tram-light)',
+    avatarColor: 'var(--color-tram)',
+    borderColor: 'var(--color-tram)',
+  },
 };
 
 export const getItemBorderColor = (
-  type: NoteItemType,
+  type: TimelineItemThemeType,
   isImportant?: boolean
 ): string => {
   if (isImportant) {
     return 'var(--color-alert)';
   }
-  return NOTE_TYPE_CONFIGS[type]?.borderColor || 'var(--color-black-20)';
+  return TIMELINE_ITEM_THEME_CONFIGS[type]?.borderColor || 'var(--color-black-20)';
 };
 
 export const getItemBackgroundColor = (
-  type: NoteItemType,
+  type: TimelineItemThemeType,
   isImportant?: boolean
 ): string => {
   if (isImportant) {
     return 'var(--color-alert-light)';
   }
-  return NOTE_TYPE_CONFIGS[type]?.background || COLOR_WHITE;
+  return TIMELINE_ITEM_THEME_CONFIGS[type]?.background || COLOR_WHITE;
 };
 
-export const getNoteTypeIcon = (type: NoteItemType): React.ComponentType =>
-  NOTE_TYPE_CONFIGS[type]?.icon || IconSpeechbubbleText;
+export const getTimelineIcon = (type: TimelineItemThemeType): React.ComponentType =>
+  TIMELINE_ITEM_THEME_CONFIGS[type]?.icon || IconSpeechbubbleText;

--- a/frontend/kesaseteli/handler/src/hooks/backend/useApplicationTimelineQuery.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/useApplicationTimelineQuery.ts
@@ -1,5 +1,8 @@
-import { ApplicationListType } from 'kesaseteli/handler/types/application';
-import { HandlerNote } from 'kesaseteli/handler/types/note';
+import {
+  APPLICATION_LIST_TYPES,
+  ApplicationListType,
+} from 'kesaseteli/handler/types/application';
+import { TimelineItem } from 'kesaseteli/handler/types/timeline';
 import {
   getEmployerApplicationTimelineKey,
   getYouthApplicationTimelineKey,
@@ -11,18 +14,19 @@ import useErrorHandler from 'shared/hooks/useErrorHandler';
 const useApplicationTimelineQuery = (
   applicationId: string | undefined,
   applicationType: ApplicationListType
-): UseQueryResult<HandlerNote[]> => {
+): UseQueryResult<TimelineItem[]> => {
   const { axios, handleResponse } = useBackendAPI();
   const handleError = useErrorHandler();
 
   const timelineKey =
-    applicationType === 'youth'
+    applicationType === APPLICATION_LIST_TYPES.YOUTH
       ? getYouthApplicationTimelineKey(applicationId ?? '')
       : getEmployerApplicationTimelineKey(applicationId ?? '');
 
   return useQuery(
     timelineKey,
-    () => handleResponse<HandlerNote[]>(axios.get<HandlerNote[]>(timelineKey)),
+    () =>
+      handleResponse<TimelineItem[]>(axios.get<TimelineItem[]>(timelineKey)),
     {
       enabled: Boolean(applicationId),
       onError: handleError,

--- a/frontend/kesaseteli/handler/src/types/application.ts
+++ b/frontend/kesaseteli/handler/src/types/application.ts
@@ -1,4 +1,9 @@
-export type ApplicationListType = 'youth' | 'employer';
+export const APPLICATION_LIST_TYPES = {
+  YOUTH: 'youth',
+  EMPLOYER: 'employer',
+} as const;
+
+export type ApplicationListType = typeof APPLICATION_LIST_TYPES[keyof typeof APPLICATION_LIST_TYPES];
 
 export enum ApplicationStatus {
   SUBMITTED = 'submitted',

--- a/frontend/kesaseteli/handler/src/types/timeline.ts
+++ b/frontend/kesaseteli/handler/src/types/timeline.ts
@@ -1,0 +1,25 @@
+import { HandlerNote } from './note';
+
+export enum TimelineItemType {
+  NOTE = 'note',
+  ACTIVITY = 'activity',
+}
+
+export enum ActionType {
+  APPLICATION_STATUS_CHANGE = 'application_status_change',
+}
+
+export type ActivityLogItem = {
+  item_type: TimelineItemType.ACTIVITY;
+  action_type: ActionType;
+  old_value: string;
+  new_value: string;
+  author_name: string;
+  created_at: string;
+};
+
+export type TimelineNoteItem = HandlerNote & {
+  item_type: TimelineItemType.NOTE;
+};
+
+export type TimelineItem = TimelineNoteItem | ActivityLogItem;


### PR DESCRIPTION
Bases on https://github.com/City-of-Helsinki/yjdh/pull/4212.

YJDH-915.

**NOTE: This PR is using django-auditlog's LogEntry database table for timeline entries. If a cronjob removes those when they have been transferred to archive, also the timeline entries will be removed. https://github.com/City-of-Helsinki/yjdh/pull/4215 continues from here and brings a dedicated model.**

This PR adds support for aggregating and displaying application audit log events (specifically application status changes) alongside manual handler notes in a unified chronological timeline within the Handlers UI sidebar.

Previously, handlers could only see manually entered notes on an application's details page. This made it difficult to quickly track and verify the full history of the application's status changes (such as moving from a draft to sent status). The goal of this change is to bring transparency to the application lifecycle by automatically showing these status updates chronologically alongside manual notes in a single sidebar timeline.

⚙️ Backend Implementation
We designed a new service layer to retrieve application status changes from the audit log system. The service filters these logs, converts them into a standardized activity log format, and merges them chronologically with manual notes. We then exposed this combined feed through a unified API endpoint. We also updated the API schema documentation so that it correctly recognizes both notes and status update events in the timeline payload.

🎨 Frontend UI
In the handler UI, we updated the application sidebar's timeline to support rendering both notes and activity logs seamlessly. Status transition cards now display with clean, recognizable visual styles:

- Helsinki Design System (HDS) colors (using tram-colored badges) to differentiate status events from notes.
- History icons alongside rich text showing the exact state transition (e.g., Draft → Sent).
- Localized text using next-i18next so transitions read naturally in the user's selected language.
We also cleaned up the timeline styling under the hood, renaming layout variables so they are generic and reusable for any future timeline item types.

🧪 Verification
- Backend: Added tests verifying that status changes are fetched correctly, sorted chronologically alongside notes, and filtered for allowed status fields.
- Frontend: Updated integration tests to assert that the application sidebar successfully renders both manual notes and automated status change events.

<img width="536" height="931" alt="image" src="https://github.com/user-attachments/assets/67744adb-b2e0-4393-87cc-14ee96149bed" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Application timelines now combine handler notes with activity events (including status changes), each labeled by type.
  * Added support for filtering timeline results to notes only, activities only, or both.
* **Documentation**
  * Added documentation describing activity log behavior, allowed fields, and the unified timeline response.
* **Tests**
  * Expanded coverage for activity log generation, filtering, and timeline ordering/serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->