### PR TITLE
fix(ks): use the full street address

### DIFF
--- a/backend/kesaseteli/scripts/populate_ytj_data_to_companies.py
+++ b/backend/kesaseteli/scripts/populate_ytj_data_to_companies.py
@@ -88,6 +88,26 @@ def _get_preferred_description(descriptions: list, preferred_langs=("1", "2")) -
     return ""
 
 
+def _compose_address(addr: dict) -> str:
+    """Compose a full address string from the given address dict."""
+    street = addr.get("street") or ""
+    building_number = addr.get("buildingNumber") or ""
+    entrance = addr.get("entrance") or ""
+    apartment_number = addr.get("apartmentNumber") or ""
+    apartment_id_suffix = addr.get("apartmentIdSuffix") or ""
+
+    address_parts = [
+        street,
+        building_number,
+        entrance,
+        apartment_number,
+        apartment_id_suffix,
+    ]
+    address = " ".join(part for part in address_parts if part)
+
+    return address
+
+
 def parse_record(record: dict) -> dict:
     """
     Parse a raw YTJ company record dict into Company model fields.
@@ -123,11 +143,11 @@ def parse_record(record: dict) -> dict:
     if addr is None:
         addr = next((a for a in addresses if a.get("type") == 2), None)
 
-    street_address = ""
+    full_address = ""
     postcode = ""
     city = ""
     if addr:
-        street_address = addr.get("street") or ""
+        full_address = _compose_address(addr)
         postcode = addr.get("postCode") or ""
         post_offices = addr.get("postOffices", [])
         for lang in ("1", "2"):
@@ -148,7 +168,7 @@ def parse_record(record: dict) -> dict:
         "name": name,
         "company_form": company_form,
         "industry": industry,
-        "street_address": street_address,
+        "street_address": full_address,
         "postcode": postcode,
         "city": city,
     }

--- a/backend/shared/shared/ytj/tests/test_ytj_client_v3.py
+++ b/backend/shared/shared/ytj/tests/test_ytj_client_v3.py
@@ -271,6 +271,21 @@ class TestYTJCompany:
         with pytest.raises(ValueError, match="Company address missing"):
             _ = company.address
 
+    def test_address_includes_building_and_apartment_details(self, company_data):
+        company_data["addresses"][0].update(
+            {
+                "street": "Esimerkkikatu",
+                "buildingNumber": "12",
+                "entrance": "B",
+                "apartmentNumber": "34",
+                "apartmentIdSuffix": "a",
+            }
+        )
+
+        company = YTJCompany.from_json(company_data)
+
+        assert company.address["street_address"] == "Esimerkkikatu 12 B 34 a"
+
     def test_city_language_priority(self, company_data):
         # Default (FI)
         company = YTJCompany.from_json(company_data)
@@ -315,3 +330,17 @@ class TestYTJCompany:
         company = YTJCompany.from_json(company_data)
         assert company.status == "Registered"
         assert company.endDate == "2025-01-01"
+
+    def test_address_with_empty_strings(self, company_data):
+        """Test that empty strings are handled correctly (not included in address)."""
+        company_data["addresses"][0].update(
+            {
+                "street": "Katutie",
+                "buildingNumber": "5",
+                "entrance": "",
+                "apartmentNumber": "",
+                "apartmentIdSuffix": "",
+            }
+        )
+        company = YTJCompany.from_json(company_data)
+        assert company.address["street_address"] == "Katutie 5"

--- a/backend/shared/shared/ytj/ytj_dataclasses.py
+++ b/backend/shared/shared/ytj/ytj_dataclasses.py
@@ -335,8 +335,23 @@ class YTJCompany:
             if not city:
                 city = company_address.postOffices[0].city
 
+        building_number = company_address.buildingNumber or ""
+        entrance = company_address.entrance or ""
+        apartment_number = company_address.apartmentNumber or ""
+        apartment_id_suffix = company_address.apartmentIdSuffix or ""
+
+        street = company_address.street or ""
+        address_parts = [
+            street,
+            building_number,
+            entrance,
+            apartment_number,
+            apartment_id_suffix,
+        ]
+        address = " ".join(part for part in address_parts if part)
+
         return {
-            "street_address": company_address.street,
+            "street_address": address.strip(),
             "postcode": company_address.postCode,
             "city": city,
         }


### PR DESCRIPTION
## Description

Fix to use the full street address instead
of just street name in addresses.

## Issues

[YJDH-970](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-970)

## Testing

Unit tests changed to reflect new fields

[YJDH-970]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Company addresses now include available building, entrance, apartment, and apartment suffix details.
  - Empty address components are omitted for cleaner, more accurate formatting.

- **Tests**
  - Added coverage for complete addresses and addresses with missing optional details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->