### PR TITLE
YJDH-900 | Frontend prep work before switching from Yarn to pnpm

### DIFF
--- a/frontend/benefit/applicant/src/components/applications/alteration/AlterationPage.tsx
+++ b/frontend/benefit/applicant/src/components/applications/alteration/AlterationPage.tsx
@@ -22,6 +22,7 @@ import {
 } from 'benefit-shared/constants';
 import {
   ButtonPresetTheme,
+  ButtonSize,
   ButtonVariant,
   IconArrowLeft,
   LoadingSpinner,
@@ -80,7 +81,7 @@ const AlterationPage = (): JSX.Element => {
           variant={ButtonVariant.Supplementary}
           iconStart={<IconArrowLeft />}
           onClick={returnToApplication}
-          size="small"
+          size={ButtonSize.Small}
         >
           {t(`common:applications.actions.back`)}
         </Button>

--- a/frontend/benefit/applicant/src/components/applications/applicationList/__tests__/useApplicationList.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/__tests__/useApplicationList.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import FrontPageContext from 'benefit/applicant/context/FrontPageContext';
 import useApplicationsQuery from 'benefit/applicant/hooks/useApplicationsQuery';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
@@ -45,7 +45,11 @@ const getApplicationData = (
   } as ApplicationData);
 
 describe('useApplicationList', () => {
-  const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
+  const wrapper = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): JSX.Element => (
     <FrontPageContext.Provider value={{ errors: [], setError: jest.fn() }}>
       {children}
     </FrontPageContext.Provider>

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListContents.tsx
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListContents.tsx
@@ -7,7 +7,7 @@ import {
 import ListItem from 'benefit/applicant/components/applications/applicationList/listItem/ListItem';
 import { ApplicationListProps } from 'benefit/applicant/components/applications/applicationList/useApplicationList';
 import ApplicationListProvider from 'benefit/applicant/context/ApplicationListProvider';
-import { Select } from 'hds-react';
+import { Option, Select } from 'hds-react';
 import React, { useEffect } from 'react';
 import LoadingSkeleton from 'react-loading-skeleton';
 import Container from 'shared/components/container/Container';
@@ -76,9 +76,9 @@ const ListContents = ({
               {(orderByOptions?.length ?? 0) > 1 && (
                 <Select
                   id={`application-list-${status.join('-')}-order-by`}
-                  options={orderByOptions || []}
-                  defaultValue={orderBy}
-                  value={[orderBy].filter(Boolean)}
+                  options={(orderByOptions as Option[]) || []}
+                  defaultValue={orderBy?.value}
+                  value={[orderBy].filter(Boolean) as Option[]}
                   onChange={(selectedOptions: OptionType[]) =>
                     setOrderBy(selectedOptions[0])
                   }

--- a/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
+++ b/frontend/benefit/applicant/src/components/applications/applicationList/listItem/ListItem.sc.ts
@@ -3,7 +3,7 @@ import { respondAbove } from 'shared/styles/mediaQueries';
 import styled, { DefaultTheme } from 'styled-components';
 
 interface AvatarProps {
-  $backgroundColor: keyof DefaultTheme['colors'];
+  $backgroundColor?: keyof DefaultTheme['colors'];
   theme: DefaultTheme;
 }
 
@@ -41,7 +41,11 @@ export const $ItemContent = styled.div`
 
 export const $Avatar = styled.div<AvatarProps>`
   ${(props: AvatarProps) => `
-    background-color: ${props.theme.colors[props.$backgroundColor]};
+    background-color: ${
+      props.$backgroundColor
+        ? props.theme.colors[props.$backgroundColor]
+        : 'transparent'
+    };
     color: ${props.theme.colors.white};
     font-size: ${props.theme.fontSize.heading.xs};
   `}

--- a/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/DeMinimisAidForm.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/deMinimisAid/DeMinimisAidForm.tsx
@@ -76,7 +76,6 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({
       </$GridCell>
       <$DeMinimisGridForm>
         <$GridCell $colSpan={4}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.granter.name}
             name={fields.granter.name}
@@ -94,7 +93,6 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={2}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.amount.name}
             name={fields.amount.name}
@@ -120,7 +118,6 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={3}>
-          {/* @ts-expect-error: The HDS React DateInput has stricter type definitions for its props, causing TS2740. */}
           <DateInput
             id={fields.grantedAt.name}
             name={fields.grantedAt.name}

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
@@ -8,6 +8,7 @@ import {
   APPLICATION_STATUSES,
 } from 'benefit-shared/constants';
 import {
+  Option as SelectOption,
   Select,
   SelectionGroup,
   TextArea,
@@ -118,7 +119,6 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
           </$SubHeader>
         </$GridCell>
         <$GridCell $colSpan={3}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.companyContactPersonFirstName.name}
             name={fields.companyContactPersonFirstName.name}
@@ -140,7 +140,6 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={3}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.companyContactPersonLastName.name}
             name={fields.companyContactPersonLastName.name}
@@ -162,7 +161,6 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={2}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.companyContactPersonPhoneNumber.name}
             name={fields.companyContactPersonPhoneNumber.name}
@@ -186,7 +184,6 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={4}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.companyContactPersonEmail.name}
             name={fields.companyContactPersonEmail.name}
@@ -212,12 +209,13 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
                 language[0]?.value
               )
             }
-            options={languageOptions}
+            options={languageOptions as SelectOption[]}
             id={fields.applicantLanguage.name}
             invalid={!!getErrorMessage(fields.applicantLanguage.name)}
             aria-invalid={!!getErrorMessage(fields.applicantLanguage.name)}
             value={[
-              formik.values.applicantLanguage ?? getDefaultLanguage(),
+              (formik.values.applicantLanguage as string) ??
+                getDefaultLanguage(),
             ].filter(Boolean)}
             required
           />
@@ -331,7 +329,6 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
         {formik.values.coOperationNegotiations && (
           <$SubFieldContainer $colSpan={7}>
             <$GridCell $colSpan={8} $rowSpan={8}>
-              {/* @ts-expect-error: The HDS React TextArea has stricter type definitions for its props, causing TS2740. */}
               <TextArea
                 id={fields.coOperationNegotiationsDescription.name}
                 name={fields.coOperationNegotiationsDescription.name}

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/ApplicationFormStep1.tsx
@@ -204,7 +204,7 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
           <Select
             texts={applicantLanguageSelectTexts}
             onChange={(language: Option[]) =>
-              formik.setFieldValue(
+              void formik.setFieldValue(
                 fields.applicantLanguage.name,
                 language[0]?.value
               )
@@ -243,8 +243,8 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
                   `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID}.no`
                 )}
                 onChange={() => {
-                  formik.setFieldValue(fields.deMinimisAid.name, false);
-                  formik.setFieldValue(fields.deMinimisAidSet.name, []);
+                  void formik.setFieldValue(fields.deMinimisAid.name, false);
+                  void formik.setFieldValue(fields.deMinimisAidSet.name, []);
                   setUnfinishedDeMinimisAid(false);
                   setDeMinimisAids([]);
                 }}
@@ -259,7 +259,7 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
                   `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID}.yes`
                 )}
                 onChange={() =>
-                  formik.setFieldValue(fields.deMinimisAid.name, true)
+                  void formik.setFieldValue(fields.deMinimisAid.name, true)
                 }
                 checked={formik.values.deMinimisAid === true}
               />
@@ -305,7 +305,7 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
                 `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.CO_OPERATION_NEGOTIATIONS}.no`
               )}
               onChange={() => {
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.coOperationNegotiations.name,
                   false
                 );
@@ -320,7 +320,10 @@ const ApplicationFormStep1: React.FC<DynamicFormStepComponentProps> = ({
                 `${translationsBase}.fields.${APPLICATION_FIELDS_STEP1_KEYS.CO_OPERATION_NEGOTIATIONS}.yes`
               )}
               onChange={() =>
-                formik.setFieldValue(fields.coOperationNegotiations.name, true)
+                void formik.setFieldValue(
+                  fields.coOperationNegotiations.name,
+                  true
+                )
               }
               checked={formik.values.coOperationNegotiations === true}
             />

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/__tests__/useApplicationFormStep1.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/__tests__/useApplicationFormStep1.test.tsx
@@ -91,14 +91,14 @@ describe('useApplicationFormStep1', () => {
       data: {
         organization_type: ORGANIZATION_TYPES.COMPANY,
       },
-    } as any);
+    } as ReturnType<typeof useCompanyQuery>);
 
     mockUseFormActions.mockReturnValue(mockFormActions);
 
     mockUseTranslation.mockReturnValue({
       t: mockT,
-      i18n: {} as any,
-    } as any);
+      i18n: {} as unknown as ReturnType<typeof useTranslation>['i18n'],
+    } as unknown as ReturnType<typeof useTranslation>);
 
     mockGetLanguageOptions.mockReturnValue([
       { label: 'Finnish', value: 'fi' },
@@ -137,7 +137,7 @@ describe('useApplicationFormStep1', () => {
       data: {
         organization_type: ORGANIZATION_TYPES.ASSOCIATION,
       },
-    } as any);
+    } as ReturnType<typeof useCompanyQuery>);
 
     const applicationWithActivities: Partial<Application> = {
       ...mockApplication,
@@ -157,7 +157,7 @@ describe('useApplicationFormStep1', () => {
       data: {
         organization_type: ORGANIZATION_TYPES.ASSOCIATION,
       },
-    } as any);
+    } as ReturnType<typeof useCompanyQuery>);
 
     const applicationWithoutActivities: Partial<Application> = {
       ...mockApplication,

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.tsx
@@ -194,7 +194,6 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
               `}
             >
               <$GridCell $colSpan={4}>
-                {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
                 <TextInput
                   id={fields.companyDepartment.name}
                   name={fields.companyDepartment.name}
@@ -211,7 +210,6 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
                 />
               </$GridCell>
               <$GridCell $colStart={1} $colSpan={4}>
-                {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
                 <TextInput
                   id={fields.alternativeCompanyStreetAddress.name}
                   name={fields.alternativeCompanyStreetAddress.name}
@@ -239,7 +237,6 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
                 />
               </$GridCell>
               <$GridCell $colSpan={2}>
-                {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
                 <TextInput
                   id={fields.alternativeCompanyPostcode.name}
                   name={fields.alternativeCompanyPostcode.name}
@@ -261,7 +258,6 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
                 />
               </$GridCell>
               <$GridCell $colSpan={4}>
-                {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
                 <TextInput
                   id={fields.alternativeCompanyCity.name}
                   name={fields.alternativeCompanyCity.name}
@@ -305,7 +301,6 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
           >
             {
               ((props: Record<string, unknown>) => (
-                // @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740.
                 <TextInput
                   {...props}
                   id={fields.companyBankAccountNumber.name}
@@ -387,7 +382,6 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
         )}
       </$GridCell>
       <$GridCell $colSpan={4}>
-        {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
         <TextInput
           id={fields.companyNumberOfEmployees.name}
           name={fields.companyNumberOfEmployees.name}
@@ -407,7 +401,6 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
         />
       </$GridCell>
       <$GridCell $colSpan={12}>
-        {/* @ts-expect-error: The HDS React TextArea has stricter type definitions for its props, causing TS2740. */}
         <TextArea
           id={fields.companyBusinessBrief.name}
           name={fields.companyBusinessBrief.name}
@@ -432,43 +425,27 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
           label={fields.purchasedService.label}
           direction="vertical"
           required
-          errorText={getErrorMessage(
-            fields.purchasedService.name
-          )}
+          errorText={getErrorMessage(fields.purchasedService.name)}
         >
           <$RadioButton
             id={`${fields.purchasedService.name}False`}
             name={fields.purchasedService.name}
             value="false"
-            label={t(
-              'common:utility.no'
-            )}
+            label={t('common:utility.no')}
             onChange={() => {
-              formik.setFieldValue(
-                fields.purchasedService.name,
-                false
-              );
+              formik.setFieldValue(fields.purchasedService.name, false);
             }}
-            checked={
-              formik.values.purchasedService === false
-            }
+            checked={formik.values.purchasedService === false}
           />
           <$RadioButton
             id={`${fields.purchasedService.name}True`}
             name={fields.purchasedService.name}
             value="true"
-            label={t(
-              'common:utility.yes'
-            )}
+            label={t('common:utility.yes')}
             onChange={() =>
-              formik.setFieldValue(
-                fields.purchasedService.name,
-                true
-              )
+              formik.setFieldValue(fields.purchasedService.name, true)
             }
-            checked={
-              formik.values.purchasedService === true
-            }
+            checked={formik.values.purchasedService === true}
           />
         </SelectionGroup>
       </$GridCell>

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/CompanyInfo.tsx
@@ -368,7 +368,7 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
                   `${translationsBase}.fields.${fields.associationHasBusinessActivities.name}.yes`
                 )}
                 onChange={() =>
-                  formik.setFieldValue(
+                  void formik.setFieldValue(
                     fields.associationHasBusinessActivities.name,
                     true
                   )
@@ -388,7 +388,7 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
           label={fields.companyNumberOfEmployees.label}
           onBlur={formik.handleBlur}
           onChange={(event) => {
-            formik.setFieldValue(
+            void formik.setFieldValue(
               fields.companyNumberOfEmployees.name,
               event.target.value.replace(/\D/g, '')
             );
@@ -433,7 +433,7 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
             value="false"
             label={t('common:utility.no')}
             onChange={() => {
-              formik.setFieldValue(fields.purchasedService.name, false);
+              void formik.setFieldValue(fields.purchasedService.name, false);
             }}
             checked={formik.values.purchasedService === false}
           />
@@ -443,7 +443,7 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
             value="true"
             label={t('common:utility.yes')}
             onChange={() =>
-              formik.setFieldValue(fields.purchasedService.name, true)
+              void formik.setFieldValue(fields.purchasedService.name, true)
             }
             checked={formik.values.purchasedService === true}
           />

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/__tests__/CompanyInfo.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/companyInfo/__tests__/CompanyInfo.test.tsx
@@ -1,5 +1,4 @@
-import { RenderResult, screen } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, RenderResult, screen } from '@testing-library/react';
 import renderComponent from 'benefit/applicant/__tests__/utils/render-component';
 import { setupUserAndRender } from 'benefit/applicant/__tests__/utils/user-render-helper';
 import { translateBackendErrorMessage } from 'benefit/applicant/utils/common';

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
@@ -294,7 +294,7 @@ const useApplicationFormStep1 = (
 
   const clearDeminimisAids = React.useCallback((): void => {
     setDeMinimisAids([]);
-    setFieldValue(APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID, null);
+    void setFieldValue(APPLICATION_FIELDS_STEP1_KEYS.DE_MINIMIS_AID, null);
   }, [setDeMinimisAids, setFieldValue]);
 
   const showDeminimisSection = hasBusinessActivitiesOrIsCompany(

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step1/useApplicationFormStep1.ts
@@ -7,7 +7,11 @@ import {
   APPLICATION_FIELDS_STEP1_KEYS,
   ORGANIZATION_TYPES,
 } from 'benefit-shared/constants';
-import { Application, ApplicationData, DeMinimisAid } from 'benefit-shared/types/application';
+import {
+  Application,
+  ApplicationData,
+  DeMinimisAid,
+} from 'benefit-shared/types/application';
 import { getErrorText } from 'benefit-shared/utils/forms';
 import { FormikProps, FormikValues, useFormik } from 'formik';
 import fromPairs from 'lodash/fromPairs';
@@ -158,6 +162,7 @@ const useFormikInstance = (
       formik
         .setFieldValue('attachments', application.attachments)
         .catch((error) => {
+          // eslint-disable-next-line no-console
           console.error('Failed to update attachments:', error);
         });
     }

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -211,7 +211,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
               value="false"
               label={t('common:utility.no')}
               onChange={() => {
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.otherFinancialSupportForEmployment.name,
                   false
                 );
@@ -226,7 +226,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
               value="true"
               label={t('common:utility.yes')}
               onChange={() => {
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.otherFinancialSupportForEmployment.name,
                   true
                 );
@@ -251,7 +251,7 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
               value="false"
               label={t('common:utility.no')}
               onChange={() => {
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.otherSubsidisedEmployed.name,
                   false
                 );
@@ -264,7 +264,10 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
               value="true"
               label={t('common:utility.yes')}
               onChange={() => {
-                formik.setFieldValue(fields.otherSubsidisedEmployed.name, true);
+                void formik.setFieldValue(
+                  fields.otherSubsidisedEmployed.name,
+                  true
+                );
               }}
               checked={formik.values.otherSubsidisedEmployed === true}
             />
@@ -588,7 +591,10 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
                 `${translationsBase}.fields.${fields.apprenticeshipProgram.name}.no`
               )}
               onChange={() => {
-                formik.setFieldValue(fields.apprenticeshipProgram.name, false);
+                void formik.setFieldValue(
+                  fields.apprenticeshipProgram.name,
+                  false
+                );
               }}
               checked={formik.values.apprenticeshipProgram === false}
             />
@@ -600,7 +606,10 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
                 `${translationsBase}.fields.${fields.apprenticeshipProgram.name}.yes`
               )}
               onChange={() => {
-                formik.setFieldValue(fields.apprenticeshipProgram.name, true);
+                void formik.setFieldValue(
+                  fields.apprenticeshipProgram.name,
+                  true
+                );
               }}
               checked={formik.values.apprenticeshipProgram === true}
             />

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step2/ApplicationFormStep2.tsx
@@ -8,7 +8,13 @@ import {
   BENEFIT_TYPES,
   ORGANIZATION_TYPES,
 } from 'benefit-shared/constants';
-import { DateInput, SelectionGroup, TextArea, TextInput, Tooltip } from 'hds-react';
+import {
+  DateInput,
+  SelectionGroup,
+  TextArea,
+  TextInput,
+  Tooltip,
+} from 'hds-react';
 import React from 'react';
 import FieldLabel from 'shared/components/forms/fields/fieldLabel/FieldLabel';
 import {
@@ -80,7 +86,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
     <form onSubmit={handleSubmit} noValidate>
       <FormSection headerLevel="h2" header={t(`${translationsBase}.heading1`)}>
         <$GridCell $colSpan={3}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.employee.firstName.name}
             name={fields.employee.firstName.name}
@@ -96,7 +101,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={3}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.employee.lastName.name}
             name={fields.employee.lastName.name}
@@ -112,7 +116,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={3}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.employee.socialSecurityNumber.name}
             name={fields.employee.socialSecurityNumber.name}
@@ -276,7 +279,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
                 padding-left: ${theme.spacing.m};
               `}
             >
-              {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
               <TextInput
                 id={fields.otherSubsidisedNumber.name}
                 name={fields.otherSubsidisedNumber.name}
@@ -306,7 +308,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
         )}
       >
         <$GridCell $colSpan={4}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.employee.jobTitle.name}
             name={fields.employee.jobTitle.name}
@@ -322,7 +323,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={3}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.employee.workingHours.name}
             name={fields.employee.workingHours.name}
@@ -343,7 +343,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={4}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.employee.collectiveBargainingAgreement.name}
             name={fields.employee.collectiveBargainingAgreement.name}
@@ -381,7 +380,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={12}>
-          {/* @ts-expect-error: The HDS React TextArea has stricter type definitions for its props, causing TS2740. */}
           <TextArea
             id={fields.roleOfEmployeeInOrganization.name}
             name={fields.roleOfEmployeeInOrganization.name}
@@ -422,7 +420,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           </$SubHeader>
         </$GridCell>
         <$GridCell $colSpan={2}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.employee.monthlyPay.name}
             name={fields.employee.monthlyPay.name}
@@ -451,7 +448,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={2}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.employee.vacationMoney.name}
             name={fields.employee.vacationMoney.name}
@@ -484,7 +480,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={2}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             id={fields.employee.otherExpenses.name}
             name={fields.employee.otherExpenses.name}
@@ -529,7 +524,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           </$SubHeader>
         </$GridCell>
         <$GridCell $colSpan={6}>
-          {/* @ts-expect-error: The HDS React DateInput has stricter type definitions for its props, causing TS2740. */}
           <DateInput
             id={fields.startDate.name}
             name={fields.startDate.name}
@@ -555,7 +549,6 @@ const ApplicationFormStep2: React.FC<DynamicFormStepComponentProps> = ({
           –
         </$GridCell>
         <$GridCell $colSpan={6}>
-          {/* @ts-expect-error: The HDS React DateInput has stricter type definitions for its props, causing TS2740. */}
           <DateInput
             id={fields.endDate.name}
             name={fields.endDate.name}

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/__tests__/useApplicationFormStep5.test.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/__tests__/useApplicationFormStep5.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { Application } from 'benefit-shared/types/application';
 

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/companyInfoView/CompanyInfoView.tsx
@@ -40,10 +40,7 @@ const CompanyInfoView: React.FC<CompanyInfoViewProps> = ({
   const theme = useTheme();
 
   const getPurchasedServiceText = (): string => {
-    if (
-      data.purchasedService === null ||
-      data.purchasedService === undefined
-    ) {
+    if (data.purchasedService === null || data.purchasedService === undefined) {
       return '-';
     }
     return data.purchasedService
@@ -148,7 +145,7 @@ const CompanyInfoView: React.FC<CompanyInfoViewProps> = ({
                   `${translationsBase}.company.fields.companyBusinessBrief.summaryLabel`
                 )}
               </$ApplicationDetailLabel>
-              <$ApplicationDetailValue $column={1}>
+              <$ApplicationDetailValue $column>
                 {data?.companyBusinessBrief &&
                   data?.companyBusinessBrief
                     .split(/\n/)

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step5/employeeView/EmployeeView.tsx
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step5/employeeView/EmployeeView.tsx
@@ -214,7 +214,7 @@ const EmployeeView: React.FC<EmployeeViewProps> = ({
                     `${translationsBase}.employee.fields.roleOfEmployeeInOrganization.summaryLabel`
                   )}
                 </$ApplicationDetailLabel>
-                <$ApplicationDetailValue $column={1}>
+                <$ApplicationDetailValue $column>
                   {data?.roleOfEmployeeInOrganization &&
                     data?.roleOfEmployeeInOrganization
                       .split('\n')

--- a/frontend/benefit/applicant/src/components/applications/forms/application/step6/__tests__/useApplicationFormStep6.test.ts
+++ b/frontend/benefit/applicant/src/components/applications/forms/application/step6/__tests__/useApplicationFormStep6.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import useLocale from 'benefit/applicant/hooks/useLocale';
 import {
   APPLICATION_STATUSES,

--- a/frontend/benefit/applicant/src/components/applications/pageContent/__tests__/PageContent.test.tsx
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/__tests__/PageContent.test.tsx
@@ -196,6 +196,14 @@ jest.mock('hds-react', () => {
     ButtonPresetTheme: {
       Coat: 'Coat',
     },
+    ButtonVariant: {
+      Primary: 'primary',
+      Secondary: 'secondary',
+      Supplementary: 'supplementary',
+      Success: 'success',
+      Danger: 'danger',
+      Clear: 'clear',
+    },
     IconInfoCircleFill: () =>
       ReactLocal.createElement('span', { 'data-testid': 'info-icon' }),
     LoadingSpinner: () =>

--- a/frontend/benefit/applicant/src/components/applications/pageContent/__tests__/usePageContent.test.ts
+++ b/frontend/benefit/applicant/src/components/applications/pageContent/__tests__/usePageContent.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 
 import { usePageContent } from '../usePageContent';
 

--- a/frontend/benefit/applicant/src/components/applications/secondInstalmentUpload/SecondInstalmentUploadPage.tsx
+++ b/frontend/benefit/applicant/src/components/applications/secondInstalmentUpload/SecondInstalmentUploadPage.tsx
@@ -7,7 +7,6 @@ import useSecondInstalmentRespondMutation from 'benefit/applicant/hooks/useSecon
 import { useTranslation } from 'benefit/applicant/i18n';
 import { ATTACHMENT_TYPES } from 'benefit-shared/constants';
 import {
-  Button,
   ButtonPresetTheme,
   ButtonVariant,
   IconArrowRight,
@@ -15,6 +14,7 @@ import {
 } from 'hds-react';
 import { useRouter } from 'next/router';
 import React from 'react';
+import Button from 'shared/components/button/Button';
 import Container from 'shared/components/container/Container';
 import { $Checkbox } from 'shared/components/forms/fields/Fields.sc';
 import {
@@ -262,7 +262,7 @@ const SecondInstalmentUploadPage: React.FC = () => {
         </p>
       )}
       <$Grid columns={1}>
-        <$GridCell colSpan={1}>
+        <$GridCell $colSpan={1}>
           <$Checkbox
             id="employer-assurance"
             name="employer-assurance"
@@ -275,7 +275,7 @@ const SecondInstalmentUploadPage: React.FC = () => {
             required
           />
         </$GridCell>
-        <$GridCell colSpan={1}>
+        <$GridCell $colSpan={1}>
           <ul>
             <AttachmentsList
               as="li"

--- a/frontend/benefit/applicant/src/components/applications/secondInstalmentUpload/SecondInstalmentUploadPage.tsx
+++ b/frontend/benefit/applicant/src/components/applications/secondInstalmentUpload/SecondInstalmentUploadPage.tsx
@@ -221,7 +221,7 @@ const SecondInstalmentUploadPage: React.FC = () => {
               </span>
             </$GridCell>
             <$GridCell $colSpan={6} justifySelf="end">
-              <span css={{ color: 'var(--color-fog)' }}>
+              <span style={{ color: 'var(--color-fog)' }}>
                 {t(
                   'common:applications.secondInstalmentUpload.applicationNumber'
                 )}
@@ -236,7 +236,7 @@ const SecondInstalmentUploadPage: React.FC = () => {
               </span>
             </$GridCell>
           </$Grid>
-          <hr css={{ marginTop: '6px', marginBottom: '6px' }} />
+          <hr style={{ marginTop: '6px', marginBottom: '6px' }} />
         </>
       )}
 

--- a/frontend/benefit/applicant/src/components/cookieConsent/CookieConsent.test.tsx
+++ b/frontend/benefit/applicant/src/components/cookieConsent/CookieConsent.test.tsx
@@ -45,7 +45,7 @@ jest.mock('hds-react', () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-    Button: actual.Button,
+    ...actual,
     CookieBanner: CookieBannerMock,
     CookieConsentContextProvider: CookieConsentContextProviderMock,
     CookieSettingsPage: CookieSettingsPageMock,

--- a/frontend/benefit/applicant/src/components/termsOfService/TermsOfService.tsx
+++ b/frontend/benefit/applicant/src/components/termsOfService/TermsOfService.tsx
@@ -68,7 +68,7 @@ const TermsOfService: React.FC<TermsOfServiceProps> = ({
           <$PageHeading>{t('common:serviceName')}</$PageHeading>
         </$GridCell>
         <$GridCell $colSpan={12}>
-          <h2 css={{ marginBottom: 0 }}>
+          <h2 style={{ marginBottom: 0 }}>
             {t('common:login.termsOfServiceHeader')}
           </h2>
         </$GridCell>

--- a/frontend/benefit/applicant/src/hooks/__tests__/useFormActions.test.tsx
+++ b/frontend/benefit/applicant/src/hooks/__tests__/useFormActions.test.tsx
@@ -59,19 +59,21 @@ describe('useFormActions - onQuietSave', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseRouter.mockReturnValue(mockRouter as any);
+    mockUseRouter.mockReturnValue(
+      mockRouter as unknown as ReturnType<typeof useRouter>
+    );
     mockUseCreateApplicationQuery.mockReturnValue({
       mutateAsync: mockCreateApplication,
       error: null,
-    } as any);
+    } as unknown as ReturnType<typeof useCreateApplicationQuery>);
     mockUseUpdateApplicationQuery.mockReturnValue({
       mutateAsync: mockUpdateApplication,
       error: null,
-    } as any);
+    } as unknown as ReturnType<typeof useUpdateApplicationQuery>);
     mockUseDeleteApplicationQuery.mockReturnValue({
       mutate: mockDeleteApplication,
       error: null,
-    } as any);
+    } as unknown as ReturnType<typeof useDeleteApplicationQuery>);
   });
 
   const wrapper = ({

--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationCalculator.tsx
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationCalculator.tsx
@@ -22,6 +22,7 @@ import {
   Fieldset,
   Notification,
   TextInput,
+  Tooltip,
 } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React, { useState } from 'react';
@@ -168,7 +169,7 @@ const AlterationCalculator = ({
     setCalculationRangeValid(true);
 
     if (!startDate || !endDate || startDate > endDate) {
-      formik.setFieldValue('recoveryAmount', '0');
+      void formik.setFieldValue('recoveryAmount', '0');
       setCalculationDescription(null);
       return;
     }
@@ -180,7 +181,7 @@ const AlterationCalculator = ({
       })
     ) {
       setCalculationRangeValid(false);
-      formik.setFieldValue('recoveryAmount', '0');
+      void formik.setFieldValue('recoveryAmount', '0');
       setCalculationDescription(null);
       setCalculationOutOfDate(false);
       return;
@@ -190,7 +191,7 @@ const AlterationCalculator = ({
       ? getNumberValue(formik.values?.manualRecoveryAmount || 0)
       : calculateAutomaticRecoveryAmount(startDate, endDate);
 
-    formik.setFieldValue('recoveryAmount', total.toFixed(2));
+    void formik.setFieldValue('recoveryAmount', total.toFixed(2));
     setCalculationDescription(
       t(`${translationBase}.calculation.resultDescription`, {
         months: diffMonths(endDate, startDate),
@@ -211,13 +212,13 @@ const AlterationCalculator = ({
   const handleChange =
     (field: string) =>
     (value: unknown): void => {
-      formik.setFieldValue(field, value);
+      void formik.setFieldValue(field, value);
       setCalculationOutOfDate(true);
       onCalculationChange(true);
     };
 
   const selectTab = (manualTab: boolean): void => {
-    formik.setFieldValue('isManual', manualTab);
+    void formik.setFieldValue('isManual', manualTab);
     setCalculationOutOfDate(true);
     onCalculationChange(true);
   };
@@ -261,9 +262,11 @@ const AlterationCalculator = ({
           <$GridCell $colSpan={6}>
             <Fieldset
               heading={t(`${translationBase}.fields.recoveryPeriod.label`)}
-              tooltipText={t(
-                `${translationBase}.fields.recoveryPeriod.helpText`
-              )}
+              tooltip={
+                <Tooltip>
+                  {t(`${translationBase}.fields.recoveryPeriod.helpText`)}
+                </Tooltip>
+              }
             >
               <$DateRange>
                 <DateInput

--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationCalculator.tsx
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationCalculator.tsx
@@ -266,7 +266,6 @@ const AlterationCalculator = ({
               )}
             >
               <$DateRange>
-                {/* @ts-expect-error TS2740: The HDS React DateInput has stricter type definitions for its props, causing TS2740. */}
                 <DateInput
                   label={t(`${translationBase}.fields.recoveryStartDate.label`)}
                   value={formik.values.recoveryStartDate}
@@ -285,7 +284,6 @@ const AlterationCalculator = ({
                   hideLabel
                 />
                 <$DateRangeSeparator aria-hidden>—</$DateRangeSeparator>
-                {/* @ts-expect-error TS2740: The HDS React DateInput has stricter type definitions for its props, causing TS2740. */}
                 <DateInput
                   label={t(`${translationBase}.fields.recoveryEndDate.label`)}
                   value={formik.values.recoveryEndDate}
@@ -312,7 +310,6 @@ const AlterationCalculator = ({
           {formik.values.isManual && (
             <>
               <$GridCell $colSpan={3}>
-                {/* @ts-expect-error TS2740: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
                 <TextInput
                   label={t(`${translationBase}.fields.recoveryAmount.label`)}
                   id="manual-recovery-amount"

--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationHandling.sc.ts
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationHandling.sc.ts
@@ -8,7 +8,7 @@ export const $PageHeading = styled.h1`
 `;
 
 type SectionProps = {
-  $headingBottomBorder: boolean;
+  $headingBottomBorder?: boolean;
   theme: DefaultTheme;
 };
 

--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationHandlingForm.tsx
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationHandlingForm.tsx
@@ -219,7 +219,6 @@ const AlterationHandlingForm = ({
         >
           <$Grid>
             <$GridCell $colSpan={8}>
-              {/* @ts-expect-error TS2740: The HDS React TextArea has stricter type definitions for its props, causing TS2740. */}
               <TextArea
                 label={
                   formik.values.isRecoverable

--- a/frontend/benefit/handler/src/components/alterationHandling/AlterationHandlingForm.tsx
+++ b/frontend/benefit/handler/src/components/alterationHandling/AlterationHandlingForm.tsx
@@ -173,7 +173,7 @@ const AlterationHandlingForm = ({
                   value="1"
                   onBlur={formik.handleBlur}
                   onChange={() => {
-                    formik.setFieldValue('isRecoverable', true);
+                    void formik.setFieldValue('isRecoverable', true);
                   }}
                   checked={formik.values.isRecoverable === true}
                 />
@@ -184,7 +184,7 @@ const AlterationHandlingForm = ({
                   value="0"
                   onBlur={formik.handleBlur}
                   onChange={() => {
-                    formik.setFieldValue('isRecoverable', false);
+                    void formik.setFieldValue('isRecoverable', false);
                   }}
                   checked={formik.values.isRecoverable === false}
                 />
@@ -235,7 +235,10 @@ const AlterationHandlingForm = ({
                 aria-invalid={!!getErrorMessage('recoveryJustification')}
                 errorText={getErrorMessage('recoveryJustification')}
                 onChange={(e) =>
-                  formik.setFieldValue('recoveryJustification', e.target.value)
+                  void formik.setFieldValue(
+                    'recoveryJustification',
+                    e.target.value
+                  )
                 }
                 onBlur={formik.handleBlur}
               />

--- a/frontend/benefit/handler/src/components/applicationForm/actionBar/ActionBarEdit.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/actionBar/ActionBarEdit.tsx
@@ -130,7 +130,6 @@ const ActionBarEdit: React.FC<ActionBarProps> = ({
                   </$GridCell>
                   <$GridCell $colSpan={12}>
                     <p>{t(`common:applications.dialog.edit.helperText`)}</p>
-                    {/* @ts-expect-error: HDS React TextArea has very strict prop requirements that are not necessary here. */}
                     <TextArea
                       id={fields.changeReason.name}
                       name={fields.changeReason.name}

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/FormContent.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/FormContent.tsx
@@ -147,7 +147,10 @@ const FormContent: React.FC<Props> = ({
               language={language}
               onBlur={formik.handleBlur}
               onChange={(value) =>
-                formik.setFieldValue(fields.paperApplicationDate.name, value)
+                void formik.setFieldValue(
+                  fields.paperApplicationDate.name,
+                  value
+                )
               }
               value={formik.values.paperApplicationDate ?? ''}
               invalid={!!getErrorMessage(fields.paperApplicationDate.name)}
@@ -270,7 +273,7 @@ const FormContent: React.FC<Props> = ({
                   `${translationsBase}.fields.${fields.associationImmediateManagerCheck.name}.no`
                 )}
                 onChange={() => {
-                  formik.setFieldValue(
+                  void formik.setFieldValue(
                     fields.associationImmediateManagerCheck.name,
                     false
                   );
@@ -288,7 +291,7 @@ const FormContent: React.FC<Props> = ({
                   `${translationsBase}.fields.${fields.associationImmediateManagerCheck.name}.yes`
                 )}
                 onChange={() =>
-                  formik.setFieldValue(
+                  void formik.setFieldValue(
                     fields.associationImmediateManagerCheck.name,
                     true
                   )
@@ -316,7 +319,7 @@ const FormContent: React.FC<Props> = ({
               value="false"
               label={t('common:utility.no')}
               onChange={() => {
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.otherFinancialSupportForEmployment.name,
                   false
                 );
@@ -331,7 +334,7 @@ const FormContent: React.FC<Props> = ({
               value="true"
               label={t('common:utility.yes')}
               onChange={() => {
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.otherFinancialSupportForEmployment.name,
                   true
                 );
@@ -356,11 +359,14 @@ const FormContent: React.FC<Props> = ({
               value="false"
               label={t('common:utility.no')}
               onChange={() => {
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.otherSubsidisedEmployed.name,
                   false
                 );
-                formik.setFieldValue(fields.otherSubsidisedNumber.name, null);
+                void formik.setFieldValue(
+                  fields.otherSubsidisedNumber.name,
+                  null
+                );
               }}
               checked={formik.values.otherSubsidisedEmployed === false}
             />
@@ -370,7 +376,10 @@ const FormContent: React.FC<Props> = ({
               value="true"
               label={t('common:utility.yes')}
               onChange={() => {
-                formik.setFieldValue(fields.otherSubsidisedEmployed.name, true);
+                void formik.setFieldValue(
+                  fields.otherSubsidisedEmployed.name,
+                  true
+                );
               }}
               checked={formik.values.otherSubsidisedEmployed === true}
             />
@@ -427,7 +436,7 @@ const FormContent: React.FC<Props> = ({
               label={fields.employee.workingHours.label}
               onBlur={formik.handleBlur}
               onChange={(e) =>
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.employee.workingHours.name,
                   stringFloatToFixed(e.target.value)
                 )
@@ -515,7 +524,7 @@ const FormContent: React.FC<Props> = ({
               label={fields.employee.monthlyPay.label}
               onBlur={formik.handleBlur}
               onChange={(e) =>
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.employee.monthlyPay.name,
                   stringFloatToFixed(e.target.value)
                 )
@@ -535,7 +544,7 @@ const FormContent: React.FC<Props> = ({
               label={fields.employee.vacationMoney.label}
               onBlur={formik.handleBlur}
               onChange={(e) =>
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.employee.vacationMoney.name,
                   stringFloatToFixed(e.target.value)
                 )
@@ -559,7 +568,7 @@ const FormContent: React.FC<Props> = ({
               label={fields.employee.otherExpenses.label}
               onBlur={formik.handleBlur}
               onChange={(e) =>
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.employee.otherExpenses.name,
                   stringFloatToFixed(e.target.value)
                 )
@@ -595,7 +604,10 @@ const FormContent: React.FC<Props> = ({
                 `${translationsBase}.fields.${fields.apprenticeshipProgram.name}.no`
               )}
               onChange={() => {
-                formik.setFieldValue(fields.apprenticeshipProgram.name, false);
+                void formik.setFieldValue(
+                  fields.apprenticeshipProgram.name,
+                  false
+                );
               }}
               checked={formik.values.apprenticeshipProgram === false}
             />
@@ -607,7 +619,10 @@ const FormContent: React.FC<Props> = ({
                 `${translationsBase}.fields.${fields.apprenticeshipProgram.name}.yes`
               )}
               onChange={() => {
-                formik.setFieldValue(fields.apprenticeshipProgram.name, true);
+                void formik.setFieldValue(
+                  fields.apprenticeshipProgram.name,
+                  true
+                );
               }}
               checked={formik.values.apprenticeshipProgram === true}
             />
@@ -630,7 +645,7 @@ const FormContent: React.FC<Props> = ({
             language={language}
             onBlur={formik.handleBlur}
             onChange={(value) =>
-              formik.setFieldValue(fields.startDate.name, value)
+              void formik.setFieldValue(fields.startDate.name, value)
             }
             value={formik.values.startDate ?? ''}
             invalid={!!getErrorMessage(fields.startDate.name)}
@@ -654,7 +669,7 @@ const FormContent: React.FC<Props> = ({
             language={language}
             onBlur={formik.handleBlur}
             onChange={(value) =>
-              formik.setFieldValue(fields.endDate.name, value)
+              void formik.setFieldValue(fields.endDate.name, value)
             }
             value={formik.values.endDate ?? ''}
             invalid={!!getErrorMessage(fields.endDate.name)}

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/FormContent.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/FormContent.tsx
@@ -1,7 +1,5 @@
 import { APPLICATION_START_DATE_WITHIN_MONTHS } from 'benefit/applicant/src/constants';
-import {
-  APPLICATION_START_DATE,
-} from 'benefit/handler/constants';
+import { APPLICATION_START_DATE } from 'benefit/handler/constants';
 import { useAlertBeforeLeaving } from 'benefit/handler/hooks/useAlertBeforeLeaving';
 import { useApplicationFormContext } from 'benefit/handler/hooks/useApplicationFormContext';
 import { useDependentFieldsEffect } from 'benefit/handler/hooks/useDependentFieldsEffect';
@@ -38,9 +36,7 @@ import {
 } from 'shared/components/forms/fields/Fields.sc';
 import Heading from 'shared/components/forms/heading/Heading';
 import FormSection from 'shared/components/forms/section/FormSection';
-import {
-  $GridCell,
-} from 'shared/components/forms/section/FormSection.sc';
+import { $GridCell } from 'shared/components/forms/section/FormSection.sc';
 import { BenefitAttachment } from 'shared/types/attachment';
 import {
   formatStringFloatValue,
@@ -144,7 +140,6 @@ const FormContent: React.FC<Props> = ({
             </$DateHeader>
           </$GridCell>
           <$GridCell $colStart={1} $colSpan={4}>
-            {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
             <DateInput
               id={fields.paperApplicationDate.name}
               name={fields.paperApplicationDate.name}
@@ -179,7 +174,6 @@ const FormContent: React.FC<Props> = ({
 
       <FormSection header={t(`${translationsBase}.headings.employment1`)}>
         <$GridCell $colSpan={3}>
-          {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
           <TextInput
             id={fields.employee.firstName.name}
             name={fields.employee.firstName.name}
@@ -194,7 +188,6 @@ const FormContent: React.FC<Props> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={3}>
-          {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
           <TextInput
             id={fields.employee.lastName.name}
             name={fields.employee.lastName.name}
@@ -209,7 +202,6 @@ const FormContent: React.FC<Props> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={2}>
-          {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
           <TextInput
             id={fields.employee.socialSecurityNumber.name}
             name={fields.employee.socialSecurityNumber.name}
@@ -368,10 +360,7 @@ const FormContent: React.FC<Props> = ({
                   fields.otherSubsidisedEmployed.name,
                   false
                 );
-                formik.setFieldValue(
-                  fields.otherSubsidisedNumber.name,
-                  null
-                );
+                formik.setFieldValue(fields.otherSubsidisedNumber.name, null);
               }}
               checked={formik.values.otherSubsidisedEmployed === false}
             />
@@ -396,7 +385,6 @@ const FormContent: React.FC<Props> = ({
                 padding-left: ${theme.spacing.m};
               `}
             >
-              {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
               <TextInput
                 id={fields.otherSubsidisedNumber.name}
                 name={fields.otherSubsidisedNumber.name}
@@ -419,7 +407,6 @@ const FormContent: React.FC<Props> = ({
       >
         <>
           <$GridCell $colSpan={4}>
-            {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
             <TextInput
               id={fields.employee.jobTitle.name}
               name={fields.employee.jobTitle.name}
@@ -434,7 +421,6 @@ const FormContent: React.FC<Props> = ({
             />
           </$GridCell>
           <$GridCell $colSpan={3}>
-            {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
             <TextInput
               id={fields.employee.workingHours.name}
               name={fields.employee.workingHours.name}
@@ -461,7 +447,6 @@ const FormContent: React.FC<Props> = ({
             </$HelpText>
           </$GridCell>
           <$GridCell $colSpan={3}>
-            {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
             <TextInput
               id={fields.employee.collectiveBargainingAgreement.name}
               name={fields.employee.collectiveBargainingAgreement.name}
@@ -489,7 +474,6 @@ const FormContent: React.FC<Props> = ({
           </$GridCell>
 
           <$GridCell $colSpan={12}>
-            {/* @ts-expect-error: The HDS React TextArea has stricter type definitions for its props, causing TS2740. */}
             <TextArea
               id={fields.roleOfEmployeeInOrganization.name}
               name={fields.roleOfEmployeeInOrganization.name}
@@ -525,7 +509,6 @@ const FormContent: React.FC<Props> = ({
           </$GridCell>
 
           <$GridCell $colSpan={2}>
-            {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
             <TextInput
               id={fields.employee.monthlyPay.name}
               name={fields.employee.monthlyPay.name}
@@ -546,7 +529,6 @@ const FormContent: React.FC<Props> = ({
             <$HelpText>{t(`${translationsBase}.eurosPerMonth`)}</$HelpText>
           </$GridCell>
           <$GridCell $colSpan={2}>
-            {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
             <TextInput
               id={fields.employee.vacationMoney.name}
               name={fields.employee.vacationMoney.name}
@@ -571,7 +553,6 @@ const FormContent: React.FC<Props> = ({
             <$HelpText>{t(`${translationsBase}.eurosPerMonth`)}</$HelpText>
           </$GridCell>
           <$GridCell $colSpan={2}>
-            {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
             <TextInput
               id={fields.employee.otherExpenses.name}
               name={fields.employee.otherExpenses.name}
@@ -641,7 +622,6 @@ const FormContent: React.FC<Props> = ({
           <$DateHeader>{t(`${translationsBase}.dateExplanation`)}</$DateHeader>
         </$GridCell>
         <$GridCell $colStart={1} $colSpan={6}>
-          {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
           <DateInput
             id={fields.startDate.name}
             name={fields.startDate.name}
@@ -665,7 +645,6 @@ const FormContent: React.FC<Props> = ({
           —
         </$GridCell>
         <$GridCell $colSpan={6}>
-          {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
           <DateInput
             id={fields.endDate.name}
             name={fields.endDate.name}

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/__tests__/useFormContent.test.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/__tests__/useFormContent.test.ts
@@ -1,0 +1,269 @@
+import '@testing-library/jest-dom';
+import '../../../../../test/i18n/i18n-test';
+
+import { renderHook } from '@testing-library/react';
+import {
+  APPLICATION_FIELD_KEYS,
+  SUPPORTED_LANGUAGES,
+} from 'benefit/handler/constants';
+import DeMinimisContext from 'benefit/handler/context/DeMinimisContext';
+import {
+  Application,
+  ApplicationFields,
+} from 'benefit/handler/types/application';
+import { EMPLOYEE_KEYS } from 'benefit-shared/constants';
+import { getErrorText } from 'benefit-shared/utils/forms';
+import { FormikProps } from 'formik';
+import React from 'react';
+import { getLanguageOptions } from 'shared/utils/common';
+
+import { useFormContent } from '../useFormContent';
+
+jest.mock('benefit-shared/utils/forms', () => ({
+  getErrorText: jest.fn(),
+}));
+
+jest.mock('shared/utils/common', () => ({
+  getLanguageOptions: jest.fn(() => [
+    { label: 'Suomi', value: 'fi' },
+    { label: 'English', value: 'en' },
+  ]),
+}));
+
+jest.mock('shared/hooks/useLocale', () => jest.fn(() => 'fi'));
+
+type UseFormContentResult = {
+  result: {
+    current: ReturnType<typeof useFormContent>;
+  };
+};
+
+const makeField = (name: string): { name: string } => ({ name });
+
+const mockFields = {
+  [APPLICATION_FIELD_KEYS.COMPANY_DEPARTMENT]: makeField('companyDepartment'),
+  [APPLICATION_FIELD_KEYS.ALTERNATIVE_COMPANY_STREET_ADDRESS]: makeField(
+    'alternativeCompanyStreetAddress'
+  ),
+  [APPLICATION_FIELD_KEYS.ALTERNATIVE_COMPANY_POSTCODE]: makeField(
+    'alternativeCompanyPostcode'
+  ),
+  [APPLICATION_FIELD_KEYS.ALTERNATIVE_COMPANY_CITY]: makeField(
+    'alternativeCompanyCity'
+  ),
+  [APPLICATION_FIELD_KEYS.DE_MINIMIS_AID]: makeField('deMinimisAid'),
+  [APPLICATION_FIELD_KEYS.BENEFIT_TYPE]: makeField('benefitType'),
+  [APPLICATION_FIELD_KEYS.START_DATE]: makeField('startDate'),
+  [APPLICATION_FIELD_KEYS.END_DATE]: makeField('endDate'),
+  [APPLICATION_FIELD_KEYS.EMPLOYEE]: {
+    [EMPLOYEE_KEYS.COMMISSION_DESCRIPTION]: makeField('commissionDescription'),
+    [EMPLOYEE_KEYS.EMPLOYEE_COMMISSION_AMOUNT]: makeField('commissionAmount'),
+    [EMPLOYEE_KEYS.JOB_TITLE]: makeField('jobTitle'),
+    [EMPLOYEE_KEYS.WORKING_HOURS]: makeField('workingHours'),
+    [EMPLOYEE_KEYS.COLLECTIVE_BARGAINING_AGREEMENT]: makeField(
+      'collectiveBargainingAgreement'
+    ),
+    [EMPLOYEE_KEYS.MONTHLY_PAY]: makeField('monthlyPay'),
+    [EMPLOYEE_KEYS.OTHER_EXPENSES]: makeField('otherExpenses'),
+    [EMPLOYEE_KEYS.VACATION_MONEY]: makeField('vacationMoney'),
+  },
+} as unknown as ApplicationFields;
+
+const mockSetFieldValue = jest.fn();
+const mockSetDeMinimisAids = jest.fn();
+
+const makeFormik = (
+  values: Partial<Application> = {}
+): FormikProps<Partial<Application>> =>
+  ({
+    touched: {},
+    errors: {},
+    values,
+    setFieldValue: mockSetFieldValue,
+  } as unknown as FormikProps<Partial<Application>>);
+
+const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element =>
+  React.createElement(
+    DeMinimisContext.Provider,
+    {
+      value: {
+        deMinimisAids: [],
+        setDeMinimisAids: mockSetDeMinimisAids,
+        unfinishedDeMinimisAidRow: false,
+        setUnfinishedDeMinimisAidRow: jest.fn(),
+      },
+    },
+    children
+  );
+
+const setup = (values: Partial<Application> = {}): UseFormContentResult =>
+  renderHook(() => useFormContent(makeFormik(values), mockFields), {
+    wrapper,
+  }) as UseFormContentResult;
+
+// Formats a Date as d.M.yyyy for formik values
+const toDateString = (date: Date): string =>
+  `${date.getDate()}.${date.getMonth() + 1}.${date.getFullYear()}`;
+
+const monthsAgo = (n: number): Date => {
+  const d = new Date();
+  d.setMonth(d.getMonth() - n);
+  return d;
+};
+
+describe('useFormContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns static values correctly', () => {
+    const { result } = setup();
+
+    expect(result.current.translationsBase).toBe(
+      'common:applications.sections'
+    );
+    expect(result.current.cbPrefix).toBe('application_consent');
+    expect(result.current.language).toBe(SUPPORTED_LANGUAGES.FI);
+    expect(result.current.textLocale).toBe('Fi');
+  });
+
+  it('returns languageOptions from getLanguageOptions', () => {
+    const { result } = setup();
+
+    expect(getLanguageOptions).toHaveBeenCalled();
+    expect(result.current.languageOptions).toEqual([
+      { label: 'Suomi', value: 'fi' },
+      { label: 'English', value: 'en' },
+    ]);
+  });
+
+  it('returns dateInputLimits with min ~1 year ago and max ~2 years ahead', () => {
+    const { result } = setup();
+    const now = new Date();
+    const { min, max } = result.current.dateInputLimits;
+
+    expect(min.getFullYear()).toBe(now.getFullYear() - 1);
+    expect(max.getFullYear()).toBe(now.getFullYear() + 2);
+  });
+
+  it('clearAlternativeAddressValues clears all alternative address fields', () => {
+    const { result } = setup();
+
+    result.current.clearAlternativeAddressValues();
+
+    expect(mockSetFieldValue).toHaveBeenCalledWith('companyDepartment', '');
+    expect(mockSetFieldValue).toHaveBeenCalledWith(
+      'alternativeCompanyStreetAddress',
+      ''
+    );
+    expect(mockSetFieldValue).toHaveBeenCalledWith(
+      'alternativeCompanyPostcode',
+      ''
+    );
+    expect(mockSetFieldValue).toHaveBeenCalledWith(
+      'alternativeCompanyCity',
+      ''
+    );
+  });
+
+  it('clearDeminimisAids resets context and clears the field', () => {
+    const { result } = setup();
+
+    result.current.clearDeminimisAids();
+
+    expect(mockSetDeMinimisAids).toHaveBeenCalledWith([]);
+    expect(mockSetFieldValue).toHaveBeenCalledWith('deMinimisAid', null);
+  });
+
+  it('clearCommissionValues clears commission description and amount', () => {
+    const { result } = setup();
+
+    result.current.clearCommissionValues();
+
+    expect(mockSetFieldValue).toHaveBeenCalledWith('commissionDescription', '');
+    expect(mockSetFieldValue).toHaveBeenCalledWith('commissionAmount', '');
+  });
+
+  it('clearContractValues clears all contract-related employee fields', () => {
+    const { result } = setup();
+
+    result.current.clearContractValues();
+
+    expect(mockSetFieldValue).toHaveBeenCalledWith('jobTitle', '');
+    expect(mockSetFieldValue).toHaveBeenCalledWith('workingHours', '');
+    expect(mockSetFieldValue).toHaveBeenCalledWith(
+      'collectiveBargainingAgreement',
+      ''
+    );
+    expect(mockSetFieldValue).toHaveBeenCalledWith('monthlyPay', '');
+    expect(mockSetFieldValue).toHaveBeenCalledWith('otherExpenses', '');
+    expect(mockSetFieldValue).toHaveBeenCalledWith('vacationMoney', '');
+  });
+
+  it('clearDatesValues clears start and end date fields', () => {
+    const { result } = setup();
+
+    result.current.clearDatesValues();
+
+    expect(mockSetFieldValue).toHaveBeenCalledWith('startDate', '');
+    expect(mockSetFieldValue).toHaveBeenCalledWith('endDate', '');
+  });
+
+  it('clearBenefitValues sets benefitType to null', () => {
+    const { result } = setup();
+
+    result.current.clearBenefitValues();
+
+    expect(mockSetFieldValue).toHaveBeenCalledWith('benefitType', null);
+  });
+
+  it('getErrorMessage delegates to getErrorText', () => {
+    (getErrorText as jest.Mock).mockReturnValue('some error');
+    const { result } = setup();
+
+    const error = result.current.getErrorMessage('startDate');
+
+    expect(getErrorText).toHaveBeenCalledWith(
+      {},
+      {},
+      'startDate',
+      expect.any(Function),
+      false
+    );
+    expect(error).toBe('some error');
+  });
+
+  describe('displayPastApplicationDatesWarning', () => {
+    it('returns false when dates are missing', () => {
+      const { result } = setup();
+      expect(result.current.displayPastApplicationDatesWarning()).toBe(false);
+    });
+
+    it('returns false when only startDate is provided', () => {
+      const { result } = setup({ startDate: '1.1.2025' });
+      expect(result.current.displayPastApplicationDatesWarning()).toBe(false);
+    });
+
+    it('returns false when both dates are within the 4-month threshold', () => {
+      const recent = toDateString(monthsAgo(1));
+      const { result } = setup({ startDate: recent, endDate: recent });
+      expect(result.current.displayPastApplicationDatesWarning()).toBe(false);
+    });
+
+    it('returns true when startDate is more than 4 months ago', () => {
+      const { result } = setup({
+        startDate: toDateString(monthsAgo(5)),
+        endDate: toDateString(monthsAgo(1)),
+      });
+      expect(result.current.displayPastApplicationDatesWarning()).toBe(true);
+    });
+
+    it('returns true when endDate is more than 4 months ago', () => {
+      const { result } = setup({
+        startDate: toDateString(monthsAgo(1)),
+        endDate: toDateString(monthsAgo(5)),
+      });
+      expect(result.current.displayPastApplicationDatesWarning()).toBe(true);
+    });
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/companySection/CompanySection.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/companySection/CompanySection.tsx
@@ -5,10 +5,14 @@ import {
   ApplicationFields,
 } from 'benefit/handler/types/application';
 import { ATTACHMENT_TYPES, ORGANIZATION_TYPES } from 'benefit-shared/constants';
-import { ApplicationData, DeMinimisAid } from 'benefit-shared/types/application';
+import {
+  ApplicationData,
+  DeMinimisAid,
+} from 'benefit-shared/types/application';
 import { FormikProps } from 'formik';
 import {
   IconCheckCircleFill,
+  Option as SelectOption,
   Select,
   SelectionGroup,
   TextArea,
@@ -178,7 +182,6 @@ const CompanySection: React.FC<Props> = ({
         {formik.values.useAlternativeAddress && (
           <$GridCell as={$Grid} $colSpan={12}>
             <$GridCell $colSpan={4}>
-              {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
               <TextInput
                 id={fields.companyDepartment.name}
                 name={fields.companyDepartment.name}
@@ -193,7 +196,6 @@ const CompanySection: React.FC<Props> = ({
               />
             </$GridCell>
             <$GridCell $colStart={1} $colSpan={4}>
-              {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
               <TextInput
                 id={fields.alternativeCompanyStreetAddress.name}
                 name={fields.alternativeCompanyStreetAddress.name}
@@ -215,7 +217,6 @@ const CompanySection: React.FC<Props> = ({
               />
             </$GridCell>
             <$GridCell $colSpan={4}>
-              {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
               <TextInput
                 id={fields.alternativeCompanyPostcode.name}
                 name={fields.alternativeCompanyPostcode.name}
@@ -237,7 +238,6 @@ const CompanySection: React.FC<Props> = ({
               />
             </$GridCell>
             <$GridCell $colSpan={4}>
-              {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
               <TextInput
                 id={fields.alternativeCompanyCity.name}
                 name={fields.alternativeCompanyCity.name}
@@ -267,7 +267,7 @@ const CompanySection: React.FC<Props> = ({
               const value =
                 fields.companyBankAccountNumber.mask?.stripVal(initValue) ??
                 initValue;
-              return formik.setFieldValue(
+              void formik.setFieldValue(
                 fields.companyBankAccountNumber.name,
                 value
               );
@@ -275,7 +275,6 @@ const CompanySection: React.FC<Props> = ({
           >
             {
               (() => (
-                // @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here.
                 <TextInput
                   id={fields.companyBankAccountNumber.name}
                   name={fields.companyBankAccountNumber.name}
@@ -315,7 +314,7 @@ const CompanySection: React.FC<Props> = ({
                   `${translationsBase}.fields.${fields.associationHasBusinessActivities.name}.no`
                 )}
                 onChange={() => {
-                  formik.setFieldValue(
+                  void formik.setFieldValue(
                     fields.associationHasBusinessActivities.name,
                     false
                   );
@@ -333,7 +332,7 @@ const CompanySection: React.FC<Props> = ({
                   `${translationsBase}.fields.${fields.associationHasBusinessActivities.name}.yes`
                 )}
                 onChange={() =>
-                  formik.setFieldValue(
+                  void formik.setFieldValue(
                     fields.associationHasBusinessActivities.name,
                     true
                   )
@@ -346,16 +345,15 @@ const CompanySection: React.FC<Props> = ({
           </$GridCell>
         )}
         <$GridCell $colSpan={8} $colStart={1}>
-          {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
           <TextInput
             id={fields.companyNumberOfEmployees.name}
             name={fields.companyNumberOfEmployees.name}
             label={fields.companyNumberOfEmployees.label}
             onBlur={formik.handleBlur}
             onChange={(event) => {
-              formik.setFieldValue(
+              void formik.setFieldValue(
                 fields.companyNumberOfEmployees.name,
-                event.target.value.replace(/\D/g, '')
+                event.target.value.replaceAll(/\D/g, '')
               );
             }}
             value={String(formik.values.companyNumberOfEmployees ?? '')}
@@ -368,7 +366,6 @@ const CompanySection: React.FC<Props> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={12}>
-          {/* @ts-expect-error: The HDS React TextArea has stricter type definitions for its props, causing TS2740. */}
           <TextArea
             id={fields.companyBusinessBrief.name}
             name={fields.companyBusinessBrief.name}
@@ -405,7 +402,7 @@ const CompanySection: React.FC<Props> = ({
                 `${translationsBase}.fields.${APPLICATION_FIELD_KEYS.PURCHASED_SERVICE}.no`
               )}
               onChange={() => {
-                formik.setFieldValue(fields.purchasedService.name, false);
+                void formik.setFieldValue(fields.purchasedService.name, false);
               }}
               // 3 states: null (none is selected), true, false
               checked={formik.values.purchasedService === false}
@@ -427,7 +424,6 @@ const CompanySection: React.FC<Props> = ({
       </FormSection>
       <FormSection header={t(`${translationsBase}.headings.company2`)}>
         <$GridCell $colSpan={4}>
-          {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
           <TextInput
             id={fields.companyContactPersonFirstName.name}
             name={fields.companyContactPersonFirstName.name}
@@ -449,7 +445,6 @@ const CompanySection: React.FC<Props> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={4}>
-          {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
           <TextInput
             id={fields.companyContactPersonLastName.name}
             name={fields.companyContactPersonLastName.name}
@@ -471,7 +466,6 @@ const CompanySection: React.FC<Props> = ({
           />
         </$GridCell>
         <$GridCell $colStart={1} $colSpan={4}>
-          {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
           <TextInput
             id={fields.companyContactPersonPhoneNumber.name}
             name={fields.companyContactPersonPhoneNumber.name}
@@ -493,7 +487,6 @@ const CompanySection: React.FC<Props> = ({
           />
         </$GridCell>
         <$GridCell $colSpan={4}>
-          {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
           <TextInput
             id={fields.companyContactPersonEmail.name}
             name={fields.companyContactPersonEmail.name}
@@ -513,19 +506,17 @@ const CompanySection: React.FC<Props> = ({
         <$GridCell $colSpan={3}>
           <Select
             texts={languageTexts}
-            onChange={(lang: Option[]) =>
-              formik.setFieldValue(fields.applicantLanguage.name, lang[0].value)
-            }
-            options={languageOptions}
+            onChange={(lang: Option[]) => {
+              void formik.setFieldValue(
+                fields.applicantLanguage.name,
+                lang[0]?.value
+              );
+            }}
+            options={languageOptions as SelectOption[]}
             id={fields.applicantLanguage.name}
             invalid={!!getErrorMessage(fields.applicantLanguage.name)}
             aria-invalid={!!getErrorMessage(fields.applicantLanguage.name)}
-            value={[
-              formik.values.applicantLanguage ?? {
-                label: 'Suomi',
-                value: 'fi',
-              },
-            ].filter(Boolean)}
+            value={[formik.values.applicantLanguage ?? 'fi'].filter(Boolean)}
             required
           />
         </$GridCell>
@@ -548,7 +539,7 @@ const CompanySection: React.FC<Props> = ({
                   `${translationsBase}.fields.${APPLICATION_FIELD_KEYS.DE_MINIMIS_AID}.no`
                 )}
                 onChange={() => {
-                  formik.setFieldValue(fields.deMinimisAid.name, false);
+                  void formik.setFieldValue(fields.deMinimisAid.name, false);
                   setDeMinimisAids([]);
                 }}
                 // 3 states: null (none is selected), true, false
@@ -562,7 +553,7 @@ const CompanySection: React.FC<Props> = ({
                   `${translationsBase}.fields.${APPLICATION_FIELD_KEYS.DE_MINIMIS_AID}.yes`
                 )}
                 onChange={() =>
-                  formik.setFieldValue(fields.deMinimisAid.name, true)
+                  void formik.setFieldValue(fields.deMinimisAid.name, true)
                 }
                 checked={formik.values.deMinimisAid === true}
               />
@@ -594,11 +585,11 @@ const CompanySection: React.FC<Props> = ({
                 `${translationsBase}.fields.${APPLICATION_FIELD_KEYS.CO_OPERATION_NEGOTIATIONS}.no`
               )}
               onChange={() => {
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   fields.coOperationNegotiations.name,
                   false
                 );
-                formik.setFieldValue(
+                void formik.setFieldValue(
                   APPLICATION_FIELD_KEYS.CO_OPERATION_NEGOTIATIONS_DESCRIPTION,
                   ''
                 );
@@ -613,7 +604,10 @@ const CompanySection: React.FC<Props> = ({
                 `${translationsBase}.fields.${APPLICATION_FIELD_KEYS.CO_OPERATION_NEGOTIATIONS}.yes`
               )}
               onChange={() =>
-                formik.setFieldValue(fields.coOperationNegotiations.name, true)
+                void formik.setFieldValue(
+                  fields.coOperationNegotiations.name,
+                  true
+                )
               }
               checked={formik.values.coOperationNegotiations === true}
             />
@@ -626,7 +620,6 @@ const CompanySection: React.FC<Props> = ({
               margin-top: ${theme.spacing.s};
             `}
           >
-            {/* @ts-expect-error: HDS React TextArea has very strict prop requirements that are not necessary here. */}
             <TextArea
               id={fields.coOperationNegotiationsDescription.name}
               name={fields.coOperationNegotiationsDescription.name}

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/companySection/deMinimisAid/DeMinimisAidForm.tsx
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/companySection/deMinimisAid/DeMinimisAidForm.tsx
@@ -94,7 +94,6 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
         bgVerticalPadding
       >
         <$GridCell $colSpan={4}>
-          {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
           <TextInput
             id={fields.granter.name}
             name={fields.granter.name}
@@ -110,7 +109,6 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
           />
         </$GridCell>
         <$GridCell $colSpan={2}>
-          {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
           <TextInput
             id={fields.amount.name}
             name={fields.amount.name}
@@ -131,7 +129,6 @@ const DeMinimisAidForm: React.FC<DeMinimisAidFormProps> = ({ data }) => {
           />
         </$GridCell>
         <$GridCell $colSpan={2}>
-          {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
           <DateInput
             id={fields.grantedAt.name}
             name={fields.grantedAt.name}

--- a/frontend/benefit/handler/src/components/applicationForm/formContent/useFormContent.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/formContent/useFormContent.ts
@@ -57,10 +57,10 @@ const useFormContent = (
     getErrorText(errors, touched, fieldName, t, false);
 
   const clearAlternativeAddressValues = React.useCallback((): void => {
-    setFieldValue(fields.companyDepartment.name, '');
-    setFieldValue(fields.alternativeCompanyStreetAddress.name, '');
-    setFieldValue(fields.alternativeCompanyPostcode.name, '');
-    setFieldValue(fields.alternativeCompanyCity.name, '');
+    void setFieldValue(fields.companyDepartment.name, '');
+    void setFieldValue(fields.alternativeCompanyStreetAddress.name, '');
+    void setFieldValue(fields.alternativeCompanyPostcode.name, '');
+    void setFieldValue(fields.alternativeCompanyCity.name, '');
   }, [
     fields.companyDepartment.name,
     fields.alternativeCompanyStreetAddress.name,
@@ -71,12 +71,12 @@ const useFormContent = (
 
   const clearDeminimisAids = React.useCallback((): void => {
     setDeMinimisAids([]);
-    setFieldValue(fields.deMinimisAid.name, null);
+    void setFieldValue(fields.deMinimisAid.name, null);
   }, [fields.deMinimisAid.name, setDeMinimisAids, setFieldValue]);
 
   const clearCommissionValues = React.useCallback((): void => {
-    setFieldValue(fields.employee.commissionDescription.name, '');
-    setFieldValue(fields.employee.commissionAmount.name, '');
+    void setFieldValue(fields.employee.commissionDescription.name, '');
+    void setFieldValue(fields.employee.commissionAmount.name, '');
   }, [
     fields.employee.commissionDescription.name,
     fields.employee.commissionAmount.name,
@@ -84,12 +84,12 @@ const useFormContent = (
   ]);
 
   const clearContractValues = React.useCallback((): void => {
-    setFieldValue(fields.employee.jobTitle.name, '');
-    setFieldValue(fields.employee.workingHours.name, '');
-    setFieldValue(fields.employee.collectiveBargainingAgreement.name, '');
-    setFieldValue(fields.employee.monthlyPay.name, '');
-    setFieldValue(fields.employee.otherExpenses.name, '');
-    setFieldValue(fields.employee.vacationMoney.name, '');
+    void setFieldValue(fields.employee.jobTitle.name, '');
+    void setFieldValue(fields.employee.workingHours.name, '');
+    void setFieldValue(fields.employee.collectiveBargainingAgreement.name, '');
+    void setFieldValue(fields.employee.monthlyPay.name, '');
+    void setFieldValue(fields.employee.otherExpenses.name, '');
+    void setFieldValue(fields.employee.vacationMoney.name, '');
   }, [
     fields.employee.jobTitle.name,
     fields.employee.workingHours.name,
@@ -101,12 +101,12 @@ const useFormContent = (
   ]);
 
   const clearDatesValues = React.useCallback((): void => {
-    setFieldValue(fields.startDate.name, '');
-    setFieldValue(fields.endDate.name, '');
+    void setFieldValue(fields.startDate.name, '');
+    void setFieldValue(fields.endDate.name, '');
   }, [fields.startDate.name, fields.endDate.name, setFieldValue]);
 
   const clearBenefitValues = React.useCallback((): void => {
-    setFieldValue(fields.benefitType.name, null);
+    void setFieldValue(fields.benefitType.name, null);
   }, [fields.benefitType.name, setFieldValue]);
 
   const displayPastApplicationDatesWarning = (): boolean => {

--- a/frontend/benefit/handler/src/components/applicationForm/reviewChanges/ReviewEditChanges.sc.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/reviewChanges/ReviewEditChanges.sc.ts
@@ -52,9 +52,9 @@ export const $ChangeSetHeader = styled.div`
   }
   span:last-child {
     font-size: 0.9em;
-    color: ${(props: $ChangeSetProps) => props.theme.colors.black50};
+    color: ${({ theme }) => theme.colors.black50};
   }
-  margin-bottom: ${(props: $ChangeSetProps) => props.theme.spacing.s};
+  margin-bottom: ${({ theme }) => theme.spacing.s};
 `;
 
 export const $ChangeSetFooter = styled.div``;

--- a/frontend/benefit/handler/src/components/applicationForm/useApplicationForm.ts
+++ b/frontend/benefit/handler/src/components/applicationForm/useApplicationForm.ts
@@ -26,7 +26,6 @@ import {
   DeMinimisAid,
 } from 'benefit-shared/types/application';
 import { FormikErrors, FormikProps, useFormik } from 'formik';
-import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 import { NextRouter, useRouter } from 'next/router';
 import { TFunction, useTranslation } from 'next-i18next';
@@ -166,7 +165,7 @@ export const useApplicationForm = (): ExtendedComponentProps => {
       !isEqual(formik.values.attachments, application.attachments)
     ) {
       const applicationWithUpdatedAttachments = {
-        ...cloneDeep(formik.values),
+        ...structuredClone(formik.values),
         attachments: getApplication(data).attachments,
       };
       setApplication(applicationWithUpdatedAttachments);
@@ -175,8 +174,8 @@ export const useApplicationForm = (): ExtendedComponentProps => {
     // Set initial application data to formik and to review changes on submit
     if (data && initialApplication === null) {
       const app = getApplication(data);
-      setApplication(cloneDeep(app));
-      setInitialApplication(cloneDeep(app));
+      setApplication(structuredClone(app));
+      setInitialApplication(structuredClone(app));
     }
 
     if (applicationDataError) {

--- a/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
+++ b/frontend/benefit/handler/src/components/applicationList/ApplicationListForInstalments.tsx
@@ -167,9 +167,7 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
             String(secondInstalment?.amountAfterRecoveries || 0)
           );
           return amountAfterRecoveries > 0 ? (
-            <>
-              {formatFloatToEvenEuros(Math.max(0, amountAfterRecoveries))}
-            </>
+            <>{formatFloatToEvenEuros(Math.max(0, amountAfterRecoveries))}</>
           ) : (
             <$Wrapper>
               <$Column>
@@ -324,7 +322,6 @@ const ApplicationListForInstalments: React.FC<ApplicationListProps> = ({
               )}
             />
             <Dialog.Content>
-              {/* @ts-expect-error -- HDS DateInput types are overly strict with TS 5.9 */}
               <DateInput
                 id="instalment-change-date-dateinput"
                 label={t(

--- a/frontend/benefit/handler/src/components/applicationReports/ApplicationReports.tsx
+++ b/frontend/benefit/handler/src/components/applicationReports/ApplicationReports.tsx
@@ -50,7 +50,6 @@ const ApplicationReports: React.FC = () => {
           />
         </$GridCell>
         <$GridCell $colSpan={3}>
-          {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
           <DateInput
             id={`${t(`${translationsBase}.fields.endDate`)}`}
             name={`${t(`${translationsBase}.fields.endDate`)}`}

--- a/frontend/benefit/handler/src/components/applicationReports/__tests__/useApplicationReports.test.ts
+++ b/frontend/benefit/handler/src/components/applicationReports/__tests__/useApplicationReports.test.ts
@@ -1,0 +1,235 @@
+import { renderHook } from '@testing-library/react';
+import {
+  EXPORT_APPLICATIONS_IN_TIME_RANGE_FORM_KEYS,
+  EXPORT_APPLICATIONS_ROUTES,
+} from 'benefit/handler/constants';
+import { BackendEndpoint } from 'benefit-shared/backend-api/backend-api';
+import { PROPOSALS_FOR_DECISION } from 'benefit-shared/constants';
+import { useQueryClient } from 'react-query';
+
+import { useApplicationReports } from '../useApplicationReports';
+
+const mockAxiosGet = jest.fn();
+const mockHandleResponse = jest.fn();
+const mockInvalidateQueries = jest.fn();
+const mockDownloadFile = jest.fn();
+const mockUseReportsApplicationBatchesQuery = jest.fn();
+const mockConvertToBackendDateFormat = jest.fn();
+const mockConvertToUIDateFormat = jest.fn();
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+jest.mock('styled-components', () => ({
+  useTheme: () => ({
+    colors: { primary: '#000' },
+  }),
+}));
+jest.mock('shared/hooks/useLocale', () => ({
+  __esModule: true,
+  default: () => 'fi',
+}));
+jest.mock('benefit/handler/hooks/useReportsApplicationBatchesQuery', () => ({
+  __esModule: true,
+  default: (proposalForDecision: PROPOSALS_FOR_DECISION) =>
+    mockUseReportsApplicationBatchesQuery(proposalForDecision),
+  getReportsApplicationBatchesQueryKey: (proposal: string) => [
+    `reports-${proposal}`,
+  ],
+}));
+jest.mock('shared/hooks/useBackendAPI', () => ({
+  __esModule: true,
+  default: () => ({
+    axios: {
+      get: mockAxiosGet,
+    },
+    handleResponse: mockHandleResponse,
+  }),
+}));
+jest.mock('react-query', () => ({
+  useQueryClient: jest.fn(() => ({
+    invalidateQueries: mockInvalidateQueries,
+  })),
+}));
+jest.mock('shared/utils/file.utils', () => ({
+  downloadFile: (...args: unknown[]) => mockDownloadFile(...args),
+}));
+jest.mock('shared/utils/date.utils', () => ({
+  convertToBackendDateFormat: (value: string) =>
+    mockConvertToBackendDateFormat(value),
+  convertToUIDateFormat: (value: string) => mockConvertToUIDateFormat(value),
+}));
+
+describe('useApplicationReports', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockAxiosGet.mockResolvedValue('mock-file-content');
+    mockHandleResponse.mockImplementation(async (value: Promise<string>) =>
+      value instanceof Promise ? value : Promise.resolve(value)
+    );
+    mockUseReportsApplicationBatchesQuery.mockImplementation(() => ({
+      data: [],
+    }));
+    mockConvertToBackendDateFormat.mockImplementation(
+      (value: string) => `backend:${value}`
+    );
+    mockConvertToUIDateFormat.mockImplementation(
+      (value: string) => `ui:${value}`
+    );
+  });
+
+  it('should return object with all expected properties', () => {
+    const { result } = renderHook(() => useApplicationReports());
+
+    expect(result.current).toBeDefined();
+    expect(result.current.t).toBeDefined();
+    expect(result.current.translationsBase).toBe('common:reports');
+    expect(result.current.theme).toBeDefined();
+    expect(result.current.language).toBe('fi');
+    expect(result.current.exportApplications).toBeDefined();
+    expect(result.current.formik).toBeDefined();
+    expect(result.current.fields).toBeDefined();
+    expect(result.current.exportApplicationsInTimeRange).toBeDefined();
+    expect(result.current.lastAcceptedApplicationsExportDate).toBeDefined();
+    expect(result.current.lastRejectedApplicationsExportDate).toBeDefined();
+  });
+
+  it('should initialize formik with empty date fields', () => {
+    const { result } = renderHook(() => useApplicationReports());
+
+    expect(result.current.formik.values.startDate).toBe('');
+    expect(result.current.formik.values.endDate).toBe('');
+  });
+
+  it('should create fields for all form keys', () => {
+    const { result } = renderHook(() => useApplicationReports());
+
+    Object.values(EXPORT_APPLICATIONS_IN_TIME_RANGE_FORM_KEYS).forEach(
+      (fieldName) => {
+        expect(result.current.fields[fieldName]).toBeDefined();
+        expect(result.current.fields[fieldName].name).toBe(fieldName);
+        expect(result.current.fields[fieldName].label).toBeDefined();
+        expect(result.current.fields[fieldName].placeholder).toBeDefined();
+      }
+    );
+  });
+
+  it('should have exportApplications as function', () => {
+    const { result } = renderHook(() => useApplicationReports());
+
+    expect(typeof result.current.exportApplications).toBe('function');
+  });
+
+  it('should have exportApplicationsInTimeRange as function', () => {
+    const { result } = renderHook(() => useApplicationReports());
+
+    expect(typeof result.current.exportApplicationsInTimeRange).toBe(
+      'function'
+    );
+  });
+
+  it('should return empty export dates when batch data is empty', () => {
+    const { result } = renderHook(() => useApplicationReports());
+
+    expect(result.current.lastAcceptedApplicationsExportDate).toBe('');
+    expect(result.current.lastRejectedApplicationsExportDate).toBe('');
+  });
+
+  it('should return converted latest accepted and rejected export dates', () => {
+    mockUseReportsApplicationBatchesQuery.mockImplementation(
+      (proposalForDecision: PROPOSALS_FOR_DECISION) => ({
+        data:
+          proposalForDecision === PROPOSALS_FOR_DECISION.ACCEPTED
+            ? [{ created_at: '2024-01-01' }, { created_at: '2024-03-15' }]
+            : [{ created_at: '2024-02-20' }],
+      })
+    );
+
+    const { result } = renderHook(() => useApplicationReports());
+
+    expect(mockConvertToUIDateFormat).toHaveBeenCalledWith('2024-03-15');
+    expect(mockConvertToUIDateFormat).toHaveBeenCalledWith('2024-02-20');
+    expect(result.current.lastAcceptedApplicationsExportDate).toBe(
+      'ui:2024-03-15'
+    );
+    expect(result.current.lastRejectedApplicationsExportDate).toBe(
+      'ui:2024-02-20'
+    );
+  });
+
+  it('should export applications and invalidate matching batch query', async () => {
+    const { result } = renderHook(() => useApplicationReports());
+
+    await result.current.exportApplications(
+      'csv/pdf',
+      EXPORT_APPLICATIONS_ROUTES.ACCEPTED,
+      PROPOSALS_FOR_DECISION.ACCEPTED
+    );
+
+    expect(mockAxiosGet).toHaveBeenCalledWith(
+      `${BackendEndpoint.HANDLER_APPLICATIONS}${EXPORT_APPLICATIONS_ROUTES.ACCEPTED}_csv_pdf/`,
+      { responseType: 'arraybuffer' }
+    );
+    expect(mockDownloadFile).toHaveBeenCalledWith(
+      'mock-file-content',
+      'csv/pdf'
+    );
+    expect(mockInvalidateQueries).toHaveBeenCalledWith([
+      `reports-${PROPOSALS_FOR_DECISION.ACCEPTED}`,
+    ]);
+  });
+
+  it('should export applications in time range with converted date params', async () => {
+    const { result, rerender } = renderHook(() => useApplicationReports());
+
+    result.current.formik.setValues({
+      startDate: '01.03.2024',
+      endDate: '31.03.2024',
+    });
+
+    rerender();
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await result.current.exportApplicationsInTimeRange('csv', true);
+
+    expect(mockConvertToBackendDateFormat).toHaveBeenCalledWith('01.03.2024');
+    expect(mockConvertToBackendDateFormat).toHaveBeenCalledWith('31.03.2024');
+    expect(mockAxiosGet).toHaveBeenCalledWith(
+      `${BackendEndpoint.HANDLER_APPLICATIONS}${EXPORT_APPLICATIONS_ROUTES.IN_TIME_RANGE}/`,
+      {
+        params: {
+          handled_at_after: 'backend:01.03.2024',
+          handled_at_before: 'backend:31.03.2024',
+          compact_list: true,
+        },
+      }
+    );
+    expect(mockDownloadFile).toHaveBeenCalledWith('mock-file-content', 'csv');
+  });
+
+  it('should have correct export applications routes available', () => {
+    const { result } = renderHook(() => useApplicationReports());
+
+    expect(result.current).toBeDefined();
+    // Routes are constants and should match expected values
+    expect(EXPORT_APPLICATIONS_ROUTES.IN_TIME_RANGE).toBeDefined();
+  });
+
+  it('should have proposal for decision constants available', () => {
+    const { result } = renderHook(() => useApplicationReports());
+
+    expect(result.current).toBeDefined();
+    // Constants should be available
+    expect(PROPOSALS_FOR_DECISION.ACCEPTED).toBeDefined();
+    expect(PROPOSALS_FOR_DECISION.REJECTED).toBeDefined();
+  });
+
+  it('should call useQueryClient hook', () => {
+    renderHook(() => useApplicationReports());
+
+    expect(useQueryClient).toHaveBeenCalled();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/CancelModalContent/CancelModalContent.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/actions/handlingApplicationActions/CancelModalContent/CancelModalContent.tsx
@@ -41,7 +41,6 @@ const CancelModalContent: React.FC<ComponentProps> = ({
             {t(`${translationsBase}.reasonCancelDialogDescription`)}
           </$GridCell>
           <$GridCell $colSpan={12}>
-            {/* @ts-expect-error: HDS React TextArea has very strict prop requirements that are not necessary here. */}
             <TextArea
               id="proccessRejectedComments"
               name="proccessRejectedComments"

--- a/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/ApplicationProcessingView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/ApplicationProcessingView.tsx
@@ -91,8 +91,8 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                 checked={
                   handledApplication?.status === APPLICATION_STATUSES.REJECTED
                 }
-                onChange={(value: boolean) => {
-                  if (value) {
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  if (event.target.checked) {
                     setHandledApplication({
                       ...handledApplication,
                       logEntryComment: '',
@@ -120,7 +120,6 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
             </$Grid>
             <$Grid>
               <$GridCell $colSpan={6}>
-                {/* @ts-expect-error: HDS React TextArea has very strict prop requirements that are not necessary here. */}
                 <TextArea
                   id="proccessRejectedComments"
                   name="proccessRejectedComments"
@@ -147,8 +146,8 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                 checked={
                   handledApplication?.status === APPLICATION_STATUSES.ACCEPTED
                 }
-                onChange={(value: boolean) => {
-                  if (value) {
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  if (event.target.checked) {
                     setHandledApplication({
                       ...handledApplication,
                       logEntryComment: '',
@@ -214,7 +213,6 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                   $colStart={1}
                   style={{ paddingTop: theme.spacing.l }}
                 >
-                  {/* @ts-expect-error: HDS React TextArea has very strict prop requirements that are not necessary here. */}
                   <TextArea
                     id="proccessAcceptedComments"
                     name="proccessAcceptedComments"
@@ -245,8 +243,8 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                   value="yes"
                   label={t(`${translationsBase}.actions.grantedAsDeminimisAid`)}
                   checked={handledApplication.grantedAsDeMinimisAid === true}
-                  onChange={(value: boolean) => {
-                    if (value) toggleGrantedAsDeMinimisAid(true);
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    if (event.target.checked) toggleGrantedAsDeMinimisAid(true);
                   }}
                 />
               </$GridCell>
@@ -259,14 +257,15 @@ const ApplicationProcessingView: React.FC<{ data: Application }> = ({
                     `${translationsBase}.actions.grantedAsDeminimisAidNo`
                   )}
                   checked={handledApplication.grantedAsDeMinimisAid === false}
-                  onChange={(value: boolean) => {
-                    if (value) toggleGrantedAsDeMinimisAid(false);
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    if (event.target.checked) {
+                      toggleGrantedAsDeMinimisAid(false);
+                    }
                   }}
                 />
               </$GridCell>
               {needsIndustryCode && (
                 <$GridCell $colSpan={6}>
-                  {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
                   <TextInput
                     id="industryCodeInput"
                     label={t(`${translationsBase}.fields.industryCode`)}

--- a/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/__tests__/ApplicationProcessingView.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/applicationProcessingView/__tests__/ApplicationProcessingView.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, RenderResult, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import renderComponent from 'benefit/handler/__tests__/utils/render-component';
 import AppContext, { AppContextType } from 'benefit/handler/context/AppContext';
+import { useDetermineAhjoMode } from 'benefit/handler/hooks/useDetermineAhjoMode';
 import { HandledAplication } from 'benefit/handler/types/application';
+import { extractCalculatorRows } from 'benefit/handler/utils/calculator';
 import { APPLICATION_STATUSES } from 'benefit-shared/constants';
 import { axe } from 'jest-axe';
 import noop from 'lodash/noop';
@@ -10,12 +13,27 @@ import theme from 'shared/styles/theme';
 
 import ApplicationProcessingView from '../ApplicationProcessingView';
 
+jest.mock('benefit/handler/hooks/useDetermineAhjoMode', () => ({
+  useDetermineAhjoMode: jest.fn(),
+}));
+
+jest.mock('benefit/handler/utils/calculator', () => ({
+  extractCalculatorRows: jest.fn(),
+}));
+
 // Finnish labels from public/locales/fi/common.json
 const LABEL_REJECT = 'Ei puolleta';
 const LABEL_ACCEPT = 'Puolletaan';
 const LABEL_DEMINIMIS_YES = 'Helsinki-lisä myönnetään de minimis-tukena';
 const LABEL_DEMINIMIS_NO = 'Helsinki-lisä ei ole hakijalle de minimis-tukea';
 const LABEL_INDUSTRY_CODE = 'TOL-koodi (toimialaluokitus)';
+
+const mockUseDetermineAhjoMode = useDetermineAhjoMode as jest.MockedFunction<
+  typeof useDetermineAhjoMode
+>;
+const mockExtractCalculatorRows = extractCalculatorRows as jest.MockedFunction<
+  typeof extractCalculatorRows
+>;
 
 const defaultAppContextValue: AppContextType = {
   isNavigationVisible: false,
@@ -63,6 +81,18 @@ const getComponent = (
   ).renderResult;
 
 describe('ApplicationProcessingView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDetermineAhjoMode.mockReturnValue(false);
+    mockExtractCalculatorRows.mockReturnValue({
+      rowsWithoutTotal: [],
+      totalRow: undefined,
+      totalRowDescription: undefined,
+      dateRangeRows: [],
+      helsinkiBenefitMonthlyRows: [],
+    });
+  });
+
   it('should render with no accessibility violations when handledApplication is null', async () => {
     const { container } = getComponent(null);
     const results = await axe(container);
@@ -167,5 +197,275 @@ describe('ApplicationProcessingView', () => {
     expect(
       screen.queryByLabelText(LABEL_DEMINIMIS_YES)
     ).not.toBeInTheDocument();
+  });
+
+  it('initializes handledApplication from decisionProposalDraft in new Ahjo mode', () => {
+    mockUseDetermineAhjoMode.mockReturnValue(true);
+    const setHandledApplication = jest.fn();
+
+    const data = {
+      ...minimalData,
+      decisionProposalDraft: {
+        status: APPLICATION_STATUSES.ACCEPTED,
+        grantedAsDeMinimisAid: true,
+        logEntryComment: 'draft comment',
+        justificationText: 'justification',
+        decisionText: 'decision',
+        decisionMakerId: '42',
+        decisionMakerName: 'Name',
+      },
+    };
+
+    getComponent(null, setHandledApplication, data);
+
+    expect(setHandledApplication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: APPLICATION_STATUSES.ACCEPTED,
+        grantedAsDeMinimisAid: true,
+        logEntryComment: 'draft comment',
+        justificationText: 'justification',
+        decisionText: 'decision',
+        decisionMakerId: '42',
+        decisionMakerName: 'Name',
+      })
+    );
+  });
+
+  it('updates status to REJECTED when reject radio is selected', async () => {
+    const user = userEvent.setup();
+    const setHandledApplication = jest.fn();
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+      logEntryComment: 'old comment',
+    };
+
+    getComponent(handledApplication, setHandledApplication);
+
+    await user.click(screen.getByLabelText(LABEL_REJECT));
+
+    expect(setHandledApplication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: APPLICATION_STATUSES.REJECTED,
+        grantedAsDeMinimisAid: false,
+        logEntryComment: '',
+      })
+    );
+  });
+
+  it('updates status to ACCEPTED when accept radio is selected', async () => {
+    const user = userEvent.setup();
+    const setHandledApplication = jest.fn();
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.REJECTED,
+      grantedAsDeMinimisAid: false,
+      logEntryComment: 'old comment',
+    };
+
+    getComponent(handledApplication, setHandledApplication);
+
+    await user.click(screen.getByLabelText(LABEL_ACCEPT));
+
+    expect(setHandledApplication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: APPLICATION_STATUSES.ACCEPTED,
+        logEntryComment: '',
+      })
+    );
+  });
+
+  it('updates rejected comment text via onCommentsChange', () => {
+    const setHandledApplication = jest.fn();
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.REJECTED,
+      grantedAsDeMinimisAid: false,
+      logEntryComment: '',
+    };
+
+    getComponent(handledApplication, setHandledApplication);
+
+    fireEvent.change(screen.getByLabelText(/Perustelu/), {
+      target: { value: 'new reject comment' },
+    });
+
+    expect(setHandledApplication).toHaveBeenCalledWith(
+      expect.objectContaining({ logEntryComment: 'new reject comment' })
+    );
+  });
+
+  it('updates accepted comment text via onCommentsChange in old Ahjo mode', () => {
+    const setHandledApplication = jest.fn();
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: false,
+      logEntryComment: '',
+    };
+
+    getComponent(handledApplication, setHandledApplication);
+
+    const acceptedComment = screen.getByLabelText(/Perustelu/);
+    fireEvent.change(acceptedComment, {
+      target: { value: 'new accept comment' },
+    });
+
+    expect(setHandledApplication).toHaveBeenCalledWith(
+      expect.objectContaining({ logEntryComment: 'new accept comment' })
+    );
+  });
+
+  it('toggles grantedAsDeMinimisAid to true from radio button', async () => {
+    const user = userEvent.setup();
+    const setHandledApplication = jest.fn();
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: false,
+      industryCodeTouched: true,
+    };
+
+    getComponent(handledApplication, setHandledApplication);
+
+    await user.click(screen.getByLabelText(LABEL_DEMINIMIS_YES));
+
+    expect(setHandledApplication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        grantedAsDeMinimisAid: true,
+        industryCodeTouched: false,
+      })
+    );
+  });
+
+  it('toggles grantedAsDeMinimisAid to false from radio button', async () => {
+    const user = userEvent.setup();
+    const setHandledApplication = jest.fn();
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+      industryCodeTouched: true,
+    };
+
+    getComponent(handledApplication, setHandledApplication);
+
+    await user.click(screen.getByLabelText(LABEL_DEMINIMIS_NO));
+
+    expect(setHandledApplication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        grantedAsDeMinimisAid: false,
+        industryCodeTouched: false,
+      })
+    );
+  });
+
+  it('renders calculator total and monthly rows when row lengths match', () => {
+    mockExtractCalculatorRows.mockReturnValue({
+      rowsWithoutTotal: [],
+      totalRow: {
+        id: 'total',
+        descriptionFi: 'Yhteensä',
+        amount: 1200,
+      } as never,
+      totalRowDescription: {
+        descriptionFi: 'Laskelman yhteenveto',
+      } as never,
+      dateRangeRows: [{ id: 'month-1', descriptionFi: '1.1-31.1' }] as never,
+      helsinkiBenefitMonthlyRows: [{ amount: 100 }] as never,
+    });
+
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: false,
+    };
+
+    getComponent(handledApplication);
+
+    expect(screen.getByText('Laskelman yhteenveto')).toBeInTheDocument();
+    expect(screen.getByText('Yhteensä')).toBeInTheDocument();
+    expect(screen.getByText('1.1-31.1')).toBeInTheDocument();
+  });
+
+  it('shows industry code + description as a single input value', () => {
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+      industryCode: '62010',
+      industryDescription: 'Ohjelmistot',
+    };
+    const data = {
+      ...minimalData,
+      company: {
+        ...minimalData.company,
+        industryCode: undefined,
+      },
+    };
+
+    getComponent(handledApplication, noop, data);
+
+    const input = screen.getByLabelText(LABEL_INDUSTRY_CODE, {
+      exact: false,
+    });
+    expect(input).toHaveValue('62010 Ohjelmistot');
+  });
+
+  it('marks industry code as touched on blur', () => {
+    const setHandledApplication = jest.fn();
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+      industryCode: '',
+      industryDescription: undefined,
+      industryCodeTouched: false,
+    };
+    const data = {
+      ...minimalData,
+      company: {
+        ...minimalData.company,
+        industryCode: undefined,
+      },
+    };
+
+    getComponent(handledApplication, setHandledApplication, data);
+
+    const input = screen.getByLabelText(LABEL_INDUSTRY_CODE, {
+      exact: false,
+    });
+    fireEvent.blur(input);
+
+    const updater = setHandledApplication.mock.calls.at(-1)?.[0] as (
+      prev: HandledAplication
+    ) => HandledAplication;
+
+    const updated = updater(handledApplication);
+    expect(updated.industryCodeTouched).toBe(true);
+  });
+
+  it('parses only code and clears description when no description is provided', () => {
+    const setHandledApplication = jest.fn();
+    const handledApplication: HandledAplication = {
+      status: APPLICATION_STATUSES.ACCEPTED,
+      grantedAsDeMinimisAid: true,
+      industryCode: '',
+      industryDescription: 'old',
+    };
+    const data = {
+      ...minimalData,
+      company: {
+        ...minimalData.company,
+        industryCode: undefined,
+      },
+    };
+
+    getComponent(handledApplication, setHandledApplication, data);
+
+    const input = screen.getByLabelText(LABEL_INDUSTRY_CODE, {
+      exact: false,
+    });
+    fireEvent.change(input, { target: { value: '62010' } });
+
+    const updater = setHandledApplication.mock.calls.at(-1)?.[0] as (
+      prev: HandledAplication
+    ) => HandledAplication;
+    const updated = updater(handledApplication);
+
+    expect(updated.industryCode).toBe('62010');
+    expect(updated.industryDescription).toBeUndefined();
   });
 });

--- a/frontend/benefit/handler/src/components/applicationReview/calculatorErrors/__tests__/CalculatorErrors.test.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/calculatorErrors/__tests__/CalculatorErrors.test.tsx
@@ -1,0 +1,76 @@
+import '@testing-library/jest-dom';
+
+import { RenderResult, screen } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { ErrorData } from 'benefit/handler/types/common';
+import React from 'react';
+
+import CalculatorErrors from '../CalculatorErrors';
+
+const renderSubject = (data: ErrorData | null | undefined): RenderResult =>
+  renderComponent(<CalculatorErrors data={data} />).renderResult;
+
+describe('CalculatorErrors', () => {
+  it('renders nothing when data is null', () => {
+    const { container } = renderSubject(null);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders calculator error title, message and calculation field errors', () => {
+    const data = {
+      calculation: {
+        override_monthly_benefit_amount: 'Pakollinen kenttä',
+        pay_subsidy_percent: 75,
+      },
+    } as unknown as ErrorData;
+
+    renderSubject(data);
+
+    expect(screen.getByText('Laskurissa on virheitä')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Ole hyvä ja tarkista laskelman tiedot ja yritä laskea uudestaan.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Helsinki-lisää € / kk: Pakollinen kenttä')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Palkkatukiprosentti: 75')).toBeInTheDocument();
+  });
+
+  it('renders pay subsidy errors with row index suffix', () => {
+    const data = {
+      paySubsidies: [
+        {
+          monthly_pay: 'Virhe 1',
+          state_aid_max_percentage: 80,
+        },
+        {
+          monthly_pay: 'Virhe 2',
+        },
+      ],
+    } as unknown as ErrorData;
+
+    renderSubject(data);
+
+    expect(screen.getByText('Palkkatuki')).toBeInTheDocument();
+    expect(screen.getByText('Bruttopalkka * 1: Virhe 1')).toBeInTheDocument();
+    expect(screen.getByText('Valtiotukimaksimi 1: 80')).toBeInTheDocument();
+    expect(screen.getByText('Bruttopalkka * 2: Virhe 2')).toBeInTheDocument();
+  });
+
+  it('renders both paySubsidies and calculation sections when both are present', () => {
+    const data = {
+      paySubsidies: [{ monthly_pay: 'Puuttuu' }],
+      calculation: {
+        pay_subsidy_percent: 50,
+      },
+    } as unknown as ErrorData;
+
+    renderSubject(data);
+
+    expect(screen.getByText('Bruttopalkka * 1: Puuttuu')).toBeInTheDocument();
+    expect(screen.getByText('Palkkatukiprosentti: 50')).toBeInTheDocument();
+  });
+});

--- a/frontend/benefit/handler/src/components/applicationReview/consentView/consentActions/ConsentActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/consentView/consentActions/ConsentActions.tsx
@@ -1,6 +1,6 @@
 import { UploadProps } from 'benefit/handler/types/application';
 import { ATTACHMENT_TYPES } from 'benefit-shared/constants';
-import { ButtonVariant, IconPlus } from 'hds-react';
+import { ButtonPresetTheme, ButtonVariant, IconPlus } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import UploadAttachment from 'shared/components/attachments/UploadAttachment';
@@ -37,7 +37,7 @@ const ConsentActions: React.FC<UploadProps> = ({
           `}
         >
           <UploadAttachment
-            theme="black"
+            theme={ButtonPresetTheme.Black}
             variant={ButtonVariant.Secondary}
             onUpload={handleUpload || (() => {})}
             isUploading={isUploading ?? false}

--- a/frontend/benefit/handler/src/components/applicationReview/employmentView/employmentActions/EmploymentActions.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/employmentView/employmentActions/EmploymentActions.tsx
@@ -1,6 +1,6 @@
 import { UploadProps } from 'benefit/handler/types/application';
 import { ATTACHMENT_TYPES } from 'benefit-shared/constants';
-import { ButtonVariant, IconPlus } from 'hds-react';
+import { ButtonPresetTheme, ButtonVariant, IconPlus } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import UploadAttachment from 'shared/components/attachments/UploadAttachment';
@@ -37,7 +37,7 @@ const EmploymentActions: React.FC<UploadProps> = ({
           `}
         >
           <UploadAttachment
-            theme="black"
+            theme={ButtonPresetTheme.Black}
             variant={ButtonVariant.Secondary}
             onUpload={handleUpload || (() => {})}
             isUploading={isUploading ?? false}

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -152,7 +152,6 @@ const PaySubsidiesSection: React.FC<PaySubsidiesSectionProps> = ({
 
           {item.paySubsidyPercent === 100 && (
             <$GridCell $colStart={3} $colSpan={2}>
-              {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
               <TextInput
                 id={fields.workTimePercent.name}
                 name={fields.workTimePercent.name}
@@ -174,7 +173,6 @@ const PaySubsidiesSection: React.FC<PaySubsidiesSectionProps> = ({
             $colStart={item.paySubsidyPercent === 100 ? 6 : 3}
             $colSpan={3}
           >
-            {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
             <DateInput
               label={t(`${translationsBase}.salarySupportPeriod`, {
                 period: formatStringFloatValue(
@@ -203,7 +201,6 @@ const PaySubsidiesSection: React.FC<PaySubsidiesSectionProps> = ({
             $colStart={item.paySubsidyPercent === 100 ? 9 : 6}
             $colSpan={3}
           >
-            {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
             <DateInput
               label={fields.endDate.label}
               id={fields.endDate.name}
@@ -376,7 +373,6 @@ const TrainingCompensationInputSection: React.FC<
       />
 
       <$GridCell $colStart={1} $colSpan={1}>
-        {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
         <TextInput
           id={fields.monthlyAmount.name}
           name={fields.monthlyAmount.name}
@@ -396,7 +392,6 @@ const TrainingCompensationInputSection: React.FC<
       </$GridCell>
 
       <$GridCell $colStart={3} $colSpan={3}>
-        {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
         <DateInput
           id={fields.trainingCompensationStartDate.name}
           name={fields.trainingCompensationStartDate.name}
@@ -421,7 +416,6 @@ const TrainingCompensationInputSection: React.FC<
       </$GridCell>
 
       <$GridCell $colStart={6} $colSpan={3}>
-        {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
         <DateInput
           id={fields.trainingCompensationEndDate.name}
           name={fields.trainingCompensationEndDate.name}
@@ -569,7 +563,6 @@ const SalaryBenefitCalculatorView: React.FC<
       </$GridCell>
 
       <$GridCell $colSpan={3}>
-        {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
         <TextInput
           id={fields.monthlyPay.name}
           name={fields.monthlyPay.name}
@@ -586,7 +579,6 @@ const SalaryBenefitCalculatorView: React.FC<
       </$GridCell>
 
       <$GridCell $colSpan={3}>
-        {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
         <TextInput
           id={fields.otherExpenses.name}
           name={fields.otherExpenses.name}
@@ -603,7 +595,6 @@ const SalaryBenefitCalculatorView: React.FC<
       </$GridCell>
 
       <$GridCell $colSpan={3}>
-        {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
         <TextInput
           id={fields.vacationMoney.name}
           name={fields.vacationMoney.name}
@@ -727,7 +718,6 @@ const SalaryBenefitCalculatorView: React.FC<
       </$GridCell>
 
       <$GridCell $colStart={1} $colSpan={2}>
-        {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
         <DateInput
           id={fields.startDate.name}
           name={fields.startDate.name}
@@ -745,7 +735,6 @@ const SalaryBenefitCalculatorView: React.FC<
 
       <$GridCell $colStart={3} $colSpan={3}>
         {/* TODO: MAX DATE */}
-        {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
         <DateInput
           id={fields.endDate.name}
           name={fields.endDate.name}

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitCalculatorView.tsx
@@ -98,7 +98,7 @@ const PaySubsidiesSection: React.FC<PaySubsidiesSectionProps> = ({
   ): void => {
     const newPaySubsidies = [...(formik.values.paySubsidies || [])];
     newPaySubsidies[index] = { ...newPaySubsidies[index], ...newValues };
-    formik.setFieldValue(fields.paySubsidies.name, newPaySubsidies);
+    void formik.setFieldValue(fields.paySubsidies.name, newPaySubsidies);
   };
 
   if ((formik.values.paySubsidies?.length ?? 0) === 0) return null;
@@ -568,7 +568,7 @@ const SalaryBenefitCalculatorView: React.FC<
           name={fields.monthlyPay.name}
           label={fields.monthlyPay.label}
           onChange={(e) =>
-            formik.setFieldValue(fields.monthlyPay.name, e.target.value)
+            void formik.setFieldValue(fields.monthlyPay.name, e.target.value)
           }
           value={formatStringFloatValue(formik.values.monthlyPay)}
           invalid={!!getErrorMessage(fields.monthlyPay.name)}
@@ -584,7 +584,7 @@ const SalaryBenefitCalculatorView: React.FC<
           name={fields.otherExpenses.name}
           label={fields.otherExpenses.label}
           onChange={(e) =>
-            formik.setFieldValue(fields.otherExpenses.name, e.target.value)
+            void formik.setFieldValue(fields.otherExpenses.name, e.target.value)
           }
           value={formatStringFloatValue(formik.values.otherExpenses)}
           invalid={!!getErrorMessage(fields.otherExpenses.name)}
@@ -600,7 +600,7 @@ const SalaryBenefitCalculatorView: React.FC<
           name={fields.vacationMoney.name}
           label={fields.vacationMoney.label}
           onChange={(e) =>
-            formik.setFieldValue(fields.vacationMoney.name, e.target.value)
+            void formik.setFieldValue(fields.vacationMoney.name, e.target.value)
           }
           value={formatStringFloatValue(formik.values.vacationMoney)}
           invalid={!!getErrorMessage(fields.vacationMoney.name)}
@@ -628,7 +628,7 @@ const SalaryBenefitCalculatorView: React.FC<
               onChange={(selectedOptions: OptionType[]) => {
                 const selectedValue = Number(selectedOptions?.[0]?.value);
                 if (!Number.isNaN(selectedValue)) {
-                  formik.setFieldValue(
+                  void formik.setFieldValue(
                     fields.stateAidMaxPercentage.name,
                     selectedValue
                   );
@@ -724,7 +724,7 @@ const SalaryBenefitCalculatorView: React.FC<
           placeholder={fields.startDate.placeholder}
           language={language}
           onChange={(value) => {
-            formik.setFieldValue(fields.startDate.name, value);
+            void formik.setFieldValue(fields.startDate.name, value);
           }}
           value={formik.values.startDate ?? ''}
           invalid={!!getErrorMessage(fields.startDate.name)}
@@ -741,7 +741,7 @@ const SalaryBenefitCalculatorView: React.FC<
           placeholder={fields.endDate.placeholder}
           language={language}
           onChange={(value) => {
-            formik.setFieldValue(fields.endDate.name, value);
+            void formik.setFieldValue(fields.endDate.name, value);
           }}
           value={formik.values.endDate ?? ''}
           invalid={!!getErrorMessage(fields.endDate.name)}

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitManualCalculatorView.tsx
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/SalaryBenefitManualCalculatorView.tsx
@@ -17,7 +17,6 @@ const SalaryBenefitManualCalculatorView: React.FC<
   return (
     <>
       <$GridCell $colStart={1} $colSpan={2}>
-        {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
         <TextInput
           id={overrideMonthlyBenefitAmount?.name}
           name={overrideMonthlyBenefitAmount?.name}
@@ -39,7 +38,6 @@ const SalaryBenefitManualCalculatorView: React.FC<
       </$GridCell>
 
       <$GridCell $colStart={1} $colSpan={6}>
-        {/* @ts-expect-error: HDS React TextArea has very strict prop requirements that are not necessary here. */}
         <TextArea
           id={overrideMonthlyBenefitAmountComment?.name}
           name={overrideMonthlyBenefitAmountComment?.name}

--- a/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/__tests__/useSalaryBenefitCalculatorData.test.ts
+++ b/frontend/benefit/handler/src/components/applicationReview/salaryBenefitCalculatorView/__tests__/useSalaryBenefitCalculatorData.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { CALCULATION_SALARY_KEYS } from 'benefit/handler/constants';
 import {
   Application,

--- a/frontend/benefit/handler/src/components/attachmentsListView/AttachmentsListView.tsx
+++ b/frontend/benefit/handler/src/components/attachmentsListView/AttachmentsListView.tsx
@@ -51,7 +51,7 @@ const AttachmentsListView: React.FC<AttachmentsListViewProps> = ({
           key={attachment.attachmentFileName}
         >
           <IconPaperclip aria-label={attachment.attachmentFileName} />
-          <span css={{ textDecoration: 'underline' }}>
+          <span style={{ textDecoration: 'underline' }}>
             {attachment.attachmentFileName}
           </span>
         </$ViewField>

--- a/frontend/benefit/handler/src/components/batchProcessing/__tests__/BatchProposals.test.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/__tests__/BatchProposals.test.tsx
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom';
+
+import { screen } from '@testing-library/react';
+import renderComponent from 'benefit/handler/__tests__/utils/render-component';
+import { BATCH_STATUSES } from 'benefit-shared/constants';
+import i18n from 'i18next';
+import React from 'react';
+
+import BatchProposals from '../BatchProposals';
+import { BatchListProps, useBatchProposal } from '../useBatches';
+
+jest.mock('../useBatches', () => ({
+  useBatchProposal: jest.fn(),
+}));
+
+jest.mock('../BatchApplicationList', () =>
+  jest.fn(({ batch }) => (
+    <div data-testid="batch-application-item">{batch.id}</div>
+  ))
+);
+
+jest.mock('hds-react', () => ({
+  LoadingSpinner: ({ small }: { small?: boolean }) => (
+    <div data-testid="loading-spinner">{small ? 'small' : 'default'}</div>
+  ),
+}));
+
+const mockUseBatchProposal = useBatchProposal as jest.MockedFunction<
+  typeof useBatchProposal
+>;
+
+const baseHookState: BatchListProps = {
+  t: i18n.t.bind(i18n),
+  batches: [],
+  shouldShowSkeleton: false,
+  shouldHideList: false,
+  getHeader: (id: string): string => id,
+  translationsBase: 'common:applications.list',
+};
+
+const status = [BATCH_STATUSES.DRAFT];
+
+const setHookState = (overrides: Partial<BatchListProps> = {}): void => {
+  mockUseBatchProposal.mockReturnValue({
+    ...baseHookState,
+    ...overrides,
+  });
+};
+
+const renderSubject = (setBatchCount = jest.fn()): jest.Mock => {
+  renderComponent(
+    <BatchProposals status={status} setBatchCount={setBatchCount} />
+  );
+  return setBatchCount;
+};
+
+describe('BatchProposals', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setHookState();
+  });
+
+  it('passes status to useBatchProposal and renders loading spinner when skeleton is shown', () => {
+    setHookState({
+      batches: [{ id: 'batch-1' }] as never,
+      shouldShowSkeleton: true,
+    });
+
+    const setBatchCount = renderSubject();
+
+    expect(mockUseBatchProposal).toHaveBeenCalledWith(status);
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+    expect(setBatchCount).toHaveBeenLastCalledWith('(0)');
+  });
+
+  it('renders empty message when list should be hidden', () => {
+    setHookState({
+      batches: [],
+      shouldHideList: true,
+    });
+
+    const setBatchCount = renderSubject();
+
+    expect(screen.getByText('Ei yhtään koontia.')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('batch-application-item')
+    ).not.toBeInTheDocument();
+    expect(setBatchCount).toHaveBeenCalledWith('(0)');
+  });
+
+  it('renders all batch items and updates batch count from list length', () => {
+    setHookState({
+      batches: [{ id: 'batch-1' }, { id: 'batch-2' }] as never,
+      shouldHideList: false,
+    });
+
+    const setBatchCount = renderSubject();
+
+    expect(screen.getByTestId('batch-application-list')).toBeInTheDocument();
+    expect(screen.getAllByTestId('batch-application-item')).toHaveLength(2);
+    expect(screen.getByText('batch-1')).toBeInTheDocument();
+    expect(screen.getByText('batch-2')).toBeInTheDocument();
+    expect(setBatchCount).toHaveBeenCalledWith('(2)');
+  });
+});

--- a/frontend/benefit/handler/src/components/batchProcessing/batchFooter/BatchFooterInspection.tsx
+++ b/frontend/benefit/handler/src/components/batchProcessing/batchFooter/BatchFooterInspection.tsx
@@ -159,7 +159,6 @@ BatchProps) => {
         <h3>{t('common:batches.form.headings.decisionDetails')}</h3>
         <$FormSection>
           <$GridCell $colSpan={3}>
-            {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
             <TextInput
               onChange={formik.handleChange}
               label={t('common:batches.form.fields.decisionMakerName')}
@@ -173,7 +172,6 @@ BatchProps) => {
           </$GridCell>
 
           <$GridCell $colSpan={3}>
-            {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
             <TextInput
               onChange={formik.handleChange}
               label={t('common:batches.form.fields.decisionMakerTitle')}
@@ -187,7 +185,6 @@ BatchProps) => {
           </$GridCell>
 
           <$GridCell $colSpan={2}>
-            {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
             <TextInput
               onChange={formik.handleChange}
               label={t('common:batches.form.fields.sectionOfTheLaw')}
@@ -201,7 +198,6 @@ BatchProps) => {
           </$GridCell>
 
           <$GridCell $colSpan={3}>
-            {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
             <DateInput
               minDate={yearFromNow}
               onChange={(value) => formik.setFieldValue('decision_date', value)}
@@ -245,7 +241,6 @@ BatchProps) => {
               {inspectorMode === 'ahjo' ? (
                 <$FormSection>
                   <$GridCell $colSpan={3}>
-                    {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
                     <TextInput
                       onChange={formik.handleChange}
                       label={t(
@@ -261,7 +256,6 @@ BatchProps) => {
                   </$GridCell>
 
                   <$GridCell $colSpan={3}>
-                    {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
                     <TextInput
                       onChange={formik.handleChange}
                       label={t(
@@ -276,7 +270,6 @@ BatchProps) => {
                     />
                   </$GridCell>
                   <$GridCell $colSpan={3}>
-                    {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
                     <TextInput
                       onChange={formik.handleChange}
                       label={t('common:batches.form.fields.p2pCheckerName')}
@@ -315,7 +308,6 @@ BatchProps) => {
               {inspectorMode === 'p2p' ? (
                 <$FormSection css="border-top: 1pox solid #000;">
                   <$GridCell $colSpan={3}>
-                    {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
                     <TextInput
                       onChange={formik.handleChange}
                       label={t('common:batches.form.fields.p2pInspectorName')}
@@ -329,7 +321,6 @@ BatchProps) => {
                   </$GridCell>
 
                   <$GridCell $colSpan={3}>
-                    {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
                     <TextInput
                       onChange={formik.handleChange}
                       label={t('common:batches.form.fields.p2pInspectorEmail')}
@@ -342,7 +333,6 @@ BatchProps) => {
                     />
                   </$GridCell>
                   <$GridCell $colSpan={3}>
-                    {/* @ts-expect-error: HDS React TextInput has very strict prop requirements that are not necessary here. */}
                     <TextInput
                       onChange={formik.handleChange}
                       label={t('common:batches.form.fields.p2pCheckerName')}

--- a/frontend/benefit/handler/src/components/header/TemporaryAhjoModeSwitch.tsx
+++ b/frontend/benefit/handler/src/components/header/TemporaryAhjoModeSwitch.tsx
@@ -1,5 +1,5 @@
 import { useDetermineAhjoMode } from 'benefit/handler/hooks/useDetermineAhjoMode';
-import { ButtonPresetTheme, ButtonVariant } from 'hds-react';
+import { ButtonPresetTheme, ButtonSize, ButtonVariant } from 'hds-react';
 import React from 'react';
 import Button from 'shared/components/button/Button';
 import {
@@ -33,7 +33,7 @@ const TemporaryAhjoModeSwitch: React.FC = () => {
       onClick={() => toggleNewAhjoMode(isNewAhjoMode)}
       theme={ButtonPresetTheme.Coat}
       variant={ButtonVariant.Supplementary}
-      size="small"
+      size={ButtonSize.Small}
     >
       Ahjo-integraatio
       <br />

--- a/frontend/benefit/handler/src/components/header/__tests__/Header.test.tsx
+++ b/frontend/benefit/handler/src/components/header/__tests__/Header.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react';
+import { ROUTES } from 'benefit/handler/constants';
+import useLogin from 'benefit/handler/hooks/useLogin';
+import useLogout from 'benefit/handler/hooks/useLogout';
+import useUserQuery from 'benefit/handler/hooks/useUserQuery';
+import { useRouter } from 'next/router';
+import React from 'react';
+
+import i18n from '../../../../test/i18n/i18n-test';
+import Header from '../Header';
+import { useHeader } from '../useHeader';
+
+const mockBaseHeader = jest.fn(
+  ({ customItems }: { customItems?: React.ReactNode }) => (
+    <div data-testid="base-header">{customItems}</div>
+  )
+);
+
+jest.mock('benefit/handler/hooks/useLogin');
+jest.mock('benefit/handler/hooks/useLogout');
+jest.mock('benefit/handler/hooks/useUserQuery');
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+jest.mock('../useHeader', () => ({
+  useHeader: jest.fn(),
+}));
+jest.mock('../HeaderNotifier', () => () => (
+  <div data-testid="header-notifier">notifier</div>
+));
+jest.mock('../Header.sc', () => ({
+  $BaseHeader: (props: { customItems?: React.ReactNode }) =>
+    mockBaseHeader(props),
+  $HeaderCustomItems: ({ children }: { children: React.ReactNode }) => (
+    <ul data-testid="custom-items">{children}</ul>
+  ),
+}));
+jest.mock('next/dynamic', () =>
+  jest.fn(() => () => (
+    <div data-testid="temporary-ahjo-mode-switch">ahjo-switch</div>
+  ))
+);
+
+const mockUseHeader = useHeader as jest.MockedFunction<typeof useHeader>;
+const mockUseLogin = useLogin as jest.MockedFunction<typeof useLogin>;
+const mockUseLogout = useLogout as jest.MockedFunction<typeof useLogout>;
+const mockUseUserQuery = useUserQuery as jest.MockedFunction<
+  typeof useUserQuery
+>;
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+describe('Header', () => {
+  const login = jest.fn();
+  const logout = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseHeader.mockReturnValue({
+      t: i18n.t as unknown as ReturnType<typeof useHeader>['t'],
+      languageOptions: [],
+      isNavigationVisible: true,
+      navigationItems: [{ label: 'Home', url: ROUTES.HOME }],
+      handleLanguageChange: jest.fn(),
+      handleNavigationItemClick: jest.fn(),
+      handleTitleClick: jest.fn(),
+    });
+    mockUseLogin.mockReturnValue(login);
+    mockUseLogout.mockReturnValue(logout);
+    mockUseRouter.mockReturnValue({
+      asPath: ROUTES.HOME,
+    } as ReturnType<typeof useRouter>);
+    mockUseUserQuery.mockReturnValue({
+      isLoading: false,
+      isSuccess: true,
+      data: {
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+      },
+    } as ReturnType<typeof useUserQuery>);
+  });
+
+  it('passes translated header props and authenticated login data to BaseHeader', () => {
+    render(<Header />);
+
+    const props = mockBaseHeader.mock.calls[0][0] as {
+      title: string;
+      titleUrl: string;
+      skipToContentLabel: string;
+      menuToggleAriaLabel: string;
+      isNavigationVisible: boolean;
+      navigationItems: Array<{ label: string; url: string }>;
+      login: {
+        isAuthenticated: boolean;
+        loginLabel: string;
+        logoutLabel: string;
+        userAriaLabelPrefix: string;
+        onLogin: () => void;
+        onLogout: () => void;
+        userName?: string;
+      };
+    };
+
+    expect(props.title).toBe('Helsinki-lisä käsittelijä');
+    expect(props.titleUrl).toBe(ROUTES.HOME);
+    expect(props.skipToContentLabel).toBe('Hyppää pääsisältöön');
+    expect(props.menuToggleAriaLabel).toBe('Valikko');
+    expect(props.isNavigationVisible).toBe(true);
+    expect(props.navigationItems).toEqual([
+      { label: 'Home', url: ROUTES.HOME },
+    ]);
+
+    expect(props.login.isAuthenticated).toBe(true);
+    expect(props.login.loginLabel).toBe('Kirjaudu sisään');
+    expect(props.login.logoutLabel).toBe('Kirjaudu ulos');
+    expect(props.login.userAriaLabelPrefix).toBe('Käyttäjä:');
+    expect(props.login.onLogin).toBe(login);
+    expect(props.login.onLogout).toBe(logout);
+    expect(props.login.userName).toBe('Ada Lovelace');
+  });
+
+  it('forces unauthenticated login state on login page', () => {
+    mockUseRouter.mockReturnValue({
+      asPath: ROUTES.LOGIN,
+    } as ReturnType<typeof useRouter>);
+
+    render(<Header />);
+
+    const props = mockBaseHeader.mock.calls[0][0] as {
+      login: { isAuthenticated: boolean };
+    };
+
+    expect(props.login.isAuthenticated).toBe(false);
+  });
+
+  it('uses noop login/logout handlers while user query is loading and renders custom items', () => {
+    mockUseUserQuery.mockReturnValue({
+      isLoading: true,
+      isSuccess: false,
+      data: undefined,
+    } as ReturnType<typeof useUserQuery>);
+
+    render(<Header />);
+
+    const props = mockBaseHeader.mock.calls[0][0] as {
+      login: {
+        isAuthenticated: boolean;
+        onLogin: () => void;
+        onLogout: () => void;
+        userName?: string;
+      };
+    };
+
+    expect(props.login.isAuthenticated).toBe(false);
+    expect(props.login.userName).toBeUndefined();
+
+    props.login.onLogin();
+    props.login.onLogout();
+
+    expect(login).not.toHaveBeenCalled();
+    expect(logout).not.toHaveBeenCalled();
+
+    expect(screen.getByTestId('header-notifier')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('temporary-ahjo-mode-switch')
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/benefit/handler/src/hooks/__tests__/useAhjoSettingsQuery.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useAhjoSettingsQuery.test.ts
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import '../../../test/i18n/i18n-test';
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useQuery } from 'react-query';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 

--- a/frontend/benefit/handler/src/hooks/__tests__/useCalculatorData.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useCalculatorData.test.ts
@@ -1,0 +1,264 @@
+import '@testing-library/jest-dom';
+import '../../../test/i18n/i18n-test';
+
+import { renderHook } from '@testing-library/react';
+import {
+  CALCULATION_TYPES,
+  PAY_SUBSIDIES_OVERRIDE,
+} from 'benefit/handler/constants';
+import {
+  Application,
+  CalculationFormProps,
+} from 'benefit/handler/types/application';
+import {
+  PAY_SUBSIDY_GRANTED,
+  PAY_SUBSIDY_PERCENT,
+} from 'benefit-shared/constants';
+import { getErrorText } from 'benefit-shared/utils/forms';
+import { FormikProps } from 'formik';
+import theme from 'shared/styles/theme';
+import { focusAndScroll } from 'shared/utils/dom.utils';
+
+import { useCalculatorData } from '../useCalculatorData';
+
+jest.mock('benefit-shared/utils/forms', () => ({
+  getErrorText: jest.fn(),
+}));
+
+jest.mock('shared/hooks/useLocale', () => jest.fn(() => 'fi'));
+
+jest.mock('shared/utils/dom.utils', () => ({
+  focusAndScroll: jest.fn(),
+}));
+
+jest.mock('styled-components', () => {
+  const actual = jest.requireActual('styled-components');
+
+  return {
+    __esModule: true,
+    ...actual,
+    useTheme: () => theme,
+  };
+});
+
+type UseCalculatorDataResult = {
+  result: {
+    current: ReturnType<typeof useCalculatorData>;
+  };
+  formik: FormikProps<CalculationFormProps>;
+  setIsRecalculationRequired: jest.Mock;
+  application: Application;
+};
+
+const buildApplication = (
+  paySubsidyGranted: PAY_SUBSIDY_GRANTED = PAY_SUBSIDY_GRANTED.GRANTED
+): Application =>
+  ({
+    paySubsidyGranted,
+  } as Application);
+
+const createFormik = (
+  overrides: Partial<FormikProps<CalculationFormProps>> = {}
+): FormikProps<CalculationFormProps> =>
+  ({
+    errors: {},
+    touched: {},
+    values: {
+      startDate: '',
+      endDate: '',
+      monthlyPay: '',
+      workTimePercent: '',
+      trainingCompensations: [],
+      paySubsidies: [],
+      overrideMonthlyBenefitAmount: '',
+      overrideMonthlyBenefitAmountComment: '',
+    },
+    dirty: false,
+    validateForm: jest.fn().mockResolvedValue({}),
+    submitForm: jest.fn(),
+    setFieldValue: jest.fn(),
+    ...overrides,
+  } as unknown as FormikProps<CalculationFormProps>);
+
+const setup = ({
+  formik = createFormik(),
+  setIsRecalculationRequired = jest.fn(),
+  application = buildApplication(),
+  calculatorType = CALCULATION_TYPES.SALARY,
+}: {
+  formik?: FormikProps<CalculationFormProps>;
+  setIsRecalculationRequired?: jest.Mock;
+  application?: Application;
+  calculatorType?: CALCULATION_TYPES;
+} = {}): UseCalculatorDataResult => ({
+  ...renderHook(() =>
+    useCalculatorData(
+      calculatorType,
+      formik,
+      setIsRecalculationRequired,
+      application
+    )
+  ),
+  formik,
+  setIsRecalculationRequired,
+  application,
+});
+
+type HookResult = ReturnType<typeof setup>['result'];
+
+const flushPromises = async (): Promise<void> => {
+  await Promise.resolve();
+};
+
+const runHandleSubmit = async (result: HookResult): Promise<void> => {
+  result.current.handleSubmit();
+  await flushPromises();
+};
+
+const runHandleClear = (result: HookResult, confirm: boolean): true => {
+  const clearResult = result.current.handleClear(confirm);
+
+  jest.runAllTimers();
+
+  return clearResult;
+};
+
+const expectClearCalls = (
+  setFieldValue: jest.Mock,
+  paySubsidies: unknown[]
+): void => {
+  expect(setFieldValue).toHaveBeenCalledWith('endDate', '');
+  expect(setFieldValue).toHaveBeenCalledWith('startDate', '');
+  expect(setFieldValue).toHaveBeenCalledWith(
+    'workTimePercent',
+    String(PAY_SUBSIDY_PERCENT.DEFAULT)
+  );
+  expect(setFieldValue).toHaveBeenCalledWith('monthlyAmount', '');
+  expect(setFieldValue).toHaveBeenCalledWith('paySubsidies', paySubsidies);
+  expect(setFieldValue).toHaveBeenCalledWith('trainingCompensations', []);
+  expect(setFieldValue).toHaveBeenCalledWith(
+    'overrideMonthlyBenefitAmount',
+    ''
+  );
+  expect(setFieldValue).toHaveBeenCalledWith(
+    'overrideMonthlyBenefitAmountComment',
+    ''
+  );
+};
+
+describe('useCalculatorData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('returns static values and delegates getErrorMessage', () => {
+    (getErrorText as jest.Mock).mockReturnValue('error text');
+    const formik = createFormik({
+      errors: { monthlyPay: 'required' },
+      touched: { monthlyPay: true },
+    });
+
+    const { result } = setup({
+      formik,
+      calculatorType: CALCULATION_TYPES.EMPLOYMENT,
+    });
+
+    expect(result.current.language).toBe('fi');
+    expect(result.current.theme).toBe(theme);
+    expect(result.current.translationsBase).toBe(
+      'common:calculators.employment'
+    );
+    expect(result.current.getErrorMessage('monthlyPay')).toBe('error text');
+    expect(getErrorText).toHaveBeenCalledWith(
+      formik.errors,
+      formik.touched,
+      'monthlyPay',
+      expect.any(Function),
+      false
+    );
+  });
+
+  it('handleSubmit submits and clears recalculation flag when validation passes', async () => {
+    const formik = createFormik({
+      validateForm: jest.fn().mockResolvedValue({}),
+      submitForm: jest.fn(),
+    });
+    const setIsRecalculationRequired = jest.fn();
+    const { result } = setup({ formik, setIsRecalculationRequired });
+
+    await runHandleSubmit(result);
+
+    expect(formik.validateForm).toHaveBeenCalled();
+    expect(setIsRecalculationRequired).toHaveBeenCalledWith(false);
+    expect(formik.submitForm).toHaveBeenCalled();
+    expect(focusAndScroll).not.toHaveBeenCalled();
+    expect(getErrorText).not.toHaveBeenCalled();
+  });
+
+  it('handleSubmit focuses the first invalid field when validation fails', async () => {
+    const formik = createFormik({
+      validateForm: jest
+        .fn()
+        .mockResolvedValue({ monthlyPay: 'required', startDate: 'required' }),
+      submitForm: jest.fn(),
+    });
+    const { result } = setup({ formik });
+
+    await runHandleSubmit(result);
+
+    expect(formik.submitForm).not.toHaveBeenCalled();
+    expect(focusAndScroll).toHaveBeenCalledWith('monthlyPay');
+  });
+
+  it.each([
+    [PAY_SUBSIDY_GRANTED.GRANTED, [PAY_SUBSIDIES_OVERRIDE]],
+    [PAY_SUBSIDY_GRANTED.NOT_GRANTED, []],
+  ])(
+    'handleClear resets calculation fields for %s subsidies',
+    (paySubsidyGranted, paySubsidies) => {
+      jest.useFakeTimers();
+      const formik = createFormik({ setFieldValue: jest.fn() });
+      const { result } = setup({
+        formik,
+        application: buildApplication(paySubsidyGranted),
+      });
+
+      expect(runHandleClear(result, true)).toBe(true);
+
+      expectClearCalls(formik.setFieldValue as jest.Mock, paySubsidies);
+      expect(focusAndScroll).toHaveBeenCalledWith('monthlyPay');
+    }
+  );
+
+  it('handleClear only scrolls when confirm is false', () => {
+    jest.useFakeTimers();
+    const formik = createFormik({ setFieldValue: jest.fn() });
+    const { result } = setup({ formik });
+
+    expect(runHandleClear(result, false)).toBe(true);
+
+    expect(formik.setFieldValue).not.toHaveBeenCalled();
+    expect(focusAndScroll).toHaveBeenCalledWith('monthlyPay');
+  });
+
+  it.each([
+    [true, 1],
+    [false, 0],
+  ])(
+    'dirty=%s updates recalculation flag call count to %i',
+    (dirty, expectedCalls) => {
+      const setIsRecalculationRequired = jest.fn();
+
+      setup({
+        formik: createFormik({ dirty }),
+        setIsRecalculationRequired,
+      });
+
+      expect(setIsRecalculationRequired).toHaveBeenCalledTimes(expectedCalls);
+      if (dirty) {
+        expect(setIsRecalculationRequired).toHaveBeenCalledWith(true);
+      }
+    }
+  );
+});

--- a/frontend/benefit/handler/src/hooks/__tests__/useChangeEmployerAssurance.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useChangeEmployerAssurance.test.ts
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import '../../../test/i18n/i18n-test';
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
 import { useMutation, useQueryClient } from 'react-query';
 import showErrorToast from 'shared/components/toast/show-error-toast';

--- a/frontend/benefit/handler/src/hooks/__tests__/useDownloadApplicationPdf.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useDownloadApplicationPdf.test.ts
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import '../../../test/i18n/i18n-test';
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
 import { useMutation } from 'react-query';
 import showErrorToast from 'shared/components/toast/show-error-toast';

--- a/frontend/benefit/handler/src/hooks/__tests__/useFormActions.test.tsx
+++ b/frontend/benefit/handler/src/hooks/__tests__/useFormActions.test.tsx
@@ -1,0 +1,592 @@
+import { renderHook } from '@testing-library/react';
+import { ROUTES } from 'benefit/handler/constants';
+import DeMinimisContext from 'benefit/handler/context/DeMinimisContext';
+import { Application } from 'benefit/handler/types/application';
+import {
+  APPLICATION_STATUSES,
+  PAY_SUBSIDY_GRANTED,
+  PAY_SUBSIDY_OPTIONS,
+} from 'benefit-shared/constants';
+import { DeMinimisAid } from 'benefit-shared/types/application';
+import camelcaseKeys from 'camelcase-keys';
+import { useRouter } from 'next/router';
+import * as React from 'react';
+import hdsToast from 'shared/components/toast/Toast';
+
+import { useRouterNavigation } from '../applicationHandling/useRouterNavigation';
+import useFormActions from '../useFormActions';
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockCreateApplication = jest.fn();
+const mockUpdateApplication = jest.fn();
+const mockDeleteApplication = jest.fn();
+const mockNavigateBack = jest.fn();
+
+let mockCreateError: unknown = null;
+let mockUpdateError: unknown = null;
+let mockDeleteError: unknown = null;
+let mockIsFormActionNew = true;
+
+// Mock all external dependencies
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'fi' },
+  }),
+}));
+jest.mock('shared/components/toast/Toast', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock('shared/utils/date.utils', () => ({
+  parseDate: jest.fn((value: string) => value),
+  convertToBackendDateFormat: jest.fn((value: string) => `backend:${value}`),
+}));
+jest.mock('shared/utils/string.utils', () => ({
+  getNumberValue: jest.fn(Number),
+  stringToFloatValue: jest.fn((value: string | undefined) =>
+    value ? Number(value) : null
+  ),
+}));
+jest.mock('shared/utils/application.utils', () => ({
+  getFullName: jest.fn((first?: string, last?: string) =>
+    [first, last].filter(Boolean).join(' ')
+  ),
+}));
+jest.mock('snakecase-keys', () => ({
+  __esModule: true,
+  default: jest.fn((value: unknown) => value),
+}));
+jest.mock('camelcase-keys', () => ({
+  __esModule: true,
+  default: jest.fn((value: unknown) => value),
+}));
+jest.mock('../useApplicationFormContext', () => ({
+  useApplicationFormContext: () => ({
+    isFormActionNew: mockIsFormActionNew,
+  }),
+}));
+jest.mock('../useCreateApplicationQuery', () => ({
+  __esModule: true,
+  default: () => ({
+    mutateAsync: mockCreateApplication,
+    error: mockCreateError,
+  }),
+}));
+jest.mock('../useDeleteApplicationQuery', () => ({
+  __esModule: true,
+  default: () => ({
+    mutate: mockDeleteApplication,
+    error: mockDeleteError,
+  }),
+}));
+jest.mock('../useUpdateApplicationQuery', () => ({
+  __esModule: true,
+  default: () => ({
+    mutateAsync: mockUpdateApplication,
+    error: mockUpdateError,
+  }),
+}));
+jest.mock('../applicationHandling/useRouterNavigation', () => ({
+  useRouterNavigation: jest.fn(() => ({
+    navigateBack: mockNavigateBack,
+  })),
+}));
+
+const createContextWrapper =
+  (deMinimisAids: DeMinimisAid[] = []) =>
+  ({ children }: { children: React.ReactNode }) =>
+    (
+      <DeMinimisContext.Provider
+        value={{
+          deMinimisAids,
+          setDeMinimisAids: () => {},
+          unfinishedDeMinimisAidRow: false,
+          setUnfinishedDeMinimisAidRow: () => {},
+        }}
+      >
+        {children}
+      </DeMinimisContext.Provider>
+    );
+
+describe('useFormActions', () => {
+  const mockApplicationFormData: Partial<Application> = {
+    id: '456',
+    status: APPLICATION_STATUSES.DRAFT,
+    startDate: '01.01.2024',
+    endDate: '31.12.2024',
+    paperApplicationDate: '01.06.2024',
+    companyNumberOfEmployees: '',
+    employee: {
+      monthlyPay: '2000',
+      vacationMoney: '500',
+      otherExpenses: '100',
+      workingHours: '37.5',
+      commissionAmount: '100',
+      firstName: 'Mia',
+      lastName: 'Tester',
+    },
+    calculation: {
+      stateAidMaxPercentage: 50,
+      overrideMonthlyBenefitAmount: '1200',
+    } as Application['calculation'],
+    paySubsidies: [],
+    trainingCompensations: [],
+    paySubsidyGranted: PAY_SUBSIDY_GRANTED.GRANTED,
+    apprenticeshipProgram: false,
+    applicantTermsInEffect: {
+      id: 'terms-1',
+      applicantConsents: [{ id: 'consent-1' }],
+    } as Application['applicantTermsInEffect'],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateError = null;
+    mockUpdateError = null;
+    mockDeleteError = null;
+    mockIsFormActionNew = true;
+
+    (useRouter as jest.Mock).mockReturnValue({
+      push: mockPush,
+      replace: mockReplace,
+    });
+
+    mockCreateApplication.mockResolvedValue({
+      id: 'new-id',
+      application_number: 1,
+      employee: { first_name: 'Mia', last_name: 'Tester' },
+    });
+    mockUpdateApplication.mockResolvedValue({
+      id: 'existing-id',
+      application_number: 2,
+      employee: { first_name: 'Mia', last_name: 'Tester' },
+    });
+    mockNavigateBack.mockResolvedValue(null);
+  });
+
+  it('should expose all action methods', () => {
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    expect(result.current).toBeDefined();
+    expect(result.current.onNext).toBeDefined();
+    expect(result.current.onSubmit).toBeDefined();
+    expect(result.current.onBack).toBeDefined();
+    expect(result.current.onSave).toBeDefined();
+    expect(result.current.onQuietSave).toBeDefined();
+    expect(result.current.onDelete).toBeDefined();
+    expect(result.current.onCompanySelected).toBeDefined();
+  });
+
+  it('should call create and complete step on onNext when form action is new', async () => {
+    const dispatchStep = jest.fn();
+
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper([{ id: 'aid-1' }]) }
+    );
+
+    await result.current.onNext(
+      mockApplicationFormData as Application,
+      dispatchStep,
+      2,
+      '',
+      mockApplicationFormData as Application
+    );
+
+    expect(mockCreateApplication).toHaveBeenCalled();
+    expect(dispatchStep).toHaveBeenCalledWith({
+      type: 'completeStep',
+      payload: 2,
+    });
+    expect(mockReplace).toHaveBeenCalledWith({ query: { id: 'new-id' } });
+  });
+
+  it('should call update and push update route on onNext when not new', async () => {
+    mockIsFormActionNew = false;
+    const dispatchStep = jest.fn();
+
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    await result.current.onNext(
+      mockApplicationFormData as Application,
+      dispatchStep,
+      1,
+      'app-1',
+      mockApplicationFormData as Application
+    );
+
+    expect(mockUpdateApplication).toHaveBeenCalled();
+    expect(dispatchStep).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith(
+      `${ROUTES.APPLICATION}?id=app-1&action=update`
+    );
+  });
+
+  it('should call update on onBack', async () => {
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    await result.current.onBack();
+
+    expect(mockUpdateApplication).toHaveBeenCalled();
+  });
+
+  it('should call update, show success toast, and navigate back on onSave', async () => {
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    await result.current.onSave(
+      mockApplicationFormData as Application,
+      'existing-id'
+    );
+
+    expect(mockUpdateApplication).toHaveBeenCalled();
+    expect(hdsToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'success',
+        labelText: 'common:notifications.applicationSaved.label',
+      })
+    );
+    expect(mockNavigateBack).toHaveBeenCalled();
+  });
+
+  it('should create on onQuietSave when id is missing', async () => {
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    await result.current.onQuietSave(
+      mockApplicationFormData as Application,
+      ''
+    );
+
+    expect(mockCreateApplication).toHaveBeenCalled();
+  });
+
+  it('should delete and redirect on onDelete success', async () => {
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    result.current.onDelete('app-delete-1');
+
+    expect(mockDeleteApplication).toHaveBeenCalledWith(
+      'app-delete-1',
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+
+    const { onSuccess } = mockDeleteApplication.mock.calls[0][1] as {
+      onSuccess: () => Promise<void>;
+    };
+    await onSuccess();
+
+    expect(hdsToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'success',
+        labelText: 'common:notifications.applicationDeleted.label',
+      })
+    );
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  it('should create and append id on onCompanySelected', async () => {
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    await result.current.onCompanySelected(mockApplicationFormData);
+
+    expect(mockCreateApplication).toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith({ query: { id: 'new-id' } });
+  });
+
+  it('should normalize values on onSubmit and default pay subsidy when undefined', async () => {
+    const appWithNull: Partial<Application> = {
+      ...mockApplicationFormData,
+      paySubsidyGranted: null,
+      companyNumberOfEmployees: '',
+      paySubsidies: [{} as NonNullable<Application['paySubsidies']>[number]],
+      trainingCompensations: [
+        { id: 'tc-1' } as NonNullable<
+          Application['trainingCompensations']
+        >[number],
+      ],
+    };
+
+    const { result } = renderHook(
+      () => useFormActions(appWithNull, mockApplicationFormData),
+      { wrapper: createContextWrapper([{ id: 'aid-1' }]) }
+    );
+
+    await result.current.onSubmit(appWithNull as Application, '');
+
+    const submittedPayload = mockCreateApplication.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(submittedPayload.status).toBe(APPLICATION_STATUSES.RECEIVED);
+    expect(submittedPayload.paySubsidyGranted).toBe(
+      PAY_SUBSIDY_GRANTED.NOT_GRANTED
+    );
+    expect(submittedPayload.paySubsidyPercent).toBeNull();
+    expect(submittedPayload.companyNumberOfEmployees).toBeNull();
+    expect(submittedPayload.deMinimisAid).toBe(true);
+    expect(submittedPayload.deMinimisAidSet).toEqual([{ id: 'aid-1' }]);
+    expect(submittedPayload.startDate).toBe('backend:01.01.2024');
+    expect(submittedPayload.endDate).toBe('backend:31.12.2024');
+    expect(submittedPayload.paperApplicationDate).toBe('backend:01.06.2024');
+    expect(submittedPayload.approveTerms).toEqual({
+      terms: 'terms-1',
+      selectedApplicantConsents: ['consent-1'],
+    });
+  });
+
+  it('should set pay subsidies override when subsidy selection changes to granted', async () => {
+    const changedValues: Partial<Application> = {
+      ...mockApplicationFormData,
+      paySubsidyGranted: PAY_SUBSIDY_GRANTED.GRANTED,
+      apprenticeshipProgram: false,
+      paySubsidies: [],
+    };
+
+    const { result } = renderHook(
+      () =>
+        useFormActions(changedValues, {
+          ...changedValues,
+          paySubsidyGranted: PAY_SUBSIDY_GRANTED.NOT_GRANTED,
+        }),
+      { wrapper: createContextWrapper() }
+    );
+
+    await result.current.onSave(changedValues as Application, 'existing-id');
+
+    const savedPayload = mockUpdateApplication.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(savedPayload.paySubsidyPercent).toBe(PAY_SUBSIDY_OPTIONS[0]);
+    expect(savedPayload.paySubsidies).toHaveLength(1);
+  });
+
+  it('should clear training compensations when apprenticeship is false', async () => {
+    const appWithProgram: Partial<Application> = {
+      ...mockApplicationFormData,
+      apprenticeshipProgram: false,
+      trainingCompensations: [
+        { id: 'tc-1' } as NonNullable<
+          Application['trainingCompensations']
+        >[number],
+      ],
+    };
+
+    const { result } = renderHook(
+      () => useFormActions(appWithProgram, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    await result.current.onSave(appWithProgram as Application, 'existing-id');
+
+    const savedPayload = mockUpdateApplication.mock.calls[0][0] as Application;
+    expect(savedPayload.trainingCompensations).toEqual([]);
+  });
+
+  it('should show generic error toast when API error response is HTML string', () => {
+    mockUpdateError = { response: { data: '<html>Error</html>' } };
+
+    renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    expect(hdsToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        labelText: 'common:error.generic.label',
+        text: 'common:error.generic.text',
+      })
+    );
+  });
+
+  it('should show validation error content toast for object error response', () => {
+    mockUpdateError = {
+      response: {
+        data: {
+          employee: { first_name: ['Missing first name'] },
+          approveTerms: true,
+          fieldA: ['Error A'],
+        },
+      },
+    };
+
+    renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    expect(hdsToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        labelText: 'common:error.generic.label',
+      })
+    );
+  });
+
+  it('should render mixed validation error values without crashing', () => {
+    mockUpdateError = {
+      response: {
+        data: {
+          employee: {
+            first_name: ['Missing', 'Required'],
+            metadata: { code: 123, active: true },
+          },
+          objectField: { reason: 'invalid' },
+          listField: [1, 2],
+        },
+      },
+    };
+
+    renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    expect(hdsToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' })
+    );
+  });
+
+  it('should handle employee validation fallback when employee error is not object', () => {
+    mockUpdateError = {
+      response: {
+        data: {
+          employee: 'invalid employee payload',
+          anotherField: ['x'],
+        },
+      },
+    };
+
+    renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    expect(hdsToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' })
+    );
+  });
+
+  it('should render unresolved error if error content generation throws', () => {
+    (camelcaseKeys as unknown as jest.Mock)
+      .mockImplementationOnce((value: unknown) => value)
+      .mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+
+    mockUpdateError = {
+      response: {
+        data: {
+          employee: { first_name: ['bad'] },
+        },
+      },
+    };
+
+    renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    expect(hdsToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' })
+    );
+  });
+
+  it('should return undefined on onNext when update throws', async () => {
+    mockUpdateApplication.mockRejectedValueOnce(new Error('next failed'));
+    const dispatchStep = jest.fn();
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    const output = await result.current.onNext(
+      mockApplicationFormData as Application,
+      dispatchStep,
+      1,
+      'app-1',
+      mockApplicationFormData as Application
+    );
+
+    expect(output).toBeUndefined();
+  });
+
+  it('should return undefined on onBack when update throws', async () => {
+    mockUpdateApplication.mockRejectedValueOnce(new Error('back failed'));
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    const output = await result.current.onBack();
+
+    expect(output).toBeUndefined();
+  });
+
+  it('should return undefined on onQuietSave when create throws', async () => {
+    mockCreateApplication.mockRejectedValueOnce(new Error('quiet failed'));
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    const output = await result.current.onQuietSave(
+      mockApplicationFormData as Application,
+      ''
+    );
+
+    expect(output).toBeUndefined();
+  });
+
+  it('should return undefined on onSave when update throws', async () => {
+    mockUpdateApplication.mockRejectedValueOnce(new Error('save failed'));
+    const { result } = renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    const output = await result.current.onSave(
+      mockApplicationFormData as Application,
+      'existing-id'
+    );
+
+    expect(output).toBeUndefined();
+  });
+
+  it('should initialize router navigation with application status', () => {
+    renderHook(
+      () => useFormActions(mockApplicationFormData, mockApplicationFormData),
+      { wrapper: createContextWrapper() }
+    );
+
+    expect(useRouterNavigation).toHaveBeenCalledWith(
+      APPLICATION_STATUSES.DRAFT
+    );
+  });
+});

--- a/frontend/benefit/handler/src/hooks/__tests__/useHandlerReviewActions.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useHandlerReviewActions.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import AppContext, { AppContextType } from 'benefit/handler/context/AppContext';
 import { useRouterNavigation } from 'benefit/handler/hooks/applicationHandling/useRouterNavigation';
 import { useApplicationActions } from 'benefit/handler/hooks/useApplicationActions';

--- a/frontend/benefit/handler/src/hooks/__tests__/useUpdateCompanyIndustryCode.test.ts
+++ b/frontend/benefit/handler/src/hooks/__tests__/useUpdateCompanyIndustryCode.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { HandlerEndpoint } from 'benefit-shared/backend-api/backend-api';
 import { useMutation } from 'react-query';
 import useBackendAPI from 'shared/hooks/useBackendAPI';

--- a/frontend/benefit/handler/src/hooks/applicationHandling/__tests__/useRouterNavigation.test.ts
+++ b/frontend/benefit/handler/src/hooks/applicationHandling/__tests__/useRouterNavigation.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { APPLICATION_LIST_TABS, ROUTES } from 'benefit/handler/constants';
 import { APPLICATION_STATUSES, BATCH_STATUSES } from 'benefit-shared/constants';
 import { useRouter } from 'next/router';

--- a/frontend/benefit/handler/src/hooks/applicationHandling/useDecisionProposalDraftMutation.tsx
+++ b/frontend/benefit/handler/src/hooks/applicationHandling/useDecisionProposalDraftMutation.tsx
@@ -31,7 +31,9 @@ const useDecisionProposalDraftMutation = (
         ? Promise.reject(new Error('Missing application id'))
         : handleResponse<DecisionProposalDraftData>(
             axios.patch(`${BackendEndpoint.DECISION_PROPOSAL_DRAFT}`, {
-              ...snakecaseKeys(decisionProposalPayload),
+              ...snakecaseKeys(
+                decisionProposalPayload as Record<string, unknown>
+              ),
             })
           ),
     {

--- a/frontend/benefit/handler/src/hooks/useCalculatorData.ts
+++ b/frontend/benefit/handler/src/hooks/useCalculatorData.ts
@@ -66,23 +66,23 @@ const useCalculatorData = (
    */
   const handleClear = (confirm: boolean): true => {
     if (confirm) {
-      formik.setFieldValue('endDate', '');
-      formik.setFieldValue('startDate', '');
-      formik.setFieldValue(
+      void formik.setFieldValue('endDate', '');
+      void formik.setFieldValue('startDate', '');
+      void formik.setFieldValue(
         'workTimePercent',
         String(PAY_SUBSIDY_PERCENT.DEFAULT)
       );
-      formik.setFieldValue('monthlyAmount', '');
-      formik.setFieldValue(
+      void formik.setFieldValue('monthlyAmount', '');
+      void formik.setFieldValue(
         'paySubsidies',
         application.paySubsidyGranted === PAY_SUBSIDY_GRANTED.NOT_GRANTED
           ? []
           : [PAY_SUBSIDIES_OVERRIDE]
       );
-      formik.setFieldValue('trainingCompensations', []);
+      void formik.setFieldValue('trainingCompensations', []);
       // Manual calculation fields
-      formik.setFieldValue('overrideMonthlyBenefitAmount', '');
-      formik.setFieldValue('overrideMonthlyBenefitAmountComment', '');
+      void formik.setFieldValue('overrideMonthlyBenefitAmount', '');
+      void formik.setFieldValue('overrideMonthlyBenefitAmountComment', '');
     }
     setTimeout(() => {
       focusAndScroll('monthlyPay');

--- a/frontend/benefit/handler/src/hooks/useFormActions.tsx
+++ b/frontend/benefit/handler/src/hooks/useFormActions.tsx
@@ -303,9 +303,7 @@ const useFormActions = (
   const getPayloadForTrainingCompensations = (
     values: Partial<Application>
   ): TrainingCompensation[] => {
-    if (
-      values.apprenticeshipProgram
-    ) {
+    if (values.apprenticeshipProgram) {
       // Return the training compensation values as they are
       return values?.trainingCompensations || [];
     }
@@ -329,9 +327,7 @@ const useFormActions = (
     } = currentValues;
 
     const normalizedPaySubsidyGranted =
-      (paySubsidyGranted === null || paySubsidyGranted === undefined)
-        ? PAY_SUBSIDY_GRANTED.NOT_GRANTED
-        : paySubsidyGranted;
+      paySubsidyGranted ?? PAY_SUBSIDY_GRANTED.NOT_GRANTED;
 
     const paySubsidyPercent =
       normalizedPaySubsidyGranted === PAY_SUBSIDY_GRANTED.NOT_GRANTED
@@ -373,9 +369,7 @@ const useFormActions = (
         : undefined,
       apprenticeshipProgram,
       companyNumberOfEmployees:
-        companyNumberOfEmployees === ''
-          ? null
-          : companyNumberOfEmployees,
+        companyNumberOfEmployees === '' ? null : companyNumberOfEmployees,
     };
 
     return {

--- a/frontend/benefit/shared/jest.config.js
+++ b/frontend/benefit/shared/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
   moduleNameMapper: {
     ['^benefit/shared/test/(.*)$']: '<rootDir>/test/$1',
     [`^benefit-shared\/(.*)$`]: '<rootDir>/src/$1',
-    [`^benefit/shared\/(.*)$`]: '<rootDir>src/$1',
+    [`^benefit/shared\/(.*)$`]: '<rootDir>/src/$1',
     [`^shared\/(.*)$`]: '<rootDir>/../../shared/src/$1',
   },
   setupFilesAfterEnv: [

--- a/frontend/benefit/shared/package.json
+++ b/frontend/benefit/shared/package.json
@@ -26,6 +26,7 @@
     "next-i18next": "^13.0.3",
     "next-router-mock": "0.9.12",
     "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-query": "^3.34.0",
     "styled-components": "^5.3.11",
     "yup": "^0.32.9"

--- a/frontend/benefit/shared/src/components/alterationForm/AlterationForm.tsx
+++ b/frontend/benefit/shared/src/components/alterationForm/AlterationForm.tsx
@@ -114,7 +114,6 @@ const AlterationForm = ({ application }: Props): JSX.Element | null => {
         {alterationType !== null && (
           <>
             <$GridCell $colSpan={3}>
-              {/* @ts-expect-error: The HDS React DateInput has stricter type definitions for its props, causing TS2740. */}
               <DateInput
                 label={t(`${translationBase}.fields.endDate.label`)}
                 helperText={t(`${translationBase}.fields.date.helpText`)}
@@ -135,7 +134,6 @@ const AlterationForm = ({ application }: Props): JSX.Element | null => {
             </$GridCell>
             {alterationType === ALTERATION_TYPE.SUSPENSION && (
               <$GridCell $colSpan={3}>
-                {/* @ts-expect-error: The HDS React DateInput has stricter type definitions for its props, causing TS2740. */}
                 <DateInput
                   label={t(`${translationBase}.fields.resumeDate.label`)}
                   helperText={t(`${translationBase}.fields.date.helpText`)}
@@ -159,7 +157,6 @@ const AlterationForm = ({ application }: Props): JSX.Element | null => {
             )}
             <$GridCell $colSpan={6} />
             <$GridCell $colSpan={6}>
-              {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
               <TextInput
                 label={
                   alterationType === ALTERATION_TYPE.SUSPENSION
@@ -190,7 +187,6 @@ const AlterationForm = ({ application }: Props): JSX.Element | null => {
           <$H2>{t(`${translationBase}.billing`)}</$H2>
         </$GridCell>
         <$GridCell $colSpan={4}>
-          {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
           <TextInput
             label={t(`${translationBase}.fields.contactPersonName.label`)}
             helperText={t(
@@ -246,7 +242,6 @@ const AlterationForm = ({ application }: Props): JSX.Element | null => {
         {useEinvoice && (
           <>
             <$GridCell $colSpan={4}>
-              {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
               <TextInput
                 label={t(
                   `${translationBase}.fields.einvoiceProviderName.label`
@@ -267,7 +262,6 @@ const AlterationForm = ({ application }: Props): JSX.Element | null => {
             </$GridCell>
             <$GridCell $colSpan={8} />
             <$GridCell $colSpan={4}>
-              {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
               <TextInput
                 label={t(
                   `${translationBase}.fields.einvoiceProviderIdentifier.label`
@@ -288,7 +282,6 @@ const AlterationForm = ({ application }: Props): JSX.Element | null => {
             </$GridCell>
             <$GridCell $colSpan={8} />
             <$GridCell $colSpan={4}>
-              {/* @ts-expect-error: The HDS React TextInput has stricter type definitions for its props, causing TS2740. */}
               <TextInput
                 label={t(`${translationBase}.fields.einvoiceAddress.label`)}
                 placeholder={t(

--- a/frontend/benefit/shared/src/components/alterationForm/AlterationForm.tsx
+++ b/frontend/benefit/shared/src/components/alterationForm/AlterationForm.tsx
@@ -6,7 +6,13 @@ import { ALTERATION_STATE, ALTERATION_TYPE } from 'benefit-shared/constants';
 import AlterationFormContext from 'benefit-shared/context/AlterationFormContext';
 import { Application } from 'benefit-shared/types/application';
 import { getErrorText } from 'benefit-shared/utils/forms';
-import { DateInput, RadioButton, SelectionGroup, TextInput } from 'hds-react';
+import {
+  DateInput,
+  RadioButton,
+  SelectionGroup,
+  TextInput,
+  Tooltip,
+} from 'hds-react';
 import React, { useContext, useMemo } from 'react';
 import {
   $Grid,
@@ -287,9 +293,11 @@ const AlterationForm = ({ application }: Props): JSX.Element | null => {
                 placeholder={t(
                   `${translationBase}.fields.einvoiceAddress.placeholder`
                 )}
-                tooltipText={t(
-                  `${translationBase}.fields.einvoiceAddress.tooltip`
-                )}
+                tooltip={
+                  <Tooltip>
+                    {t(`${translationBase}.fields.einvoiceAddress.tooltip`)}
+                  </Tooltip>
+                }
                 value={formik.values.einvoiceAddress}
                 id="alteration-einvoice-address"
                 name="einvoiceAddress"

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -2,8 +2,8 @@ module.exports = {
   transform: {
     '^.+\\.(t|j)sx?$': '@swc/jest',
   },
-  transformIgnorePatterns: ['/node_modules/(?!(uuid)/)'],
-  setupFiles: [require.resolve('./jest.setup.js')],
+  transformIgnorePatterns: ['/node_modules/(?!.pnpm/(uuid|hds-react)@)/'],
+  setupFilesAfterEnv: [require.resolve('./jest.setup.js')],
   testEnvironment: 'jsdom',
   collectCoverageFrom: [
     './src/**/*.{ts,tsx,js,jsx}',

--- a/frontend/kesaseteli/employer/src/components/dashboard/ApplicationTable/ApplicationTableFilterBar.tsx
+++ b/frontend/kesaseteli/employer/src/components/dashboard/ApplicationTable/ApplicationTableFilterBar.tsx
@@ -1,4 +1,4 @@
-import { Select, ToggleButton, Tooltip } from 'hds-react';
+import { Option, Select, ToggleButton, Tooltip } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import { OptionType } from 'shared/types/common';
@@ -78,9 +78,9 @@ const ApplicationTableFilterBar: React.FC = () => {
           texts={{
             label: t('common:dashboard.filterBar.yearFilterLabel'),
           }}
-          options={options}
-          value={selectedOption ? [selectedOption] : []}
-          onChange={(selectedOptions: OptionType[]) => {
+          options={options as Option[]}
+          value={selectedOption ? ([selectedOption] as Option[]) : []}
+          onChange={(selectedOptions: Option[]) => {
             if (selectedOptions[0]) {
               onChangeYear(selectedOptions[0].value?.toString());
             }
@@ -97,7 +97,7 @@ const ApplicationTableFilterBar: React.FC = () => {
         tooltip={
           <Tooltip
             id="application-table-filter-mine-tooltip"
-            label={t('common:dashboard.filterBar.tooltipLabel')}
+            tooltipLabel={t('common:dashboard.filterBar.tooltipLabel')}
             buttonLabel={t('common:dashboard.filterBar.tooltipButtonLabel')}
           >
             {t('common:dashboard.filterBar.tooltipText')}

--- a/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationApi.test.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationApi.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import showErrorToast from 'shared/components/toast/show-error-toast';
 import type Application from 'shared/types/application';
 
@@ -80,8 +80,21 @@ const createAxiosError = (
 };
 
 describe('useApplicationApi - fetchEmployment', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      .mockImplementation(() => undefined);
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it('calls onSuccess callback with updated application data on successful fetch', async () => {

--- a/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationFormField.test.tsx
+++ b/frontend/kesaseteli/employer/src/hooks/application/__tests__/useApplicationFormField.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import React from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 import Application from 'shared/types/application-form-data';
@@ -17,7 +17,10 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
 describe('useApplicationFormField', () => {
   it('returns field metadata, value, and sets focus', () => {
-    const { result } = renderHook(() => useApplicationFormField('contact_person_name'), { wrapper: Wrapper });
+    const { result } = renderHook(
+      () => useApplicationFormField('contact_person_name'),
+      { wrapper: Wrapper }
+    );
 
     expect(result.current.fieldName).toBe('contact_person_name');
     expect(result.current.getValue()).toBe('John Doe');
@@ -52,7 +55,10 @@ describe('useApplicationFormField', () => {
     expect(result.current.field.getErrorText()).toBeUndefined();
 
     act(() => {
-      result.current.setError('contact_person_name', { type: 'custom', message: 'Custom Error Message' });
+      result.current.setError('contact_person_name', {
+        type: 'custom',
+        message: 'Custom Error Message',
+      });
     });
     expect(result.current.field.hasError()).toBe(true);
     expect(result.current.field.getErrorText()).toBe('Custom Error Message');
@@ -61,7 +67,9 @@ describe('useApplicationFormField', () => {
       result.current.setError('contact_person_name', { type: 'required' });
     });
     expect(result.current.field.hasError()).toBe(true);
-    expect(result.current.field.getErrorText()).toBe('Tieto puuttuu tai on virheellinen');
+    expect(result.current.field.getErrorText()).toBe(
+      'Tieto puuttuu tai on virheellinen'
+    );
 
     act(() => {
       result.current.field.clearErrors();
@@ -74,8 +82,12 @@ describe('useApplicationFormField', () => {
       () => {
         const formContext = useFormContext<Application>();
         void formContext.formState.errors;
-        const hiredAssessment = useApplicationFormField<string>('summer_vouchers.0.hired_without_voucher_assessment');
-        const contract = useApplicationFormField('summer_vouchers.0.employment_contract');
+        const hiredAssessment = useApplicationFormField<string>(
+          'summer_vouchers.0.hired_without_voucher_assessment'
+        );
+        const contract = useApplicationFormField(
+          'summer_vouchers.0.employment_contract'
+        );
         return {
           hiredAssessment,
           contract,
@@ -86,16 +98,28 @@ describe('useApplicationFormField', () => {
     );
 
     act(() => {
-      result.current.setError('summer_vouchers.0.hired_without_voucher_assessment', { type: 'required' });
-      result.current.setError('summer_vouchers.0.employment_contract', { type: 'required' });
+      result.current.setError(
+        'summer_vouchers.0.hired_without_voucher_assessment',
+        { type: 'required' }
+      );
+      result.current.setError('summer_vouchers.0.employment_contract', {
+        type: 'required',
+      });
     });
 
-    expect(result.current.hiredAssessment.getErrorText()).toBe('Valitse jokin vaihtoehto');
-    expect(result.current.contract.getErrorText()).toBe('Liitä ainakin yksi tiedosto');
+    expect(result.current.hiredAssessment.getErrorText()).toBe(
+      'Valitse jokin vaihtoehto'
+    );
+    expect(result.current.contract.getErrorText()).toBe(
+      'Liitä ainakin yksi tiedosto'
+    );
   });
 
   it('triggers validation and sets focus gracefully', async () => {
-    const { result } = renderHook(() => useApplicationFormField('contact_person_name'), { wrapper: Wrapper });
+    const { result } = renderHook(
+      () => useApplicationFormField('contact_person_name'),
+      { wrapper: Wrapper }
+    );
 
     let triggerResult = false;
     await act(async () => {

--- a/frontend/kesaseteli/employer/src/hooks/application/__tests__/useLoadDraftOrCreateNewApplication.test.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/__tests__/useLoadDraftOrCreateNewApplication.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import useApplicationsQuery from 'kesaseteli/employer/hooks/backend/useApplicationsQuery';
 import useCreateApplicationQuery from 'kesaseteli/employer/hooks/backend/useCreateApplicationQuery';
 import ApplicationPersistenceService from 'kesaseteli/employer/services/ApplicationPersistenceService';

--- a/frontend/kesaseteli/employer/src/hooks/application/__tests__/useResetApplicationFormValuesEffect.test.ts
+++ b/frontend/kesaseteli/employer/src/hooks/application/__tests__/useResetApplicationFormValuesEffect.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
 import ApplicationPersistenceService from 'kesaseteli/employer/services/ApplicationPersistenceService';
 import { UseFormReturn } from 'react-hook-form';
@@ -58,7 +58,9 @@ describe('useResetApplicationFormValuesEffect', () => {
       },
     });
 
-    (ApplicationPersistenceService.getEmployerData as jest.Mock).mockReturnValue(null);
+    (
+      ApplicationPersistenceService.getEmployerData as jest.Mock
+    ).mockReturnValue(null);
 
     runHook(false);
 
@@ -66,7 +68,9 @@ describe('useResetApplicationFormValuesEffect', () => {
     const [resetValues, resetOptions] = mockReset.mock.calls[0];
     expect(resetValues.id).toBe('app-123');
     expect(resetValues.contact_person_name).toBe('John Doe');
-    expect(resetValues.summer_vouchers[0].employee_name).toBe('Voucher Employee');
+    expect(resetValues.summer_vouchers[0].employee_name).toBe(
+      'Voucher Employee'
+    );
     expect(resetOptions).toEqual({ keepDirty: false });
   });
 
@@ -88,7 +92,9 @@ describe('useResetApplicationFormValuesEffect', () => {
       contact_person_name: 'Employer Name',
       street_address: 'New Address',
     };
-    (ApplicationPersistenceService.getEmployerData as jest.Mock).mockReturnValue(mockEmployerData);
+    (
+      ApplicationPersistenceService.getEmployerData as jest.Mock
+    ).mockReturnValue(mockEmployerData);
 
     runHook(false);
 
@@ -110,14 +116,18 @@ describe('useResetApplicationFormValuesEffect', () => {
       },
     });
 
-    (ApplicationPersistenceService.getEmployerData as jest.Mock).mockReturnValue(null);
+    (
+      ApplicationPersistenceService.getEmployerData as jest.Mock
+    ).mockReturnValue(null);
 
     runHook(false);
 
     expect(mockReset).toHaveBeenCalledTimes(1);
     const [resetValues] = mockReset.mock.calls[0];
     expect(resetValues.summer_vouchers).toHaveLength(1);
-    expect(resetValues.summer_vouchers[0].summer_voucher_serial_number).toBe('');
+    expect(resetValues.summer_vouchers[0].summer_voucher_serial_number).toBe(
+      ''
+    );
   });
 
   it('merges current user typed changes if form is dirty', () => {
@@ -150,7 +160,9 @@ describe('useResetApplicationFormValuesEffect', () => {
       ],
     };
     mockGetValues.mockReturnValue(mockUserTypedValues);
-    (ApplicationPersistenceService.getEmployerData as jest.Mock).mockReturnValue(null);
+    (
+      ApplicationPersistenceService.getEmployerData as jest.Mock
+    ).mockReturnValue(null);
 
     runHook(true);
 
@@ -158,8 +170,12 @@ describe('useResetApplicationFormValuesEffect', () => {
     const [resetValues, resetOptions] = mockReset.mock.calls[0];
     expect(resetValues.contact_person_name).toBe('User Edited Name');
     expect(resetValues.street_address).toBe('User Typed Address');
-    expect(resetValues.summer_vouchers[0].employee_name).toBe('User Edited Employee');
-    expect(resetValues.summer_vouchers[0].summer_voucher_serial_number).toBe('123');
+    expect(resetValues.summer_vouchers[0].employee_name).toBe(
+      'User Edited Employee'
+    );
+    expect(resetValues.summer_vouchers[0].summer_voucher_serial_number).toBe(
+      '123'
+    );
     expect(resetOptions).toEqual({ keepDirty: true });
   });
 });

--- a/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useApplicationsQuery.test.tsx
+++ b/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useApplicationsQuery.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useQuery } from 'react-query';
 
 import useApplicationsQuery from '../useApplicationsQuery';

--- a/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useCreateApplicationQuery.test.tsx
+++ b/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useCreateApplicationQuery.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { useRouter } from 'next/router';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';

--- a/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useDeleteApplicationQuery.test.tsx
+++ b/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useDeleteApplicationQuery.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import React from 'react';
 import {
   InvalidateQueryFilters,

--- a/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useOpenAttachment.test.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useOpenAttachment.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import useBackendAPI from 'shared/hooks/useBackendAPI';
 import { KesaseteliAttachment } from 'shared/types/attachment';
 

--- a/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useOperationPermitted.test.ts
+++ b/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useOperationPermitted.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import useUserQuery from 'kesaseteli/employer/hooks/backend/useUserQuery';
 import useAuth from 'shared/hooks/useAuth';
 import useIsRouting from 'shared/hooks/useIsRouting';

--- a/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useUserQuery.test.tsx
+++ b/frontend/kesaseteli/employer/src/hooks/backend/__tests__/useUserQuery.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { ROUTES } from 'kesaseteli-shared/constants/routes';
 import { useRouter } from 'next/router';
 import React from 'react';

--- a/frontend/kesaseteli/employer/src/hooks/employments/__tests__/useGetEmploymentErrors.test.tsx
+++ b/frontend/kesaseteli/employer/src/hooks/employments/__tests__/useGetEmploymentErrors.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import React from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 

--- a/frontend/kesaseteli/employer/src/hooks/employments/__tests__/useValidateEmployment.test.tsx
+++ b/frontend/kesaseteli/employer/src/hooks/employments/__tests__/useValidateEmployment.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 

--- a/frontend/kesaseteli/employer/src/hooks/employments/__tests__/useValidateEmploymentsNotEmpty.test.tsx
+++ b/frontend/kesaseteli/employer/src/hooks/employments/__tests__/useValidateEmploymentsNotEmpty.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useFormContext } from 'react-hook-form';
 
 import useValidateEmploymentsNotEmpty from '../useValidateEmploymentsNotEmpty';

--- a/frontend/kesaseteli/employer/src/hooks/employments/__tests__/useWatchEmployeeDisplayName.test.tsx
+++ b/frontend/kesaseteli/employer/src/hooks/employments/__tests__/useWatchEmployeeDisplayName.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 

--- a/frontend/kesaseteli/employer/src/pages/thankyou.tsx
+++ b/frontend/kesaseteli/employer/src/pages/thankyou.tsx
@@ -1,4 +1,8 @@
-import { ButtonVariant, IconCheckCircleFill } from 'hds-react';
+import {
+  ButtonVariant,
+  IconCheckCircleFill,
+  NotificationSize,
+} from 'hds-react';
 import withEmployerAuth from 'kesaseteli/employer/hocs/withEmployerAuth';
 import useApplicationApi from 'kesaseteli/employer/hooks/application/useApplicationApi';
 import useApplicationsQuery from 'kesaseteli/employer/hooks/backend/useApplicationsQuery';
@@ -121,7 +125,7 @@ const ThankYouPage: NextPage = () => {
         <$Notification
           label={t('common:thankyouPage.thankyouMessageLabel')}
           type="success"
-          size="large"
+          size={NotificationSize.Large}
         >
           {t(`common:thankyouPage.thankyouMessageContent`)}
         </$Notification>

--- a/frontend/kesaseteli/handler/src/__tests__/utils/backend/backend-nocks.ts
+++ b/frontend/kesaseteli/handler/src/__tests__/utils/backend/backend-nocks.ts
@@ -24,16 +24,17 @@ export const waitForBackendRequestsToComplete = async (): Promise<void> => {
     .pendingMocks()
     .filter((m) => !m.includes(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION));
   if (pending.length > 0) {
-    // eslint-disable-next-line no-console
-    console.log('pending nocks', pending);
-    await waitFor(() => {
-      const currentPending = nock
-        .pendingMocks()
-        .filter(
-          (m) => !m.includes(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)
-        );
-      expect(currentPending).toHaveLength(0);
-    });
+    await waitFor(
+      () => {
+        const currentPending = nock
+          .pendingMocks()
+          .filter(
+            (m) => !m.includes(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)
+          );
+        expect(currentPending).toHaveLength(0);
+      },
+      { timeout: 5000 }
+    );
   }
 };
 

--- a/frontend/kesaseteli/handler/src/components/applicationList/searchFilters/StatusFilter.tsx
+++ b/frontend/kesaseteli/handler/src/components/applicationList/searchFilters/StatusFilter.tsx
@@ -84,9 +84,9 @@ const StatusFilter = ({
         options={options}
         value={selectedOptions}
         invalid={isInvalid}
-        onChange={(nextSelectedOptions: OptionType<ApplicationStatus>[]) => {
+        onChange={(nextSelectedOptions) => {
           const nextStatuses = nextSelectedOptions.map(
-            (option) => option.value
+            (option) => option.value as ApplicationStatus
           );
           setSelectedStatuses(nextStatuses);
           // Only update query if selection is valid (not empty) to avoid querying every status

--- a/frontend/kesaseteli/handler/src/components/employer-application/EmployerApplicationAttachments.tsx
+++ b/frontend/kesaseteli/handler/src/components/employer-application/EmployerApplicationAttachments.tsx
@@ -1,4 +1,4 @@
-import { IconPlus, RadioButton } from 'hds-react';
+import { ButtonPresetTheme, IconPlus, RadioButton } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React, { useRef, useState } from 'react';
 import Button from 'shared/components/button/Button';
@@ -183,7 +183,7 @@ const EmployerApplicationAttachments: React.FC<Props> = ({ application }) => {
           isLoading={uploadMutation.isLoading}
           loadingText={t('common:upload.isUploading')}
           iconStart={<IconPlus />}
-          theme="coat"
+          theme={ButtonPresetTheme.Coat}
         >
           {isMobile
             ? t('common:handlerApplication.attachmentsInputPlaceholderMobile')

--- a/frontend/kesaseteli/handler/src/components/employer-application/EmployerApplicationHandlerView.tsx
+++ b/frontend/kesaseteli/handler/src/components/employer-application/EmployerApplicationHandlerView.tsx
@@ -68,7 +68,6 @@ const EmployerApplicationPanel: React.FC<
  */
 const EmployerApplicationHandlerView: React.FC<Props> = ({ application }) => {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useState(0);
   const theme = useTheme();
   const isMobile = useMediaQuery(`(max-width: ${theme.breakpoints.m})`);
   const [isNotificationOpen, setIsNotificationOpen] = useState(true);
@@ -108,7 +107,7 @@ const EmployerApplicationHandlerView: React.FC<Props> = ({ application }) => {
           onClose={() => setIsNotificationOpen(false)}
         />
       )}
-      <$StickyTabs index={activeTab} onChange={setActiveTab}>
+      <$StickyTabs initiallyActiveTab={0}>
         <TabList>
           {vouchers.map((voucher, index) => (
             <Tab key={voucher.id || index}>

--- a/frontend/kesaseteli/handler/src/components/form/VtjErrorNotification.tsx
+++ b/frontend/kesaseteli/handler/src/components/form/VtjErrorNotification.tsx
@@ -1,4 +1,4 @@
-import { NotificationProps } from 'hds-react';
+import { NotificationProps, NotificationSize } from 'hds-react';
 import VtjExceptionType from 'kesaseteli/handler/types/vtj-exception-type';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
@@ -14,7 +14,7 @@ type Props = {
 const VtjErrorNotification: React.FC<Props> = ({
   reason,
   type = 'alert',
-  size = 'small',
+  size = NotificationSize.Small,
   params,
 }) => {
   const { t } = useTranslation();

--- a/frontend/kesaseteli/handler/src/components/notes/NoteForm.tsx
+++ b/frontend/kesaseteli/handler/src/components/notes/NoteForm.tsx
@@ -1,6 +1,7 @@
-import { Button, ButtonSize, ButtonVariant, Checkbox, RadioButton } from 'hds-react';
+import { ButtonSize, ButtonVariant, Checkbox, RadioButton } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React, { useState } from 'react';
+import Button from 'shared/components/button/Button';
 import useLocale from 'shared/hooks/useLocale';
 
 import {
@@ -91,7 +92,6 @@ const NoteForm: React.FC<Props> = ({
 
   return (
     <$FormContainer onSubmit={handleSubmit} noValidate>
-      {/* @ts-expect-error: HDS React TextArea has stricter type definitions for its props, causing TS2740 */}
       <$TextArea
         id={isEditing ? `edit-note-${initialNote?.id}` : 'add-note-content'}
         label={
@@ -114,14 +114,22 @@ const NoteForm: React.FC<Props> = ({
       <$Toolbar>
         <$OptionsGroup>
           <RadioButton
-            id={isEditing ? `note-type-internal-${initialNote?.id}` : 'note-type-internal'}
+            id={
+              isEditing
+                ? `note-type-internal-${initialNote?.id}`
+                : 'note-type-internal'
+            }
             label={t('common:handlerNotes.noteType.internal')}
             value={NoteType.INTERNAL}
             checked={noteType === NoteType.INTERNAL}
             onChange={() => setNoteType(NoteType.INTERNAL)}
           />
           <RadioButton
-            id={isEditing ? `note-type-external-${initialNote?.id}` : 'note-type-external'}
+            id={
+              isEditing
+                ? `note-type-external-${initialNote?.id}`
+                : 'note-type-external'
+            }
             label={t('common:handlerNotes.noteType.external_message')}
             value={NoteType.EXTERNAL_MESSAGE}
             checked={noteType === NoteType.EXTERNAL_MESSAGE}
@@ -129,7 +137,11 @@ const NoteForm: React.FC<Props> = ({
           />
           <$Separator aria-hidden="true" />
           <Checkbox
-            id={isEditing ? `note-is-important-${initialNote?.id}` : 'note-is-important'}
+            id={
+              isEditing
+                ? `note-is-important-${initialNote?.id}`
+                : 'note-is-important'
+            }
             label={t('common:handlerNotes.isImportantLabel')}
             checked={isImportant}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>

--- a/frontend/kesaseteli/handler/src/components/notes/__tests__/NotesSection.test.tsx
+++ b/frontend/kesaseteli/handler/src/components/notes/__tests__/NotesSection.test.tsx
@@ -41,7 +41,6 @@ describe('NotesSection', () => {
         id="notes-accordion"
         heading="Käsittelijän huomiot"
         initiallyOpen
-        onToggle={() => { }}
       >
         <NotesSection
           applicationId="app-1"

--- a/frontend/kesaseteli/handler/src/components/sidebar/__tests__/useSidebarState.test.ts
+++ b/frontend/kesaseteli/handler/src/components/sidebar/__tests__/useSidebarState.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 
 import useSidebarState from '../useSidebarState';
 

--- a/frontend/kesaseteli/handler/src/components/timeline/TimelineItem.sc.ts
+++ b/frontend/kesaseteli/handler/src/components/timeline/TimelineItem.sc.ts
@@ -32,7 +32,13 @@ const getAvatarSize = ($size?: 'small' | 'large'): string =>
 const getSvgSize = ($size?: 'small' | 'large'): string =>
   $size === 'small' ? '14px' : '18px';
 
-export const $TimelineItemCard = styled.li<{ $size?: 'small' | 'large' }>`
+type TimelineItemCardProps = {
+  $type: TimelineItemThemeType;
+  $isImportant: boolean;
+  $size?: 'small' | 'large';
+};
+
+export const $TimelineItemCard = styled.li<TimelineItemCardProps>`
   --timeline-item-line-color: ${getBorderColor};
   --timeline-item-border-color: ${getBorderColor};
   --timeline-item-background-color: ${getBackgroundColor};

--- a/frontend/kesaseteli/handler/src/hooks/__tests__/useSessionStorageState.test.ts
+++ b/frontend/kesaseteli/handler/src/hooks/__tests__/useSessionStorageState.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable scanjs-rules/property_sessionStorage, scanjs-rules/identifier_sessionStorage */
-import { act,renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 
 import useSessionStorageState from '../useSessionStorageState';
 

--- a/frontend/kesaseteli/handler/src/hooks/application/__tests__/useApplicationWithoutSsnFormField.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/application/__tests__/useApplicationWithoutSsnFormField.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import React from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 

--- a/frontend/kesaseteli/handler/src/hooks/application/__tests__/useGetApplicationWithoutSsnFormFieldLabel.test.ts
+++ b/frontend/kesaseteli/handler/src/hooks/application/__tests__/useGetApplicationWithoutSsnFormFieldLabel.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 
 import useGetApplicationWithoutSsnFormFieldLabel from '../useGetApplicationWithoutSsnFormFieldLabel';
 

--- a/frontend/kesaseteli/handler/src/hooks/application/__tests__/useHandleApplicationWithoutSsnSubmit.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/application/__tests__/useHandleApplicationWithoutSsnSubmit.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { fakeCreatedYouthApplication } from 'kesaseteli-shared/__tests__/utils/fake-objects';
 import mockRouter from 'next-router-mock';
 import React from 'react';

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useApplicationTimelineQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useApplicationTimelineQuery.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import nock from 'nock';
 import React from 'react';
@@ -49,9 +49,12 @@ describe('useApplicationTimelineQuery', () => {
       .get(new RegExp(BackendEndpoint.YOUTH_APPLICATIONS))
       .reply(200, []);
 
-    const { result } = renderHook(() => useApplicationTimelineQuery(undefined, 'youth'), {
-      wrapper,
-    });
+    const { result } = renderHook(
+      () => useApplicationTimelineQuery(undefined, 'youth'),
+      {
+        wrapper,
+      }
+    );
 
     expect(result.current.isIdle).toBe(true);
     expect(interceptor.isDone()).toBe(false);
@@ -60,11 +63,11 @@ describe('useApplicationTimelineQuery', () => {
   it('fetches youth application timeline successfully by id', async () => {
     const mockData = [{ id: '1', content: 'test note 1' }];
     nock(API_BASE_TEST_URL).get(YOUTH_ENDPOINT).reply(200, mockData);
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () => useApplicationTimelineQuery(TEST_ID, 'youth'),
       { wrapper }
     );
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockData);
     expect(nock.isDone()).toBe(true);
   });
@@ -72,22 +75,22 @@ describe('useApplicationTimelineQuery', () => {
   it('fetches employer application timeline successfully by id', async () => {
     const mockData = [{ id: '2', content: 'test note 2' }];
     nock(API_BASE_TEST_URL).get(EMPLOYER_ENDPOINT).reply(200, mockData);
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () => useApplicationTimelineQuery(TEST_ID, 'employer'),
       { wrapper }
     );
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockData);
     expect(nock.isDone()).toBe(true);
   });
 
   it('calls useErrorHandler on 500 error', async () => {
     nock(API_BASE_TEST_URL).get(YOUTH_ENDPOINT).reply(500, 'server error');
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () => useApplicationTimelineQuery(TEST_ID, 'youth'),
       { wrapper }
     );
-    await waitFor(() => result.current.isError);
+    await waitFor(() => expect(result.current.isError).toBe(true));
     expect(mockErrorHandler).toHaveBeenCalled();
   });
 });

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useCreateNoteMutation.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useCreateNoteMutation.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import nock from 'nock';
 import React from 'react';

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useCreateYouthApplicationWithoutSsnQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useCreateYouthApplicationWithoutSsnQuery.test.tsx
@@ -1,5 +1,5 @@
 // Integration test: Verifies request payloads are mapped correctly and endpoints are called using nock
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import nock from 'nock';
 import React from 'react';
@@ -72,14 +72,14 @@ describe('useCreateYouthApplicationWithoutSsnQuery (Integration)', () => {
       })
       .reply(200, mockCreatedResponse);
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () => useCreateYouthApplicationWithoutSsnQuery(),
       { wrapper }
     );
 
     result.current.mutate(formData);
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockCreatedResponse);
     expect(nock.isDone()).toBe(true);
   });

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useDeleteNoteMutation.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useDeleteNoteMutation.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import nock from 'nock';
 import React from 'react';

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useEmployerApplicationQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useEmployerApplicationQuery.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import nock from 'nock';
 import React from 'react';
@@ -51,32 +51,29 @@ describe('useEmployerApplicationQuery', () => {
   it('fetches application data successfully by id', async () => {
     const mockData = { id: TEST_ID, status: 'submitted' };
     nock(API_BASE_TEST_URL).get(ENDPOINT).reply(200, mockData);
-    const { result, waitFor } = renderHook(
-      () => useEmployerApplicationQuery(TEST_ID),
-      { wrapper }
-    );
-    await waitFor(() => result.current.isSuccess);
+    const { result } = renderHook(() => useEmployerApplicationQuery(TEST_ID), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockData);
     expect(nock.isDone()).toBe(true);
   });
 
   it('calls useErrorHandler on 500 error', async () => {
     nock(API_BASE_TEST_URL).get(ENDPOINT).reply(500, 'server error');
-    const { result, waitFor } = renderHook(
-      () => useEmployerApplicationQuery(TEST_ID),
-      { wrapper }
-    );
-    await waitFor(() => result.current.isError);
+    const { result } = renderHook(() => useEmployerApplicationQuery(TEST_ID), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
     expect(mockErrorHandler).toHaveBeenCalled();
   });
 
   it('does NOT call useErrorHandler on 404 error', async () => {
     nock(API_BASE_TEST_URL).get(ENDPOINT).reply(404, 'not found');
-    const { result, waitFor } = renderHook(
-      () => useEmployerApplicationQuery(TEST_ID),
-      { wrapper }
-    );
-    await waitFor(() => result.current.isError);
+    const { result } = renderHook(() => useEmployerApplicationQuery(TEST_ID), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
     expect(mockErrorHandler).not.toHaveBeenCalled();
   });
 });

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useEmployerApplicationsListQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useEmployerApplicationsListQuery.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import nock from 'nock';
 import React from 'react';
@@ -54,7 +54,7 @@ describe('useEmployerApplicationsListQuery', () => {
       })
       .reply(200, mockListResponse);
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () =>
         useEmployerApplicationsListQuery({
           status: ['submitted', 'handling'],
@@ -64,7 +64,7 @@ describe('useEmployerApplicationsListQuery', () => {
         }),
       { wrapper }
     );
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockListResponse);
     expect(nock.isDone()).toBe(true);
   });
@@ -75,11 +75,11 @@ describe('useEmployerApplicationsListQuery', () => {
       .query(true) // match any query params
       .reply(500, 'server error');
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () => useEmployerApplicationsListQuery({ limit: 20, offset: 0 }),
       { wrapper }
     );
-    await waitFor(() => result.current.isError);
+    await waitFor(() => expect(result.current.isError).toBe(true));
     expect(mockErrorHandler).toHaveBeenCalled();
   });
 
@@ -94,7 +94,7 @@ describe('useEmployerApplicationsListQuery', () => {
       )
       .reply(200, mockListResponse);
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () =>
         useEmployerApplicationsListQuery({
           status: [],
@@ -103,7 +103,7 @@ describe('useEmployerApplicationsListQuery', () => {
         }),
       { wrapper }
     );
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockListResponse);
     expect(nock.isDone()).toBe(true);
   });

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useHandlerNotesQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useHandlerNotesQuery.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import nock from 'nock';
 import React from 'react';
@@ -48,9 +48,12 @@ describe('useHandlerNotesQuery', () => {
       .get(BackendEndpoint.HANDLER_NOTES)
       .reply(200, []);
 
-    const { result } = renderHook(() => useHandlerNotesQuery(TEST_TARGET_TYPE), {
-      wrapper,
-    });
+    const { result } = renderHook(
+      () => useHandlerNotesQuery(TEST_TARGET_TYPE),
+      {
+        wrapper,
+      }
+    );
 
     expect(result.current.isIdle).toBe(true);
     expect(interceptor.isDone()).toBe(false);
@@ -63,11 +66,11 @@ describe('useHandlerNotesQuery', () => {
       .query({ target_type: TEST_TARGET_TYPE, target_id: TEST_TARGET_ID })
       .reply(200, mockData);
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () => useHandlerNotesQuery(TEST_TARGET_TYPE, TEST_TARGET_ID),
       { wrapper }
     );
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockData);
     expect(nock.isDone()).toBe(true);
   });
@@ -78,11 +81,11 @@ describe('useHandlerNotesQuery', () => {
       .query({ target_type: TEST_TARGET_TYPE, target_id: TEST_TARGET_ID })
       .reply(500, 'server error');
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () => useHandlerNotesQuery(TEST_TARGET_TYPE, TEST_TARGET_ID),
       { wrapper }
     );
-    await waitFor(() => result.current.isError);
+    await waitFor(() => expect(result.current.isError).toBe(true));
     expect(mockErrorHandler).toHaveBeenCalled();
     expect(nock.isDone()).toBe(true);
   });

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useLogin.test.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useLogin.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import mockRouter from 'next-router-mock';
 
 import useLogin from '../useLogin';

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useLogout.test.ts
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useLogout.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import mockRouter from 'next-router-mock';
 
 import useLogout from '../useLogout';

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useSummerVoucherConfigurationQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useSummerVoucherConfigurationQuery.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import nock from 'nock';
 import React from 'react';
@@ -60,12 +60,11 @@ describe('useSummerVoucherConfigurationQuery', () => {
       .get(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)
       .reply(200, mockConfigurationData);
 
-    const { result, waitFor } = renderHook(
-      () => useSummerVoucherConfigurationQuery(),
-      { wrapper }
-    );
+    const { result } = renderHook(() => useSummerVoucherConfigurationQuery(), {
+      wrapper,
+    });
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockConfigurationData);
     expect(nock.isDone()).toBe(true);
   });
@@ -75,12 +74,11 @@ describe('useSummerVoucherConfigurationQuery', () => {
       .get(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)
       .reply(500);
 
-    const { result, waitFor } = renderHook(
-      () => useSummerVoucherConfigurationQuery(),
-      { wrapper }
-    );
+    const { result } = renderHook(() => useSummerVoucherConfigurationQuery(), {
+      wrapper,
+    });
 
-    await waitFor(() => result.current.isError);
+    await waitFor(() => expect(result.current.isError).toBe(true));
     expect(mockErrorHandler).toHaveBeenCalled();
     expect(nock.isDone()).toBe(true);
   });

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useUpdateNoteMutation.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useUpdateNoteMutation.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import nock from 'nock';
 import React from 'react';

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useUserQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useUserQuery.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { ROUTES } from 'kesaseteli-shared/constants/routes';
 import { useRouter } from 'next/router';
 import React from 'react';

--- a/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useYouthApplicationsListQuery.test.tsx
+++ b/frontend/kesaseteli/handler/src/hooks/backend/__tests__/useYouthApplicationsListQuery.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import nock from 'nock';
 import React from 'react';
@@ -48,7 +48,7 @@ describe('useYouthApplicationsListQuery', () => {
       .query({ status: 'submitted', limit: '20', offset: '0' })
       .reply(200, mockListResponse);
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () =>
         useYouthApplicationsListQuery({
           status: ['submitted'],
@@ -57,7 +57,7 @@ describe('useYouthApplicationsListQuery', () => {
         }),
       { wrapper }
     );
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockListResponse);
     expect(nock.isDone()).toBe(true);
   });
@@ -79,7 +79,7 @@ describe('useYouthApplicationsListQuery', () => {
       })
       .reply(200, mockListResponse);
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () =>
         useYouthApplicationsListQuery({
           status: ['submitted', 'additional_information_provided'],
@@ -89,7 +89,7 @@ describe('useYouthApplicationsListQuery', () => {
         }),
       { wrapper }
     );
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockListResponse);
     expect(nock.isDone()).toBe(true);
   });
@@ -100,11 +100,11 @@ describe('useYouthApplicationsListQuery', () => {
       .query(true)
       .reply(500, 'server error');
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () => useYouthApplicationsListQuery({ limit: 20, offset: 0 }),
       { wrapper }
     );
-    await waitFor(() => result.current.isError);
+    await waitFor(() => expect(result.current.isError).toBe(true));
     expect(mockErrorHandler).toHaveBeenCalled();
   });
 
@@ -119,7 +119,7 @@ describe('useYouthApplicationsListQuery', () => {
       )
       .reply(200, mockListResponse);
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () =>
         useYouthApplicationsListQuery({
           status: [],
@@ -128,7 +128,7 @@ describe('useYouthApplicationsListQuery', () => {
         }),
       { wrapper }
     );
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockListResponse);
     expect(nock.isDone()).toBe(true);
   });

--- a/frontend/kesaseteli/handler/src/pages/dashboard.tsx
+++ b/frontend/kesaseteli/handler/src/pages/dashboard.tsx
@@ -66,7 +66,7 @@ const Dashboard: NextPage = () => {
           <$ButtonContainer>
             <Button
               variant={ButtonVariant.Secondary}
-              iconRight={<IconArrowRight />}
+              iconEnd={<IconArrowRight />}
               onClick={handleYouthApplicationsClick}
             >
               {t('common:header.youthApplicationsLabel')}
@@ -82,7 +82,7 @@ const Dashboard: NextPage = () => {
           <$ButtonContainer>
             <Button
               variant={ButtonVariant.Secondary}
-              iconRight={<IconArrowRight />}
+              iconEnd={<IconArrowRight />}
               onClick={handleEmployerApplicationsClick}
             >
               {t('common:header.employerApplicationsLabel')}

--- a/frontend/kesaseteli/handler/src/pages/login.tsx
+++ b/frontend/kesaseteli/handler/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import { ButtonPresetTheme, IconSignin } from 'hds-react';
+import { ButtonPresetTheme, IconSignin, NotificationSize } from 'hds-react';
 import useLogin from 'kesaseteli/handler/hooks/backend/useLogin';
 import { GetStaticProps, NextPage } from 'next';
 import Head from 'next/head';
@@ -52,7 +52,7 @@ const Login: NextPage = () => {
       <$Notification
         label={t(notificationLabelKey)}
         type={notificationType}
-        size="large"
+        size={NotificationSize.Large}
       >
         {notificationContent}
       </$Notification>

--- a/frontend/kesaseteli/shared/src/__tests__/utils/component-apis/header-api.ts
+++ b/frontend/kesaseteli/shared/src/__tests__/utils/component-apis/header-api.ts
@@ -31,15 +31,15 @@ const expectations = {
   errorToastIsShown: async (
     errorMessage = /tapahtui tuntematon virhe/i
   ): Promise<void> => {
+    let toast: HTMLElement | null = null;
     await waitFor(() => {
-      // eslint-disable-next-line unicorn/prefer-query-selector
-      const toast = document.getElementById('HDSToastContainer');
-      expect(toast).not.toBeNull();
-      expect(
-        within(toast as HTMLElement).getByRole('heading', {
-          name: errorMessage,
-        })
-      ).toBeInTheDocument();
+      const toastElement = document.querySelector('#HDSToastContainer');
+      expect(toastElement).not.toBeNull();
+      toast = toastElement as HTMLElement;
+    });
+
+    await within(toast!).findByRole('heading', {
+      name: errorMessage,
     });
   },
 };

--- a/frontend/kesaseteli/shared/src/hooks/__tests__/useMatomo.test.ts
+++ b/frontend/kesaseteli/shared/src/hooks/__tests__/useMatomo.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import singletonRouter from 'next-router-mock';
 import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
 import { initMatomo, trackPageView } from 'shared/utils/matomo';

--- a/frontend/kesaseteli/shared/src/hooks/__tests__/useSummerVoucherConfigurationQuery.test.tsx
+++ b/frontend/kesaseteli/shared/src/hooks/__tests__/useSummerVoucherConfigurationQuery.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { BackendEndpoint } from 'kesaseteli-shared/backend-api/backend-api';
 import SummerVoucherConfiguration from 'kesaseteli-shared/types/summer-voucher-configuration';
 import nock from 'nock';
@@ -40,6 +40,14 @@ const languageDataMock = languages.reduce<LanguageSummerVoucherConfigurations>(
 
 jest.mock('next-i18next', () => ({
   useTranslation: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({
+    t: (key: string) => key,
+    i18n: { language: 'fi' },
+  })),
+  initReactI18next: { type: '3rdParty', init: jest.fn() },
 }));
 
 jest.mock('shared/hooks/useErrorHandler', () => ({
@@ -107,12 +115,12 @@ describe('useSummerVoucherConfigurationQuery', () => {
       .get(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)
       .reply(200, languageDataMock[firstLang]);
 
-    const { result, waitFor, rerender } = renderHook(
+    const { result, rerender } = renderHook(
       () => useSummerVoucherConfigurationQuery(),
       { wrapper }
     );
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(languageDataMock[firstLang]);
     expect(nock.isDone()).toBe(true);
 
@@ -133,7 +141,9 @@ describe('useSummerVoucherConfigurationQuery', () => {
         .reply(200, languageDataMock[lang]);
 
       rerender();
-      await waitFor(() => result.current.isSuccess, { timeout: 5000 });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true), {
+        timeout: 5000,
+      });
 
       expect(result.current.data).toEqual(languageDataMock[lang]);
       expect(nock.isDone()).toBe(true);
@@ -150,12 +160,11 @@ describe('useSummerVoucherConfigurationQuery', () => {
       .get(BackendEndpoint.SUMMER_VOUCHER_CONFIGURATION)
       .reply(500);
 
-    const { result, waitFor } = renderHook(
-      () => useSummerVoucherConfigurationQuery(),
-      { wrapper }
-    );
+    const { result } = renderHook(() => useSummerVoucherConfigurationQuery(), {
+      wrapper,
+    });
 
-    await waitFor(() => result.current.isError);
+    await waitFor(() => expect(result.current.isError).toBe(true));
 
     expect(mockErrorHandler).toHaveBeenCalled();
     expect(nock.isDone()).toBe(true);

--- a/frontend/kesaseteli/shared/src/hooks/__tests__/useSummerVoucherConfigurationQuery.test.tsx
+++ b/frontend/kesaseteli/shared/src/hooks/__tests__/useSummerVoucherConfigurationQuery.test.tsx
@@ -56,6 +56,10 @@ const mockUseErrorHandler = useErrorHandler as jest.Mock;
 const mockUseLocale = useLocale as jest.Mock;
 const mockErrorHandler = jest.fn();
 
+const TypedQueryClientProvider = QueryClientProvider as React.ComponentType<
+  React.PropsWithChildren<{ client: QueryClient }>
+>;
+
 describe('useSummerVoucherConfigurationQuery', () => {
   beforeAll(() => {
     nock.disableNetConnect();
@@ -75,7 +79,9 @@ describe('useSummerVoucherConfigurationQuery', () => {
 
   const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <BackendAPIProvider baseURL={API_BASE_TEST_URL}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <TypedQueryClientProvider client={queryClient}>
+        {children}
+      </TypedQueryClientProvider>
     </BackendAPIProvider>
   );
 

--- a/frontend/kesaseteli/youth/src/components/additional-info-form/AdditionalInfoForm.tsx
+++ b/frontend/kesaseteli/youth/src/components/additional-info-form/AdditionalInfoForm.tsx
@@ -1,3 +1,4 @@
+import { ButtonPresetTheme, NotificationSize } from 'hds-react';
 import useCreateAdditionalInfoQuery from 'kesaseteli/youth/hooks/backend/useCreateAdditionalInfoQuery';
 import useRegisterInput from 'kesaseteli/youth/hooks/useRegisterInput';
 import { ADDITIONAL_INFO_REASON_TYPE } from 'kesaseteli-shared/constants/additional-info-reason-type';
@@ -40,7 +41,7 @@ const AdditionalInfoForm: React.FC<Props> = ({ applicationId }) => {
       <$Notification
         label={t(`common:additionalInfo.notification.confirmed`)}
         type="success"
-        size="large"
+        size={NotificationSize.Large}
       >
         {t(`common:additionalInfo.notification.confirmedDescription`)}
       </$Notification>
@@ -75,7 +76,7 @@ const AdditionalInfoForm: React.FC<Props> = ({ applicationId }) => {
           <$GridCell>
             <SaveFormButton
               saveQuery={useCreateAdditionalInfoQuery(applicationId)}
-              theme="black"
+              theme={ButtonPresetTheme.Black}
             >
               {t(`common:additionalInfo.form.sendButton`)}
             </SaveFormButton>

--- a/frontend/kesaseteli/youth/src/hooks/__tests__/useHandleYouthApplicationSubmit.test.tsx
+++ b/frontend/kesaseteli/youth/src/hooks/__tests__/useHandleYouthApplicationSubmit.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import {
   isYouthApplicationCreationError,
   isYouthApplicationValidationError,

--- a/frontend/kesaseteli/youth/src/hooks/backend/__tests__/useCreateAdditionalInfoQuery.test.tsx
+++ b/frontend/kesaseteli/youth/src/hooks/backend/__tests__/useCreateAdditionalInfoQuery.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import AdditionalInfoFormData from 'kesaseteli-shared/types/additional-info-form-data';
 import nock from 'nock';
 import React from 'react';
@@ -52,7 +52,7 @@ describe('useCreateAdditionalInfoQuery', () => {
       .post(`/v1/youthapplications/${applicationId}/additional_info/`)
       .reply(200, { id: 'info-123' });
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () =>
         useCreateAdditionalInfoQuery(applicationId, {
           onSuccess: mockOnSuccess,
@@ -67,7 +67,7 @@ describe('useCreateAdditionalInfoQuery', () => {
       } as unknown as AdditionalInfoFormData);
     });
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(mockOnSuccess).toHaveBeenCalled();
   });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,6 @@
     "@swc/jest": "^0.2.36",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^14.3.0",
-    "@testing-library/react-hooks": "^8.0.0",
     "@testing-library/testcafe": "^4.4.1",
     "@testing-library/user-event": "^14.1.1",
     "@types/faker": "^5.5.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,6 +74,8 @@
     "@types/leaflet": "^1.7.9",
     "@types/node": "^22.13.1",
     "@types/pretty": "^2.0.1",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
     "@types/react-input-mask": "2.0.5",
     "@types/react-leaflet": "^2.8.2",
     "@types/react-leaflet-markercluster": "^3.0.0",
@@ -144,6 +146,8 @@
     "typescript": "^5.9.3"
   },
   "resolutions": {
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
     "js-cookie": "^3.0.8",
     "underscore": "^1.13.8",
     "tmp": "^0.2.6",

--- a/frontend/shared/src/__tests__/utils/component.utils.ts
+++ b/frontend/shared/src/__tests__/utils/component.utils.ts
@@ -20,16 +20,12 @@ export const waitForLoadingCompleted = async (): Promise<void> => {
 export const waitForBackendRequestsToComplete = async (): Promise<void> => {
   await waitForLoadingCompleted();
   if (nock.pendingMocks().length > 0) {
-    // eslint-disable-next-line no-console
-    console.log('pending nocks', nock.pendingMocks());
     // eslint-disable-next-line testing-library/prefer-find-by
     await waitFor(
       () => {
         expect(nock.isDone()).toBeTruthy();
       },
-      { timeout: 500 }
+      { timeout: 5000 }
     );
-    // eslint-disable-next-line no-console
-    console.log('no more pending nocks');
   }
 };

--- a/frontend/shared/src/__tests__/utils/render-component/render-component.tsx
+++ b/frontend/shared/src/__tests__/utils/render-component/render-component.tsx
@@ -10,6 +10,10 @@ import HiddenLoadingIndicator from 'shared/components/hidden-loading-indicator/H
 import theme from 'shared/styles/theme';
 import { ThemeProvider } from 'styled-components';
 
+const TypedQueryClientProvider = QueryClientProvider as React.ComponentType<
+  React.PropsWithChildren<{ client: QueryClient }>
+>;
+
 export type Result = {
   queryClient: QueryClient;
   renderResult: RenderResult;
@@ -22,12 +26,10 @@ const renderComponent =
     const queryClient = createReactQueryTestClient(axios, backendUrl);
     const renderResult = render(
       <BackendAPIContext.Provider value={createAxiosTestContext(backendUrl)}>
-        <QueryClientProvider client={queryClient}>
-          <ThemeProvider theme={theme}>
-            {Element}
-          </ThemeProvider>
+        <TypedQueryClientProvider client={queryClient}>
+          <ThemeProvider theme={theme}>{Element}</ThemeProvider>
           <HiddenLoadingIndicator />
-        </QueryClientProvider>
+        </TypedQueryClientProvider>
       </BackendAPIContext.Provider>,
       router
     );

--- a/frontend/shared/src/__tests__/utils/render-component/render-page.tsx
+++ b/frontend/shared/src/__tests__/utils/render-component/render-page.tsx
@@ -23,7 +23,7 @@ type Props = {
   backendUrl: string;
   Header: React.FC;
   Footer?: React.FC;
-  AuthProvider?: React.FC;
+  AuthProvider?: React.FC<React.PropsWithChildren>;
   confirmDialog?: boolean;
 };
 

--- a/frontend/shared/src/__tests__/utils/setupTests.ts
+++ b/frontend/shared/src/__tests__/utils/setupTests.ts
@@ -1,3 +1,18 @@
+import { webcrypto } from 'node:crypto';
+
+// Polyfill structuredClone for jsdom
+if (typeof globalThis.structuredClone === 'undefined') {
+  globalThis.structuredClone = (obj: any) => {
+    return JSON.parse(JSON.stringify(obj));
+  };
+}
+
+if (typeof globalThis.crypto === 'undefined') {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+  });
+}
+
 import '@testing-library/jest-dom';
 
 import { toHaveNoViolations } from 'jest-axe';
@@ -29,12 +44,13 @@ const messagesToIgnore = [
   'An update to',
   'Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component',
   'Using ReactElement as a label is against good usability and accessibility practices. Please prefer plain strings.',
-  'react-i18next:: You will need to pass in an i18next instance by using initReactI18next',
   'downshift: A component has changed the uncontrolled prop',
   'ReactDOM.render is no longer supported in React 18',
   'All radio buttons in a SelectionGroup are unchecked',
   'Could not parse CSS stylesheet',
   'i18next is made possible by our own product, Locize',
+  'Support for defaultProps will be removed from function components',
+  'AxiosError',
 ];
 
 // Directly replace console methods instead of using jest.spyOn so that
@@ -43,11 +59,14 @@ const createFilter =
   (original: (...data: unknown[]) => void) =>
   (...args: unknown[]) => {
     const firstArg = args[0];
-    const message = isString(firstArg)
-      ? firstArg
-      : firstArg instanceof Error
-      ? firstArg.message
-      : '';
+    let message = '';
+    if (isString(firstArg)) {
+      message = firstArg;
+    } else if (firstArg instanceof Error) {
+      message = firstArg.name
+        ? `${firstArg.name}: ${firstArg.message}`
+        : firstArg.message;
+    }
     if (
       args.length > 0 &&
       message.length > 0 &&

--- a/frontend/shared/src/components/accordion/Accordion.module.sc.ts
+++ b/frontend/shared/src/components/accordion/Accordion.module.sc.ts
@@ -2,13 +2,18 @@ import styled from 'styled-components';
 
 import { AccordionProps } from './accordion.d';
 
-export const $Accordion = styled.div<AccordionProps>`
-  ${(props: AccordionProps) =>
+type AccordionStyleProps = Pick<
+  AccordionProps,
+  'card' | 'border' | 'headerBackgroundColor'
+>;
+
+export const $Accordion = styled.div<AccordionStyleProps>`
+  ${(props: AccordionStyleProps) =>
     !props.card
       ? `
     border-bottom: 1px solid var(--color-black-60)`
       : ''}
-  ${(props: AccordionProps) =>
+  ${(props: AccordionStyleProps) =>
     props.card
       ? `
     background-color: var(--color-black-60);
@@ -16,12 +21,14 @@ export const $Accordion = styled.div<AccordionProps>`
     padding-right: var(--spacing-m);
     `
       : ''};
-  ${(props: AccordionProps) => (props.border ? `border: 2px solid var(--color-black-60)` : '')};
+  ${(props: AccordionStyleProps) =>
+    props.border ? `border: 2px solid var(--color-black-60)` : ''};
 `;
 
-export const $AccordionHeader = styled.div<AccordionProps>`
+export const $AccordionHeader = styled.div<AccordionStyleProps>`
   position: relative;
-  background-color: ${(props: AccordionProps) => props.headerBackgroundColor};
+  background-color: ${(props: AccordionStyleProps) =>
+    props.headerBackgroundColor};
   color: var(--color-black-90);
   font-size: var(--fontsize-heading-m);
   font-weight: bold;

--- a/frontend/shared/src/components/accordion/Accordion.tsx
+++ b/frontend/shared/src/components/accordion/Accordion.tsx
@@ -22,7 +22,16 @@ const Accordion: React.FC<AccordionProps> = (props: AccordionProps) => {
     id,
     initiallyOpen = false,
     onToggle = noop,
+    card,
+    border,
+    headerBackgroundColor,
   } = props;
+
+  const styleProps = {
+    card,
+    border,
+    headerBackgroundColor,
+  };
 
   const { isOpen, buttonProps, contentProps } = useAccordion({
     initiallyOpen,
@@ -32,8 +41,11 @@ const Accordion: React.FC<AccordionProps> = (props: AccordionProps) => {
   const angleIcon = isOpen ? <IconAngleUp /> : <IconAngleDown />;
 
   return (
-    <$Accordion {...props} data-testid={`${id}-${isOpen ? 'open' : 'closed'}`}>
-      <$AccordionHeader {...props}>
+    <$Accordion
+      {...styleProps}
+      data-testid={`${id}-${isOpen ? 'open' : 'closed'}`}
+    >
+      <$AccordionHeader {...styleProps}>
         <$HeadingContainer
           role="button"
           tabIndex={0}

--- a/frontend/shared/src/components/attachments/AttachmentsList.tsx
+++ b/frontend/shared/src/components/attachments/AttachmentsList.tsx
@@ -1,4 +1,4 @@
-import { ButtonVariant, IconPlus } from 'hds-react';
+import { ButtonPresetTheme, ButtonVariant, IconPlus } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import * as React from 'react';
 import AttachmentItem from 'shared/components/attachments/AttachmentItem';
@@ -86,7 +86,7 @@ const AttachmentsList = <T extends Attachment>({
       <UploadAttachment
         buttonRef={buttonRef}
         name={name}
-        theme="coat"
+        theme={ButtonPresetTheme.Coat}
         variant={ButtonVariant.Primary}
         onUpload={onUpload}
         isUploading={isUploading}

--- a/frontend/shared/src/components/button/Button.tsx
+++ b/frontend/shared/src/components/button/Button.tsx
@@ -3,37 +3,37 @@ import {
   ButtonVariant,
   LoadingSpinner,
 } from 'hds-react';
-import * as React from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { $Button } from './Button.sc';
 
-export type ButtonProps = HdsButtonProps & {
-  loadingText?: string;
-  isLoading?: boolean;
-};
+const StyledButton = $Button as React.ComponentType<
+  HdsButtonProps & React.RefAttributes<HTMLButtonElement>
+>;
+
+export type ButtonProps = Omit<HdsButtonProps, 'children'> &
+  React.PropsWithChildren<{
+    loadingText?: string;
+    isLoading?: boolean;
+  }>;
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ loadingText, isLoading, ...props }, ref) => {
     const { t } = useTranslation();
-    const buttonText = isLoading
-      ? loadingText || t('common:loading')
-      : props.children;
-    const disabled = isLoading || props.disabled;
-    const iconStart = isLoading ? <LoadingSpinner small /> : props.iconStart;
-    const variant = isLoading ? ButtonVariant.Clear : props.variant;
+    const normalizedProps: HdsButtonProps = {
+      ...props,
+      children: (isLoading
+        ? loadingText || t('common:loading')
+        : props.children) as string,
+      disabled: isLoading || props.disabled,
+      variant: isLoading
+        ? ButtonVariant.Clear
+        : props.variant ?? ButtonVariant.Primary,
+      iconStart: isLoading ? <LoadingSpinner small /> : props.iconStart ?? null,
+    };
 
-    return (
-      <$Button
-        {...props}
-        ref={ref}
-        disabled={disabled}
-        iconStart={iconStart}
-        variant={variant as ButtonVariant}
-      >
-        {buttonText}
-      </$Button>
-    );
+    return <StyledButton {...normalizedProps} ref={ref} />;
   }
 );
 

--- a/frontend/shared/src/components/confirm-dialog/Portal.tsx
+++ b/frontend/shared/src/components/confirm-dialog/Portal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import PORTAL_ID from 'shared/constants/portal-id';
 
-const Portal: React.FC = ({ children }) => {
+const Portal: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {

--- a/frontend/shared/src/components/forms/buttons/SaveFormButton.tsx
+++ b/frontend/shared/src/components/forms/buttons/SaveFormButton.tsx
@@ -1,4 +1,4 @@
-import { ButtonPresetTheme, ButtonProps } from 'hds-react';
+import { ButtonPresetTheme } from 'hds-react';
 import React from 'react';
 import {
   FieldValues,
@@ -12,7 +12,7 @@ import LinkButton from 'shared/components/link-button/LinkButton';
 import useErrorHandler from 'shared/hooks/useErrorHandler';
 
 type Props<FormData extends FieldValues, BackendResponseData> = Omit<
-  ButtonProps,
+  React.ComponentProps<typeof Button | typeof LinkButton>,
   'onClick' | 'onError'
 > & {
   saveQuery: UseMutationResult<BackendResponseData, unknown, FormData>;

--- a/frontend/shared/src/components/forms/fields/dateInputWithSeparator/DateInputWithSeparator.tsx
+++ b/frontend/shared/src/components/forms/fields/dateInputWithSeparator/DateInputWithSeparator.tsx
@@ -2,21 +2,18 @@ import { DateInput, DateInputProps } from 'hds-react';
 import React from 'react';
 
 const DateInputWithSeparator: React.FC<DateInputProps> = (props) => (
-  <>
-    {/* @ts-expect-error: HDS React DateInput has very strict prop requirements that are not necessary here. */}
-    <DateInput
-      {...props}
-      css={`
-        display: flex;
-        align-items: center;
-        :after {
-          margin-left: var(--spacing-s);
-          content: '-';
-          font-weight: bold;
-        }
-      `}
-    />
-  </>
+  <DateInput
+    {...props}
+    css={`
+      display: flex;
+      align-items: center;
+      :after {
+        margin-left: var(--spacing-s);
+        content: '-';
+        font-weight: bold;
+      }
+    `}
+  />
 );
 
 export default DateInputWithSeparator;

--- a/frontend/shared/src/components/forms/inputs/DateInput.tsx
+++ b/frontend/shared/src/components/forms/inputs/DateInput.tsx
@@ -44,7 +44,7 @@ const DateInput = <T extends FieldValues>({
   const locale = useLocale();
   const { register } = useFormContext<T>();
   const validate = React.useCallback(
-    (value) => isString(value) && isValidDate(parseDate(value)),
+    (value: unknown) => isString(value) && isValidDate(parseDate(value)),
     []
   );
   const reactHookFormProps = register(id, {

--- a/frontend/shared/src/components/forms/inputs/Dropdown.tsx
+++ b/frontend/shared/src/components/forms/inputs/Dropdown.tsx
@@ -70,9 +70,12 @@ const Dropdown = <T extends FieldValues, O extends Option>({
   };
 
   const texts = useMemo(() => {
-    const baseTexts: Partial<SelectTexts> = {
-      label: label || '',
+    const baseTexts = {
+      label: typeof label === 'string' ? label : '',
       placeholder,
+    } as Partial<SelectTexts> & {
+      filterLabel?: string;
+      filterPlaceholder?: string;
     };
     if (filterLabel) {
       baseTexts.filterLabel = filterLabel;
@@ -80,7 +83,7 @@ const Dropdown = <T extends FieldValues, O extends Option>({
     if (filterPlaceholder) {
       baseTexts.filterPlaceholder = filterPlaceholder;
     }
-    return baseTexts;
+    return baseTexts as Partial<SelectTexts>;
   }, [label, placeholder, filterLabel, filterPlaceholder]);
 
   const sharedSelectProps = {

--- a/frontend/shared/src/components/forms/inputs/MultiSelectDropdown.tsx
+++ b/frontend/shared/src/components/forms/inputs/MultiSelectDropdown.tsx
@@ -111,7 +111,7 @@ const MultiSelectDropdown = <T extends FieldValues, O extends Option>({
     id: inputId,
     required,
     texts: {
-      label,
+      label: label as string,
       placeholder,
     },
     options: hdsOptions,

--- a/frontend/shared/src/components/forms/inputs/TextInput.tsx
+++ b/frontend/shared/src/components/forms/inputs/TextInput.tsx
@@ -41,7 +41,7 @@ const TextInput = <T extends FieldValues>({
   type = 'text',
   placeholder,
   initialValue,
-  label,
+  label = '',
   errorText,
   registerOptions = {},
   onChange,
@@ -81,7 +81,9 @@ const TextInput = <T extends FieldValues>({
     <$GridCell {...$gridCellProps}>
       <$TextInput
         {...registerEvents}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        onChange={(
+          e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+        ) => {
           void registerEvents.onChange(e);
           if (onChange) {
             onChange(e.target.value);
@@ -95,18 +97,14 @@ const TextInput = <T extends FieldValues>({
             onBlur(e);
           }
         }}
-        as={getComponentType(type)}
+        as={getComponentType(type) as React.ElementType}
         key={id}
         id={id}
         data-testid={id}
         name={id}
         placeholder={placeholder}
         required={Boolean(registerOptions.required)}
-        max={
-          registerOptions.maxLength
-            ? String(registerOptions.maxLength)
-            : undefined
-        }
+        max={(registerOptions.maxLength as number) ?? undefined}
         helperText={helperText ?? lengthIndicator}
         defaultValue={initialValue}
         onWheel={preventScrolling}

--- a/frontend/shared/src/components/header/Header.tsx
+++ b/frontend/shared/src/components/header/Header.tsx
@@ -99,7 +99,7 @@ const Header: React.FC<HeaderProps> = ({
       (event?: Event | MouseEvent) => {
         event?.preventDefault();
         closeMenu();
-        goToPage(url as string);
+        goToPage(url);
       },
     [closeMenu, goToPage]
   );
@@ -174,7 +174,7 @@ const Header: React.FC<HeaderProps> = ({
 
           {languages && onLanguageChange && (
             <HdsHeader.LanguageSelector
-              ariaLabel={t('common:header.languageMenuButtonAriaLabel')}
+              aria-label={t('common:header.languageMenuButtonAriaLabel')}
             />
           )}
         </HdsHeader.ActionBar>

--- a/frontend/shared/src/components/link-button/LinkButton.tsx
+++ b/frontend/shared/src/components/link-button/LinkButton.tsx
@@ -4,10 +4,11 @@ import React from 'react';
 
 import $LinkButton from './LinkButton.sc';
 
-type Props = Omit<ButtonProps, 'size' | 'variant'> & {
-  isLoading?: boolean;
-  loadingText?: string;
-};
+type Props = Omit<ButtonProps, 'children' | 'size' | 'variant'> &
+  React.PropsWithChildren<{
+    isLoading?: boolean;
+    loadingText?: string;
+  }>;
 
 /**
  * LinkButton is a button that looks like a link.

--- a/frontend/shared/src/components/messaging/Actions.tsx
+++ b/frontend/shared/src/components/messaging/Actions.tsx
@@ -45,7 +45,6 @@ const Actions: React.FC<ActionProps> = ({
     <>
       {notification && <$Notification>{notification}</$Notification>}
       <$Actions>
-        {/* @ts-expect-error: The HDS React TextArea has stricter type definitions for its props, causing TS2740. */}
         <TextArea
           disabled={!canWriteNewMessages}
           id={componentId}

--- a/frontend/shared/src/components/modal/__tests__/Modal.test.tsx
+++ b/frontend/shared/src/components/modal/__tests__/Modal.test.tsx
@@ -4,6 +4,14 @@ import { render, RenderResult } from 'shared/__tests__/utils/test-utils';
 
 import Modal, { ModalProps } from '../Modal';
 
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({
+    t: (key: string) => key,
+    i18n: { language: 'fi' },
+  })),
+  initReactI18next: { type: '3rdParty', init: jest.fn() },
+}));
+
 describe('Modal', () => {
   const initialProps: ModalProps = {
     id: 'modal-id',

--- a/frontend/shared/src/components/table/Table.tsx
+++ b/frontend/shared/src/components/table/Table.tsx
@@ -112,7 +112,7 @@ const Table = <D extends { id: string }>({
 TableProps<D>): React.ReactElement => {
   const selectorCol: Column<D> = React.useMemo(
     () => ({
-      Cell: ({ row }: { row: Row }) => {
+      Cell: ({ row }: { row: Row<D> }) => {
         const { title, style, checked, onChange } =
           row.getToggleRowSelectedProps();
         return (
@@ -152,7 +152,7 @@ TableProps<D>): React.ReactElement => {
         toggleAllRowsSelected,
         toggleRowSelected,
       }: {
-        row: Row;
+        row: Row<D>;
         toggleAllRowsSelected: (selected: boolean) => void;
         toggleRowSelected: (rowId: string) => void;
       }) => {
@@ -179,7 +179,7 @@ TableProps<D>): React.ReactElement => {
 
   const expanderCol: Column<D> = React.useMemo(
     () => ({
-      Cell: ({ row }: { row: Row }) => (
+      Cell: ({ row }: { row: Row<D> }) => (
         <div {...row.getToggleRowExpandedProps()}>
           <IconAngleDown size={IconSize.Medium} />
         </div>

--- a/frontend/shared/src/contexts/DialogContext.tsx
+++ b/frontend/shared/src/contexts/DialogContext.tsx
@@ -83,7 +83,9 @@ export const DialogContext = React.createContext<
   () => {},
 ]);
 
-export const DialogContextProvider: React.FC = ({ children }) => {
+export const DialogContextProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
   const [state, dispatch] = useReducer(reducer, initialState);
   return (
     <DialogContext.Provider value={[state, dispatch]}>

--- a/frontend/shared/src/contexts/WizardContext.ts
+++ b/frontend/shared/src/contexts/WizardContext.ts
@@ -6,6 +6,7 @@ export type WizardProps = {
   header?: React.ReactNode;
   footer?: React.ReactNode;
   initialStep?: number;
+  children?: React.ReactNode;
 };
 
 export type WizardValues = {

--- a/frontend/shared/src/hooks/__tests__/useLeaveConfirm.test.ts
+++ b/frontend/shared/src/hooks/__tests__/useLeaveConfirm.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import Router from 'next/router';
 
 import useConfirm from '../useConfirm';

--- a/frontend/shared/src/hooks/useCookieConsentParams.ts
+++ b/frontend/shared/src/hooks/useCookieConsentParams.ts
@@ -1,5 +1,6 @@
 import { CookieConsentChangeEvent, CookieConsentContextProps } from 'hds-react';
 import { useMemo } from 'react';
+
 import { trackPageView } from '../utils/matomo';
 
 const MATOMO_ENABLED = process.env.NEXT_PUBLIC_MATOMO_ENABLED;

--- a/frontend/shared/src/types/react-query.d.ts
+++ b/frontend/shared/src/types/react-query.d.ts
@@ -1,0 +1,7 @@
+import React from 'react';
+
+declare module 'react-query' {
+  interface QueryClientProviderProps {
+    children?: React.ReactNode;
+  }
+}

--- a/frontend/shared/src/utils/mask-gdpr-data.ts
+++ b/frontend/shared/src/utils/mask-gdpr-data.ts
@@ -1,4 +1,3 @@
-import cloneDeep from 'lodash/cloneDeep';
 import { isRecord } from 'shared/utils/object.utils';
 import { isString } from 'shared/utils/type-guards';
 /**
@@ -47,7 +46,7 @@ export const maskAttribute = (
   object: Record<string, unknown>,
   attributes: string[]
 ): typeof object => {
-  const clonedObject = cloneDeep(object);
+  const clonedObject = structuredClone(object);
   recursiveMask(clonedObject, attributes);
   return clonedObject;
 };

--- a/frontend/shared/src/utils/matomo.ts
+++ b/frontend/shared/src/utils/matomo.ts
@@ -65,9 +65,11 @@ export function trackPageView(url?: string): void {
   if (previousUrl && previousUrl !== currentUrl) {
     window._paq.push(['setReferrerUrl', previousUrl]);
   }
-  window._paq.push(['setCustomUrl', currentUrl]);
-  window._paq.push(['setDocumentTitle', document.title]);
-  window._paq.push(['trackPageView']);
+  window._paq.push(
+    ['setCustomUrl', currentUrl],
+    ['setDocumentTitle', document.title],
+    ['trackPageView']
+  );
 
   previousUrl = currentUrl;
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4200,10 +4200,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.9.tgz#b6f785caa7ea1fe4414d9df42ee0ab67f23d8a6d"
   integrity sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==
 
-"@types/react-dom@^18.0.0":
-  version "18.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.3.tgz#a022ea08c75a476fe5e96b675c3e673363853831"
-  integrity sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==
+"@types/react-dom@18.2.7", "@types/react-dom@^18.0.0":
+  version "18.2.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.7.tgz#67222a08c0a6ae0a0da33c3532348277c70abb63"
+  integrity sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==
   dependencies:
     "@types/react" "*"
 
@@ -4238,10 +4238,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.43"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
-  integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
+"@types/react@*", "@types/react@18.2.21":
+  version "18.2.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
+  integrity sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3773,14 +3773,6 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz#7d0164bffce4647f506039de0a97f6fcbd20f4bf"
-  integrity sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
-
 "@testing-library/react@^14.3.0":
   version "14.3.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.3.1.tgz#29513fc3770d6fb75245c4e1245c470e4ffdd830"
@@ -14804,13 +14796,6 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
-
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^2.0.1:
   version "2.0.4"


### PR DESCRIPTION
### Background
Before migrating the frontend monorepo from Yarn to pnpm, the codebase needs to build and pass tests under stricter, hoisting-free dependency resolution. pnpm's non-flat node_modules surfaces implicit/phantom dependencies and stricter React 18 typings that Yarn's flat layout hid. This PR resolves those issues so the actual package-manager switch (part 2) can be a clean, low-risk change.

### Changes

**Dependencies & typings**
- Pin `@types/react` (`18.2.21`) and `@types/react-dom` (`18.2.7`) as explicit `devDependencies` and `resolutions` so a single React 18 type version is enforced across the workspace.
- Remove the deprecated `@testing-library/react-hooks` dependency (its functionality is now built into `@testing-library/react` v14).
- Add `shared/src/types/react-query.d.ts` to augment `react-query`'s `QueryClientProviderProps` with an explicit `children` prop, fixing React 18 typing gaps.

**Test suite migration**
- Migrate all hook tests from `@testing-library/react-hooks` to `renderHook`/`waitFor` from `@testing-library/react`.
- Replace the old `waitForNextUpdate` / destructured `waitFor` pattern with `await waitFor(() => expect(...).toBe(true))`.
- Add `structuredClone` and `crypto` (`node:crypto` `webcrypto`) polyfills in `setupTests.ts` for jsdom.
- Update console-filter setup to include the `name` in `Error` messages and ignore new expected warnings (`defaultProps` removal, `AxiosError`).

**Component & type fixes (React 18 strictness)**
- Fix `children` / `React.ReactNode` typing across shared components (`Button`, `Accordion`, `TextInput`, `Dropdown`, `DateInputWithSeparator`, `Header`, `Table`, `LinkButton`, etc.).
- Wrap HDS/styled and `QueryClientProvider` elements in explicitly typed component aliases to satisfy stricter prop types.
- Resolve lint and type issues across handler/employer/youth apps and shared utilities.

**Net effect**
- No functional/runtime behavior change intended — purely typing, test-infra, and dependency hygiene.
- yarn.lock updated to reflect the dependency changes.