### PR TITLE
YJDH-977 | Kesäseteli frontends: Add required cookie groups to cookie settings pages

### DIFF
--- a/frontend/kesaseteli/employer/src/pages/_app.tsx
+++ b/frontend/kesaseteli/employer/src/pages/_app.tsx
@@ -4,12 +4,12 @@ import 'hds-design-tokens';
 import AuthProvider from 'kesaseteli/employer/auth/AuthProvider';
 import Footer from 'kesaseteli/employer/components/footer/Footer';
 import Header from 'kesaseteli/employer/components/header/Header';
+import getRequiredEmployerCookieGroups from 'kesaseteli/employer/utils/get-required-employer-cookie-groups';
 import { getBackendDomain } from 'kesaseteli-shared/backend-api/backend-api';
 import { COOKIE_CONSENT_SITE_NAME } from 'kesaseteli-shared/constants/cookie-consent';
 import { ROUTES } from 'kesaseteli-shared/constants/routes';
 import useMatomo from 'kesaseteli-shared/hooks/useMatomo';
 import createQueryClient from 'kesaseteli-shared/query-client/create-query-client';
-import getRequiredCookieGroups from 'kesaseteli-shared/utils/getRequiredCookieGroups';
 import { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
@@ -21,19 +21,11 @@ import BaseApp from 'shared/components/app/BaseApp';
 import ConfirmDialog from 'shared/components/confirm-dialog/ConfirmDialog';
 import Portal from 'shared/components/confirm-dialog/Portal';
 import { DialogContextProvider } from 'shared/contexts/DialogContext';
-import { type RequiredGroups } from 'shared/utils/cookieConsentSettings';
 
 const CookieConsent = dynamic(
   () => import('kesaseteli-shared/components/cookieConsent/CookieConsent'),
   { ssr: false }
 );
-
-const getRequiredEmployerCookieGroups = (): RequiredGroups =>
-  getRequiredCookieGroups({
-    includeSessionIdCookie: true, // Needed because of Django's session handling
-    includeSamlSessionCookie: true, // Needed because of Suomi.fi login
-    includeCsrfTokenCookie: true, // Needed because of POSTing data to backend
-  });
 
 const App: React.FC<AppProps> = (appProps) => {
   const isMatomoConfigured = useMatomo();

--- a/frontend/kesaseteli/employer/src/pages/cookie-settings.tsx
+++ b/frontend/kesaseteli/employer/src/pages/cookie-settings.tsx
@@ -1,3 +1,4 @@
+import getRequiredEmployerCookieGroups from 'kesaseteli/employer/utils/get-required-employer-cookie-groups';
 import CookieSettings from 'kesaseteli-shared/components/cookieSettings/CookieSettings';
 import { GetStaticProps, NextPage } from 'next';
 import { useTranslation } from 'next-i18next';
@@ -11,6 +12,7 @@ const CookieSettingsPage: NextPage = () => {
     <CookieSettings
       title={`${t('common:appName')} - ${t('common:cookieSettings')}`}
       siteName={t('common:appName')}
+      requiredGroups={getRequiredEmployerCookieGroups()}
     />
   );
 };

--- a/frontend/kesaseteli/employer/src/utils/get-required-employer-cookie-groups.ts
+++ b/frontend/kesaseteli/employer/src/utils/get-required-employer-cookie-groups.ts
@@ -1,0 +1,11 @@
+import getRequiredCookieGroups from 'kesaseteli-shared/utils/getRequiredCookieGroups';
+import type { RequiredGroups } from 'shared/utils/cookieConsentSettings';
+
+const getRequiredEmployerCookieGroups = (): RequiredGroups =>
+  getRequiredCookieGroups({
+    includeSessionIdCookie: true, // Needed because of Django's session handling
+    includeSamlSessionCookie: true, // Needed because of Suomi.fi login
+    includeCsrfTokenCookie: true, // Needed because of POSTing data to backend
+  });
+
+export default getRequiredEmployerCookieGroups;

--- a/frontend/kesaseteli/handler/src/pages/_app.tsx
+++ b/frontend/kesaseteli/handler/src/pages/_app.tsx
@@ -4,12 +4,12 @@ import 'hds-design-tokens';
 import Footer from 'kesaseteli/handler/components/footer/Footer';
 import Header from 'kesaseteli/handler/components/header/Header';
 import { UserProvider } from 'kesaseteli/handler/contexts/UserContext';
+import getRequiredHandlerCookieGroups from 'kesaseteli/handler/utils/get-required-handler-cookie-groups';
 import { getBackendDomain } from 'kesaseteli-shared/backend-api/backend-api';
 import { COOKIE_CONSENT_SITE_NAME } from 'kesaseteli-shared/constants/cookie-consent';
 import { ROUTES } from 'kesaseteli-shared/constants/routes';
 import useMatomo from 'kesaseteli-shared/hooks/useMatomo';
 import createQueryClient from 'kesaseteli-shared/query-client/create-query-client';
-import getRequiredCookieGroups from 'kesaseteli-shared/utils/getRequiredCookieGroups';
 import { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
@@ -24,7 +24,6 @@ import {
   DialogContext,
   DialogContextProvider,
 } from 'shared/contexts/DialogContext';
-import { type RequiredGroups } from 'shared/utils/cookieConsentSettings';
 
 const CookieConsent = dynamic(
   () => import('kesaseteli-shared/components/cookieConsent/CookieConsent'),
@@ -32,12 +31,6 @@ const CookieConsent = dynamic(
 );
 
 const queryClient = createQueryClient();
-
-const getRequiredHandlerCookieGroups = (): RequiredGroups =>
-  getRequiredCookieGroups({
-    includeSessionIdCookie: true, // Needed because of Django's session handling
-    includeCsrfTokenCookie: true, // Needed because of POSTing data to backend
-  });
 
 const App: React.FC<AppProps> = (appProps: AppProps) => {
   const isMatomoConfigured = useMatomo();

--- a/frontend/kesaseteli/handler/src/pages/cookie-settings.tsx
+++ b/frontend/kesaseteli/handler/src/pages/cookie-settings.tsx
@@ -1,3 +1,4 @@
+import getRequiredHandlerCookieGroups from 'kesaseteli/handler/utils/get-required-handler-cookie-groups';
 import CookieSettings from 'kesaseteli-shared/components/cookieSettings/CookieSettings';
 import { GetStaticProps, NextPage } from 'next';
 import { useTranslation } from 'next-i18next';
@@ -11,6 +12,7 @@ const CookieSettingsPage: NextPage = () => {
     <CookieSettings
       title={`${t('common:appName')} - ${t('common:cookieSettings')}`}
       siteName={t('common:appName')}
+      requiredGroups={getRequiredHandlerCookieGroups()}
     />
   );
 };

--- a/frontend/kesaseteli/handler/src/utils/get-required-handler-cookie-groups.ts
+++ b/frontend/kesaseteli/handler/src/utils/get-required-handler-cookie-groups.ts
@@ -1,0 +1,10 @@
+import getRequiredCookieGroups from 'kesaseteli-shared/utils/getRequiredCookieGroups';
+import type { RequiredGroups } from 'shared/utils/cookieConsentSettings';
+
+const getRequiredHandlerCookieGroups = (): RequiredGroups =>
+  getRequiredCookieGroups({
+    includeSessionIdCookie: true, // Needed because of Django's session handling
+    includeCsrfTokenCookie: true, // Needed because of POSTing data to backend
+  });
+
+export default getRequiredHandlerCookieGroups;

--- a/frontend/kesaseteli/youth/src/pages/_app.tsx
+++ b/frontend/kesaseteli/youth/src/pages/_app.tsx
@@ -3,12 +3,12 @@ import 'hds-design-tokens';
 
 import Footer from 'kesaseteli/youth/components/footer/Footer';
 import Header from 'kesaseteli/youth/components/header/Header';
+import getRequiredYouthCookieGroups from 'kesaseteli/youth/utils/get-required-youth-cookie-groups';
 import { getBackendDomain } from 'kesaseteli-shared/backend-api/backend-api';
 import { COOKIE_CONSENT_SITE_NAME } from 'kesaseteli-shared/constants/cookie-consent';
 import { ROUTES } from 'kesaseteli-shared/constants/routes';
 import useMatomo from 'kesaseteli-shared/hooks/useMatomo';
 import createQueryClient from 'kesaseteli-shared/query-client/create-query-client';
-import getRequiredCookieGroups from 'kesaseteli-shared/utils/getRequiredCookieGroups';
 import { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
@@ -17,7 +17,6 @@ import React from 'react';
 import { QueryClientProvider } from 'react-query';
 import BackendAPIProvider from 'shared/backend-api/BackendAPIProvider';
 import BaseApp from 'shared/components/app/BaseApp';
-import { type RequiredGroups } from 'shared/utils/cookieConsentSettings';
 
 const CookieConsent = dynamic(
   () => import('kesaseteli-shared/components/cookieConsent/CookieConsent'),
@@ -25,9 +24,6 @@ const CookieConsent = dynamic(
 );
 
 const queryClient = createQueryClient();
-
-const getRequiredYouthCookieGroups = (): RequiredGroups =>
-  getRequiredCookieGroups();
 
 const App: React.FC<AppProps> = (appProps: AppProps) => {
   const isMatomoConfigured = useMatomo();

--- a/frontend/kesaseteli/youth/src/pages/cookie-settings.tsx
+++ b/frontend/kesaseteli/youth/src/pages/cookie-settings.tsx
@@ -1,3 +1,4 @@
+import getRequiredYouthCookieGroups from 'kesaseteli/youth/utils/get-required-youth-cookie-groups';
 import CookieSettings from 'kesaseteli-shared/components/cookieSettings/CookieSettings';
 import { GetStaticProps, NextPage } from 'next';
 import { useTranslation } from 'next-i18next';
@@ -11,6 +12,7 @@ const CookieSettingsPage: NextPage = () => {
     <CookieSettings
       title={`${t('common:appName')} - ${t('common:cookieSettings')}`}
       siteName={t('common:appName')}
+      requiredGroups={getRequiredYouthCookieGroups()}
     />
   );
 };

--- a/frontend/kesaseteli/youth/src/utils/get-required-youth-cookie-groups.ts
+++ b/frontend/kesaseteli/youth/src/utils/get-required-youth-cookie-groups.ts
@@ -1,0 +1,7 @@
+import getRequiredCookieGroups from 'kesaseteli-shared/utils/getRequiredCookieGroups';
+import type { RequiredGroups } from 'shared/utils/cookieConsentSettings';
+
+const getRequiredYouthCookieGroups = (): RequiredGroups =>
+  getRequiredCookieGroups();
+
+export default getRequiredYouthCookieGroups;


### PR DESCRIPTION
## Description :sparkles:

Kesäseteli frontends:
- Add required cookie groups to cookie settings pages

## Related

- [YJDH-977](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-977): Add required cookie groups to cookie settings pages
- [YJDH-969](https://helsinkisolutionoffice.atlassian.net/browse/YJDH-969): PR City-of-Helsinki/yjdh#4242 added required cookies

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[YJDH-977]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[YJDH-969]: https://helsinkisolutionoffice.atlassian.net/browse/YJDH-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie consent handling across the employer, handler, and youth applications.
  * Cookie settings now consistently preserve the cookies required for secure sessions, authentication, and request protection.
  * Required cookie groups are now applied consistently when opening cookie settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->