### PR TITLE
test(benefit): decouple tests from environment variables

### DIFF
--- a/backend/benefit/applications/tests/test_ahjo_authentication.py
+++ b/backend/benefit/applications/tests/test_ahjo_authentication.py
@@ -15,6 +15,14 @@ from applications.services.ahjo_authentication import (
 TOKEN_EXPIRY_SECONDS = 30000
 
 
+@pytest.fixture(autouse=True)
+def ahjo_connector_settings(settings):
+    settings.AHJO_TOKEN_URL = "https://ahjo-token-url.test"
+    settings.AHJO_CLIENT_ID = "ahjo-client-id"
+    settings.AHJO_CLIENT_SECRET = "ahjo-client-secret"
+    settings.AHJO_REDIRECT_URL = "https://ahjo-redirect-url.test"
+
+
 @pytest.fixture
 def ahjo_connector():
     return AhjoConnector()
@@ -61,15 +69,33 @@ def ahjo_code():
     )
 
 
-def test_is_configured(ahjo_connector):
-    ahjo_connector.AHJO_TOKEN_URL = "http://example.com/token"
-    ahjo_connector.AHJO_CLIENT_ID = "client_id"
-    ahjo_connector.AHJO_CLIENT_SECRET = "client_secret"
-    ahjo_connector.AHJO_REDIRECT_URL = "http://example.com/redirect"
+def test_is_configured_success():
+    ahjo_connector = AhjoConnector()
+    ahjo_connector.token_url = "https://ahjo-token-url.test"
+    ahjo_connector.client_id = "client_id"
+    ahjo_connector.client_secret = "client_secret"
+    ahjo_connector.redirect_uri = "https://ahjo-redirect-url.test"
     assert ahjo_connector.is_configured() is True
 
-    # Test with missing config options
-    ahjo_connector.token_url = ""
+
+@pytest.mark.parametrize("token_url", ["https://ahjo-token-url.test", ""])
+@pytest.mark.parametrize("client_id", ["client_id", ""])
+@pytest.mark.parametrize("client_secret", ["client_secret", ""])
+@pytest.mark.parametrize("redirect_uri", ["https://ahjo-redirect-url.test", ""])
+def test_is_configured_failure(
+    token_url: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+):
+    if token_url and client_id and client_secret and redirect_uri:
+        pytest.skip("success case is covered by test_is_configured_success")
+
+    ahjo_connector = AhjoConnector()
+    ahjo_connector.token_url = token_url
+    ahjo_connector.client_id = client_id
+    ahjo_connector.client_secret = client_secret
+    ahjo_connector.redirect_uri = redirect_uri
     assert ahjo_connector.is_configured() is False
 
 
@@ -78,7 +104,7 @@ def test_get_new_token(ahjo_connector, ahjo_code, token_response):
     # Test with valid auth code
     with requests_mock.Mocker() as m:
         m.post(
-            "https://johdontyopoytahyte.hel.fi/ids4/connect/token",
+            ahjo_connector.token_url,
             json=token_response,
         )
 
@@ -101,7 +127,7 @@ def test_refresh_token(ahjo_connector, ahjo_setting, token_response):
 
     with requests_mock.Mocker() as m:
         m.post(
-            "https://johdontyopoytahyte.hel.fi/ids4/connect/token",
+            ahjo_connector.token_url,
             json=token_response,
         )
 
@@ -124,7 +150,7 @@ def test_refresh_expired_token(ahjo_connector, ahjo_setting, token_response):
     ahjo_setting.save()
     with requests_mock.Mocker() as m:
         m.post(
-            "https://johdontyopoytahyte.hel.fi/ids4/connect/token",
+            ahjo_connector.token_url,
             json=token_response,
         )
 
@@ -137,9 +163,7 @@ def test_do_token_request(ahjo_connector: AhjoConnector, token_response):
     # Test with successful request
 
     with requests_mock.Mocker() as m:
-        m.post(
-            "https://johdontyopoytahyte.hel.fi/ids4/connect/token", json=token_response
-        )
+        m.post(ahjo_connector.token_url, json=token_response)
 
         token = ahjo_connector.do_token_request({})
         assert isinstance(token, AhjoToken)
@@ -148,7 +172,7 @@ def test_do_token_request(ahjo_connector: AhjoConnector, token_response):
         assert isinstance(token.expires_in, int)
 
         # Test with failed request
-        m.post("https://johdontyopoytahyte.hel.fi/ids4/connect/token", status_code=400)
+        m.post(ahjo_connector.token_url, status_code=400)
         with pytest.raises(AhjoTokenRetrievalError):
             ahjo_connector.do_token_request({})
 
@@ -166,7 +190,7 @@ def test_get_token_from_db(ahjo_connector: AhjoConnector, ahjo_setting):
     # Test with no token in database
     AhjoSetting.objects.all().delete()
     with pytest.raises(ImproperlyConfigured):
-        token = ahjo_connector.get_token_from_db()
+        ahjo_connector.get_token_from_db()
 
 
 def test_check_if_token_is_expired(expired_token, non_expired_token):

--- a/backend/benefit/applications/tests/test_ahjo_integration.py
+++ b/backend/benefit/applications/tests/test_ahjo_integration.py
@@ -398,6 +398,7 @@ def test_get_attachment_unauthorized_ip_not_allowed(
     ahjo_client, ahjo_user_token, attachment, settings
 ):
     settings.NEXT_PUBLIC_MOCK_FLAG = False
+    settings.DISABLE_AHJO_SAFE_LIST_CHECK = False
     url = reverse("ahjo_attachment_url", kwargs={"uuid": attachment.id})
     auth_headers = {"HTTP_AUTHORIZATION": "Token " + ahjo_user_token.key}
 
@@ -714,6 +715,7 @@ def test_ahjo_callback_unauthorized_ip_not_allowed(
     ahjo_client, ahjo_user_token, decided_application, settings, request_type
 ):
     settings.NEXT_PUBLIC_MOCK_FLAG = False
+    settings.DISABLE_AHJO_SAFE_LIST_CHECK = False
     url = reverse(
         "ahjo_callback_url",
         kwargs={"request_type": request_type, "uuid": decided_application.id},

--- a/backend/benefit/applications/tests/test_ahjo_requests.py
+++ b/backend/benefit/applications/tests/test_ahjo_requests.py
@@ -38,6 +38,12 @@ def ahjo_open_case_request(application_with_ahjo_case_id):
     return AhjoOpenCaseRequest(application_with_ahjo_case_id)
 
 
+@pytest.fixture(autouse=True)
+def setup_settings(settings):
+    settings.API_BASE_URL = "http://test.test"
+    settings.AHJO_REST_API_URL = "http://ahjo-rest-api-url.test"
+
+
 @pytest.mark.parametrize(
     "ahjo_request_class, request_type, request_method, url_part",
     [
@@ -76,8 +82,6 @@ def test_ahjo_requests_without_application(
     AhjoSetting.objects.create(
         name=AhjoSettingName.SIGNER_ORG_IDS, data=["1234567", "7654321"]
     )
-
-    settings.API_BASE_URL = "http://test.com"
     request_instance = ahjo_request_class()
 
     assert request_instance.request_type == request_type
@@ -176,7 +180,6 @@ def test_ahjo_application_requests(
     handler = application.calculation.handler
     handler.ad_username = "test"
     handler.save()
-    settings.API_BASE_URL = "http://test.com"
 
     request = ahjo_request_class(application)
     assert request.application == application

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -41,6 +41,22 @@ def set_up_ytj_mock_requests(
     requests_mock.get(business_details_url, json=business_details_response)
 
 
+@pytest.fixture(autouse=True)
+def setup_settings(settings):
+    settings.SERVICE_BUS_BASE_URL = "https://service-bus.test"
+    settings.SERVICE_BUS_AUTH_USERNAME = "service_bus_username"
+    settings.SERVICE_BUS_AUTH_PASSWORD = "service_bus_password"
+    settings.SERVICE_BUS_TIMEOUT = 30
+    settings.SERVICE_BUS_SEARCH_LIMIT = 10
+
+    settings.YRTTI_BASE_URL = "https://yrtti.test"
+    settings.YRTTI_AUTH_USERNAME = "yrtti_username"
+    settings.YRTTI_AUTH_PASSWORD = "yrtti_password"
+    settings.YRTTI_TIMEOUT = 30
+    settings.YRTTI_SEARCH_LIMIT = 10
+    settings.YRTTI_DISABLE = False
+
+
 @pytest.mark.django_db
 def test_get_company_unauthenticated(anonymous_client):
     response = anonymous_client.get(get_company_api_url())

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -3,8 +3,6 @@ from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
-from django.conf import settings
-from django.test import override_settings
 from requests import HTTPError
 
 from applications.tests.conftest import *  # noqa
@@ -18,27 +16,12 @@ from companies.tests.data.company_data import (
 from shared.service_bus.enums import YtjOrganizationCode
 from terms.tests.factories import TermsOfServiceApprovalFactory
 
-SERVICE_BUS_INFO_PATH = f"{settings.SERVICE_BUS_BASE_URL}/GetCompany"
-YRTTI_BASIC_INFO_PATH = f"{settings.YRTTI_BASE_URL}/BasicInfo"
-
 
 def get_company_api_url(business_id=""):
     url = "/v1/company/"
     if business_id:
         url = f"{url}get/{business_id}/"
     return url
-
-
-def set_up_ytj_mock_requests(
-    ytj_response: dict, business_details_response: dict, requests_mock
-):
-    """Set up the mock responses."""
-    business_id = ytj_response["results"][0]["businessId"]
-    ytj_url = f"{settings.YTJ_BASE_URL}/{business_id}"
-    business_details_url = ytj_response["results"][0]["bisDetailsUri"]
-
-    requests_mock.get(ytj_url, json=ytj_response)
-    requests_mock.get(business_details_url, json=business_details_response)
 
 
 @pytest.fixture(autouse=True)
@@ -57,6 +40,24 @@ def setup_settings(settings):
     settings.YRTTI_DISABLE = False
 
 
+@pytest.fixture
+def mock_service_bus_get_company_post(requests_mock, settings):
+    def _mock_service_bus_get_company_post(**kwargs):
+        matcher = re.compile(re.escape(f"{settings.SERVICE_BUS_BASE_URL}/GetCompany"))
+        requests_mock.post(matcher, **kwargs)
+
+    return _mock_service_bus_get_company_post
+
+
+@pytest.fixture
+def mock_yrtti_basic_info_post(requests_mock, settings):
+    def _mock_yrtti_basic_info_post(**kwargs):
+        matcher = re.compile(re.escape(f"{settings.YRTTI_BASE_URL}/BasicInfo"))
+        requests_mock.post(matcher, **kwargs)
+
+    return _mock_yrtti_basic_info_post
+
+
 @pytest.mark.django_db
 def test_get_company_unauthenticated(anonymous_client):
     response = anonymous_client.get(get_company_api_url())
@@ -65,8 +66,9 @@ def test_get_company_unauthenticated(anonymous_client):
 
 
 @pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=True)
-def test_get_mock_company(api_client, mock_get_organisation_roles_and_create_company):
+@pytest.mark.usefixtures("mock_get_organisation_roles_and_create_company")
+def test_get_mock_company(api_client, settings):
+    settings.NEXT_PUBLIC_MOCK_FLAG = True
     response = api_client.get(get_company_api_url())
 
     assert response.status_code == 200
@@ -75,10 +77,9 @@ def test_get_mock_company(api_client, mock_get_organisation_roles_and_create_com
 
 
 @pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=True)
-def test_get_mock_company_results_in_error(
-    api_client, mock_get_organisation_roles_and_create_company
-):
+@pytest.mark.usefixtures("mock_get_organisation_roles_and_create_company")
+def test_get_mock_company_results_in_error(api_client, settings):
+    settings.NEXT_PUBLIC_MOCK_FLAG = True
     api_client.credentials(HTTP_SESSION_ID="-1")
     response = api_client.get(get_company_api_url())
     assert response.status_code == 404
@@ -89,8 +90,9 @@ def test_get_mock_company_results_in_error(
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("mock_get_organisation_roles_and_create_company")
 def test_get_company_from_service_bus_invalid_response(
-    api_client, requests_mock, mock_get_organisation_roles_and_create_company
+    api_client, mock_service_bus_get_company_post
 ):
     business_id = DUMMY_SERVICE_BUS_RESPONSE["GetCompanyResult"]["Company"][
         "BusinessId"
@@ -98,8 +100,7 @@ def test_get_company_from_service_bus_invalid_response(
     response = deepcopy(DUMMY_SERVICE_BUS_RESPONSE)
     response["GetCompanyResult"]["Company"] = {}
 
-    matcher = re.compile(re.escape(SERVICE_BUS_INFO_PATH))
-    requests_mock.post(matcher, json=response)
+    mock_service_bus_get_company_post(json=response)
     response = api_client.get(get_company_api_url(business_id))
 
     assert response.status_code == 500
@@ -110,14 +111,13 @@ def test_get_company_from_service_bus_invalid_response(
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("mock_get_organisation_roles_and_create_company")
 def test_get_organisation_from_service_bus(
     api_client,
     bf_user,
-    requests_mock,
-    mock_get_organisation_roles_and_create_company,
+    mock_service_bus_get_company_post,
 ):
-    matcher = re.compile(re.escape(SERVICE_BUS_INFO_PATH))
-    requests_mock.post(matcher, json=DUMMY_SERVICE_BUS_RESPONSE)
+    mock_service_bus_get_company_post(json=DUMMY_SERVICE_BUS_RESPONSE)
     business_id = DUMMY_SERVICE_BUS_RESPONSE["GetCompanyResult"]["Company"][
         "BusinessId"
     ]
@@ -135,16 +135,15 @@ def test_get_organisation_from_service_bus(
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("mock_get_organisation_roles_and_create_company")
 def test_get_organisation_from_service_bus_missing_business_line(
     api_client,
     bf_user,
-    requests_mock,
-    mock_get_organisation_roles_and_create_company,
+    mock_service_bus_get_company_post,
 ):
     dummy_copy = deepcopy(DUMMY_SERVICE_BUS_RESPONSE)
     dummy_copy["GetCompanyResult"]["Company"]["BusinessLine"] = None
-    matcher = re.compile(re.escape(SERVICE_BUS_INFO_PATH))
-    requests_mock.post(matcher, json=dummy_copy)
+    mock_service_bus_get_company_post(json=dummy_copy)
     response = api_client.get(get_company_api_url())
     assert response.status_code == 200
 
@@ -167,7 +166,8 @@ def test_get_company_from_yrtti(
     api_client,
     bf_user,
     terms_of_service,
-    requests_mock,
+    mock_service_bus_get_company_post,
+    mock_yrtti_basic_info_post,
     mock_get_organisation_roles_and_create_association,
 ):
     TermsOfServiceApprovalFactory(
@@ -176,10 +176,8 @@ def test_get_company_from_yrtti(
         terms=terms_of_service,
     )
     business_id = DUMMY_YRTTI_RESPONSE["BasicInfoResponse"]["BusinessId"]
-    matcher = re.compile(re.escape(SERVICE_BUS_INFO_PATH))
-    requests_mock.post(matcher, text="Error", status_code=404)
-    matcher = re.compile(re.escape(YRTTI_BASIC_INFO_PATH))
-    requests_mock.post(matcher, json=DUMMY_YRTTI_RESPONSE)
+    mock_service_bus_get_company_post(text="Error", status_code=404)
+    mock_yrtti_basic_info_post(json=DUMMY_YRTTI_RESPONSE)
     response = api_client.get(get_company_api_url(business_id))
     assert response.status_code == 200
 
@@ -198,12 +196,13 @@ def test_get_company_from_yrtti(
 
 @pytest.mark.django_db
 def test_get_company_from_service_bus_and_yrtti_results_in_error(
-    api_client, requests_mock, mock_get_organisation_roles_and_create_company
+    api_client,
+    mock_service_bus_get_company_post,
+    mock_yrtti_basic_info_post,
+    mock_get_organisation_roles_and_create_company,
 ):
-    matcher = re.compile(re.escape(SERVICE_BUS_INFO_PATH))
-    requests_mock.post(matcher, text="Error", status_code=404)
-    matcher = re.compile(re.escape(YRTTI_BASIC_INFO_PATH))
-    requests_mock.post(matcher, text="Error", status_code=404)
+    mock_service_bus_get_company_post(text="Error", status_code=404)
+    mock_yrtti_basic_info_post(text="Error", status_code=404)
     # Delete company so that API cannot return object from DB
     mock_get_organisation_roles_and_create_company.delete()
     with pytest.raises(HTTPError):
@@ -211,11 +210,11 @@ def test_get_company_from_service_bus_and_yrtti_results_in_error(
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("mock_get_organisation_roles_and_create_company")
 def test_get_company_from_service_bus_and_yrtti_with_fallback_data(
-    api_client, requests_mock, mock_get_organisation_roles_and_create_company
+    api_client, mock_service_bus_get_company_post, mock_yrtti_basic_info_post
 ):
-    matcher = re.compile(re.escape(SERVICE_BUS_INFO_PATH))
-    requests_mock.post(matcher, json=DUMMY_SERVICE_BUS_RESPONSE)
+    mock_service_bus_get_company_post(json=DUMMY_SERVICE_BUS_RESPONSE)
     response = api_client.get(get_company_api_url())
 
     # First request to save Company to DB
@@ -223,10 +222,8 @@ def test_get_company_from_service_bus_and_yrtti_with_fallback_data(
     assert Company.objects.count() == 1
 
     # Now assuming request to YTJ & YRTTI doesn't return any data
-    matcher = re.compile(re.escape(SERVICE_BUS_INFO_PATH))
-    requests_mock.post(matcher, text="Error", status_code=404)
-    matcher = re.compile(re.escape(YRTTI_BASIC_INFO_PATH))
-    requests_mock.post(matcher, text="Error", status_code=404)
+    mock_service_bus_get_company_post(text="Error", status_code=404)
+    mock_yrtti_basic_info_post(text="Error", status_code=404)
 
     response = api_client.get(get_company_api_url())
     # Still be able to query company data
@@ -334,8 +331,8 @@ def get_search_url(name):
 
 
 @pytest.mark.django_db
-@override_settings(NEXT_PUBLIC_MOCK_FLAG=True)
-def test_search_organisations_mock(api_client):
+def test_search_organisations_mock(api_client, settings):
+    settings.NEXT_PUBLIC_MOCK_FLAG = True
     response = api_client.get(get_search_url("test"))
     assert response.status_code == 200
     assert isinstance(response.data, list)


### PR DESCRIPTION
Using the example env values for local environment makes some of the tests fail because the test setup doesn't set any values for the settings. The tests expect certain values for the tests and this, of course, goes to hell when setting up a local environment.

Also switch to fake urls instead of real ones. Just in case.

Refs: HL-1847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for AHJO authentication, token handling, and connector configuration success/failure scenarios.
  * Standardized AHJO test setup by centralizing base URL and authentication settings via shared fixtures.
  * Reinforced IP-restriction/authorization tests by explicitly controlling safe-list checking behavior.
  * Strengthened company/organization API tests using reusable request-mocking fixtures for Service Bus and YRTTI flows, including success, error, mock, search, and fallback cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->