### PR TITLE
feat(benefit): replace eauth with suomifi-on-behalf

### DIFF
--- a/.env.benefit-backend.example
+++ b/.env.benefit-backend.example
@@ -26,10 +26,17 @@ OIDC_OP_LOGOUT_CALLBACK_URL=https://localhost:8000/oidc/logout_callback/
 
 HELSINKI_PROFILE_API_URL=https://profile-api.test.hel.ninja/graphql/
 HELSINKI_PROFILE_SCOPE=https://api.hel.fi/auth/helsinkiprofile
+# Derived from the effective Profile API URL when unset; set to override.
+# SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_API_URL falls back to HELSINKI_PROFILE_API_URL.
+# SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_AUDIENCE=profile-api-test
 
 LOGIN_REDIRECT_URL=https://localhost:3000/
 LOGIN_REDIRECT_URL_FAILURE=https://localhost:3000/login?error=true
 LOGOUT_REDIRECT_URL=https://localhost:3000/login?logout=true
+
+# The Suomi.fi on-behalf library reads its own SUOMIFI_ON_BEHALF_* variables and falls
+# back to the equivalent variable above when one is unset, e.g.
+# SUOMIFI_ON_BEHALF_LOGIN_SUCCESS_URL=https://localhost:3000/
 
 EAUTHORIZATIONS_BASE_URL=https://asiointivaltuustarkastus.test.suomi.fi
 EAUTHORIZATIONS_CLIENT_ID=TEST

--- a/backend/benefit/common/exception_handlers.py
+++ b/backend/benefit/common/exception_handlers.py
@@ -1,0 +1,28 @@
+from django.utils.translation import gettext_lazy as _
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+from suomifi_on_behalf import CompanyResolutionError
+
+# Shared message for the case where a company cannot be resolved because the upstream
+# YTJ/YRTTI APIs are unavailable and no company is stored locally as a fallback.
+COMPANY_RESOLUTION_ERROR_MESSAGE = _(
+    "YTJ API is under heavy load or no company found with the given business id"
+)
+
+
+def benefit_exception_handler(exc, context):
+    """DRF exception handler that maps company-resolution failures to a controlled 404.
+
+    ``CompanyResolutionError`` is a plain ``Exception`` (not an ``APIException``), so
+    without this handler it would surface as an uncaught 500. Mapping it here gives a
+    single, consistent controlled response for every caller that resolves a company -
+    permission checks, serializers and views alike - instead of each having to catch it.
+    """
+    response = exception_handler(exc, context)
+    if response is None and isinstance(exc, CompanyResolutionError):
+        return Response(
+            COMPANY_RESOLUTION_ERROR_MESSAGE,
+            status=status.HTTP_404_NOT_FOUND,
+        )
+    return response

--- a/backend/benefit/common/permissions.py
+++ b/backend/benefit/common/permissions.py
@@ -2,8 +2,8 @@ from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from rest_framework import permissions
 from rest_framework.exceptions import PermissionDenied
+from suomifi_on_behalf import get_organization_roles
 
-from shared.oidc.utils import get_organization_roles
 from users.utils import get_company_from_request
 
 

--- a/backend/benefit/common/permissions.py
+++ b/backend/benefit/common/permissions.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
+from requests.exceptions import HTTPError
 from rest_framework import permissions
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import NotFound, PermissionDenied
 from suomifi_on_behalf import get_organization_roles
 
 from users.utils import get_company_from_request
@@ -57,7 +58,19 @@ class TermsOfServiceAccepted(permissions.BasePermission):
         else:
             from terms.models import TermsOfServiceApproval
 
-            company = get_company_from_request(request)
+            try:
+                company = get_company_from_request(request)
+            except HTTPError:
+                # The upstream YTJ/YRTTI APIs are unavailable and the company is not
+                # stored locally as a fallback, so terms approval cannot be resolved.
+                # Map this to the same controlled 404 that the company views return,
+                # instead of letting the HTTPError surface as a 500.
+                raise NotFound(
+                    _(
+                        "YTJ API is under heavy load or no company found with the"
+                        " given business id"
+                    )
+                )
             if not company:
                 # company deleted from the db? Whatever has happened, applicant can't
                 # proceed without a company.

--- a/backend/benefit/common/permissions.py
+++ b/backend/benefit/common/permissions.py
@@ -1,8 +1,7 @@
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
-from requests.exceptions import HTTPError
 from rest_framework import permissions
-from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.exceptions import PermissionDenied
 from suomifi_on_behalf import get_organization_roles
 
 from users.utils import get_company_from_request
@@ -58,19 +57,10 @@ class TermsOfServiceAccepted(permissions.BasePermission):
         else:
             from terms.models import TermsOfServiceApproval
 
-            try:
-                company = get_company_from_request(request)
-            except HTTPError:
-                # The upstream YTJ/YRTTI APIs are unavailable and the company is not
-                # stored locally as a fallback, so terms approval cannot be resolved.
-                # Map this to the same controlled 404 that the company views return,
-                # instead of letting the HTTPError surface as a 500.
-                raise NotFound(
-                    _(
-                        "YTJ API is under heavy load or no company found with the"
-                        " given business id"
-                    )
-                )
+            # If the upstream YTJ/YRTTI APIs are unavailable and the company is not
+            # stored locally, get_company_from_request raises CompanyResolutionError,
+            # which the global exception handler maps to a controlled 404.
+            company = get_company_from_request(request)
             if not company:
                 # company deleted from the db? Whatever has happened, applicant can't
                 # proceed without a company.

--- a/backend/benefit/common/tests/test_exception_handlers.py
+++ b/backend/benefit/common/tests/test_exception_handlers.py
@@ -1,0 +1,22 @@
+from suomifi_on_behalf import CompanyResolutionError
+
+from common.exception_handlers import (
+    COMPANY_RESOLUTION_ERROR_MESSAGE,
+    benefit_exception_handler,
+)
+
+
+def test_company_resolution_error_maps_to_controlled_404():
+    response = benefit_exception_handler(
+        CompanyResolutionError("upstream down"), context={}
+    )
+
+    assert response is not None
+    assert response.status_code == 404
+    assert response.data == COMPANY_RESOLUTION_ERROR_MESSAGE
+
+
+def test_unhandled_exception_is_not_swallowed():
+    # Exceptions the default handler doesn't recognise must keep returning None so the
+    # framework still turns them into a 500 rather than being silently masked.
+    assert benefit_exception_handler(ValueError("boom"), context={}) is None

--- a/backend/benefit/companies/api/v1/views.py
+++ b/backend/benefit/companies/api/v1/views.py
@@ -13,6 +13,11 @@ from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
 from stdnum.fi import ytunnus
+from suomifi_on_behalf import (
+    CompanyResolutionError,
+    get_company,
+    get_organization_roles,
+)
 
 from common.permissions import BFIsAuthenticated, BFIsHandler, TermsOfServiceAccepted
 from companies.api.v1.serializers import (
@@ -22,11 +27,11 @@ from companies.api.v1.serializers import (
 )
 from companies.models import Company
 from companies.services import (
+    get_or_create_company_using_company_data,
     get_or_create_organisation_with_business_id,
     search_organisations,
 )
 from companies.tests.data.company_data import get_dummy_company_data
-from shared.oidc.utils import get_organization_roles
 
 LOGGER = logging.getLogger(__name__)
 
@@ -101,16 +106,13 @@ class GetUsersOrganizationView(APIView):
                 status.HTTP_404_NOT_FOUND,
             )
         try:
-            company = get_or_create_organisation_with_business_id(business_id)
-        except HTTPError:
-            # Since YTJ public API is not 100% reliable, we can use the Company data
-            # saved in our DB as a fallback data, this Company data should be the
-            # data that we got from the latest request to YTJ
-            try:
-                company = Company.objects.get(business_id=business_id)
-            except Company.DoesNotExist:
-                # Throw error if API failed or no object found in both places
-                return self.ytj_api_error
+            company_data = get_company(request)
+        except CompanyResolutionError:
+            # The upstream YTJ/YRTTI APIs are unavailable and no company is stored
+            # locally as a fallback.
+            return self.ytj_api_error
+        try:
+            company = get_or_create_company_using_company_data(company_data)
         except (ValueError, KeyError) as err:
             LOGGER.debug(
                 "Could not handle the response from Palveluväylä and YRTTI API,"

--- a/backend/benefit/companies/api/v1/views.py
+++ b/backend/benefit/companies/api/v1/views.py
@@ -14,11 +14,11 @@ from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
 from stdnum.fi import ytunnus
 from suomifi_on_behalf import (
-    CompanyResolutionError,
     get_company,
     get_organization_roles,
 )
 
+from common.exception_handlers import COMPANY_RESOLUTION_ERROR_MESSAGE
 from common.permissions import BFIsAuthenticated, BFIsHandler, TermsOfServiceAccepted
 from companies.api.v1.serializers import (
     CompanySearchSerializer,
@@ -44,10 +44,7 @@ class GetUsersOrganizationView(APIView):
     @property
     def ytj_api_error(self):
         return Response(
-            __(
-                "YTJ API is under heavy load or no company found with the given"
-                " business id"
-            ),
+            COMPANY_RESOLUTION_ERROR_MESSAGE,
             status.HTTP_404_NOT_FOUND,
         )
 
@@ -105,12 +102,10 @@ class GetUsersOrganizationView(APIView):
                 "No business id found for the user",
                 status.HTTP_404_NOT_FOUND,
             )
-        try:
-            company_data = get_company(request)
-        except CompanyResolutionError:
-            # The upstream YTJ/YRTTI APIs are unavailable and no company is stored
-            # locally as a fallback.
-            return self.ytj_api_error
+        # If the upstream YTJ/YRTTI APIs are unavailable and no company is stored
+        # locally as a fallback, get_company raises CompanyResolutionError, which the
+        # global exception handler (common.exception_handlers) maps to a controlled 404.
+        company_data = get_company(request)
         try:
             company = get_or_create_company_using_company_data(company_data)
         except (ValueError, KeyError) as err:

--- a/backend/benefit/companies/resolvers.py
+++ b/backend/benefit/companies/resolvers.py
@@ -1,0 +1,86 @@
+from requests.exceptions import RequestException
+from suomifi_on_behalf import CompanyResolutionError
+
+from companies.models import Company
+from shared.service_bus.service_bus_client import ServiceBusClient
+from shared.yrtti.yrtti_client import YRTTIClient
+
+
+def _get_business_id(request) -> str:
+    roles = request.session.get("organization_roles") or {}
+    business_id = roles.get("identifier")
+    if not business_id:
+        raise CompanyResolutionError(
+            "No business id ('identifier') in session organization_roles"
+        )
+    return business_id
+
+
+def _company_to_dict(company: Company) -> dict:
+    return {
+        "name": company.name,
+        "business_id": company.business_id,
+        "company_form": company.company_form,
+        "company_form_code": company.company_form_code,
+        "industry": company.industry,
+        "industry_code": company.industry_code,
+        "street_address": company.street_address,
+        "postcode": company.postcode,
+        "city": company.city,
+    }
+
+
+class ServiceBusCompanyResolver:
+    """Resolve company data from Palveluväylä / Service Bus (YTJ)."""
+
+    def __call__(self, request) -> dict:
+        business_id = _get_business_id(request)
+        try:
+            company_data = ServiceBusClient().get_organisation_info_with_business_id(
+                business_id
+            )
+        except RequestException as e:
+            raise CompanyResolutionError(str(e)) from e
+        if not company_data:
+            raise CompanyResolutionError(
+                f"Service Bus returned no company for business id {business_id}"
+            )
+        return company_data
+
+
+class YrttiCompanyResolver:
+    """Resolve association data from YRTTI."""
+
+    def __call__(self, request) -> dict:
+        business_id = _get_business_id(request)
+        try:
+            association_data = YRTTIClient().get_association_info_with_business_id(
+                business_id
+            )
+        except RequestException as e:
+            raise CompanyResolutionError(str(e)) from e
+        if not association_data:
+            raise CompanyResolutionError(
+                f"YRTTI returned no association for business id {business_id}"
+            )
+        return association_data
+
+
+class DbCompanyResolver:
+    """
+    Return the company already stored in benefit's database.
+    Raises CompanyResolutionError if the company doesn't exist in the database.
+
+    Should be used as terminal fallback, i.e. after every other company resolver has
+    failed.
+    """
+
+    def __call__(self, request) -> dict:
+        business_id = _get_business_id(request)
+        try:
+            company = Company.objects.get(business_id=business_id)
+        except Company.DoesNotExist as e:
+            raise CompanyResolutionError(
+                f"No stored company for business id {business_id}"
+            ) from e
+        return _company_to_dict(company)

--- a/backend/benefit/companies/tests/conftest.py
+++ b/backend/benefit/companies/tests/conftest.py
@@ -33,14 +33,14 @@ ASSOCIATION_ROLE_JSON = [
 
 @pytest.fixture()
 def mock_get_organisation_roles_and_create_company(requests_mock):
-    matcher = re.compile(re.escape(settings.EAUTHORIZATIONS_BASE_URL))
+    matcher = re.compile(re.escape(settings.SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_BASE_URL))
     requests_mock.get(matcher, json=COMPANY_ROLE_JSON)
     return CompanyFactory(business_id=COMPANY_ROLE_JSON[0]["identifier"])
 
 
 @pytest.fixture()
 def mock_get_organisation_roles_and_create_association(requests_mock):
-    matcher = re.compile(re.escape(settings.EAUTHORIZATIONS_BASE_URL))
+    matcher = re.compile(re.escape(settings.SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_BASE_URL))
     requests_mock.get(matcher, json=ASSOCIATION_ROLE_JSON)
     return CompanyFactory(
         business_id=ASSOCIATION_ROLE_JSON[0]["identifier"],

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -201,12 +201,42 @@ def test_get_company_from_service_bus_and_yrtti_results_in_error(
     mock_yrtti_basic_info_post,
     mock_get_organisation_roles_and_create_company,
 ):
+    # NOTE: the HTTPError raised here originates in the TermsOfServiceAccepted
+    # permission (get_company_from_request -> get_or_create_organisation_with_business_id),
+    # which runs before the view body. The view's own get_company()/CompanyResolutionError
+    # branch is exercised separately in the test below.
     mock_service_bus_get_company_post(text="Error", status_code=404)
     mock_yrtti_basic_info_post(text="Error", status_code=404)
     # Delete company so that API cannot return object from DB
     mock_get_organisation_roles_and_create_company.delete()
     with pytest.raises(HTTPError):
         api_client.get(get_company_api_url())
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mock_get_organisation_roles_and_create_company")
+def test_get_company_upstream_failure_no_local_fallback_returns_ytj_api_error(
+    api_client,
+    settings,
+    mock_service_bus_get_company_post,
+    mock_yrtti_basic_info_post,
+):
+    # Bypass the TermsOfServiceAccepted permission so the request reaches the view
+    # body; otherwise the permission resolves the company itself and raises first.
+    settings.DISABLE_TOS_APPROVAL_CHECK = True
+    mock_service_bus_get_company_post(text="Error", status_code=404)
+    mock_yrtti_basic_info_post(text="Error", status_code=404)
+    # No company stored locally, so the DbCompanyResolver fallback also fails and
+    # get_company() raises CompanyResolutionError.
+    Company.objects.all().delete()
+
+    response = api_client.get(get_company_api_url())
+
+    assert response.status_code == 404
+    assert (
+        response.data
+        == "YTJ API is under heavy load or no company found with the given business id"
+    )
 
 
 @pytest.mark.django_db

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -202,10 +202,11 @@ def test_get_company_from_service_bus_and_yrtti_results_in_error(
 ):
     # The upstream failure here originates in the TermsOfServiceAccepted permission
     # (get_company_from_request -> get_or_create_organisation_with_business_id), which
-    # runs before the view body. The permission catches the upstream HTTPError and maps
-    # it to the same controlled 404 the view body returns, instead of letting it surface
-    # as a 500. The view's own get_company()/CompanyResolutionError branch is exercised
-    # separately in the test below.
+    # runs before the view body. get_company_from_request maps the upstream failure to
+    # a CompanyResolutionError, which the global exception handler turns into the same
+    # controlled 404 the view body returns, instead of letting it surface as a 500.
+    # The view's own get_company()/CompanyResolutionError branch is exercised separately
+    # in the test below.
     mock_service_bus_get_company_post(text="Error", status_code=404)
     mock_yrtti_basic_info_post(text="Error", status_code=404)
     # Delete company so that API cannot return object from DB
@@ -214,10 +215,8 @@ def test_get_company_from_service_bus_and_yrtti_results_in_error(
     response = api_client.get(get_company_api_url())
 
     assert response.status_code == 404
-    # The permission raises DRF's NotFound, so the body uses the standard
-    # {"detail": ...} envelope rather than the view's bare-string body.
     assert (
-        response.data["detail"]
+        response.data
         == "YTJ API is under heavy load or no company found with the given business id"
     )
 

--- a/backend/benefit/companies/tests/test_api.py
+++ b/backend/benefit/companies/tests/test_api.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
-from requests import HTTPError
 
 from applications.tests.conftest import *  # noqa
 from companies.api.v1.serializers import CompanySerializer
@@ -201,16 +200,26 @@ def test_get_company_from_service_bus_and_yrtti_results_in_error(
     mock_yrtti_basic_info_post,
     mock_get_organisation_roles_and_create_company,
 ):
-    # NOTE: the HTTPError raised here originates in the TermsOfServiceAccepted
-    # permission (get_company_from_request -> get_or_create_organisation_with_business_id),
-    # which runs before the view body. The view's own get_company()/CompanyResolutionError
-    # branch is exercised separately in the test below.
+    # The upstream failure here originates in the TermsOfServiceAccepted permission
+    # (get_company_from_request -> get_or_create_organisation_with_business_id), which
+    # runs before the view body. The permission catches the upstream HTTPError and maps
+    # it to the same controlled 404 the view body returns, instead of letting it surface
+    # as a 500. The view's own get_company()/CompanyResolutionError branch is exercised
+    # separately in the test below.
     mock_service_bus_get_company_post(text="Error", status_code=404)
     mock_yrtti_basic_info_post(text="Error", status_code=404)
     # Delete company so that API cannot return object from DB
     mock_get_organisation_roles_and_create_company.delete()
-    with pytest.raises(HTTPError):
-        api_client.get(get_company_api_url())
+
+    response = api_client.get(get_company_api_url())
+
+    assert response.status_code == 404
+    # The permission raises DRF's NotFound, so the body uses the standard
+    # {"detail": ...} envelope rather than the view's bare-string body.
+    assert (
+        response.data["detail"]
+        == "YTJ API is under heavy load or no company found with the given business id"
+    )
 
 
 @pytest.mark.django_db

--- a/backend/benefit/helsinkibenefit/oidc_urls.py
+++ b/backend/benefit/helsinkibenefit/oidc_urls.py
@@ -1,0 +1,8 @@
+from django.urls import include, path
+
+from shared.oidc.urls import base_oidc_urlpatterns
+
+urlpatterns = base_oidc_urlpatterns + [
+    # Eauth from suomifi-on-behalf (replaces shared.oidc's eAuthorizations flow)
+    path("", include("suomifi_on_behalf.urls")),
+]

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -201,6 +201,7 @@ env = environ.Env(
     SOCIAL_AUTH_TUNNISTAMO_SECRET=(str, ""),
     SOCIAL_AUTH_TUNNISTAMO_OIDC_ENDPOINT=(str, ""),
     HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED=(bool, True),
+    SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_AUDIENCE=(str, "profile-api-test"),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -594,6 +595,43 @@ OIDC_REDIRECT_ALLOWED_HOSTS = env.list(
     default=[urlparse(ADFS_LOGIN_REDIRECT_URL).netloc],
 )
 OIDC_REDIRECT_REQUIRE_HTTPS = env.bool("OIDC_REDIRECT_REQUIRE_HTTPS", default=True)
+
+# django-helsinki-suomifi-on-behalf (Suomi.fi eAuthorizations / Valtuudet on-behalf).
+# Existing env-driven settings are mapped to the library's namespaced settings so no
+# deployment configuration needs to change.
+SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_BASE_URL = EAUTHORIZATIONS_BASE_URL
+SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_CLIENT_ID = EAUTHORIZATIONS_CLIENT_ID
+SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_CLIENT_SECRET = EAUTHORIZATIONS_CLIENT_SECRET
+SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_API_OAUTH_SECRET = EAUTHORIZATIONS_API_OAUTH_SECRET
+
+SUOMIFI_ON_BEHALF_LOGIN_ERROR_URL = LOGIN_REDIRECT_URL_FAILURE
+
+SUOMIFI_ON_BEHALF_OIDC_USERINFO_ENDPOINT = OIDC_OP_USER_ENDPOINT
+
+SUOMIFI_ON_BEHALF_REDIRECT_ALLOWED_HOSTS = OIDC_REDIRECT_ALLOWED_HOSTS
+SUOMIFI_ON_BEHALF_REDIRECT_REQUIRE_HTTPS = OIDC_REDIRECT_REQUIRE_HTTPS
+
+SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_API_URL = HELSINKI_PROFILE_API_URL
+SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_SCOPE = HELSINKI_PROFILE_SCOPE
+SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_AUDIENCE = env.str(
+    "SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_AUDIENCE"
+)
+SUOMIFI_ON_BEHALF_TUNNISTUS_API_TOKENS_ENDPOINT = TUNNISTUS_API_TOKENS_ENDPOINT
+
+SUOMIFI_ON_BEHALF_SSN_RESOLVERS = [
+    "suomifi_on_behalf.ssn.OidcUserinfoSsnResolver",
+    "suomifi_on_behalf.ssn.HelsinkiProfileSsnResolver",
+]
+
+SUOMIFI_ON_BEHALF_COMPANY_RESOLVERS = [
+    "companies.resolvers.ServiceBusCompanyResolver",
+    "companies.resolvers.YrttiCompanyResolver",
+    "companies.resolvers.DbCompanyResolver",
+]
+
+# benefit's Company model is the source of truth, so the library must not cache company
+# data in the session (nothing in benefit reads request.session["company"]).
+SUOMIFI_ON_BEHALF_CACHE_COMPANY_IN_SESSION = False
 # Authentication settings end
 
 FIELD_ENCRYPTION_KEYS = [ENCRYPTION_KEY]

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -102,20 +102,12 @@ env = environ.Env(
     OIDC_OP_BASE_URL=(str, ""),
     OIDC_SAVE_PERSONALLY_IDENTIFIABLE_INFO=(bool, True),
     OIDC_OP_LOGOUT_CALLBACK_URL=(str, "/"),
-    TUNNISTAMO_API_TOKENS_ENDPOINT=(str, ""),
-    HELSINKI_PROFILE_SCOPE=(str, "https://api.hel.fi/auth/helsinkiprofile"),
-    HELSINKI_PROFILE_API_URL=(str, "https://api.hel.fi/profiili/graphql/"),
     LOGIN_REDIRECT_URL=(str, "/"),
-    LOGIN_REDIRECT_URL_FAILURE=(str, "/"),
     LOGOUT_REDIRECT_URL=(str, "/"),
     ADFS_LOGIN_REDIRECT_URL=(str, "/"),
     ADFS_LOGIN_REDIRECT_URL_FAILURE=(str, "/"),
     OIDC_REDIRECT_ALLOWED_HOSTS=(list, []),
     OIDC_REDIRECT_REQUIRE_HTTPS=(bool, True),
-    EAUTHORIZATIONS_BASE_URL=(str, "https://asiointivaltuustarkastus.test.suomi.fi"),
-    EAUTHORIZATIONS_CLIENT_ID=(str, "sample_client_id"),
-    EAUTHORIZATIONS_CLIENT_SECRET=(str, ""),
-    EAUTHORIZATIONS_API_OAUTH_SECRET=(str, ""),
     ADFS_CLIENT_ID=(str, "client_id"),
     ADFS_CLIENT_SECRET=(str, "client_secret"),
     ADFS_TENANT_ID=(str, "tenant_id"),
@@ -201,7 +193,30 @@ env = environ.Env(
     SOCIAL_AUTH_TUNNISTAMO_SECRET=(str, ""),
     SOCIAL_AUTH_TUNNISTAMO_OIDC_ENDPOINT=(str, ""),
     HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED=(bool, True),
-    SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_AUDIENCE=(str, "profile-api-test"),
+    # Legacy non-namespaced variables, read only as a fallback by the mapping block
+    # further below. Remove once every environment sets the namespaced variables.
+    EAUTHORIZATIONS_BASE_URL=(str, "https://asiointivaltuustarkastus.test.suomi.fi"),
+    EAUTHORIZATIONS_CLIENT_ID=(str, "sample_client_id"),
+    EAUTHORIZATIONS_CLIENT_SECRET=(str, ""),
+    EAUTHORIZATIONS_API_OAUTH_SECRET=(str, ""),
+    HELSINKI_PROFILE_API_URL=(str, "https://api.hel.fi/profiili/graphql/"),
+    HELSINKI_PROFILE_SCOPE=(str, "https://api.hel.fi/auth/helsinkiprofile"),
+    LOGIN_REDIRECT_URL_FAILURE=(str, "/"),
+    # django-helsinki-suomifi-on-behalf. Unset or empty means "use the legacy
+    # variable above", see the mapping block further below.
+    SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_BASE_URL=(str, ""),
+    SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_CLIENT_ID=(str, ""),
+    SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_CLIENT_SECRET=(str, ""),
+    SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_API_OAUTH_SECRET=(str, ""),
+    SUOMIFI_ON_BEHALF_LOGIN_SUCCESS_URL=(str, ""),
+    SUOMIFI_ON_BEHALF_LOGIN_ERROR_URL=(str, ""),
+    SUOMIFI_ON_BEHALF_OIDC_USERINFO_ENDPOINT=(str, ""),
+    SUOMIFI_ON_BEHALF_REDIRECT_ALLOWED_HOSTS=(list, []),
+    SUOMIFI_ON_BEHALF_REDIRECT_REQUIRE_HTTPS=(bool, None),
+    SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_API_URL=(str, ""),
+    SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_SCOPE=(str, ""),
+    SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_AUDIENCE=(str, ""),
+    SUOMIFI_ON_BEHALF_TUNNISTUS_API_TOKENS_ENDPOINT=(str, ""),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -530,11 +545,6 @@ OIDC_API_TOKEN_AUTH = {
     "USER_RESOLVER": "users.api.v1.authentications.resolve_user",
 }
 
-TUNNISTAMO_API_TOKENS_ENDPOINT = env.str("TUNNISTAMO_API_TOKENS_ENDPOINT")
-TUNNISTUS_API_TOKENS_ENDPOINT = f"{OIDC_OP_BASE_URL}/protocol/openid-connect/token"
-HELSINKI_PROFILE_SCOPE = env.str("HELSINKI_PROFILE_SCOPE")
-HELSINKI_PROFILE_API_URL = env.str("HELSINKI_PROFILE_API_URL")
-
 OIDC_RP_SCOPES = "openid profile email"
 OIDC_AUTH = {"OIDC_LEEWAY": env.int("OIDC_LEEWAY")}
 
@@ -561,13 +571,7 @@ OIDC_OP_LOGOUT_CALLBACK_URL = env.str("OIDC_OP_LOGOUT_CALLBACK_URL")
 OIDC_DISABLE_LANGUAGE_COOKIE = False
 
 LOGIN_REDIRECT_URL = env.str("LOGIN_REDIRECT_URL")
-LOGIN_REDIRECT_URL_FAILURE = env.str("LOGIN_REDIRECT_URL_FAILURE")
 LOGOUT_REDIRECT_URL = env.str("LOGOUT_REDIRECT_URL")
-
-EAUTHORIZATIONS_BASE_URL = env.str("EAUTHORIZATIONS_BASE_URL")
-EAUTHORIZATIONS_CLIENT_ID = env.str("EAUTHORIZATIONS_CLIENT_ID")
-EAUTHORIZATIONS_CLIENT_SECRET = env.str("EAUTHORIZATIONS_CLIENT_SECRET")
-EAUTHORIZATIONS_API_OAUTH_SECRET = env.str("EAUTHORIZATIONS_API_OAUTH_SECRET")
 
 # Azure ADFS
 LOGIN_URL = "django_auth_adfs:login"
@@ -597,27 +601,74 @@ OIDC_REDIRECT_ALLOWED_HOSTS = env.list(
 )
 OIDC_REDIRECT_REQUIRE_HTTPS = env.bool("OIDC_REDIRECT_REQUIRE_HTTPS", default=True)
 
+
+def helsinki_profile_audience(api_url: str) -> str:
+    """
+    Derive the Helsinki Profile API token audience from the Profile API URL.
+
+    Can be removed after environments have been fully migrated to
+    set the SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_AUDIENCE variable.
+    """
+    if "test" in api_url:
+        return "profile-api-test"
+    if "stage" in api_url:
+        return "profile-api-stage"
+    return "profile-api"
+
+
 # django-helsinki-suomifi-on-behalf (Suomi.fi eAuthorizations / Valtuudet on-behalf).
-# Existing env-driven settings are mapped to the library's namespaced settings so no
-# deployment configuration needs to change.
-SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_BASE_URL = EAUTHORIZATIONS_BASE_URL
-SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_CLIENT_ID = EAUTHORIZATIONS_CLIENT_ID
-SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_CLIENT_SECRET = EAUTHORIZATIONS_CLIENT_SECRET
-SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_API_OAUTH_SECRET = EAUTHORIZATIONS_API_OAUTH_SECRET
+# Every setting can be given directly as a SUOMIFI_ON_BEHALF_* env variable. When one is
+# unset or empty, the legacy non-namespaced variable is used, so no deployment
+# configuration needs to change.
+SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_BASE_URL = env.str(
+    "SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_BASE_URL"
+) or env.str("EAUTHORIZATIONS_BASE_URL")
+SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_CLIENT_ID = env.str(
+    "SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_CLIENT_ID"
+) or env.str("EAUTHORIZATIONS_CLIENT_ID")
+SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_CLIENT_SECRET = env.str(
+    "SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_CLIENT_SECRET"
+) or env.str("EAUTHORIZATIONS_CLIENT_SECRET")
+SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_API_OAUTH_SECRET = env.str(
+    "SUOMIFI_ON_BEHALF_EAUTHORIZATIONS_API_OAUTH_SECRET"
+) or env.str("EAUTHORIZATIONS_API_OAUTH_SECRET")
 
-SUOMIFI_ON_BEHALF_LOGIN_ERROR_URL = LOGIN_REDIRECT_URL_FAILURE
+SUOMIFI_ON_BEHALF_LOGIN_SUCCESS_URL = (
+    env.str("SUOMIFI_ON_BEHALF_LOGIN_SUCCESS_URL") or LOGIN_REDIRECT_URL
+)
+SUOMIFI_ON_BEHALF_LOGIN_ERROR_URL = env.str(
+    "SUOMIFI_ON_BEHALF_LOGIN_ERROR_URL"
+) or env.str("LOGIN_REDIRECT_URL_FAILURE")
 
-SUOMIFI_ON_BEHALF_OIDC_USERINFO_ENDPOINT = OIDC_OP_USER_ENDPOINT
+SUOMIFI_ON_BEHALF_OIDC_USERINFO_ENDPOINT = (
+    env.str("SUOMIFI_ON_BEHALF_OIDC_USERINFO_ENDPOINT") or OIDC_OP_USER_ENDPOINT
+)
 
-SUOMIFI_ON_BEHALF_REDIRECT_ALLOWED_HOSTS = OIDC_REDIRECT_ALLOWED_HOSTS
-SUOMIFI_ON_BEHALF_REDIRECT_REQUIRE_HTTPS = OIDC_REDIRECT_REQUIRE_HTTPS
+SUOMIFI_ON_BEHALF_REDIRECT_ALLOWED_HOSTS = (
+    env.list("SUOMIFI_ON_BEHALF_REDIRECT_ALLOWED_HOSTS") or OIDC_REDIRECT_ALLOWED_HOSTS
+)
+# Not `or`: False is a meaningful value here, and an empty variable is read as None.
+_redirect_require_https = env.bool("SUOMIFI_ON_BEHALF_REDIRECT_REQUIRE_HTTPS")
+SUOMIFI_ON_BEHALF_REDIRECT_REQUIRE_HTTPS = (
+    OIDC_REDIRECT_REQUIRE_HTTPS
+    if _redirect_require_https is None
+    else _redirect_require_https
+)
 
-SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_API_URL = HELSINKI_PROFILE_API_URL
-SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_SCOPE = HELSINKI_PROFILE_SCOPE
+SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_API_URL = env.str(
+    "SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_API_URL"
+) or env.str("HELSINKI_PROFILE_API_URL")
+SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_SCOPE = env.str(
+    "SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_SCOPE"
+) or env.str("HELSINKI_PROFILE_SCOPE")
+# Unset means "derive from the Profile API URL", which is what the audience was before
+# this library made it a setting. Set the env variable to override.
 SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_AUDIENCE = env.str(
     "SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_AUDIENCE"
+) or helsinki_profile_audience(SUOMIFI_ON_BEHALF_HELSINKI_PROFILE_API_URL)
+SUOMIFI_ON_BEHALF_TUNNISTUS_API_TOKENS_ENDPOINT = (
+    env.str("SUOMIFI_ON_BEHALF_TUNNISTUS_API_TOKENS_ENDPOINT") or OIDC_OP_TOKEN_ENDPOINT
 )
-SUOMIFI_ON_BEHALF_TUNNISTUS_API_TOKENS_ENDPOINT = TUNNISTUS_API_TOKENS_ENDPOINT
 
 SUOMIFI_ON_BEHALF_SSN_RESOLVERS = [
     "suomifi_on_behalf.ssn.OidcUserinfoSsnResolver",

--- a/backend/benefit/helsinkibenefit/settings.py
+++ b/backend/benefit/helsinkibenefit/settings.py
@@ -463,6 +463,7 @@ REST_FRAMEWORK = {
     ],
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "EXCEPTION_HANDLER": "common.exception_handlers.benefit_exception_handler",
 }  # TODO: Replace with actual authentication & permissions.
 
 SPECTACULAR_SETTINGS = {

--- a/backend/benefit/helsinkibenefit/tests/test_settings.py
+++ b/backend/benefit/helsinkibenefit/tests/test_settings.py
@@ -1,6 +1,8 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 
 class TestSentryConfiguration:
     """Tests for Sentry configuration and traces sampler."""
@@ -105,3 +107,20 @@ class TestSentryConfiguration:
         import helsinkibenefit.settings  # noqa: F401
 
         assert not mock_sentry_init.called
+
+
+class TestHelsinkiProfileAudience:
+    """Tests for deriving the Helsinki Profile API token audience."""
+
+    @pytest.mark.parametrize(
+        "api_url,expected",
+        [
+            ("https://profile-api.test.hel.ninja/graphql/", "profile-api-test"),
+            ("https://profile-api.stage.hel.ninja/graphql/", "profile-api-stage"),
+            ("https://api.hel.fi/profiili/graphql/", "profile-api"),
+        ],
+    )
+    def test_audience_is_derived_from_profile_api_url(self, api_url, expected):
+        from helsinkibenefit.settings import helsinki_profile_audience
+
+        assert helsinki_profile_audience(api_url) == expected

--- a/backend/benefit/helsinkibenefit/urls.py
+++ b/backend/benefit/helsinkibenefit/urls.py
@@ -196,7 +196,7 @@ urlpatterns = [
         SearchView.as_view(),
         name="search_applications",
     ),
-    path("oidc/", include("shared.oidc.urls")),
+    path("oidc/", include("helsinkibenefit.oidc_urls")),
     path("oauth2/", include("shared.azure_adfs.urls")),
     path("pysocial/", include("social_django.urls", namespace="social")),
     path("helauth/", include("helusers.urls")),

--- a/backend/benefit/requirements-dev.txt
+++ b/backend/benefit/requirements-dev.txt
@@ -56,7 +56,7 @@ parso==0.8.5
     # via jedi
 pexpect==4.9.0
     # via ipython
-pip-tools==7.5.2
+pip-tools==7.6.0
     # via -r requirements-dev.in
 pluggy==1.6.0
     # via

--- a/backend/benefit/requirements.in
+++ b/backend/benefit/requirements.in
@@ -4,6 +4,7 @@ django-cors-headers
 django-environ
 django-extensions
 django-filter
+django-helsinki-suomifi-on-behalf
 django-helusers
 social-auth-app-django
 django-localflavor

--- a/backend/benefit/requirements.txt
+++ b/backend/benefit/requirements.txt
@@ -95,7 +95,7 @@ django-extensions==4.1
     #   yjdh-backend-shared
 django-filter==25.2
     # via -r requirements.in
-django-helsinki-suomifi-on-behalf==1.0.0
+django-helsinki-suomifi-on-behalf==2.0.0
     # via -r requirements.in
 django-helusers==1.1.0
     # via

--- a/backend/benefit/requirements.txt
+++ b/backend/benefit/requirements.txt
@@ -61,6 +61,7 @@ django==5.2.15
     #   django-cors-headers
     #   django-extensions
     #   django-filter
+    #   django-helsinki-suomifi-on-behalf
     #   django-helusers
     #   django-localflavor
     #   django-logger-extra
@@ -93,6 +94,8 @@ django-extensions==4.1
     #   -r requirements.in
     #   yjdh-backend-shared
 django-filter==25.2
+    # via -r requirements.in
+django-helsinki-suomifi-on-behalf==1.0.0
     # via -r requirements.in
 django-helusers==1.1.0
     # via
@@ -248,6 +251,7 @@ requests==2.33.1
     #   -r requirements.in
     #   azure-core
     #   django-auth-adfs
+    #   django-helsinki-suomifi-on-behalf
     #   django-helusers
     #   drf-oidc-auth
     #   mozilla-django-oidc

--- a/backend/benefit/users/tests/test_utils.py
+++ b/backend/benefit/users/tests/test_utils.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+import pytest
+from django.http import Http404
+from requests.exceptions import HTTPError
+from suomifi_on_behalf import CompanyResolutionError
+
+from users.utils import get_company_from_request
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("upstream_error", [HTTPError("down"), Http404("not found")])
+def test_get_company_from_request_maps_upstream_failure_to_resolution_error(
+    settings, upstream_error
+):
+    # No company exists locally for this business id, so the DB lookup misses and the
+    # upstream call is attempted. Both HTTPError (outage) and Http404 (not found) must
+    # be normalised to a single CompanyResolutionError.
+    settings.NEXT_PUBLIC_MOCK_FLAG = False
+    with (
+        patch("users.utils.get_business_id_from_request", return_value="1234567-8"),
+        patch(
+            "users.utils.get_or_create_organisation_with_business_id",
+            side_effect=upstream_error,
+        ),
+    ):
+        with pytest.raises(CompanyResolutionError):
+            get_company_from_request(request=object())
+
+
+@pytest.mark.django_db
+def test_get_company_from_request_returns_none_without_business_id(settings):
+    settings.NEXT_PUBLIC_MOCK_FLAG = False
+    with patch("users.utils.get_business_id_from_request", return_value=None):
+        assert get_company_from_request(request=object()) is None

--- a/backend/benefit/users/utils.py
+++ b/backend/benefit/users/utils.py
@@ -1,8 +1,8 @@
 from django.conf import settings
+from suomifi_on_behalf import get_organization_roles
 
 from companies.models import Company
 from companies.services import get_or_create_organisation_with_business_id
-from shared.oidc.utils import get_organization_roles
 
 
 def get_request_user_from_context(serializer):

--- a/backend/benefit/users/utils.py
+++ b/backend/benefit/users/utils.py
@@ -1,5 +1,7 @@
 from django.conf import settings
-from suomifi_on_behalf import get_organization_roles
+from django.http import Http404
+from requests.exceptions import RequestException
+from suomifi_on_behalf import CompanyResolutionError, get_organization_roles
 
 from companies.models import Company
 from companies.services import get_or_create_organisation_with_business_id
@@ -32,7 +34,14 @@ def get_company_from_request(request):
             # In case we cannot find the Company in DB, try to query it from 3rd party
             # source
             # This should cover the case when first applicant of company log in because
-            # their company hasn't been created yet
-            return get_or_create_organisation_with_business_id(business_id)
+            # their company hasn't been created yet.
+            # Map upstream failures (YTJ/YRTTI unavailable, or no company found) to a
+            # single CompanyResolutionError so every caller gets a consistent,
+            # controlled response via the global exception handler instead of an
+            # uncaught HTTPError/Http404 surfacing as a 500.
+            try:
+                return get_or_create_organisation_with_business_id(business_id)
+            except (RequestException, Http404) as exc:
+                raise CompanyResolutionError(str(exc)) from exc
     else:
         return None

--- a/backend/shared/shared/oidc/urls.py
+++ b/backend/shared/shared/oidc/urls.py
@@ -20,7 +20,10 @@ from shared.oidc.views.mock_views import (
     MockUserInfoView,
 )
 
-urlpatterns = [
+# Base OIDC url patterns (Helsinki OIDC login/logout/userinfo/callback + mock
+# proxy + mozilla_django_oidc), shared by every project. Projects append their own
+# on-behalf/eAuthorizations mechanism on top of this list.
+base_oidc_urlpatterns = [
     path(
         "authenticate/",
         MockEnabledProxyView(
@@ -64,6 +67,9 @@ urlpatterns = [
         name="oidc_backchannel_logout",
     ),
     path("", include("mozilla_django_oidc.urls")),
+]
+
+urlpatterns = base_oidc_urlpatterns + [
     path(
         "eauthorizations/authenticate/",
         EauthAuthenticationRequestView.as_view(),


### PR DESCRIPTION
Replace the eauth flow in Helsinki Benefit with the [django-helsinki-suomifi-on-behalf library](https://github.com/City-of-Helsinki/django-helsinki-suomifi-on-behalf). Lot of the implementation was copied from YJDH, so Helsinki Benefit is a pretty good dogfooding candidate for it.

The library functions in a similar way to how it did in YJDH. The main difference is that SSN/company resolving is not hard-coded but rather handled by configurable resolvers and supports custom resolvers. The library also only handles Suomi.fi mandate part; the intiial authentication and company data handling must still be provided by the service. For more information, see the library's README and docs.

The settings were made backwards-compatible so that the code functions even if deployed before configuring the new, namespaced variables (SUOMIFI_ON_BEHALF_*). The old settings should be removed on a later date, once all environments have been configured to point to the new settings instead.

**For KuVa-developers:**

shared.oidc.urls was edited so that Benefit could grab the OIDC urls only and append the new stuff on top of it. Shouldn't affect Kesäseteli, but please confirm this.

Refs: HP-3084


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for acting on behalf of an organization during sign-in and authentication flows.
- Added organization-specific authentication, logout, callback, and user information routes.
- Added company detail resolution from authorized organization information.
- Added configurable authentication and Helsinki Profile settings.

## Bug Fixes
- Improved company lookup error handling when organization information is unavailable or invalid.
- Company resolution failures now return a controlled 404 response instead of an unhandled error.
- Updated organization role handling to support the new authentication flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->