### PR TITLE
YJDH-969 | Kesäseteli frontends: Configure missing required cookies to cookie consent

### DIFF
--- a/frontend/kesaseteli/employer/src/pages/_app.tsx
+++ b/frontend/kesaseteli/employer/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import { COOKIE_CONSENT_SITE_NAME } from 'kesaseteli-shared/constants/cookie-con
 import { ROUTES } from 'kesaseteli-shared/constants/routes';
 import useMatomo from 'kesaseteli-shared/hooks/useMatomo';
 import createQueryClient from 'kesaseteli-shared/query-client/create-query-client';
+import getRequiredCookieGroups from 'kesaseteli-shared/utils/getRequiredCookieGroups';
 import { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
@@ -20,11 +21,19 @@ import BaseApp from 'shared/components/app/BaseApp';
 import ConfirmDialog from 'shared/components/confirm-dialog/ConfirmDialog';
 import Portal from 'shared/components/confirm-dialog/Portal';
 import { DialogContextProvider } from 'shared/contexts/DialogContext';
+import { type RequiredGroups } from 'shared/utils/cookieConsentSettings';
 
 const CookieConsent = dynamic(
   () => import('kesaseteli-shared/components/cookieConsent/CookieConsent'),
   { ssr: false }
 );
+
+const getRequiredEmployerCookieGroups = (): RequiredGroups =>
+  getRequiredCookieGroups({
+    includeSessionIdCookie: true, // Needed because of Django's session handling
+    includeSamlSessionCookie: true, // Needed because of Suomi.fi login
+    includeCsrfTokenCookie: true, // Needed because of POSTing data to backend
+  });
 
 const App: React.FC<AppProps> = (appProps) => {
   const isMatomoConfigured = useMatomo();
@@ -41,7 +50,10 @@ const App: React.FC<AppProps> = (appProps) => {
         <AuthProvider>
           <DialogContextProvider>
             {showCookieBanner && (
-              <CookieConsent siteName={COOKIE_CONSENT_SITE_NAME} />
+              <CookieConsent
+                requiredGroups={getRequiredEmployerCookieGroups()}
+                siteName={COOKIE_CONSENT_SITE_NAME}
+              />
             )}
             <BaseApp header={<Header />} footer={<Footer />} {...appProps} />
             <Portal>

--- a/frontend/kesaseteli/handler/src/pages/_app.tsx
+++ b/frontend/kesaseteli/handler/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import { COOKIE_CONSENT_SITE_NAME } from 'kesaseteli-shared/constants/cookie-con
 import { ROUTES } from 'kesaseteli-shared/constants/routes';
 import useMatomo from 'kesaseteli-shared/hooks/useMatomo';
 import createQueryClient from 'kesaseteli-shared/query-client/create-query-client';
+import getRequiredCookieGroups from 'kesaseteli-shared/utils/getRequiredCookieGroups';
 import { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
@@ -23,6 +24,7 @@ import {
   DialogContext,
   DialogContextProvider,
 } from 'shared/contexts/DialogContext';
+import { type RequiredGroups } from 'shared/utils/cookieConsentSettings';
 
 const CookieConsent = dynamic(
   () => import('kesaseteli-shared/components/cookieConsent/CookieConsent'),
@@ -30,6 +32,12 @@ const CookieConsent = dynamic(
 );
 
 const queryClient = createQueryClient();
+
+const getRequiredHandlerCookieGroups = (): RequiredGroups =>
+  getRequiredCookieGroups({
+    includeSessionIdCookie: true, // Needed because of Django's session handling
+    includeCsrfTokenCookie: true, // Needed because of POSTing data to backend
+  });
 
 const App: React.FC<AppProps> = (appProps: AppProps) => {
   const isMatomoConfigured = useMatomo();
@@ -46,7 +54,10 @@ const App: React.FC<AppProps> = (appProps: AppProps) => {
         <UserProvider>
           <DialogContextProvider>
             {showCookieBanner && (
-              <CookieConsent siteName={COOKIE_CONSENT_SITE_NAME} />
+              <CookieConsent
+                requiredGroups={getRequiredHandlerCookieGroups()}
+                siteName={COOKIE_CONSENT_SITE_NAME}
+              />
             )}
             <BaseApp header={<Header />} footer={<Footer />} {...appProps} />
             <Portal>

--- a/frontend/kesaseteli/shared/src/constants/cookie-consent.ts
+++ b/frontend/kesaseteli/shared/src/constants/cookie-consent.ts
@@ -1,3 +1,50 @@
+import { type Language } from 'shared/i18n/i18n';
+
 // Non-localizable site name for cookie consent,
 // does not use non-ascii characters for maximum compatibility.
 export const COOKIE_CONSENT_SITE_NAME = 'Kesaseteli';
+
+// Named values for HDS's unnamed storage types 1–5
+export enum StorageType {
+  Cookie = 1,
+  LocalStorage = 2,
+  SessionStorage = 3,
+  IndexedDB = 4,
+  CacheStorage = 5,
+}
+
+export const ESSENTIAL_COOKIES_TITLE = {
+  fi: 'Välttämättömät toiminnalliset evästeet',
+  sv: 'Nödvändiga funktionella cookies',
+  en: 'Essential functional cookies',
+} as const satisfies Record<Language, string>;
+
+export const ESSENTIAL_COOKIES_DESCRIPTION = {
+  fi: 'Välttämättömät evästeet auttavat tekemään verkkosivustosta käyttökelpoisen sallimalla perustoimintoja, kuten sivulla siirtymisen ja sivuston suojattujen alueiden käytön. Verkkosivusto ei toimi kunnolla ilman näitä evästeitä eikä niihin tarvita suostumusta.',
+  sv: 'Nödvändiga cookies hjälper till att göra webbplatsen användbar genom att tillåta grundläggande funktioner som att navigera på sidan och använda de skyddade områdena på webbplatsen. Webbplatsen fungerar inte korrekt utan dessa cookies och kräver inte samtycke.',
+  en: 'Essential cookies help to make the website usable by allowing basic functions, navigating the page and using the protected areas of the site. The website will not work properly without these cookies and their consent is not required.',
+} as const satisfies Record<Language, string>;
+
+export const AUTH_SESSION_COOKIE_DESCRIPTION = {
+  fi: 'Tunnistautumisistunnon säilymiseksi vaadittu eväste.',
+  sv: 'Cookie som krävs för att bevara autentiseringssession.',
+  en: 'Required to persist the authentication session.',
+} as const satisfies Record<Language, string>;
+
+export const SECURITY_CONTROL_COOKIE_DESCRIPTION = {
+  fi: 'Tietoturvakontrolli',
+  sv: 'Datasäkerhetskontroll',
+  en: 'A security control',
+} as const satisfies Record<Language, string>;
+
+export const LOCALIZED_TWO_HOURS = {
+  fi: '2 tuntia',
+  sv: '2 timmar',
+  en: '2 hours',
+} as const satisfies Record<Language, string>;
+
+export const LOCALIZED_364_DAYS = {
+  fi: '364 päivää',
+  sv: '364 dagar',
+  en: '364 days',
+} as const satisfies Record<Language, string>;

--- a/frontend/kesaseteli/shared/src/utils/__tests__/getRequiredCookieGroups.test.ts
+++ b/frontend/kesaseteli/shared/src/utils/__tests__/getRequiredCookieGroups.test.ts
@@ -1,0 +1,78 @@
+import {
+  ESSENTIAL_COOKIES_DESCRIPTION,
+  ESSENTIAL_COOKIES_TITLE,
+} from 'kesaseteli-shared/constants/cookie-consent';
+import getRequiredCookieGroups from 'kesaseteli-shared/utils/getRequiredCookieGroups';
+import {
+  type RequiredGroups,
+  getDefaultKesaseteliRequiredGroups,
+} from 'shared/utils/cookieConsentSettings';
+
+const getEssentialGroup = (
+  groups: RequiredGroups
+): RequiredGroups[number] | undefined =>
+  groups.find((group) => group.groupId === 'essential');
+
+const getEssentialCookies = (
+  groups: RequiredGroups
+): RequiredGroups[number]['cookies'] => getEssentialGroup(groups)?.cookies ?? [];
+
+const allCookieProps = {
+  includeSessionIdCookie: true,
+  includeSamlSessionCookie: true,
+  includeCsrfTokenCookie: true,
+} as const;
+
+describe('getRequiredCookieGroups', () => {
+  it('returns only the default groups when no cookies are requested', () => {
+    expect(getRequiredCookieGroups()).toEqual(
+      getDefaultKesaseteliRequiredGroups()
+    );
+    expect(
+      getRequiredCookieGroups({
+        includeSessionIdCookie: false,
+        includeSamlSessionCookie: false,
+        includeCsrfTokenCookie: false,
+      })
+    ).toEqual(getDefaultKesaseteliRequiredGroups());
+  });
+
+  it('keeps the default groups and appends the essential group', () => {
+    const defaultGroups = getDefaultKesaseteliRequiredGroups();
+    const groups = getRequiredCookieGroups({ includeCsrfTokenCookie: true });
+
+    expect(groups).toHaveLength(defaultGroups.length + 1);
+    expect(groups.slice(0, defaultGroups.length)).toEqual(defaultGroups);
+    expect(groups[groups.length - 1]).toMatchObject({
+      groupId: 'essential',
+      title: ESSENTIAL_COOKIES_TITLE,
+      description: ESSENTIAL_COOKIES_DESCRIPTION,
+    });
+  });
+
+  it.each([
+    [{ includeSessionIdCookie: true }, ['sessionid']],
+    [{ includeSamlSessionCookie: true }, ['kesaseteli_saml_session']],
+    [{ includeCsrfTokenCookie: true }, ['yjdhcsrftoken']],
+    [
+      allCookieProps,
+      ['sessionid', 'kesaseteli_saml_session', 'yjdhcsrftoken'],
+    ],
+  ])('includes the requested cookies %j in a fixed order', (props, names) => {
+    expect(
+      getEssentialCookies(getRequiredCookieGroups(props)).map(
+        (cookie) => cookie.name
+      )
+    ).toEqual(names);
+  });
+
+  it('uses the same host as the default groups for every cookie', () => {
+    const expectedHost = getDefaultKesaseteliRequiredGroups()[0].cookies[0].host;
+    const cookies = getEssentialCookies(
+      getRequiredCookieGroups(allCookieProps)
+    );
+    cookies.forEach((cookie) => {
+      expect(cookie.host).toBe(expectedHost);
+    });
+  });
+});

--- a/frontend/kesaseteli/shared/src/utils/getRequiredCookieGroups.ts
+++ b/frontend/kesaseteli/shared/src/utils/getRequiredCookieGroups.ts
@@ -1,0 +1,85 @@
+import {
+  AUTH_SESSION_COOKIE_DESCRIPTION,
+  ESSENTIAL_COOKIES_DESCRIPTION,
+  ESSENTIAL_COOKIES_TITLE,
+  LOCALIZED_364_DAYS,
+  LOCALIZED_TWO_HOURS,
+  SECURITY_CONTROL_COOKIE_DESCRIPTION,
+  StorageType,
+} from 'kesaseteli-shared/constants/cookie-consent';
+import {
+  type RequiredGroups,
+  getDefaultKesaseteliRequiredGroups,
+} from 'shared/utils/cookieConsentSettings';
+
+type Props = {
+  includeSessionIdCookie?: boolean;
+  includeSamlSessionCookie?: boolean;
+  includeCsrfTokenCookie?: boolean;
+};
+
+const getRequiredCookieGroups = ({
+  includeSessionIdCookie,
+  includeSamlSessionCookie,
+  includeCsrfTokenCookie,
+}: Props = {}): RequiredGroups => {
+  const defaultGroups = getDefaultKesaseteliRequiredGroups();
+  const host = defaultGroups[0].cookies[0].host; // eslint-disable-line prefer-destructuring
+
+  const sessionIdCookie = {
+    // Must match the actual used value of SESSION_COOKIE_NAME in backend,
+    // see https://docs.djangoproject.com/en/5.2/ref/settings/#session-cookie-name
+    name: 'sessionid',
+    host,
+    description: AUTH_SESSION_COOKIE_DESCRIPTION,
+    // Must match the actual used value of SESSION_COOKIE_AGE in backend, see
+    // https://docs.djangoproject.com/en/5.2/ref/settings/#session-cookie-age
+    expiration: LOCALIZED_TWO_HOURS,
+    storageType: StorageType.Cookie,
+  } as const;
+
+  const samlSessionCookie = {
+    // Must match the actual used value of SAML_SESSION_COOKIE_NAME in backend, see
+    // https://djangosaml2.readthedocs.io/contents/setup.html
+    name: 'kesaseteli_saml_session',
+    host,
+    description: AUTH_SESSION_COOKIE_DESCRIPTION,
+    // Must match the actual used value of SESSION_COOKIE_AGE in backend, see
+    // https://docs.djangoproject.com/en/5.2/ref/settings/#session-cookie-age
+    expiration: LOCALIZED_TWO_HOURS,
+    storageType: StorageType.Cookie,
+  } as const;
+
+  const csrfTokenCookie = {
+    // Must match the actual used value of CSRF_COOKIE_NAME in backend, see
+    // https://docs.djangoproject.com/en/5.2/ref/settings/#csrf-cookie-name
+    name: 'yjdhcsrftoken',
+    host,
+    description: SECURITY_CONTROL_COOKIE_DESCRIPTION,
+    // Must match the actual used value of CSRF_COOKIE_AGE in backend, see
+    // https://docs.djangoproject.com/en/5.2/ref/settings/#csrf-cookie-age
+    expiration: LOCALIZED_364_DAYS,
+    storageType: StorageType.Cookie,
+  } as const;
+
+  const essentialCookies = [
+    ...(includeSessionIdCookie ? [sessionIdCookie] : []),
+    ...(includeSamlSessionCookie ? [samlSessionCookie] : []),
+    ...(includeCsrfTokenCookie ? [csrfTokenCookie] : []),
+  ];
+
+  if (essentialCookies.length === 0) {
+    return defaultGroups;
+  }
+
+  const essentialCookiesGroup = {
+    groupId: 'essential',
+    title: ESSENTIAL_COOKIES_TITLE,
+    description: ESSENTIAL_COOKIES_DESCRIPTION,
+    cookies: essentialCookies,
+  };
+
+  return [...defaultGroups, essentialCookiesGroup];
+};
+
+export default getRequiredCookieGroups;

--- a/frontend/kesaseteli/youth/src/pages/_app.tsx
+++ b/frontend/kesaseteli/youth/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import { COOKIE_CONSENT_SITE_NAME } from 'kesaseteli-shared/constants/cookie-con
 import { ROUTES } from 'kesaseteli-shared/constants/routes';
 import useMatomo from 'kesaseteli-shared/hooks/useMatomo';
 import createQueryClient from 'kesaseteli-shared/query-client/create-query-client';
+import getRequiredCookieGroups from 'kesaseteli-shared/utils/getRequiredCookieGroups';
 import { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
@@ -16,6 +17,7 @@ import React from 'react';
 import { QueryClientProvider } from 'react-query';
 import BackendAPIProvider from 'shared/backend-api/BackendAPIProvider';
 import BaseApp from 'shared/components/app/BaseApp';
+import { type RequiredGroups } from 'shared/utils/cookieConsentSettings';
 
 const CookieConsent = dynamic(
   () => import('kesaseteli-shared/components/cookieConsent/CookieConsent'),
@@ -23,6 +25,9 @@ const CookieConsent = dynamic(
 );
 
 const queryClient = createQueryClient();
+
+const getRequiredYouthCookieGroups = (): RequiredGroups =>
+  getRequiredCookieGroups();
 
 const App: React.FC<AppProps> = (appProps: AppProps) => {
   const isMatomoConfigured = useMatomo();
@@ -37,7 +42,10 @@ const App: React.FC<AppProps> = (appProps: AppProps) => {
     <BackendAPIProvider baseURL={getBackendDomain()}>
       <QueryClientProvider client={queryClient}>
         {showCookieBanner && (
-          <CookieConsent siteName={COOKIE_CONSENT_SITE_NAME} />
+          <CookieConsent
+            requiredGroups={getRequiredYouthCookieGroups()}
+            siteName={COOKIE_CONSENT_SITE_NAME}
+          />
         )}
         <BaseApp header={<Header />} footer={<Footer />} {...appProps} />
       </QueryClientProvider>


### PR DESCRIPTION
## Description :sparkles:

### Configure missing required cookies to cookie consent in Kesäseteli's frontends

For example employer UI's `fetch_employee_data` endpoint call did not always work properly as sometimes the cookie consent mechanism had deleted the unlisted `yjdhcsrftoken` cookie required for the endpoint to work. This commit adds the required cookies to employer, youth and handler UIs' cookie consent configurations.

## Issues :bug:

[YJDH-969](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-969)

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-969]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cookie consent now identifies essential cookies used for sessions, authentication, and security protections.
  * Cookie descriptions include storage types, purposes, and localized expiration details.
  * Cookie requirements are tailored across employer, handler, and youth applications.
* **Bug Fixes**
  * Improved consistency in required-cookie handling and consent configuration across applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->